### PR TITLE
fix(client): demarkus editor fix with wait

### DIFF
--- a/client/cmd/demarkus/main.go
+++ b/client/cmd/demarkus/main.go
@@ -601,7 +601,7 @@ var waitEditors = map[string]string{
 }
 
 func editorCommand(fields []string, file string) (name string, args []string) {
-	args = make([]string, len(fields)-1, len(fields))
+	args = make([]string, len(fields)-1, len(fields)+1)
 	copy(args, fields[1:])
 
 	base := filepath.Base(fields[0])

--- a/client/cmd/demarkus/main_test.go
+++ b/client/cmd/demarkus/main_test.go
@@ -74,11 +74,11 @@ func TestEditorCommand(t *testing.T) {
 			wantArgs: []string{"--wait", "/tmp/doc.md"},
 		},
 		{
-			name:     "gui editor already has -w",
-			fields:   []string{"code", "-w"},
+			name:     "non-gui editor with one arg",
+			fields:   []string{"nano", "-R"},
 			file:     "/tmp/doc.md",
-			wantName: "code",
-			wantArgs: []string{"-w", "/tmp/doc.md"},
+			wantName: "nano",
+			wantArgs: []string{"-R", "/tmp/doc.md"},
 		},
 		{
 			name:     "full path gui editor gets --wait",


### PR DESCRIPTION
editors like zed were not writing to the demarkus server, it was detecting blank content after file exited 