### PR TITLE
feat(tui): Add external URL launching to TUI with allowlist support

### DIFF
--- a/client/cmd/demarkus-tui/links_test.go
+++ b/client/cmd/demarkus-tui/links_test.go
@@ -12,6 +12,47 @@ func osc8(url, text string) string {
 	return "\x1b]8;;" + url + "\x07" + text + "\x1b]8;;\x07"
 }
 
+func TestParseSchemeList(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{"empty disables", "", nil, false},
+		{"default set", "http,https,gemini,mailto", []string{"http", "https", "gemini", "mailto"}, false},
+		{"trims whitespace", "  http ,  https  ", []string{"http", "https"}, false},
+		{"drops empty entries", "http,,https,", []string{"http", "https"}, false},
+		{"preserves scheme special chars", "coap+tcp,svn-ssh,soap.beep", []string{"coap+tcp", "svn-ssh", "soap.beep"}, false},
+		{"rejects space in entry", "http, foo bar, https", nil, true},
+		{"rejects digit-leading scheme", "1http", nil, true},
+		{"rejects special chars", "http@s", nil, true},
+		{"rejects slash", "http/s", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSchemeList(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("want error for %q, got nil with result %v", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("got[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestIsExternalURL(t *testing.T) {
 	tests := []struct {
 		url  string
@@ -19,6 +60,8 @@ func TestIsExternalURL(t *testing.T) {
 	}{
 		{"mark://localhost/doc.md", false},
 		{"mark://host:6309/path", false},
+		{"MARK://host/doc.md", false}, // case-insensitive scheme matching
+		{"Mark://host/doc.md", false},
 		{"/index.md", false},
 		{"./doc.md", false},
 		{"doc.md", false},

--- a/client/cmd/demarkus-tui/links_test.go
+++ b/client/cmd/demarkus-tui/links_test.go
@@ -12,6 +12,35 @@ func osc8(url, text string) string {
 	return "\x1b]8;;" + url + "\x07" + text + "\x1b]8;;\x07"
 }
 
+func TestIsExternalURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"mark://localhost/doc.md", false},
+		{"mark://host:6309/path", false},
+		{"/index.md", false},
+		{"./doc.md", false},
+		{"doc.md", false},
+		{"", false},
+		{"http://example.com", true},
+		{"https://example.com/path", true},
+		{"gemini://example.org/", true},
+		{"mailto:alice@example.com", true}, // opaque form, no //
+		{"mailto://alice@example.com", true},
+		{"file:///etc/passwd", true},
+		{"javascript:alert(1)", true},
+		{"1http://starts-with-digit", false}, // scheme must start with alpha
+	}
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			if got := isExternalURL(tt.url); got != tt.want {
+				t.Errorf("isExternalURL(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestInjectLinkMarkers(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/client/cmd/demarkus-tui/main.go
+++ b/client/cmd/demarkus-tui/main.go
@@ -755,9 +755,11 @@ func isExternalURL(raw string) bool {
 	return scheme != "" && scheme != "mark"
 }
 
-// schemeOf returns the scheme component of raw, or the empty string if raw
-// has no scheme. Matches RFC 3986 scheme syntax: ALPHA *( ALPHA / DIGIT / + / - / . )
-// terminated by a colon, before any /, ?, #, or end of string.
+// schemeOf returns the scheme component of raw in canonical lowercase form,
+// or the empty string if raw has no scheme. Matches RFC 3986 scheme syntax:
+// ALPHA *( ALPHA / DIGIT / + / - / . ) terminated by a colon, before any /, ?,
+// #, or end of string. Schemes are case-insensitive per RFC 3986 §3.1; we
+// normalise to lowercase here so callers can compare directly.
 func schemeOf(raw string) string {
 	for i, r := range raw {
 		switch {
@@ -766,7 +768,7 @@ func schemeOf(raw string) string {
 				return ""
 			}
 		case r == ':':
-			return raw[:i]
+			return strings.ToLower(raw[:i])
 		case isAlpha(r) || isDigit(r) || r == '+' || r == '-' || r == '.':
 			// valid scheme char, continue
 		default:
@@ -1462,6 +1464,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	externalSchemes, err := parseSchemeList(*externalLinks)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid -external-links value: %v\n", err)
+		os.Exit(1)
+	}
+
 	client := fetch.NewClient(fetch.Options{
 		Cache:    cache.New(cache.DefaultDir()),
 		Insecure: *insecure,
@@ -1474,7 +1482,7 @@ func main() {
 	}
 
 	p := tea.NewProgram(
-		initialModel(initialURL, client, styleName, parseSchemeList(*externalLinks)),
+		initialModel(initialURL, client, styleName, externalSchemes),
 	)
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -1484,17 +1492,44 @@ func main() {
 
 // parseSchemeList splits a comma-separated scheme list, trimming whitespace
 // and dropping empty entries. Returns nil for an empty input (disables external
-// launching).
-func parseSchemeList(csv string) []string {
+// launching). Invalid entries fail the whole parse — a misconfigured flag must
+// not silently swallow unrecognisable schemes, because the user would assume
+// the scheme is enabled when it never matches anything.
+func parseSchemeList(csv string) ([]string, error) {
 	if csv == "" {
-		return nil
+		return nil, nil
 	}
 	parts := strings.Split(csv, ",")
 	out := make([]string, 0, len(parts))
 	for _, p := range parts {
-		if s := strings.TrimSpace(p); s != "" {
-			out = append(out, s)
+		s := strings.TrimSpace(p)
+		if s == "" {
+			continue
+		}
+		if !isValidScheme(s) {
+			return nil, fmt.Errorf("invalid URL scheme %q (schemes must match ALPHA *( ALPHA / DIGIT / \"+\" / \"-\" / \".\" ))", s)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// isValidScheme reports whether s is a syntactically valid URL scheme per
+// RFC 3986: starts with ALPHA, followed by any of ALPHA / DIGIT / + / - / .
+func isValidScheme(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if i == 0 {
+			if !isAlpha(r) {
+				return false
+			}
+			continue
+		}
+		if !isAlpha(r) && !isDigit(r) && r != '+' && r != '-' && r != '.' {
+			return false
 		}
 	}
-	return out
+	return true
 }

--- a/client/cmd/demarkus-tui/main.go
+++ b/client/cmd/demarkus-tui/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"github.com/latebit/demarkus/client/internal/fetch"
 	"github.com/latebit/demarkus/client/internal/graph"
 	"github.com/latebit/demarkus/client/internal/graphstore"
+	"github.com/latebit/demarkus/client/internal/launcher"
 	"github.com/latebit/demarkus/client/internal/links"
 	"github.com/latebit/demarkus/client/internal/tokens"
 	"github.com/latebit/demarkus/protocol"
@@ -99,6 +101,11 @@ type model struct {
 
 	// Terminal style — "dark" or "light", resolved once before Bubbletea starts.
 	styleName string
+
+	// External links: URL schemes (e.g. "http", "https") to open in the system
+	// handler when followed. mark:// is always handled internally. Empty slice
+	// disables external launching entirely.
+	externalSchemes []string
 }
 
 type fetchResult struct {
@@ -106,6 +113,12 @@ type fetchResult struct {
 	err    error
 	url    string
 	seq    uint64
+}
+
+// externalOpenResult is sent after an attempt to open a URL in the system handler.
+type externalOpenResult struct {
+	url string
+	err error
 }
 
 // clearBookmarkMsg signals the transient bookmark message should be cleared.
@@ -207,7 +220,7 @@ const helpText = `
     Esc          Exit bookmarks / dismiss help / blur address bar
 `
 
-func initialModel(initialURL string, client *fetch.Client, styleName string) model {
+func initialModel(initialURL string, client *fetch.Client, styleName string, externalSchemes []string) model {
 	ti := textinput.New()
 	ti.Placeholder = "mark://host:port/path"
 	ti.Prompt = " "
@@ -231,17 +244,18 @@ func initialModel(initialURL string, client *fetch.Client, styleName string) mod
 	}
 
 	return model{
-		addressBar:    ti,
-		focus:         focusAddressBar,
-		client:        client,
-		loading:       initialURL != "",
-		histIdx:       -1,
-		linkIdx:       -1,
-		hoverIdx:      -1,
-		bookmarkStore: bs,
-		bookmarkMsg:   bmMsg,
-		graphStore:    gs,
-		styleName:     styleName,
+		addressBar:      ti,
+		focus:           focusAddressBar,
+		client:          client,
+		loading:         initialURL != "",
+		histIdx:         -1,
+		linkIdx:         -1,
+		hoverIdx:        -1,
+		bookmarkStore:   bs,
+		bookmarkMsg:     bmMsg,
+		graphStore:      gs,
+		styleName:       styleName,
+		externalSchemes: externalSchemes,
 	}
 }
 
@@ -272,6 +286,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleCrawlResult(msg)
 	case fetchResult:
 		return m.handleFetchResult(msg)
+	case externalOpenResult:
+		return m.handleExternalOpenResult(msg)
 	case viewportReady:
 		return m.handleViewportReady()
 	case clearBookmarkMsg:
@@ -281,6 +297,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	return m, nil
+}
+
+func (m model) handleExternalOpenResult(msg externalOpenResult) (tea.Model, tea.Cmd) {
+	switch {
+	case msg.err == nil:
+		m.bookmarkMsg = "Opened in system handler"
+	case errors.Is(msg.err, launcher.ErrDisallowedScheme):
+		m.bookmarkMsg = "Scheme not allowed: " + msg.url
+	case errors.Is(msg.err, launcher.ErrNoHandler):
+		m.bookmarkMsg = "No URL handler available on this system"
+	default:
+		m.bookmarkMsg = "Failed to open: " + msg.err.Error()
+	}
+	return m.startBookmarkMsgClear()
 }
 
 func (m model) handleMouseHover(msg tea.MouseMotionMsg) model {
@@ -334,14 +364,7 @@ func (m model) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 				if r.line != contentLine || contentCol < r.startCol || contentCol >= r.endCol {
 					continue
 				}
-				target := m.links[r.idx]
-				m.addressBar.SetValue(target)
-				m.loading = true
-				m.fetchSeq++
-				m.links = nil
-				m.linkIdx = -1
-				m.hoverIdx = -1
-				return m, m.doFetch(target)
+				return m.followLink(m.links[r.idx])
 			}
 			m.focus = focusViewport
 			m.addressBar.Blur()
@@ -677,16 +700,84 @@ func (m model) handleTabNavigation() (tea.Model, tea.Cmd) {
 
 func (m model) handleLinkFollow() (tea.Model, tea.Cmd) {
 	if m.linkIdx >= 0 && m.linkIdx < len(m.links) {
-		target := m.links[m.linkIdx]
-		m.addressBar.SetValue(target)
-		m.loading = true
-		m.fetchSeq++
-		m.links = nil
-		m.linkIdx = -1
-		return m, m.doFetch(target)
+		return m.followLink(m.links[m.linkIdx])
 	}
 	return m, nil
 }
+
+// followLink dispatches the target URL based on its scheme. mark:// URLs
+// fetch normally; allowlisted external schemes are handed to the system
+// handler without changing the current document.
+func (m model) followLink(target string) (tea.Model, tea.Cmd) {
+	if isExternalURL(target) {
+		return m.openExternal(target)
+	}
+	m.addressBar.SetValue(target)
+	m.loading = true
+	m.fetchSeq++
+	m.links = nil
+	m.linkIdx = -1
+	m.hoverIdx = -1
+	return m, m.doFetch(target)
+}
+
+// openExternal launches target in the user's system handler if its scheme
+// is in the allowlist. Current page state is preserved — the TUI stays on
+// the document that contained the link.
+func (m model) openExternal(target string) (tea.Model, tea.Cmd) {
+	if len(m.externalSchemes) == 0 {
+		m.bookmarkMsg = "External links disabled"
+		return m.startBookmarkMsgClear()
+	}
+	return m, func() tea.Msg {
+		err := launcher.Open(target, m.externalSchemes)
+		return externalOpenResult{url: target, err: err}
+	}
+}
+
+// startBookmarkMsgClear schedules the transient status message to be cleared.
+// Reuses the bookmarkMsg/bookmarkSeq machinery since it already implements
+// exactly the "show for 2s, clear on sequence match" pattern we need.
+func (m model) startBookmarkMsgClear() (tea.Model, tea.Cmd) {
+	m.bookmarkSeq++
+	seq := m.bookmarkSeq
+	return m, tea.Tick(2*time.Second, func(time.Time) tea.Msg {
+		return clearBookmarkMsg{seq: seq}
+	})
+}
+
+// isExternalURL reports whether raw has a non-empty, non-mark scheme.
+// Bare paths, relative references, and mark:// URLs are treated as internal.
+// Both authority-form (scheme://...) and opaque-form (mailto:user@...) are
+// recognised.
+func isExternalURL(raw string) bool {
+	scheme := schemeOf(raw)
+	return scheme != "" && scheme != "mark"
+}
+
+// schemeOf returns the scheme component of raw, or the empty string if raw
+// has no scheme. Matches RFC 3986 scheme syntax: ALPHA *( ALPHA / DIGIT / + / - / . )
+// terminated by a colon, before any /, ?, #, or end of string.
+func schemeOf(raw string) string {
+	for i, r := range raw {
+		switch {
+		case i == 0:
+			if !isAlpha(r) {
+				return ""
+			}
+		case r == ':':
+			return raw[:i]
+		case isAlpha(r) || isDigit(r) || r == '+' || r == '-' || r == '.':
+			// valid scheme char, continue
+		default:
+			return ""
+		}
+	}
+	return ""
+}
+
+func isAlpha(r rune) bool { return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') }
+func isDigit(r rune) bool { return r >= '0' && r <= '9' }
 
 func (m model) handleGraphToggle() (tea.Model, tea.Cmd) {
 	url := m.addressBar.Value()
@@ -864,7 +955,12 @@ func (m model) statusBarView() string {
 
 	// Show selected link in status bar (link navigation mode).
 	if m.linkIdx >= 0 && m.linkIdx < len(m.links) {
-		hint := fmt.Sprintf("[%d/%d] %s", m.linkIdx+1, len(m.links), m.links[m.linkIdx])
+		target := m.links[m.linkIdx]
+		prefix := ""
+		if isExternalURL(target) {
+			prefix = "↗ "
+		}
+		hint := fmt.Sprintf("[%d/%d] %s%s", m.linkIdx+1, len(m.links), prefix, target)
 		return style.Foreground(lipgloss.Color("12")).Render(hint)
 	}
 
@@ -1351,6 +1447,8 @@ func detectStyle() string {
 func main() {
 	insecure := flag.Bool("insecure", false, "skip TLS certificate verification")
 	style := flag.String("style", "auto", "color style: dark, light, or auto")
+	externalLinks := flag.String("external-links", strings.Join(launcher.DefaultAllowlist, ","),
+		"comma-separated URL schemes to open in the system handler; empty string disables")
 	flag.Parse()
 
 	styleName := *style
@@ -1376,10 +1474,27 @@ func main() {
 	}
 
 	p := tea.NewProgram(
-		initialModel(initialURL, client, styleName),
+		initialModel(initialURL, client, styleName, parseSchemeList(*externalLinks)),
 	)
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// parseSchemeList splits a comma-separated scheme list, trimming whitespace
+// and dropping empty entries. Returns nil for an empty input (disables external
+// launching).
+func parseSchemeList(csv string) []string {
+	if csv == "" {
+		return nil
+	}
+	parts := strings.Split(csv, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.TrimSpace(p); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
 }

--- a/client/internal/launcher/launcher.go
+++ b/client/internal/launcher/launcher.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"runtime"
 	"slices"
+	"strings"
 )
 
 // ErrDisallowedScheme is returned when the URL's scheme is not in the allowlist.
@@ -76,8 +77,12 @@ func openWith(rawURL string, allowed []string, goos string, run runner) error {
 	return run(name, args...)
 }
 
+// schemeAllowed reports whether scheme is in allowed, comparing
+// case-insensitively per RFC 3986 §3.1.
 func schemeAllowed(scheme string, allowed []string) bool {
-	return slices.Contains(allowed, scheme)
+	return slices.ContainsFunc(allowed, func(a string) bool {
+		return strings.EqualFold(a, scheme)
+	})
 }
 
 // handlerFor returns the launcher binary and argv for the given platform.

--- a/client/internal/launcher/launcher.go
+++ b/client/internal/launcher/launcher.go
@@ -1,0 +1,103 @@
+// Package launcher opens URLs in the user's default system handler.
+//
+// It is intentionally narrow: given a URL and a scheme allowlist, it dispatches
+// to the platform's handler (open, xdg-open, rundll32) by passing the URL as a
+// single argv argument — never through a shell, never via string concatenation.
+// Unknown or excluded schemes are rejected before any process is spawned.
+//
+// This package exists so the TUI can follow http/https/gemini/mailto links in
+// the user's default handler. The demarkus server only serves markdown, so
+// this is strictly about non-mark:// links in rendered documents — not about
+// fetching binary content over the protocol. It is not used by the CLI or MCP
+// server, which are non-interactive and must not spawn GUI processes.
+package launcher
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"slices"
+)
+
+// ErrDisallowedScheme is returned when the URL's scheme is not in the allowlist.
+var ErrDisallowedScheme = errors.New("scheme not in allowlist")
+
+// ErrNoHandler is returned when the platform's expected launcher binary is not
+// on PATH (e.g. xdg-open missing on a minimal Linux install).
+var ErrNoHandler = errors.New("no URL handler available on this system")
+
+// runner executes a launcher binary with args. It is injectable for tests.
+// The real implementation starts the process and releases it so the caller
+// does not block on the handler's exit.
+type runner func(name string, args ...string) error
+
+func execRunner(name string, args ...string) error {
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return fmt.Errorf("%w: %s not found on PATH", ErrNoHandler, name)
+	}
+	cmd := exec.Command(path, args...)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start %s: %w", name, err)
+	}
+	// Detach: we don't care about the handler's exit code, and we must not
+	// block the TUI on the browser process.
+	return cmd.Process.Release()
+}
+
+// Open opens rawURL in the user's default handler for its scheme.
+//
+// Only schemes in allowed are launched; any other scheme returns
+// ErrDisallowedScheme. The URL is passed as a single argv argument to the
+// platform handler — no shell is invoked, so URL contents are never
+// interpreted as shell syntax.
+func Open(rawURL string, allowed []string) error {
+	return openWith(rawURL, allowed, runtime.GOOS, execRunner)
+}
+
+func openWith(rawURL string, allowed []string, goos string, run runner) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("parse url: %w", err)
+	}
+	if u.Scheme == "" {
+		return fmt.Errorf("%w: missing scheme", ErrDisallowedScheme)
+	}
+	if !schemeAllowed(u.Scheme, allowed) {
+		return fmt.Errorf("%w: %q", ErrDisallowedScheme, u.Scheme)
+	}
+
+	name, args := handlerFor(goos, rawURL)
+	if name == "" {
+		return fmt.Errorf("%w: unsupported platform %q", ErrNoHandler, goos)
+	}
+	return run(name, args...)
+}
+
+func schemeAllowed(scheme string, allowed []string) bool {
+	return slices.Contains(allowed, scheme)
+}
+
+// handlerFor returns the launcher binary and argv for the given platform.
+// The URL is always the final argv arg — never embedded in a shell string.
+func handlerFor(goos, rawURL string) (name string, args []string) {
+	switch goos {
+	case "darwin":
+		return "open", []string{rawURL}
+	case "linux", "freebsd", "openbsd", "netbsd":
+		return "xdg-open", []string{rawURL}
+	case "windows":
+		// rundll32 invokes the URL handler directly. The URL is still an
+		// argv arg — Windows performs its own quoting, but no shell is used.
+		return "rundll32", []string{"url.dll,FileProtocolHandler", rawURL}
+	default:
+		return "", nil
+	}
+}
+
+// DefaultAllowlist is the set of URL schemes the TUI opens externally by default.
+// file, javascript, and data are deliberately excluded — they have a long
+// history of handler-level RCEs and filesystem smuggling.
+var DefaultAllowlist = []string{"http", "https", "gemini", "mailto"}

--- a/client/internal/launcher/launcher_test.go
+++ b/client/internal/launcher/launcher_test.go
@@ -1,0 +1,163 @@
+package launcher
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type spy struct {
+	called bool
+	name   string
+	args   []string
+	err    error
+}
+
+func (s *spy) run(name string, args ...string) error {
+	s.called = true
+	s.name = name
+	s.args = append([]string(nil), args...)
+	return s.err
+}
+
+func TestOpen_SchemeAllowlist(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		allowed []string
+		wantErr error
+	}{
+		{"http allowed", "http://example.com", []string{"http", "https"}, nil},
+		{"https allowed", "https://example.com/path", []string{"http", "https"}, nil},
+		{"gemini allowed", "gemini://gemini.circumlunar.space/", []string{"gemini"}, nil},
+		{"mailto allowed", "mailto:alice@example.com", []string{"mailto"}, nil},
+		{"http not in allowlist", "http://example.com", []string{"https"}, ErrDisallowedScheme},
+		{"file rejected by default", "file:///etc/passwd", DefaultAllowlist, ErrDisallowedScheme},
+		{"javascript rejected by default", "javascript:alert(1)", DefaultAllowlist, ErrDisallowedScheme},
+		{"data rejected by default", "data:text/html,<script>alert(1)</script>", DefaultAllowlist, ErrDisallowedScheme},
+		{"vscode rejected by default", "vscode://open?file=/etc/passwd", DefaultAllowlist, ErrDisallowedScheme},
+		{"bare path rejected", "/index.md", DefaultAllowlist, ErrDisallowedScheme},
+		{"empty url rejected", "", DefaultAllowlist, ErrDisallowedScheme},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &spy{}
+			err := openWith(tt.url, tt.allowed, "darwin", s.run)
+			if tt.wantErr == nil && err != nil {
+				t.Fatalf("want nil error, got %v", err)
+			}
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Fatalf("want error %v, got %v", tt.wantErr, err)
+			}
+			if tt.wantErr != nil && s.called {
+				t.Fatal("runner should not be called when scheme is disallowed")
+			}
+			if tt.wantErr == nil && !s.called {
+				t.Fatal("runner should be called when scheme is allowed")
+			}
+		})
+	}
+}
+
+func TestOpen_PlatformDispatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		goos     string
+		url      string
+		wantName string
+		wantArgs []string
+	}{
+		{"darwin uses open", "darwin", "https://example.com", "open", []string{"https://example.com"}},
+		{"linux uses xdg-open", "linux", "https://example.com", "xdg-open", []string{"https://example.com"}},
+		{"freebsd uses xdg-open", "freebsd", "https://example.com", "xdg-open", []string{"https://example.com"}},
+		{"openbsd uses xdg-open", "openbsd", "https://example.com", "xdg-open", []string{"https://example.com"}},
+		{"netbsd uses xdg-open", "netbsd", "https://example.com", "xdg-open", []string{"https://example.com"}},
+		{"windows uses rundll32", "windows", "https://example.com", "rundll32", []string{"url.dll,FileProtocolHandler", "https://example.com"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &spy{}
+			if err := openWith(tt.url, []string{"https"}, tt.goos, s.run); err != nil {
+				t.Fatalf("openWith: %v", err)
+			}
+			if s.name != tt.wantName {
+				t.Errorf("name: got %q, want %q", s.name, tt.wantName)
+			}
+			if !reflect.DeepEqual(s.args, tt.wantArgs) {
+				t.Errorf("args: got %v, want %v", s.args, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestOpen_UnsupportedPlatform(t *testing.T) {
+	s := &spy{}
+	err := openWith("https://example.com", []string{"https"}, "plan9", s.run)
+	if !errors.Is(err, ErrNoHandler) {
+		t.Fatalf("want ErrNoHandler, got %v", err)
+	}
+	if s.called {
+		t.Fatal("runner must not be called on unsupported platform")
+	}
+}
+
+// TestOpen_ShellMetacharactersPreserved confirms that URL contents containing
+// shell metacharacters are passed verbatim to the handler as a single argv arg.
+// This is the critical security property of the package: no shell is ever
+// invoked, so ;, $(), backticks, &&, newlines, etc. cannot escape.
+func TestOpen_ShellMetacharactersPreserved(t *testing.T) {
+	// These URLs contain characters that a shell would interpret if we ever
+	// built a shell command string. net/url.Parse must accept them and the
+	// runner must see them byte-for-byte in args[0].
+	malicious := []string{
+		"https://example.com/?q=%3B%20rm%20-rf%20%2F",       // ; rm -rf /
+		"https://example.com/?q=%24%28whoami%29",            // $(whoami)
+		"https://example.com/?q=%60id%60",                   // `id`
+		"https://example.com/?q=%26%26%20curl%20evil",       // && curl evil
+		"https://example.com/?q=%0Acat%20%2Fetc%2Fpasswd",   // \ncat /etc/passwd
+		"https://example.com/?q=%7C%20nc%20attacker%201234", // | nc attacker 1234
+	}
+	for _, raw := range malicious {
+		t.Run(raw, func(t *testing.T) {
+			s := &spy{}
+			if err := openWith(raw, []string{"https"}, "darwin", s.run); err != nil {
+				t.Fatalf("openWith: %v", err)
+			}
+			if len(s.args) != 1 {
+				t.Fatalf("expected exactly 1 arg, got %d: %v", len(s.args), s.args)
+			}
+			if s.args[0] != raw {
+				t.Errorf("URL mutated in argv: got %q, want %q", s.args[0], raw)
+			}
+		})
+	}
+}
+
+func TestOpen_RunnerErrorPropagated(t *testing.T) {
+	want := errors.New("handler crashed")
+	s := &spy{err: want}
+	err := openWith("https://example.com", []string{"https"}, "darwin", s.run)
+	if !errors.Is(err, want) {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+}
+
+func TestDefaultAllowlist(t *testing.T) {
+	want := map[string]bool{"http": true, "https": true, "gemini": true, "mailto": true}
+	if len(DefaultAllowlist) != len(want) {
+		t.Fatalf("default allowlist size changed: %v", DefaultAllowlist)
+	}
+	for _, s := range DefaultAllowlist {
+		if !want[s] {
+			t.Errorf("unexpected scheme in default allowlist: %q", s)
+		}
+	}
+	forbidden := []string{"file", "javascript", "data", "vscode"}
+	for _, bad := range forbidden {
+		for _, s := range DefaultAllowlist {
+			if s == bad {
+				t.Errorf("dangerous scheme %q must not be in default allowlist", bad)
+			}
+		}
+	}
+}

--- a/client/internal/launcher/launcher_test.go
+++ b/client/internal/launcher/launcher_test.go
@@ -38,6 +38,9 @@ func TestOpen_SchemeAllowlist(t *testing.T) {
 		{"vscode rejected by default", "vscode://open?file=/etc/passwd", DefaultAllowlist, ErrDisallowedScheme},
 		{"bare path rejected", "/index.md", DefaultAllowlist, ErrDisallowedScheme},
 		{"empty url rejected", "", DefaultAllowlist, ErrDisallowedScheme},
+		{"uppercase URL scheme matches lowercase allowlist", "HTTPS://example.com", []string{"https"}, nil},
+		{"uppercase allowlist entry matches lowercase URL scheme", "https://example.com", []string{"HTTPS"}, nil},
+		{"mixed case on both sides", "HtTpS://example.com", []string{"Https"}, nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/site/client/index.md
+++ b/docs/site/client/index.md
@@ -69,6 +69,25 @@ demarkus-tui --insecure mark://localhost:6309/index.md
 - `d` — document graph view (loads stored graph instantly, live crawl updates in background)
 - `?` — help
 
+### External links
+
+The TUI follows `mark://` links internally. Links to `http`, `https`, `gemini`, and `mailto` URLs are opened in the system's default handler (`open` / `xdg-open` / `rundll32`). Selected external links are shown in the status bar with an `↗` prefix to distinguish them from internal navigation.
+
+Configure the scheme allowlist with `-external-links`:
+
+```bash
+# default: open http/https/gemini/mailto
+demarkus-tui mark://localhost:6309/
+
+# only http and https
+demarkus-tui -external-links "http,https" mark://localhost:6309/
+
+# disable external launching entirely — non-mark links report an error
+demarkus-tui -external-links "" mark://localhost:6309/
+```
+
+URLs are passed as argv arguments to the system handler — no shell is invoked. Schemes not in the allowlist (including `file:`, `javascript:`, `data:`) are rejected before any process is spawned. See [Security Model](../security/index.md#external-links-in-the-tui) for details.
+
 ## MCP (`demarkus-mcp`)
 
 The MCP server exposes Demarkus as tools for LLM agents over stdio.

--- a/docs/site/security/index.md
+++ b/docs/site/security/index.md
@@ -95,6 +95,19 @@ demarkus-publish -root /srv/demarkus/content -path /index.md -body "# Hello"
 
 Full versioning is preserved because `demarkus-publish` writes directly to the versioned store on disk. The server just serves what's there.
 
+## External Links in the TUI
+
+The TUI (`demarkus-tui`) can follow links whose scheme is not `mark://` — for example `https://`, `gemini://`, or `mailto:` — by handing the URL to the operating system's default handler (`open` on macOS, `xdg-open` on Linux, `rundll32 url.dll,FileProtocolHandler` on Windows).
+
+The security-relevant properties of this path:
+
+- **Scheme allowlist, narrow by default.** Only `http`, `https`, `gemini`, and `mailto` are opened. Dangerous schemes like `file:`, `javascript:`, `data:`, and custom handlers (`vscode:`, `steam:`, `ms-*:`) are rejected. Configure with `-external-links "http,https"` or disable entirely with `-external-links ""`.
+- **URL is passed as an argv argument, never through a shell.** Shell metacharacters in a URL (`;`, `$(…)`, backticks, `|`, newlines) cannot escape into command execution because no shell is ever invoked.
+- **Content-served URLs are not fetched automatically.** Following an external link is a deliberate user action (Enter on a selected link or a mouse click) — documents cannot auto-open external URLs.
+- **The CLI and MCP server never launch external handlers.** They are non-interactive and must not spawn GUI processes on the user's behalf. Only the TUI does this.
+
+The residual risk is the external handler itself. If your browser, email client, or Gemini reader has a vulnerability that can be triggered by a crafted URL, that vulnerability is reachable via external links in a demarkus document. Keeping the default scheme allowlist narrow limits which handlers a malicious document can reach.
+
 ## Comparison
 
 | | SSH | Web + CGI | Gemini | Demarkus |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External URL launching via the OS default handler.
  * New CLI flag to configure allowed external URL schemes (defaults include http, https, gemini, mailto).
  * TUI shows a visual indicator for external link targets.

* **Documentation**
  * Added docs describing external link behavior, security considerations, and CLI configuration.

* **Tests**
  * Added unit tests for scheme parsing, external-URL classification, and launcher behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->