### PR TITLE
feat(filestore): Migrate version storage layout to per-document subdirectories

### DIFF
--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -1040,8 +1040,8 @@ func TestVersionsChainValid(t *testing.T) {
 	})
 
 	t.Run("tampered chain", func(t *testing.T) {
-		// Corrupt v1 on disk.
-		v1Path := filepath.Join(dir, "versions", "doc.md.v1")
+		// Corrupt v1 on disk (per-document subdirectory layout).
+		v1Path := filepath.Join(dir, "versions", "doc.md", "v1")
 		if err := os.WriteFile(v1Path, []byte("# TAMPERED\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -4,14 +4,20 @@
 // through the protocol (with a versions directory) are served. Flat files
 // without version history are treated as non-existent.
 //
-// Layout:
+// Layout (per-document subdirectory):
 //
 //	root/
-//	  doc.md              ← symlink to versions/doc.md.v3
+//	  doc.md              ← symlink to versions/doc.md/v3
 //	  versions/
-//	    doc.md.v1
-//	    doc.md.v2
-//	    doc.md.v3
+//	    doc.md/
+//	      v1
+//	      v2
+//	      v3
+//
+// The store also supports a legacy flat layout (versions/doc.md.v{N}) for
+// backward compatibility. Old-layout documents are migrated to the per-document
+// subdirectory layout on the next write.
+// TODO(v1): remove flat layout support and migration code.
 package store
 
 import (
@@ -72,6 +78,43 @@ const maxStoreFrontmatter = 1024
 // metaPrefix is the key prefix for publisher-provided metadata in store
 // frontmatter. On disk: "meta.type: journal". Stripped when returned to clients.
 const metaPrefix = "meta."
+
+// isPerDocLayout reports whether a document uses the per-document subdirectory
+// layout (versions/{base}/v{N}) rather than the flat layout (versions/{base}.v{N}).
+// TODO(v1): remove once all stores have been migrated; assume per-doc layout.
+func isPerDocLayout(versionsDir, base string) bool {
+	info, err := os.Stat(filepath.Join(versionsDir, base))
+	return err == nil && info.IsDir()
+}
+
+// resolveVersionFile returns the absolute path to an existing version file,
+// checking per-doc layout first then falling back to flat layout. This handles
+// partially-migrated stores where some versions may still be in the old layout.
+// TODO(v1): remove flat layout fallback; always use per-doc path directly.
+func resolveVersionFile(versionsDir, base string, version int) string {
+	perDoc := filepath.Join(versionsDir, base, fmt.Sprintf("v%d", version))
+	if _, err := os.Stat(perDoc); err == nil {
+		return perDoc
+	}
+	flat := filepath.Join(versionsDir, fmt.Sprintf("%s.v%d", base, version))
+	if _, err := os.Stat(flat); err == nil {
+		return flat
+	}
+	// Neither exists; return per-doc path so callers get a meaningful error.
+	return perDoc
+}
+
+// newVersionFilePath returns the absolute path for a new version file,
+// always using the per-document subdirectory layout.
+func newVersionFilePath(versionsDir, base string, version int) string {
+	return filepath.Join(versionsDir, base, fmt.Sprintf("v%d", version))
+}
+
+// newVersionSymlinkTarget returns the relative symlink target for a new version,
+// always using the per-document subdirectory layout.
+func newVersionSymlinkTarget(base string, version int) string {
+	return filepath.Join("versions", base, fmt.Sprintf("v%d", version))
+}
 
 // Store provides read access to a versioned document directory.
 type Store struct {
@@ -398,6 +441,8 @@ func (s *Store) CurrentVersion(reqPath string) int {
 }
 
 // findVersions looks for versioned files in the versions directory.
+// Supports both per-document subdirectory layout (versions/{base}/v{N})
+// and flat layout (versions/{base}.v{N}).
 // Returns nil if no versions directory or no matching files exist.
 func (s *Store) findVersions(reqPath string) []VersionInfo {
 	cleaned := filepath.Clean(reqPath)
@@ -405,6 +450,46 @@ func (s *Store) findVersions(reqPath string) []VersionInfo {
 	base := filepath.Base(cleaned)
 
 	versionsDir := filepath.Join(s.root, filepath.Dir(cleaned), "versions")
+
+	if isPerDocLayout(versionsDir, base) {
+		return s.findVersionsPerDoc(versionsDir, base)
+	}
+	return s.findVersionsFlat(versionsDir, base)
+}
+
+// findVersionsPerDoc reads versions from the per-document subdirectory layout.
+func (s *Store) findVersionsPerDoc(versionsDir, base string) []VersionInfo {
+	docDir := filepath.Join(versionsDir, base)
+	entries, err := os.ReadDir(docDir)
+	if err != nil {
+		return nil
+	}
+
+	var versions []VersionInfo
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasPrefix(e.Name(), "v") {
+			continue
+		}
+		numStr := e.Name()[1:] // strip "v" prefix
+		num, err := strconv.Atoi(numStr)
+		if err != nil || num < 1 {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		versions = append(versions, VersionInfo{
+			Version:  num,
+			Modified: info.ModTime().UTC().Truncate(time.Second),
+		})
+	}
+	return versions
+}
+
+// findVersionsFlat reads versions from the flat layout.
+// TODO(v1): remove this function; all stores will use per-doc layout.
+func (s *Store) findVersionsFlat(versionsDir, base string) []VersionInfo {
 	entries, err := os.ReadDir(versionsDir)
 	if err != nil {
 		return nil
@@ -440,11 +525,22 @@ func (s *Store) getVersion(reqPath string, version int) (*Document, error) {
 	cleaned = strings.TrimLeft(cleaned, "/")
 	base := filepath.Base(cleaned)
 
-	// Build path relative to root: versions/doc.md.v1
-	versionPath := filepath.Join(filepath.Dir(cleaned), "versions", fmt.Sprintf("%s.v%d", base, version))
-	filePath, err := s.resolve("/" + versionPath)
-	if err != nil {
-		return nil, err
+	// Try per-doc layout first, fall back to flat layout for backward compatibility.
+	// TODO(v1): remove flat layout fallback.
+	dir := filepath.Dir(cleaned)
+	perDocPath := "/" + filepath.Join(dir, "versions", base, fmt.Sprintf("v%d", version))
+	filePath, err := s.resolve(perDocPath)
+	if err == nil {
+		if _, statErr := os.Stat(filePath); statErr != nil {
+			filePath = "" // per-doc path resolved but file doesn't exist; try flat
+		}
+	}
+	if filePath == "" {
+		flatPath := "/" + filepath.Join(dir, "versions", fmt.Sprintf("%s.v%d", base, version))
+		filePath, err = s.resolve(flatPath)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	info, err := os.Stat(filePath)
@@ -496,7 +592,12 @@ func (s *Store) Archive(reqPath string, archived bool) error {
 		return os.ErrNotExist
 	}
 
-	versionRelPath := "/" + filepath.Join(dir, "versions", fmt.Sprintf("%s.v%d", base, currentVersion))
+	// Resolve the version file path, trying per-doc layout first.
+	// TODO(v1): remove flat layout fallback.
+	versionsDir := filepath.Join(s.root, dir, "versions")
+	resolvedFile := resolveVersionFile(versionsDir, base, currentVersion)
+	rel, _ := filepath.Rel(s.root, resolvedFile)
+	versionRelPath := "/" + rel
 	versionFile, err := s.resolve(versionRelPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -633,36 +734,21 @@ func (s *Store) Write(reqPath string, content []byte, meta map[string]string) (*
 	}
 
 	// For existing documents: reject writes to archived documents (closes
-	// TOCTOU gap with handler) and migrate flat files to v1 if needed.
+	// TOCTOU gap with handler), run migrations, and check for duplicate content.
 	if next > 1 {
-		if s.isCurrentArchived(versionsDir, base, next-1) {
-			return nil, ErrArchived
-		}
-		if err := s.migrateFlatFile(versionsDir, base, currentFile); err != nil {
-			return nil, err
-		}
-
-		// Skip creating a new version if content and metadata are identical.
-		prevFile := filepath.Join(versionsDir, fmt.Sprintf("%s.v%d", base, next-1))
-		prevData, err := os.ReadFile(prevFile)
-		if err == nil {
-			if bytes.Equal(extractBody(prevData), content) && metaEqual(extractMetadata(prevData), meta) {
-				info, err := os.Stat(prevFile)
-				if err != nil {
-					return nil, fmt.Errorf("stat current version: %w", err)
-				}
-				return &Document{
-					Content:  content,
-					Modified: info.ModTime().UTC().Truncate(time.Second),
-					Version:  next - 1,
-					Archived: false,
-					Metadata: meta,
-				}, ErrNotModified
-			}
+		doc, err := s.prepareExistingDoc(versionsDir, base, currentFile, next, content, meta)
+		if doc != nil || err != nil {
+			return doc, err
 		}
 	}
 
-	versionFile := filepath.Join(versionsDir, fmt.Sprintf("%s.v%d", base, next))
+	// Create per-document subdirectory for new documents.
+	docDir := filepath.Join(versionsDir, base)
+	if err := os.MkdirAll(docDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create per-doc versions dir: %w", err)
+	}
+
+	vFile := newVersionFilePath(versionsDir, base, next)
 
 	stored, err := buildVersionFile(versionsDir, base, next, content, meta)
 	if err != nil {
@@ -676,7 +762,7 @@ func (s *Store) Write(reqPath string, content []byte, meta map[string]string) (*
 
 	// Immutability guard + atomic write: O_CREATE|O_EXCL fails if the file
 	// already exists, preventing TOCTOU races between a stat check and rename.
-	f, err := os.OpenFile(versionFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	f, err := os.OpenFile(vFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
 		if os.IsExist(err) {
 			return nil, fmt.Errorf("version %d: %w", next, ErrVersionExists)
@@ -685,11 +771,11 @@ func (s *Store) Write(reqPath string, content []byte, meta map[string]string) (*
 	}
 	if _, err := f.Write(stored); err != nil {
 		_ = f.Close()
-		_ = os.Remove(versionFile)
+		_ = os.Remove(vFile)
 		return nil, fmt.Errorf("write version file: %w", err)
 	}
 	if err := f.Close(); err != nil {
-		_ = os.Remove(versionFile)
+		_ = os.Remove(vFile)
 		return nil, fmt.Errorf("close version file: %w", err)
 	}
 
@@ -697,7 +783,7 @@ func (s *Store) Write(reqPath string, content []byte, meta map[string]string) (*
 	// Create a temp symlink then rename over the current path so readers
 	// never see a missing file. Use a relative target so the content
 	// directory can be relocated without breaking links.
-	relTarget := filepath.Join("versions", fmt.Sprintf("%s.v%d", base, next))
+	relTarget := newVersionSymlinkTarget(base, next)
 	tmpLink := currentFile + ".tmp"
 	_ = os.Remove(tmpLink) // clean up any stale temp link
 	if err := os.Symlink(relTarget, tmpLink); err != nil {
@@ -708,7 +794,7 @@ func (s *Store) Write(reqPath string, content []byte, meta map[string]string) (*
 		return nil, fmt.Errorf("rename current file: %w", err)
 	}
 
-	info, err := os.Stat(versionFile)
+	info, err := os.Stat(vFile)
 	if err != nil {
 		return nil, fmt.Errorf("stat version file: %w", err)
 	}
@@ -722,6 +808,54 @@ func (s *Store) Write(reqPath string, content []byte, meta map[string]string) (*
 		Archived: false,
 		Metadata: meta,
 	}, nil
+}
+
+// prepareExistingDoc handles pre-write checks for existing documents:
+// rejects archived documents, migrates flat files and old layout to per-doc
+// subdirectories, and returns ErrNotModified if content is unchanged.
+// Returns (nil, nil) when the caller should proceed with writing a new version.
+func (s *Store) prepareExistingDoc(versionsDir, base, currentFile string, next int, content []byte, meta map[string]string) (*Document, error) {
+	archived, err := s.isCurrentArchived(versionsDir, base, next-1)
+	if err != nil {
+		return nil, err
+	}
+	if archived {
+		return nil, ErrArchived
+	}
+	if err := s.migrateFlatFile(versionsDir, base, currentFile); err != nil {
+		return nil, err
+	}
+	if !isPerDocLayout(versionsDir, base) {
+		if err := s.migrateToPerDocDir(versionsDir, base, currentFile); err != nil {
+			return nil, err
+		}
+	}
+
+	// Skip creating a new version if content and metadata are identical.
+	// After migration, always use per-doc layout for reads.
+	prevFile := newVersionFilePath(versionsDir, base, next-1)
+	prevData, err := os.ReadFile(prevFile)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("read previous version: %w", err)
+		}
+		// File doesn't exist — proceed with writing the new version.
+		return nil, nil
+	}
+	if bytes.Equal(extractBody(prevData), content) && metaEqual(extractMetadata(prevData), meta) {
+		info, err := os.Stat(prevFile)
+		if err != nil {
+			return nil, fmt.Errorf("stat current version: %w", err)
+		}
+		return &Document{
+			Content:  content,
+			Modified: info.ModTime().UTC().Truncate(time.Second),
+			Version:  next - 1,
+			Archived: false,
+			Metadata: meta,
+		}, ErrNotModified
+	}
+	return nil, nil
 }
 
 // WriteVersion is like Write but performs an optimistic concurrency check.
@@ -841,8 +975,8 @@ func (s *Store) VerifyChain(reqPath string) error {
 	for i, curr := range versions[1:] {
 		prev := versions[i]
 
-		prevFile := filepath.Join(versionsDir, fmt.Sprintf("%s.v%d", base, prev.Version))
-		currFile := filepath.Join(versionsDir, fmt.Sprintf("%s.v%d", base, curr.Version))
+		prevFile := resolveVersionFile(versionsDir, base, prev.Version)
+		currFile := resolveVersionFile(versionsDir, base, curr.Version)
 
 		prevData, err := os.ReadFile(prevFile)
 		if err != nil {
@@ -981,7 +1115,7 @@ func buildVersionFile(versionsDir, base string, version int, content []byte, met
 	sb.WriteString(fmt.Sprintf("version: %d\n", version))
 	sb.WriteString("archived: false\n")
 	if version > 1 {
-		prevFile := filepath.Join(versionsDir, fmt.Sprintf("%s.v%d", base, version-1))
+		prevFile := resolveVersionFile(versionsDir, base, version-1)
 		prevData, err := os.ReadFile(prevFile)
 		if err != nil {
 			return nil, fmt.Errorf("read previous version for hashing: %w", err)
@@ -1083,16 +1217,31 @@ func extractBody(data []byte) []byte {
 }
 
 // migrateFlatFile promotes a flat file (no version history) to v1 in the
-// versions directory. If v1 already exists (concurrent write), it is a no-op.
+// versions directory using the per-document subdirectory layout.
+// If v1 already exists (concurrent write), it is a no-op.
+// TODO(v1): remove this function; flat files without version history won't exist.
 func (s *Store) migrateFlatFile(versionsDir, base, currentFile string) error {
-	v1File := filepath.Join(versionsDir, fmt.Sprintf("%s.v1", base))
-	if _, err := os.Stat(v1File); !errors.Is(err, os.ErrNotExist) {
-		return nil // v1 already exists
+	// Check both layouts for an existing v1.
+	perDocV1 := newVersionFilePath(versionsDir, base, 1)
+	if _, err := os.Stat(perDocV1); !errors.Is(err, os.ErrNotExist) {
+		return nil // v1 already exists (new layout)
+	}
+	flatV1 := filepath.Join(versionsDir, fmt.Sprintf("%s.v1", base))
+	if _, err := os.Stat(flatV1); !errors.Is(err, os.ErrNotExist) {
+		return nil // v1 already exists (old layout, will be migrated by migrateToPerDocDir)
 	}
 	flatData, err := os.ReadFile(currentFile)
 	if err != nil {
 		return fmt.Errorf("read flat file for migration: %w", err)
 	}
+
+	// Create per-document subdirectory.
+	docDir := filepath.Join(versionsDir, base)
+	if err := os.MkdirAll(docDir, 0o755); err != nil {
+		return fmt.Errorf("create per-doc dir for migration: %w", err)
+	}
+
+	v1File := newVersionFilePath(versionsDir, base, 1)
 	v1Data := []byte("---\nversion: 1\n---\n")
 	v1Data = append(v1Data, flatData...)
 	// Use exclusive create to prevent overwriting a v1 that appeared
@@ -1116,12 +1265,84 @@ func (s *Store) migrateFlatFile(versionsDir, base, currentFile string) error {
 	return nil
 }
 
+// migrateToPerDocDir moves version files from the flat layout (versions/{base}.v{N})
+// to the per-document subdirectory layout (versions/{base}/v{N}).
+// Updates the current symlink to point at the new location.
+// No-op if already using per-document layout or no flat files exist.
+// TODO(v1): remove this function; all stores will use per-doc layout.
+func (s *Store) migrateToPerDocDir(versionsDir, base, currentFile string) error {
+	// Create per-document subdirectory.
+	docDir := filepath.Join(versionsDir, base)
+	if err := os.MkdirAll(docDir, 0o755); err != nil {
+		return fmt.Errorf("create per-doc dir for migration: %w", err)
+	}
+
+	// Find all flat-layout version files for this document.
+	entries, err := os.ReadDir(versionsDir)
+	if err != nil {
+		return fmt.Errorf("read versions dir for migration: %w", err)
+	}
+
+	prefix := base + ".v"
+	var highestVersion int
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasPrefix(e.Name(), prefix) {
+			continue
+		}
+		numStr := strings.TrimPrefix(e.Name(), prefix)
+		num, err := strconv.Atoi(numStr)
+		if err != nil || num < 1 {
+			continue
+		}
+
+		oldPath := filepath.Join(versionsDir, e.Name())
+		newPath := newVersionFilePath(versionsDir, base, num)
+
+		// Skip if already migrated (e.g. concurrent migration).
+		if _, err := os.Stat(newPath); err == nil {
+			_ = os.Remove(oldPath)
+			if num > highestVersion {
+				highestVersion = num
+			}
+			continue
+		}
+
+		if err := os.Rename(oldPath, newPath); err != nil {
+			return fmt.Errorf("migrate version %d: %w", num, err)
+		}
+		if num > highestVersion {
+			highestVersion = num
+		}
+	}
+
+	// Update symlink to point at the new location.
+	if highestVersion > 0 {
+		relTarget := newVersionSymlinkTarget(base, highestVersion)
+		tmpLink := currentFile + ".tmp"
+		_ = os.Remove(tmpLink)
+		if err := os.Symlink(relTarget, tmpLink); err != nil {
+			return fmt.Errorf("symlink during migration: %w", err)
+		}
+		if err := os.Rename(tmpLink, currentFile); err != nil {
+			_ = os.Remove(tmpLink)
+			return fmt.Errorf("rename symlink during migration: %w", err)
+		}
+	}
+
+	return nil
+}
+
 // isCurrentArchived checks whether the given version file is archived.
-func (s *Store) isCurrentArchived(versionsDir, base string, version int) bool {
-	path := filepath.Join(versionsDir, fmt.Sprintf("%s.v%d", base, version))
+// Returns (false, nil) if the file doesn't exist (new document).
+// Returns an error for non-ErrNotExist read failures.
+func (s *Store) isCurrentArchived(versionsDir, base string, version int) (bool, error) {
+	path := resolveVersionFile(versionsDir, base, version)
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return false
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read version file for archive check: %w", err)
 	}
-	return isArchived(data)
+	return isArchived(data), nil
 }

--- a/server/internal/store/store_test.go
+++ b/server/internal/store/store_test.go
@@ -27,6 +27,7 @@ func TestGet_FlatFileRejected(t *testing.T) {
 	}
 }
 
+// TODO(v1): update this test to use per-doc layout once flat layout support is removed.
 func TestGet_VersionedFile(t *testing.T) {
 	root := t.TempDir()
 	versionsDir := filepath.Join(root, "versions")
@@ -187,6 +188,7 @@ func TestVersions_FlatFileRejected(t *testing.T) {
 	}
 }
 
+// TODO(v1): update this test to use per-doc layout once flat layout support is removed.
 func TestVersions_MultipleVersions(t *testing.T) {
 	root := t.TempDir()
 	versionsDir := filepath.Join(root, "versions")
@@ -259,8 +261,8 @@ func TestWrite_NewDocument(t *testing.T) {
 		t.Errorf("content = %q, want %q", doc.Content, "# Hello\n")
 	}
 
-	// Version file should exist with store frontmatter.
-	vData, err := os.ReadFile(filepath.Join(root, "versions", "new.md.v1"))
+	// Version file should exist with store frontmatter (per-doc layout).
+	vData, err := os.ReadFile(filepath.Join(root, "versions", "new.md", "v1"))
 	if err != nil {
 		t.Fatalf("read version file: %v", err)
 	}
@@ -296,8 +298,8 @@ func TestWrite_CreatesVersion(t *testing.T) {
 		t.Errorf("version = %d, want 2", doc.Version)
 	}
 
-	// versions/doc.md.v2 must exist.
-	if _, err := os.Stat(filepath.Join(root, "versions", "doc.md.v2")); err != nil {
+	// versions/doc.md/v2 must exist.
+	if _, err := os.Stat(filepath.Join(root, "versions", "doc.md", "v2")); err != nil {
 		t.Errorf("version file not created: %v", err)
 	}
 }
@@ -318,7 +320,7 @@ func TestWrite_Increments(t *testing.T) {
 
 	// All three version files must exist.
 	for i := 1; i <= 3; i++ {
-		path := filepath.Join(root, "versions", fmt.Sprintf("doc.md.v%d", i))
+		path := filepath.Join(root, "versions", "doc.md", fmt.Sprintf("v%d", i))
 		if _, err := os.Stat(path); err != nil {
 			t.Errorf("missing version file v%d: %v", i, err)
 		}
@@ -349,7 +351,7 @@ func TestWrite_CreatesSubdirectory(t *testing.T) {
 	}
 
 	// Verify the version file was created on disk.
-	versionFile := filepath.Join(root, "newdir", "versions", "doc.md.v1")
+	versionFile := filepath.Join(root, "newdir", "versions", "doc.md", "v1")
 	if _, err := os.Stat(versionFile); err != nil {
 		t.Errorf("version file not found: %v", err)
 	}
@@ -415,9 +417,13 @@ func TestWrite_ImmutabilityGuard(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// No doc.md on disk → next=1. Pre-create v1 to simulate a concurrent writer
-	// that won the race and already wrote v1 before we get to the atomic rename.
-	if err := os.WriteFile(filepath.Join(versionsDir, "doc.md.v1"), []byte("# already there\n"), 0o644); err != nil {
+	// No doc.md on disk → next=1. Pre-create v1 in per-doc layout to simulate
+	// a concurrent writer that won the race and already wrote v1.
+	docDir := filepath.Join(versionsDir, "doc.md")
+	if err := os.MkdirAll(docDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(docDir, "v1"), []byte("# already there\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -445,11 +451,11 @@ func TestWrite_HashChain(t *testing.T) {
 		t.Fatalf("write v2: %v", err)
 	}
 
-	v1Data, err := os.ReadFile(filepath.Join(root, "versions", "doc.md.v1"))
+	v1Data, err := os.ReadFile(filepath.Join(root, "versions", "doc.md", "v1"))
 	if err != nil {
 		t.Fatalf("read v1: %v", err)
 	}
-	v2Data, err := os.ReadFile(filepath.Join(root, "versions", "doc.md.v2"))
+	v2Data, err := os.ReadFile(filepath.Join(root, "versions", "doc.md", "v2"))
 	if err != nil {
 		t.Fatalf("read v2: %v", err)
 	}
@@ -494,7 +500,7 @@ func TestWrite_DuplicateContentIsNoOp(t *testing.T) {
 	}
 
 	// No v2 file should exist.
-	v2Path := filepath.Join(root, "versions", "doc.md.v2")
+	v2Path := filepath.Join(root, "versions", "doc.md", "v2")
 	if _, err := os.Stat(v2Path); !errors.Is(err, os.ErrNotExist) {
 		t.Error("v2 file should not exist for duplicate content")
 	}
@@ -824,7 +830,7 @@ func TestVerifyChain_Tampered(t *testing.T) {
 	}
 
 	// Tamper with v1 after the chain is formed.
-	v1Path := filepath.Join(root, "versions", "doc.md.v1")
+	v1Path := filepath.Join(root, "versions", "doc.md", "v1")
 	if err := os.WriteFile(v1Path, []byte("# TAMPERED\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -835,6 +841,82 @@ func TestVerifyChain_Tampered(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "chain broken") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TODO(v1): remove this test once flat layout support and migration code are removed.
+func TestWrite_MigratesOldLayoutToPerDoc(t *testing.T) {
+	root := t.TempDir()
+
+	// Set up old flat layout manually: versions/doc.md.v1 and versions/doc.md.v2.
+	versionsDir := filepath.Join(root, "versions")
+	if err := os.MkdirAll(versionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	v1Content := []byte("---\nversion: 1\narchived: false\n---\n# V1\n")
+	if err := os.WriteFile(filepath.Join(versionsDir, "doc.md.v1"), v1Content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h := sha256.Sum256(v1Content)
+	v2Content := fmt.Appendf(nil, "---\nversion: 2\narchived: false\nprevious-hash: sha256-%x\n---\n# V2\n", h)
+	if err := os.WriteFile(filepath.Join(versionsDir, "doc.md.v2"), v2Content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create symlink in old layout.
+	if err := os.Symlink(filepath.Join("versions", "doc.md.v2"), filepath.Join(root, "doc.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	s := New(root)
+
+	// Reads should work with old layout.
+	doc, err := s.Get("/doc.md", 0)
+	if err != nil {
+		t.Fatalf("Get before migration: %v", err)
+	}
+	if doc.Version != 2 {
+		t.Errorf("version = %d, want 2", doc.Version)
+	}
+
+	// Write v3, which should trigger migration.
+	doc, err = s.Write("/doc.md", []byte("# V3\n"), nil)
+	if err != nil {
+		t.Fatalf("Write v3: %v", err)
+	}
+	if doc.Version != 3 {
+		t.Errorf("version = %d, want 3", doc.Version)
+	}
+
+	// Old flat files should be gone.
+	if _, err := os.Stat(filepath.Join(versionsDir, "doc.md.v1")); !errors.Is(err, os.ErrNotExist) {
+		t.Error("old flat v1 should have been removed")
+	}
+	if _, err := os.Stat(filepath.Join(versionsDir, "doc.md.v2")); !errors.Is(err, os.ErrNotExist) {
+		t.Error("old flat v2 should have been removed")
+	}
+
+	// New per-doc files should exist.
+	docDir := filepath.Join(versionsDir, "doc.md")
+	for i := 1; i <= 3; i++ {
+		if _, err := os.Stat(filepath.Join(docDir, fmt.Sprintf("v%d", i))); err != nil {
+			t.Errorf("missing per-doc v%d: %v", i, err)
+		}
+	}
+
+	// Symlink should point to new layout.
+	target, err := os.Readlink(filepath.Join(root, "doc.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != filepath.Join("versions", "doc.md", "v3") {
+		t.Errorf("symlink target = %q, want %q", target, filepath.Join("versions", "doc.md", "v3"))
+	}
+
+	// Hash chain should be valid across the migration boundary.
+	if err := s.VerifyChain("/doc.md"); err != nil {
+		t.Errorf("chain verification failed after migration: %v", err)
 	}
 }
 
@@ -981,7 +1063,7 @@ func TestWrite_WithMetadata(t *testing.T) {
 	}
 
 	// Version file should contain meta. prefixed keys.
-	vData, err := os.ReadFile(filepath.Join(root, "versions", "doc.md.v1"))
+	vData, err := os.ReadFile(filepath.Join(root, "versions", "doc.md", "v1"))
 	if err != nil {
 		t.Fatalf("read version file: %v", err)
 	}
@@ -1028,7 +1110,7 @@ func TestWrite_NilMetadata(t *testing.T) {
 	}
 
 	// Version file should not contain any meta. lines.
-	vData, err := os.ReadFile(filepath.Join(root, "versions", "doc.md.v1"))
+	vData, err := os.ReadFile(filepath.Join(root, "versions", "doc.md", "v1"))
 	if err != nil {
 		t.Fatalf("read version file: %v", err)
 	}

--- a/server/internal/store/store_test.go
+++ b/server/internal/store/store_test.go
@@ -920,6 +920,168 @@ func TestWrite_MigratesOldLayoutToPerDoc(t *testing.T) {
 	}
 }
 
+func TestWrite_SubdirectoryPerDocLayout(t *testing.T) {
+	root := t.TempDir()
+	s := New(root)
+
+	// Write to a deeply nested path.
+	doc, err := s.Write("/a/b/c/doc.md", []byte("# Deep\n"), nil)
+	if err != nil {
+		t.Fatalf("Write v1: %v", err)
+	}
+	if doc.Version != 1 {
+		t.Errorf("version = %d, want 1", doc.Version)
+	}
+
+	// Verify per-doc layout at the correct nesting.
+	vFile := filepath.Join(root, "a", "b", "c", "versions", "doc.md", "v1")
+	if _, err := os.Stat(vFile); err != nil {
+		t.Fatalf("version file not found: %v", err)
+	}
+
+	// Write v2.
+	doc, err = s.Write("/a/b/c/doc.md", []byte("# Deep v2\n"), nil)
+	if err != nil {
+		t.Fatalf("Write v2: %v", err)
+	}
+	if doc.Version != 2 {
+		t.Errorf("version = %d, want 2", doc.Version)
+	}
+
+	// Symlink should point to per-doc layout.
+	target, err := os.Readlink(filepath.Join(root, "a", "b", "c", "doc.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != filepath.Join("versions", "doc.md", "v2") {
+		t.Errorf("symlink = %q, want %q", target, filepath.Join("versions", "doc.md", "v2"))
+	}
+
+	// Read back via Get.
+	got, err := s.Get("/a/b/c/doc.md", 0)
+	if err != nil {
+		t.Fatalf("Get current: %v", err)
+	}
+	if got.Version != 2 {
+		t.Errorf("Get version = %d, want 2", got.Version)
+	}
+
+	// Read specific version.
+	got, err = s.Get("/a/b/c/doc.md", 1)
+	if err != nil {
+		t.Fatalf("Get v1: %v", err)
+	}
+	if got.Version != 1 {
+		t.Errorf("Get v1 version = %d, want 1", got.Version)
+	}
+
+	// Versions listing.
+	versions, err := s.Versions("/a/b/c/doc.md")
+	if err != nil {
+		t.Fatalf("Versions: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Fatalf("versions count = %d, want 2", len(versions))
+	}
+
+	// Hash chain integrity.
+	if err := s.VerifyChain("/a/b/c/doc.md"); err != nil {
+		t.Errorf("chain verification failed: %v", err)
+	}
+
+	// Append.
+	doc, err = s.Append("/a/b/c/doc.md", 2, []byte("Appended."), nil)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if doc.Version != 3 {
+		t.Errorf("version = %d, want 3", doc.Version)
+	}
+}
+
+func TestWrite_SubdirectoryMigration(t *testing.T) {
+	root := t.TempDir()
+
+	// Set up old flat layout in a subdirectory.
+	subdir := filepath.Join(root, "docs", "guides")
+	versionsDir := filepath.Join(subdir, "versions")
+	if err := os.MkdirAll(versionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	v1Content := []byte("---\nversion: 1\narchived: false\n---\n# Guide\n")
+	if err := os.WriteFile(filepath.Join(versionsDir, "setup.md.v1"), v1Content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("versions", "setup.md.v1"), filepath.Join(subdir, "setup.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	s := New(root)
+
+	// Read should work with old layout.
+	doc, err := s.Get("/docs/guides/setup.md", 0)
+	if err != nil {
+		t.Fatalf("Get before migration: %v", err)
+	}
+	if doc.Version != 1 {
+		t.Errorf("version = %d, want 1", doc.Version)
+	}
+
+	// Write v2 triggers migration.
+	doc, err = s.Write("/docs/guides/setup.md", []byte("# Updated Guide\n"), nil)
+	if err != nil {
+		t.Fatalf("Write v2: %v", err)
+	}
+	if doc.Version != 2 {
+		t.Errorf("version = %d, want 2", doc.Version)
+	}
+
+	// Old flat file should be gone.
+	if _, err := os.Stat(filepath.Join(versionsDir, "setup.md.v1")); !errors.Is(err, os.ErrNotExist) {
+		t.Error("old flat v1 should have been removed")
+	}
+
+	// New per-doc files should exist.
+	docDir := filepath.Join(versionsDir, "setup.md")
+	for i := 1; i <= 2; i++ {
+		if _, err := os.Stat(filepath.Join(docDir, fmt.Sprintf("v%d", i))); err != nil {
+			t.Errorf("missing per-doc v%d: %v", i, err)
+		}
+	}
+
+	// Symlink updated.
+	target, err := os.Readlink(filepath.Join(subdir, "setup.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != filepath.Join("versions", "setup.md", "v2") {
+		t.Errorf("symlink = %q, want %q", target, filepath.Join("versions", "setup.md", "v2"))
+	}
+
+	// Hash chain valid.
+	if err := s.VerifyChain("/docs/guides/setup.md"); err != nil {
+		t.Errorf("chain verification failed: %v", err)
+	}
+
+	// Multiple documents in same subdirectory.
+	doc, err = s.Write("/docs/guides/install.md", []byte("# Install\n"), nil)
+	if err != nil {
+		t.Fatalf("Write install.md: %v", err)
+	}
+	if doc.Version != 1 {
+		t.Errorf("version = %d, want 1", doc.Version)
+	}
+
+	// Both documents should have independent per-doc dirs.
+	if _, err := os.Stat(filepath.Join(versionsDir, "install.md", "v1")); err != nil {
+		t.Errorf("install.md per-doc v1 not found: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(versionsDir, "setup.md", "v2")); err != nil {
+		t.Errorf("setup.md per-doc v2 not found: %v", err)
+	}
+}
+
 func TestAppend(t *testing.T) {
 	root := t.TempDir()
 	s := New(root)


### PR DESCRIPTION
this will be able to now handles 10s of thousands of versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure Updates**
  * Reorganized on-disk version storage to a per-document directory layout.
  * Automatic migration from legacy flat format with backward compatibility and transparent reads/writes.
  * Version discovery and retrieval now support both legacy and per-document layouts.

* **Tests**
  * Updated tests to assert per-document layout behavior.
  * Added migration and subdirectory-specific tests to validate migration, integrity, and symlink updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->