### PR TITLE
fix(install): Add WSL environment detection and systemd availability checks

### DIFF
--- a/docs/site/client/index.md
+++ b/docs/site/client/index.md
@@ -24,7 +24,7 @@ demarkus --insecure mark://localhost:6309/index.md
 demarkus --insecure -X LIST mark://localhost:6309/
 
 # Publish a document
-demarkus --insecure -X PUBLISH -auth $TOKEN mark://localhost:6309/hello.md -body "# Hello"
+demarkus --insecure -X PUBLISH -auth $TOKEN -body "# Hello" mark://localhost:6309/hello.md
 
 # View version history
 demarkus --insecure -X VERSIONS mark://localhost:6309/hello.md

--- a/docs/site/server/index.md
+++ b/docs/site/server/index.md
@@ -43,7 +43,7 @@ demarkus-server -root /srv/site -tokens /etc/demarkus/tokens.toml
 #### 3) Publish with the token
 
 ```bash
-demarkus --insecure -X PUBLISH -auth <raw-token> mark://localhost:6309/hello.md -body "# Hello World"
+demarkus --insecure -X PUBLISH -auth <raw-token> -body "# Hello World" mark://localhost:6309/hello.md
 ```
 
 ### Read Access (Private Paths)

--- a/docs/site/tools/index.md
+++ b/docs/site/tools/index.md
@@ -71,7 +71,7 @@ When accessing protected paths, clients send a token for reads (FETCH, LIST, VER
 #### Writing to a server
 
 ```bash
-demarkus --insecure -X PUBLISH -auth <raw-token> mark://localhost:6309/hello.md -body "# Hello World"
+demarkus --insecure -X PUBLISH -auth <raw-token> -body "# Hello World" mark://localhost:6309/hello.md
 ```
 
 #### Reading from a private server

--- a/install.sh
+++ b/install.sh
@@ -828,13 +828,8 @@ do_install() {
     return
   fi
 
-  # Server install requires elevated privileges on Linux
-  if [ "$PLATFORM" = "linux" ] && [ "$(id -u)" -ne 0 ]; then
-    log_error "Server install requires root. Run with sudo or as root."
-    exit 1
-  fi
-
-  # WSL: server requires WSL2 with systemd
+  # WSL: server requires WSL2 with systemd. Check this BEFORE the root check
+  # so WSL1 / no-systemd users aren't told to sudo-retry a run that can't succeed.
   if [ "$IS_WSL" = true ]; then
     if [ "$IS_WSL2" != true ]; then
       log_error "WSL1 detected. Demarkus server requires WSL2."
@@ -863,6 +858,12 @@ do_install() {
     log_warn "Running inside WSL2."
     log_warn "UDP port 6309 (QUIC) does not auto-forward from the Windows host."
     log_warn "For external access, see: https://latebit-io.github.io/demarkus/install/windows/"
+  fi
+
+  # Server install requires elevated privileges on Linux
+  if [ "$PLATFORM" = "linux" ] && [ "$(id -u)" -ne 0 ]; then
+    log_error "Server install requires root. Run with sudo or as root."
+    exit 1
   fi
 
   check_install_permissions

--- a/install.sh
+++ b/install.sh
@@ -1120,9 +1120,9 @@ do_install() {
     echo ""
     log_info "Publish your first document:"
     if [ -n "$domain" ] && [ "$no_tls" = false ]; then
-      echo "  demarkus -X PUBLISH -auth \$TOKEN mark://${domain}/index.md -body \"# Hello World\""
+      echo "  demarkus -X PUBLISH -auth \$TOKEN -body \"# Hello World\" mark://${domain}/index.md"
     else
-      echo "  demarkus --insecure -X PUBLISH -auth \$TOKEN mark://localhost:6309/index.md -body \"# Hello World\""
+      echo "  demarkus --insecure -X PUBLISH -auth \$TOKEN -body \"# Hello World\" mark://localhost:6309/index.md"
     fi
   fi
   echo ""

--- a/install.sh
+++ b/install.sh
@@ -134,16 +134,14 @@ check_install_permissions() {
 detect_platform() {
   OS=$(uname -s | tr '[:upper:]' '[:lower:]')
   ARCH=$(uname -m)
+  IS_WSL=false
 
   case "$OS" in
     linux)
-      # Detect WSL
-      if grep -qi microsoft /proc/version 2>/dev/null; then
-        log_error "Running inside WSL. For Windows/WSL2 setup, see:"
-        log_error "  https://latebit-io.github.io/demarkus/install/windows/"
-        exit 1
-      fi
       PLATFORM="linux"
+      if grep -qi microsoft /proc/version 2>/dev/null; then
+        IS_WSL=true
+      fi
       ;;
     darwin) PLATFORM="darwin" ;;
     msys*|cygwin*|mingw*)
@@ -829,6 +827,27 @@ do_install() {
   if [ "$PLATFORM" = "linux" ] && [ "$(id -u)" -ne 0 ]; then
     log_error "Server install requires root. Run with sudo or as root."
     exit 1
+  fi
+
+  # WSL2 server install requires systemd to be enabled
+  if [ "$IS_WSL" = true ]; then
+    if [ ! -d /run/systemd/system ]; then
+      log_error "Running inside WSL2 without systemd enabled."
+      log_error ""
+      log_error "Enable systemd:"
+      log_error "  1. Add to /etc/wsl.conf:"
+      log_error "       [boot]"
+      log_error "       systemd=true"
+      log_error "  2. From PowerShell:  wsl --shutdown"
+      log_error "  3. Re-open WSL and retry."
+      log_error ""
+      log_error "Or install the client only:"
+      log_error "  curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPO}/main/install.sh | bash -s -- --client-only"
+      exit 1
+    fi
+    log_warn "Running inside WSL2."
+    log_warn "UDP port 6309 (QUIC) does not auto-forward from the Windows host."
+    log_warn "For external access, see: https://latebit-io.github.io/demarkus/install/windows/"
   fi
 
   check_install_permissions

--- a/install.sh
+++ b/install.sh
@@ -135,12 +135,17 @@ detect_platform() {
   OS=$(uname -s | tr '[:upper:]' '[:lower:]')
   ARCH=$(uname -m)
   IS_WSL=false
+  IS_WSL2=false
 
   case "$OS" in
     linux)
       PLATFORM="linux"
       if grep -qi microsoft /proc/version 2>/dev/null; then
         IS_WSL=true
+        # WSL2's kernel osrelease contains "WSL2"; WSL1 does not
+        if grep -qi 'wsl2' /proc/sys/kernel/osrelease 2>/dev/null; then
+          IS_WSL2=true
+        fi
       fi
       ;;
     darwin) PLATFORM="darwin" ;;
@@ -829,8 +834,18 @@ do_install() {
     exit 1
   fi
 
-  # WSL2 server install requires systemd to be enabled
+  # WSL: server requires WSL2 with systemd
   if [ "$IS_WSL" = true ]; then
+    if [ "$IS_WSL2" != true ]; then
+      log_error "WSL1 detected. Demarkus server requires WSL2."
+      log_error ""
+      log_error "Convert your distro to WSL2 from PowerShell:"
+      log_error "  wsl --list --verbose         # find your distro name"
+      log_error "  wsl --set-version <distro> 2"
+      log_error ""
+      log_error "Then re-run this installer."
+      exit 1
+    fi
     if [ ! -d /run/systemd/system ]; then
       log_error "Running inside WSL2 without systemd enabled."
       log_error ""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WSL handling in the installer: detects WSL1 vs WSL2, aborts on unsupported WSL1 with remediation guidance, and validates WSL2 server prerequisites before proceeding.
  * Adds a client-only fallback when server prerequisites aren't met.

* **Chores**
  * Installer now emits warnings and guidance when WSL2 may require additional host-side setup (including QUIC UDP port 6309 forwarding).

* **Documentation**
  * Updated CLI publish examples to reorder the -body argument before the target URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->