### PR TITLE
feat(plugin): Add Claude memory plugin with demarkus server integrationai

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "demarkus",
+  "owner": {
+    "name": "latebit",
+    "url": "https://github.com/latebit-io"
+  },
+  "description": "Plugins that connect Claude Code to a demarkus server.",
+  "plugins": [
+    {
+      "name": "demarkus-memory",
+      "source": "./plugins/claude-code",
+      "description": "Zero-config local memory for Claude Code. Spawns a local demarkus-server and wires MCP tools for fetch/publish/append/graph over your own versioned markdown store.",
+      "version": "0.1.0",
+      "category": "memory",
+      "tags": ["memory", "demarkus", "mark-protocol", "local-first"],
+      "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/claude-code"
+    }
+  ]
+}

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "demarkus-memory",
+  "version": "0.1.0",
+  "description": "Local, versioned memory for Claude Code via demarkus. Zero-config install: spawns a local demarkus-server, auto-generates a token, wires MCP tools for fetch/publish/append/graph.",
+  "author": {
+    "name": "latebit",
+    "url": "https://github.com/latebit-io"
+  },
+  "homepage": "https://github.com/latebit-io/demarkus",
+  "license": "MIT",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude-code/commands/soul-init.md
+++ b/plugins/claude-code/commands/soul-init.md
@@ -1,0 +1,38 @@
+---
+description: Detect and configure the demarkus-memory soul (reuse existing or install new)
+---
+
+Configure the demarkus-memory plugin's connection to a demarkus-server. Run this once to set up, or again to reconfigure.
+
+## Steps
+
+1. Run detection using the Bash tool:
+
+   `bash "${CLAUDE_PLUGIN_ROOT}/scripts/detect-soul.sh"`
+
+2. Read the output carefully:
+
+   - If the output is exactly `NO_SERVER`, no demarkus-server is running. Run:
+     `bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh" default`
+     Then tell the user: "no existing soul detected — created a fresh install at `~/.demarkus/soul/`."
+
+   - If the output starts with `SERVERS`, one or more demarkus-server processes are running. Each following line is `PID PORT ROOT`. Show all of them to the user in a clean list, then ask:
+
+     > Detected running demarkus-server(s). Pick one to reuse for this plugin's memory, or say "isolated" to create a separate instance on its own port:
+
+     Expect the user to either:
+
+     - Pick a row (by PID, port, or "the one at /path") → run:
+       `bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh" reuse --port <PORT> --root <ROOT>`
+       using the values from the chosen row. This appends a plugin token to that server's `tokens.toml` and sends SIGHUP to reload.
+     - Say "isolated" or "new" → run:
+       `bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh" isolated`
+       This creates a separate soul at `~/.demarkus/plugin-soul/` on a free port in `16310+`.
+
+3. After setup, report back the chosen mode, soul path, and port. Tell the user they can verify with `/soul`.
+
+## Important
+
+- If multiple demarkus-servers are running and the user is ambiguous, ask which one by PID or path before proceeding — do not guess.
+- The config lives at `~/.demarkus/plugin-memory.conf`. Rerunning this command overwrites it.
+- In `reuse` mode, the plugin does not manage the server's lifecycle — if the user stops that server later, the plugin's memory will be unavailable until they restart it or rerun `/soul-init`.

--- a/plugins/claude-code/commands/soul-init.md
+++ b/plugins/claude-code/commands/soul-init.md
@@ -14,7 +14,7 @@ Configure the demarkus-memory plugin's connection to a demarkus-server. Run this
 
    - If the output is exactly `NO_SERVER`, no demarkus-server is running. Run:
      `bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh" default`
-     Then tell the user: "no existing soul detected — created a fresh install at `~/.demarkus/soul/`."
+     Do not assume the install landed at `~/.demarkus/soul/` — `default` falls back to isolated mode on a different root and port when 6310 is taken. Use step 3 to report the actual mode, soul path, and port from the script's stderr or `~/.demarkus/plugin-memory.conf`.
 
    - If the output starts with `SERVERS`, one or more demarkus-server processes are running. Each following line is `PID PORT ROOT`. Show all of them to the user in a clean list, then ask:
 

--- a/plugins/claude-code/commands/soul-journal.md
+++ b/plugins/claude-code/commands/soul-journal.md
@@ -1,17 +1,37 @@
 ---
-description: Append an entry to the demarkus soul's journal
+description: Append an entry to today's journal for the current project
 argument-hint: <entry text>
 ---
 
-Process the following entry for `/journal.md` in the demarkus-memory soul:
+Append the following entry to today's journal file for the current project. One journal file per day per project, appended as the day progresses.
 
-1. `mark_fetch /journal.md` to determine the current state.
-2. If fetch returns `not-found`, create the document with `mark_publish` (expected_version=0) containing:
-   - `## YYYY-MM-DD` (today's date in UTC)
-   - a blank line
-   - the entry text
-3. If fetch returns `ok`, append with `mark_append` (leave `expected_version` unset so the tool auto-resolves):
-   - include `## YYYY-MM-DD` followed by a blank line **only when that heading is not already present in the fetched body for today**
-   - then append the entry text under today's section
+## Steps
+
+1. **Resolve the project slug.** Read `CLAUDE_PROJECT_DIR` via the Bash tool (`basename "$CLAUDE_PROJECT_DIR"`). Lowercase it and replace spaces with hyphens. If `CLAUDE_PROJECT_DIR` is unset, ask the user which project.
+
+2. **Compute the target path.** Use today's date in UTC as `YYYY-MM-DD`. Target: `/<project>/journal/<YYYY-MM-DD>.md`.
+
+3. **Check existence.** Call `mark_fetch` on the target path:
+
+   - If the result is `not-found`: the file does not exist yet. Create it with `mark_publish` (`expected_version: 0`) containing:
+
+     ```
+     # <Project> journal — <YYYY-MM-DD>
+
+     <entry text>
+     ```
+
+     Also consider whether this is the project's first entry overall — if `mark_fetch /<project>/` or `/index.md` suggests the project subtree doesn't exist yet, add a bullet `- [<Project>](/<project>/)` to `/index.md` (fetch, edit, publish with correct `expected_version`) after the journal entry is created.
+
+   - If the result is `ok`: the file already exists for today. Call `mark_append` on it with:
+
+     ```
+
+     <entry text>
+     ```
+
+     Leave `expected_version` unset so the tool auto-resolves it. Always prefix the entry body with a leading blank line so it separates visually from the previous entry.
+
+4. **Confirm.** Tell the user the full path you wrote to so they can find it.
 
 Entry: $ARGUMENTS

--- a/plugins/claude-code/commands/soul-journal.md
+++ b/plugins/claude-code/commands/soul-journal.md
@@ -3,6 +3,15 @@ description: Append an entry to the demarkus soul's journal
 argument-hint: <entry text>
 ---
 
-Append the following entry to `/journal.md` in the demarkus-memory soul using the `mark_append` MCP tool. Prefix the entry with a level-2 heading containing today's UTC date in `YYYY-MM-DD` format (skip if the heading already exists today). Leave `expected_version` unset so the tool auto-resolves it. If `/journal.md` does not exist yet, create it with `mark_publish` instead of appending.
+Process the following entry for `/journal.md` in the demarkus-memory soul:
+
+1. `mark_fetch /journal.md` to determine the current state.
+2. If fetch returns `not-found`, create the document with `mark_publish` (expected_version=0) containing:
+   - `## YYYY-MM-DD` (today's date in UTC)
+   - a blank line
+   - the entry text
+3. If fetch returns `ok`, append with `mark_append` (leave `expected_version` unset so the tool auto-resolves):
+   - include `## YYYY-MM-DD` followed by a blank line **only when that heading is not already present in the fetched body for today**
+   - then append the entry text under today's section
 
 Entry: $ARGUMENTS

--- a/plugins/claude-code/commands/soul-journal.md
+++ b/plugins/claude-code/commands/soul-journal.md
@@ -1,0 +1,8 @@
+---
+description: Append an entry to the demarkus soul's journal
+argument-hint: <entry text>
+---
+
+Append the following entry to `/journal.md` in the demarkus-memory soul using the `mark_append` MCP tool. Prefix the entry with a level-2 heading containing today's UTC date in `YYYY-MM-DD` format (skip if the heading already exists today). Leave `expected_version` unset so the tool auto-resolves it. If `/journal.md` does not exist yet, create it with `mark_publish` instead of appending.
+
+Entry: $ARGUMENTS

--- a/plugins/claude-code/commands/soul.md
+++ b/plugins/claude-code/commands/soul.md
@@ -1,0 +1,5 @@
+---
+description: Show the local demarkus soul index
+---
+
+Use the `mark_fetch` MCP tool to fetch `/index.md` from the demarkus-memory server and render the full contents to the user. If the index does not exist, say so and suggest populating it.

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -32,7 +32,7 @@ main() {
   if ! load_config; then
     log "no plugin config — running default setup"
     "${SCRIPTS_DIR}/setup.sh" default
-    load_config
+    load_config || die "setup.sh completed but ${PLUGIN_CONFIG} is missing or invalid"
   fi
 
   ensure_binaries

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SessionStart hook for the demarkus-memory plugin.
+#
+# On every session:
+#   - If the plugin is already configured (~/.demarkus/plugin-memory.conf exists),
+#     ensure the managed server is running and seed /index.md if the soul is empty.
+#   - If not configured yet, run the default setup automatically: try port 6310 at
+#     ~/.demarkus/soul/, fall back to an isolated install on 16310+ if 6310 is
+#     taken. The user can rerun /soul-init at any time to reconfigure
+#     (e.g. to adopt an existing demarkus-server they were already running).
+#
+# No core-code changes. Pure composition of existing CLI surface.
+
+set -euo pipefail
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="${HOOK_DIR}/../scripts"
+# shellcheck source=../scripts/lib.sh
+. "${SCRIPTS_DIR}/lib.sh"
+
+seed_index() {
+  local seed_file="${HOOK_DIR}/../seed/index.md"
+  local target="${SOUL_DIR}/index.md"
+  [[ -f "${target}"    ]] && return 0
+  [[ -f "${seed_file}" ]] || return 0
+  cp "${seed_file}" "${target}"
+  log "seeded ${target}"
+}
+
+main() {
+  if ! load_config; then
+    log "no plugin config — running default setup"
+    "${SCRIPTS_DIR}/setup.sh" default
+    load_config
+  fi
+
+  ensure_binaries
+
+  case "${MODE}" in
+    default|isolated)
+      ensure_managed_server "${SOUL_DIR}" "${PORT}"
+      ;;
+    reuse)
+      # User-managed server; verify it's still up but don't try to start it.
+      if ! pgrep -f "demarkus-server.*-root +${SOUL_DIR}\b" >/dev/null 2>&1; then
+        warn "configured to reuse server at ${SOUL_DIR} but none is running; run /soul-init to reconfigure"
+      fi
+      ;;
+    *)
+      die "unknown MODE in ${PLUGIN_CONFIG}: ${MODE}"
+      ;;
+  esac
+
+  seed_index
+
+  log "ready (mode=${MODE}, soul=${SOUL_DIR}, port=${PORT})"
+}
+
+main "$@"

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -21,6 +21,7 @@ SCRIPTS_DIR="${HOOK_DIR}/../scripts"
 seed_index() {
   local seed_file="${HOOK_DIR}/../seed/index.md"
   local target="${SOUL_DIR}/index.md"
+  [[ -d "${SOUL_DIR}" && -w "${SOUL_DIR}" ]] || return 0
   [[ -f "${target}"    ]] && return 0
   [[ -f "${seed_file}" ]] || return 0
   cp "${seed_file}" "${target}"
@@ -42,7 +43,7 @@ main() {
       ;;
     reuse)
       # User-managed server; verify it's still up but don't try to start it.
-      if ! pgrep -f "demarkus-server.*-root +${SOUL_DIR}\b" >/dev/null 2>&1; then
+      if [[ -z "$(pid_of_server_at_root "${SOUL_DIR}")" ]]; then
         warn "configured to reuse server at ${SOUL_DIR} but none is running; run /soul-init to reconfigure"
       fi
       ;;

--- a/plugins/claude-code/scripts/detect-soul.sh
+++ b/plugins/claude-code/scripts/detect-soul.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# detect-soul.sh — report running demarkus-server processes.
+#
+# Output:
+#   "NO_SERVER"                       — nothing detected
+#   "SERVERS" followed by one row     — one running server; row is "PID PORT ROOT"
+#   "SERVERS" followed by many rows   — multiple running servers
+#
+# Used by /soul-init to decide whether to offer the "reuse" path.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+results=$(find_running_demarkus)
+if [[ -z "${results}" ]]; then
+  echo "NO_SERVER"
+  exit 0
+fi
+
+echo "SERVERS"
+echo "${results}"

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Shared helpers for the demarkus-memory plugin scripts.
+# Source this file; do not execute it directly.
+
+# Paths — always the same regardless of mode.
+readonly PLUGIN_HOME="${HOME}/.demarkus"
+readonly PLUGIN_BIN_DIR="${PLUGIN_HOME}/bin"
+readonly PLUGIN_CONFIG="${PLUGIN_HOME}/plugin-memory.conf"
+readonly PLUGIN_TOKEN_FILE="${PLUGIN_HOME}/plugin-memory.token"
+readonly TOKEN_LABEL="claude-code-plugin"
+
+# Soul dirs that setup.sh may choose.
+readonly SHARED_SOUL_DIR="${PLUGIN_HOME}/soul"
+readonly ISOLATED_SOUL_DIR="${PLUGIN_HOME}/plugin-soul"
+
+readonly DEMARKUS_PROTOCOL_PORT=6309   # demarkus-server's built-in default when nothing else is set
+readonly DEFAULT_PORT=6310             # plugin's first-choice port for its own managed server
+readonly ISOLATED_PORT_START=16310
+readonly ISOLATED_PORT_END=16509
+
+readonly SERVER_VERSION="0.17.4"
+readonly CLIENT_VERSION="0.12.24"
+
+log()  { echo "[demarkus-memory] $*" >&2; }
+warn() { echo "[demarkus-memory] warning: $*" >&2; }
+die()  { echo "[demarkus-memory] error: $*" >&2; exit 1; }
+
+# load_config — sources the config file, sets SOUL_DIR, PORT, MODE.
+# Returns 1 if config missing; dies on malformed config.
+load_config() {
+  [[ -f "${PLUGIN_CONFIG}" ]] || return 1
+  # shellcheck source=/dev/null
+  . "${PLUGIN_CONFIG}"
+  [[ -n "${SOUL_DIR:-}" && -n "${PORT:-}" && -n "${MODE:-}" ]] \
+    || die "${PLUGIN_CONFIG} is malformed (missing SOUL_DIR/PORT/MODE)"
+}
+
+# save_config SOUL_DIR PORT MODE
+save_config() {
+  local soul="$1" port="$2" mode="$3"
+  mkdir -p "${PLUGIN_HOME}"
+  cat > "${PLUGIN_CONFIG}.tmp" <<EOF
+# demarkus-memory plugin config — managed by scripts/setup.sh
+SOUL_DIR=${soul@Q}
+PORT=${port}
+MODE=${mode@Q}
+EOF
+  mv "${PLUGIN_CONFIG}.tmp" "${PLUGIN_CONFIG}"
+}
+
+detect_platform() {
+  local os arch
+  case "$(uname -s)" in
+    Darwin) os="darwin" ;;
+    Linux)  os="linux"  ;;
+    *)      die "unsupported OS: $(uname -s)" ;;
+  esac
+  case "$(uname -m)" in
+    arm64|aarch64) arch="arm64" ;;
+    x86_64)        arch="amd64" ;;
+    *)             die "unsupported arch: $(uname -m)" ;;
+  esac
+  echo "${os}_${arch}"
+}
+
+# sha256_verify CHECKSUMS_FILE ARCHIVE — portable across macOS/Linux.
+sha256_verify() {
+  local checksums_file="$1" archive="$2"
+  local expected actual
+  expected=$(grep " ${archive}\$" "${checksums_file}" | awk '{print $1}')
+  [[ -n "${expected}" ]] || die "no checksum entry for ${archive}"
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual=$(sha256sum "${archive}" | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    actual=$(shasum -a 256 "${archive}" | awk '{print $1}')
+  else
+    die "no sha256 tool available (install sha256sum or shasum)"
+  fi
+  [[ "${actual}" == "${expected}" ]] \
+    || die "checksum mismatch for ${archive} (expected ${expected}, got ${actual})"
+}
+
+# ensure_binaries — download + install to PLUGIN_BIN_DIR if any are missing.
+ensure_binaries() {
+  if [[ -x "${PLUGIN_BIN_DIR}/demarkus-server" \
+     && -x "${PLUGIN_BIN_DIR}/demarkus-mcp" \
+     && -x "${PLUGIN_BIN_DIR}/demarkus-token" ]]; then
+    return 0
+  fi
+
+  mkdir -p "${PLUGIN_BIN_DIR}"
+  command -v curl >/dev/null 2>&1 || die "curl is required for first-run binary download"
+  command -v tar  >/dev/null 2>&1 || die "tar is required for first-run binary download"
+
+  local plat
+  plat=$(detect_platform)
+
+  local tmp
+  tmp=$(mktemp -d)
+  trap 'rm -rf "${tmp}"' RETURN
+
+  log "downloading demarkus binaries (server v${SERVER_VERSION}, client v${CLIENT_VERSION}, ${plat})"
+
+  local server_archive="demarkus-server_${SERVER_VERSION}_${plat}.tar.gz"
+  local server_base="https://github.com/latebit-io/demarkus/releases/download/server%2Fv${SERVER_VERSION}"
+  curl -fsSL -o "${tmp}/${server_archive}"    "${server_base}/${server_archive}"              || die "download ${server_archive}"
+  curl -fsSL -o "${tmp}/server_checksums.txt" "${server_base}/demarkus-server_checksums.txt"  || die "download server checksums"
+  (cd "${tmp}" && sha256_verify server_checksums.txt "${server_archive}")
+  tar -xzf "${tmp}/${server_archive}" -C "${tmp}"
+
+  local mcp_archive="demarkus-mcp_${CLIENT_VERSION}_${plat}.tar.gz"
+  local client_base="https://github.com/latebit-io/demarkus/releases/download/client%2Fv${CLIENT_VERSION}"
+  curl -fsSL -o "${tmp}/${mcp_archive}"       "${client_base}/${mcp_archive}"                 || die "download ${mcp_archive}"
+  curl -fsSL -o "${tmp}/client_checksums.txt" "${client_base}/demarkus-client_checksums.txt"  || die "download client checksums"
+  (cd "${tmp}" && sha256_verify client_checksums.txt "${mcp_archive}")
+  tar -xzf "${tmp}/${mcp_archive}" -C "${tmp}"
+
+  install -m 0755 "${tmp}/demarkus-server" "${PLUGIN_BIN_DIR}/demarkus-server"
+  install -m 0755 "${tmp}/demarkus-token"  "${PLUGIN_BIN_DIR}/demarkus-token"
+  install -m 0755 "${tmp}/demarkus-mcp"    "${PLUGIN_BIN_DIR}/demarkus-mcp"
+  log "binaries installed to ${PLUGIN_BIN_DIR}"
+}
+
+# _proc_env PID VAR — echoes the value of env var VAR for process PID, or empty.
+# Portable across macOS (ps eww) and Linux (/proc/<pid>/environ).
+_proc_env() {
+  local pid="$1" var="$2"
+  if [[ -r "/proc/${pid}/environ" ]]; then
+    tr '\0' '\n' < "/proc/${pid}/environ" 2>/dev/null | awk -F= -v v="${var}" '$1==v {print substr($0, length(v)+2); exit}'
+    return
+  fi
+  ps eww -p "${pid}" 2>/dev/null | tr ' ' '\n' | awk -F= -v v="${var}" '$1==v {print substr($0, length(v)+2); exit}'
+}
+
+# find_running_demarkus — emits "PID PORT ROOT" per process, one per line.
+# Empty output when no demarkus-server is running. Args take precedence over
+# env vars; falls back to DEMARKUS_PORT/DEMARKUS_ROOT env when flags are absent.
+find_running_demarkus() {
+  local pids
+  pids=$(pgrep -f demarkus-server 2>/dev/null || true)
+  [[ -z "${pids}" ]] && return 0
+  local pid args port root
+  while read -r pid; do
+    [[ -z "${pid}" ]] && continue
+    args=$(ps -p "${pid}" -o args= 2>/dev/null || true)
+    [[ -z "${args}" ]] && continue
+    port=$(echo "${args}" | grep -oE -- '-port +[0-9]+' | awk '{print $2}')
+    if [[ -z "${port}" ]]; then
+      port=$(_proc_env "${pid}" DEMARKUS_PORT)
+    fi
+    port="${port:-${DEMARKUS_PROTOCOL_PORT}}"
+    root=$(echo "${args}" | grep -oE -- '-root +[^ ]+' | awk '{print $2}')
+    if [[ -z "${root}" ]]; then
+      root=$(_proc_env "${pid}" DEMARKUS_ROOT)
+    fi
+    [[ -z "${root}" ]] && root="(unknown)"
+    echo "${pid} ${port} ${root}"
+  done <<< "${pids}"
+}
+
+# port_is_free PORT — true if nothing appears to own UDP PORT. Best-effort
+# (lsof is most reliable; falls back to permissive true if lsof is missing).
+port_is_free() {
+  local port="$1"
+  if command -v lsof >/dev/null 2>&1; then
+    if lsof -iUDP:"${port}" -nP 2>/dev/null | grep -q 'UDP'; then
+      return 1
+    fi
+  fi
+  return 0
+}
+
+# find_free_port_from START — echoes the first apparently-free port in
+# [START, START+199]. Dies if none are free.
+find_free_port_from() {
+  local start="$1"
+  local end=$((start + 199))
+  local p
+  for (( p=start; p<=end; p++ )); do
+    if port_is_free "${p}"; then
+      echo "${p}"
+      return 0
+    fi
+  done
+  die "no free UDP port in ${start}..${end}"
+}
+
+# ensure_token_entry TOKENS_TOML
+# Generates a plugin-scoped token, writes the raw token to PLUGIN_TOKEN_FILE
+# (mode 0600), and appends an entry for TOKEN_LABEL to TOKENS_TOML. Idempotent.
+ensure_token_entry() {
+  local tokens_toml="$1"
+
+  if [[ -f "${PLUGIN_TOKEN_FILE}" ]] && [[ -f "${tokens_toml}" ]] \
+     && grep -q "tokens\.${TOKEN_LABEL}\]" "${tokens_toml}" 2>/dev/null; then
+    return 0
+  fi
+
+  # Stale state — revoke any prior entry with our label before regenerating.
+  if [[ -f "${tokens_toml}" ]] && grep -q "tokens\.${TOKEN_LABEL}\]" "${tokens_toml}" 2>/dev/null; then
+    "${PLUGIN_BIN_DIR}/demarkus-token" revoke \
+      -label  "${TOKEN_LABEL}" \
+      -tokens "${tokens_toml}" 2>/dev/null || true
+  fi
+
+  mkdir -p "$(dirname "${tokens_toml}")" "$(dirname "${PLUGIN_TOKEN_FILE}")"
+
+  if ! "${PLUGIN_BIN_DIR}/demarkus-token" generate \
+        -label  "${TOKEN_LABEL}" \
+        -paths  "/*" \
+        -ops    "publish,archive" \
+        -tokens "${tokens_toml}" \
+        2>/dev/null > "${PLUGIN_TOKEN_FILE}.tmp"; then
+    rm -f "${PLUGIN_TOKEN_FILE}.tmp"
+    die "demarkus-token generate failed (tokens.toml: ${tokens_toml})"
+  fi
+
+  mv "${PLUGIN_TOKEN_FILE}.tmp" "${PLUGIN_TOKEN_FILE}"
+  chmod 600 "${PLUGIN_TOKEN_FILE}"
+  log "generated plugin token (label=${TOKEN_LABEL})"
+}
+
+# ensure_managed_server SOUL_DIR PORT
+# Spawns a demarkus-server for SOUL_DIR on PORT if ours isn't already running.
+# Writes PID to ${SOUL_DIR}/.pid. For default/isolated modes only — do not
+# call for reuse mode (the user's server is not ours to restart).
+ensure_managed_server() {
+  local soul_dir="$1" port="$2"
+  local pid_file="${soul_dir}/.pid"
+  local log_file="${soul_dir}/.log"
+
+  if [[ -f "${pid_file}" ]] && kill -0 "$(cat "${pid_file}")" 2>/dev/null; then
+    return 0
+  fi
+  rm -f "${pid_file}"
+
+  mkdir -p "${soul_dir}"
+
+  nohup "${PLUGIN_BIN_DIR}/demarkus-server" \
+        -root   "${soul_dir}" \
+        -port   "${port}" \
+        -tokens "${soul_dir}/tokens.toml" \
+        >> "${log_file}" 2>&1 &
+  local pid=$!
+  echo "${pid}" > "${pid_file}"
+  disown || true
+
+  sleep 0.3
+  if ! kill -0 "${pid}" 2>/dev/null; then
+    rm -f "${pid_file}"
+    local tail_info=""
+    [[ -f "${log_file}" ]] && tail_info=$'\n'"recent log:"$'\n'"$(tail -5 "${log_file}")"
+    die "demarkus-server failed to start (port ${port} may be in use; re-run /soul-init)${tail_info}"
+  fi
+  log "spawned demarkus-server (pid=${pid}, port=${port}, root=${soul_dir})"
+}

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 # Shared helpers for the demarkus-memory plugin scripts.
 # Source this file; do not execute it directly.
+# shellcheck disable=SC2034  # many constants are consumed only by sourcing scripts (setup.sh, session-start.sh, mcp-wrapper.sh)
+
+# Requires Bash 3.2+ (macOS stock bash). No Bash 4+ features are used.
+if [ -n "${BASH_VERSINFO:-}" ] && [ "${BASH_VERSINFO[0]}" -lt 3 ]; then
+  echo "[demarkus-memory] error: bash 3.2+ required (got ${BASH_VERSION:-unknown})" >&2
+  return 1 2>/dev/null || exit 1
+fi
 
 # Paths — always the same regardless of mode.
 readonly PLUGIN_HOME="${HOME}/.demarkus"
@@ -39,11 +46,16 @@ load_config() {
 save_config() {
   local soul="$1" port="$2" mode="$3"
   mkdir -p "${PLUGIN_HOME}"
+  # printf '%q' produces bash-re-parseable quoted values (Bash 2+) — safer than
+  # ${var@Q} which requires Bash 4.4+ (macOS stock bash is 3.2).
+  local soul_q mode_q
+  soul_q=$(printf '%q' "${soul}")
+  mode_q=$(printf '%q' "${mode}")
   cat > "${PLUGIN_CONFIG}.tmp" <<EOF
 # demarkus-memory plugin config — managed by scripts/setup.sh
-SOUL_DIR=${soul@Q}
+SOUL_DIR=${soul_q}
 PORT=${port}
-MODE=${mode@Q}
+MODE=${mode_q}
 EOF
   mv "${PLUGIN_CONFIG}.tmp" "${PLUGIN_CONFIG}"
 }
@@ -132,6 +144,35 @@ _proc_env() {
   ps eww -p "${pid}" 2>/dev/null | tr ' ' '\n' | awk -F= -v v="${var}" '$1==v {print substr($0, length(v)+2); exit}'
 }
 
+# pid_of_server_at_root ROOT — emits the PID of a demarkus-server whose
+# -root flag or DEMARKUS_ROOT env var equals ROOT (literal match, no regex).
+# Empty output when none match. Handles paths containing regex metacharacters
+# or spaces safely.
+pid_of_server_at_root() {
+  local target="$1"
+  local pids pid args env_root
+  pids=$(pgrep -f demarkus-server 2>/dev/null || true)
+  [[ -z "${pids}" ]] && return 0
+  while read -r pid; do
+    [[ -z "${pid}" ]] && continue
+    args=$(ps -p "${pid}" -o args= 2>/dev/null || true)
+    # Literal substring match across both "-root TARGET" and "-root=TARGET" forms,
+    # at end of args or followed by more args.
+    case "${args}" in
+      *" -root ${target} "* | *" -root ${target}" | \
+      *" -root=${target} "* | *" -root=${target}")
+        echo "${pid}"
+        return 0
+        ;;
+    esac
+    env_root=$(_proc_env "${pid}" DEMARKUS_ROOT)
+    if [[ "${env_root}" == "${target}" ]]; then
+      echo "${pid}"
+      return 0
+    fi
+  done <<< "${pids}"
+}
+
 # find_running_demarkus — emits "PID PORT ROOT" per process, one per line.
 # Empty output when no demarkus-server is running. Args take precedence over
 # env vars; falls back to DEMARKUS_PORT/DEMARKUS_ROOT env when flags are absent.
@@ -144,12 +185,13 @@ find_running_demarkus() {
     [[ -z "${pid}" ]] && continue
     args=$(ps -p "${pid}" -o args= 2>/dev/null || true)
     [[ -z "${args}" ]] && continue
-    port=$(echo "${args}" | grep -oE -- '-port +[0-9]+' | awk '{print $2}')
+    # Accept both "-port 6310" and "-port=6310" (Go flag package supports both).
+    port=$(echo "${args}" | grep -oE -- '-port[= ]+[0-9]+' | sed -E 's/.*[= ]//')
     if [[ -z "${port}" ]]; then
       port=$(_proc_env "${pid}" DEMARKUS_PORT)
     fi
     port="${port:-${DEMARKUS_PROTOCOL_PORT}}"
-    root=$(echo "${args}" | grep -oE -- '-root +[^ ]+' | awk '{print $2}')
+    root=$(echo "${args}" | grep -oE -- '-root[= ]+[^ ]+' | sed -E 's/^-root[= ]+//')
     if [[ -z "${root}" ]]; then
       root=$(_proc_env "${pid}" DEMARKUS_ROOT)
     fi
@@ -158,14 +200,28 @@ find_running_demarkus() {
   done <<< "${pids}"
 }
 
-# port_is_free PORT — true if nothing appears to own UDP PORT. Best-effort
-# (lsof is most reliable; falls back to permissive true if lsof is missing).
+# port_is_free PORT — true if nothing appears to own UDP PORT. Uses lsof when
+# available (macOS + many Linux), falls back to ss (Linux default), and warns
+# once before degrading to permissive when neither is installed. If the check
+# is wrong, the caller's spawn will fail loudly via the post-spawn PID probe in
+# ensure_managed_server.
 port_is_free() {
   local port="$1"
   if command -v lsof >/dev/null 2>&1; then
     if lsof -iUDP:"${port}" -nP 2>/dev/null | grep -q 'UDP'; then
       return 1
     fi
+    return 0
+  fi
+  if command -v ss >/dev/null 2>&1; then
+    if ss -lunH 2>/dev/null | awk '{print $4}' | grep -qE "[:.]${port}\$"; then
+      return 1
+    fi
+    return 0
+  fi
+  if [[ -z "${_PORT_CHECK_WARNED:-}" ]]; then
+    warn "no lsof or ss available; port availability checks are best-effort (server bind will fail loudly if the port is actually taken)"
+    _PORT_CHECK_WARNED=1
   fi
   return 0
 }
@@ -229,6 +285,11 @@ ensure_managed_server() {
   local pid_file="${soul_dir}/.pid"
   local log_file="${soul_dir}/.log"
 
+  # Note: the read+kill below is not atomic (classic TOCTOU), but the PID-reuse
+  # window is microseconds and the worst-case failure is "plugin thinks a stale
+  # PID is alive, skips spawn, MCP connections fail, user reruns /soul-init" —
+  # not data loss. flock would add a macOS/Linux portability burden that isn't
+  # worth closing this theoretical race.
   if [[ -f "${pid_file}" ]] && kill -0 "$(cat "${pid_file}")" 2>/dev/null; then
     return 0
   fi
@@ -245,12 +306,24 @@ ensure_managed_server() {
   echo "${pid}" > "${pid_file}"
   disown || true
 
-  sleep 0.3
-  if ! kill -0 "${pid}" 2>/dev/null; then
-    rm -f "${pid_file}"
-    local tail_info=""
-    [[ -f "${log_file}" ]] && tail_info=$'\n'"recent log:"$'\n'"$(tail -5 "${log_file}")"
-    die "demarkus-server failed to start (port ${port} may be in use; re-run /soul-init)${tail_info}"
-  fi
+  # Bounded poll: fail fast if the process died (bind or startup error),
+  # succeed once the port is observed as bound, or accept once we reach the
+  # attempt cap with the process still alive (permissive when no lsof/ss is
+  # available to probe the port).
+  local attempts=0
+  local max_attempts=20  # ~2s at 100ms intervals
+  while (( attempts < max_attempts )); do
+    if ! kill -0 "${pid}" 2>/dev/null; then
+      rm -f "${pid_file}"
+      local tail_info=""
+      [[ -f "${log_file}" ]] && tail_info=$'\n'"recent log:"$'\n'"$(tail -5 "${log_file}")"
+      die "demarkus-server failed to start (port ${port} may be in use; re-run /soul-init)${tail_info}"
+    fi
+    if ! port_is_free "${port}"; then
+      break
+    fi
+    sleep 0.1
+    attempts=$((attempts + 1))
+  done
   log "spawned demarkus-server (pid=${pid}, port=${port}, root=${soul_dir})"
 }

--- a/plugins/claude-code/scripts/mcp-wrapper.sh
+++ b/plugins/claude-code/scripts/mcp-wrapper.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# mcp-wrapper.sh — launches demarkus-mcp with the right token and port.
+#
+# Claude Code launches MCP subprocesses with a fixed env, so the plugin can't
+# hand the token over at spawn time via a hook. Instead .mcp.json invokes this
+# wrapper, which reads the plugin config + token file, exports DEMARKUS_AUTH,
+# and execs demarkus-mcp. The MCP binary already honors DEMARKUS_AUTH via the
+# standard tokens.Resolve cascade — no core change.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+if ! load_config; then
+  echo "[demarkus-memory] plugin is not configured — SessionStart hook may not have run yet" >&2
+  exit 1
+fi
+
+if [[ ! -x "${PLUGIN_BIN_DIR}/demarkus-mcp" ]]; then
+  echo "[demarkus-memory] demarkus-mcp not installed at ${PLUGIN_BIN_DIR}" >&2
+  exit 1
+fi
+
+if [[ -f "${PLUGIN_TOKEN_FILE}" ]]; then
+  DEMARKUS_AUTH="$(cat "${PLUGIN_TOKEN_FILE}")"
+  export DEMARKUS_AUTH
+fi
+
+exec "${PLUGIN_BIN_DIR}/demarkus-mcp" \
+  -host "mark://localhost:${PORT}" \
+  -insecure \
+  "$@"

--- a/plugins/claude-code/scripts/mcp-wrapper.sh
+++ b/plugins/claude-code/scripts/mcp-wrapper.sh
@@ -25,6 +25,10 @@ fi
 
 if [[ -f "${PLUGIN_TOKEN_FILE}" ]]; then
   DEMARKUS_AUTH="$(cat "${PLUGIN_TOKEN_FILE}")"
+  if [[ -z "${DEMARKUS_AUTH}" ]]; then
+    echo "[demarkus-memory] token file ${PLUGIN_TOKEN_FILE} exists but is empty — run /soul-init to regenerate" >&2
+    exit 1
+  fi
   export DEMARKUS_AUTH
 fi
 

--- a/plugins/claude-code/scripts/setup.sh
+++ b/plugins/claude-code/scripts/setup.sh
@@ -43,8 +43,8 @@ do_reuse() {
   local port="" root=""
   while (( $# )); do
     case "$1" in
-      --port) port="$2"; shift 2 ;;
-      --root) root="$2"; shift 2 ;;
+      --port) [[ -n "${2:-}" ]] || die "--port requires a value"; port="$2"; shift 2 ;;
+      --root) [[ -n "${2:-}" ]] || die "--root requires a value"; root="$2"; shift 2 ;;
       *) die "unknown arg: $1" ;;
     esac
   done
@@ -57,7 +57,7 @@ do_reuse() {
   # Ask the adopted server to reload tokens. It may not be ours, but SIGHUP
   # is the documented mechanism and has no effect on other signal handlers.
   local target_pid
-  target_pid=$(pgrep -f "demarkus-server.*-root +${root}\b" 2>/dev/null | head -1 || true)
+  target_pid=$(pid_of_server_at_root "${root}" 2>/dev/null || true)
   if [[ -n "${target_pid}" ]]; then
     if kill -HUP "${target_pid}" 2>/dev/null; then
       log "sent SIGHUP to adopted server (pid=${target_pid}) to reload tokens"

--- a/plugins/claude-code/scripts/setup.sh
+++ b/plugins/claude-code/scripts/setup.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# setup.sh — configure the demarkus-memory plugin's soul.
+#
+# Usage:
+#   setup.sh default                       # try port 6310 at ~/.demarkus/soul/;
+#                                          # falls back to isolated if 6310 is taken
+#   setup.sh reuse --port N --root PATH    # adopt an already-running server
+#   setup.sh isolated                      # always spawn ours at ~/.demarkus/plugin-soul/
+#                                          # on a free port in the isolated range
+#
+# Writes ~/.demarkus/plugin-memory.conf on success. Idempotent.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+do_default() {
+  ensure_binaries
+  if ! port_is_free "${DEFAULT_PORT}"; then
+    log "port ${DEFAULT_PORT} is in use — falling back to isolated mode"
+    do_isolated
+    return
+  fi
+  ensure_token_entry "${SHARED_SOUL_DIR}/tokens.toml"
+  ensure_managed_server "${SHARED_SOUL_DIR}" "${DEFAULT_PORT}"
+  save_config "${SHARED_SOUL_DIR}" "${DEFAULT_PORT}" "default"
+  log "default setup complete (soul=${SHARED_SOUL_DIR}, port=${DEFAULT_PORT})"
+}
+
+do_isolated() {
+  ensure_binaries
+  local port
+  port=$(find_free_port_from "${ISOLATED_PORT_START}")
+  ensure_token_entry "${ISOLATED_SOUL_DIR}/tokens.toml"
+  ensure_managed_server "${ISOLATED_SOUL_DIR}" "${port}"
+  save_config "${ISOLATED_SOUL_DIR}" "${port}" "isolated"
+  log "isolated setup complete (soul=${ISOLATED_SOUL_DIR}, port=${port})"
+}
+
+do_reuse() {
+  local port="" root=""
+  while (( $# )); do
+    case "$1" in
+      --port) port="$2"; shift 2 ;;
+      --root) root="$2"; shift 2 ;;
+      *) die "unknown arg: $1" ;;
+    esac
+  done
+  [[ -n "${port}" && -n "${root}" ]] \
+    || die "reuse requires --port N --root PATH"
+
+  ensure_binaries
+  ensure_token_entry "${root}/tokens.toml"
+
+  # Ask the adopted server to reload tokens. It may not be ours, but SIGHUP
+  # is the documented mechanism and has no effect on other signal handlers.
+  local target_pid
+  target_pid=$(pgrep -f "demarkus-server.*-root +${root}\b" 2>/dev/null | head -1 || true)
+  if [[ -n "${target_pid}" ]]; then
+    if kill -HUP "${target_pid}" 2>/dev/null; then
+      log "sent SIGHUP to adopted server (pid=${target_pid}) to reload tokens"
+    else
+      warn "SIGHUP to pid ${target_pid} failed; tokens may not be active until the server restarts"
+    fi
+  else
+    warn "no running server found with -root ${root}; proceeding with config, but /soul-init may need a rerun once it's up"
+  fi
+
+  save_config "${root}" "${port}" "reuse"
+  log "reuse setup complete (soul=${root}, port=${port})"
+}
+
+main() {
+  local mode="${1:-}"
+  shift || true
+  case "${mode}" in
+    default)  do_default ;;
+    reuse)    do_reuse "$@" ;;
+    isolated) do_isolated ;;
+    *)        die "usage: setup.sh default | reuse --port N --root PATH | isolated" ;;
+  esac
+}
+
+main "$@"

--- a/plugins/claude-code/seed/index.md
+++ b/plugins/claude-code/seed/index.md
@@ -1,21 +1,27 @@
-# My Soul
+# Projects
 
-Personal memory for Claude Code agents, served by a local demarkus server.
+Personal memory for Claude Code agents, organized by project. The top-level `/index.md` is a project list. Each project lives in its own subdirectory with a consistent internal structure.
 
-Every document here is versioned — writes never destroy prior content. The agent can fetch, publish, append, archive, and walk the link graph via the `mark_*` MCP tools.
+## Project List
 
-## Sections
+_No projects yet. Add a link below when the agent creates a project subtree._
 
-- [Journal](/journal.md) — session notes, things that happened
-- [Notes](/notes.md) — anything worth remembering
+## Per-Project Structure
 
-## How to Use
+Each `/<project>/` subtree contains:
 
-Ask the agent to "remember X" or "what do I know about Y" and it will route through these tools. Mention a topic and it can create a dedicated page under `/topics/` or similar — the structure is entirely up to you.
+- `plan/tasks.md` — active work, priorities, what's in flight
+- `architecture.md` — system design, module boundaries, key decisions
+- `patterns.md` — code patterns, conventions, idioms
+- `roadmap.md` — what's done, what's next, what's deliberately not prioritized
+- `adr/` — Architecture Decision Records, one file per decision (e.g. `0001-auth-model.md`)
+- `journal/` — dated session notes, one file per day (`YYYY-MM-DD.md`), appended as the day progresses
+
+The agent keeps this layout consistent across projects so `/soul`, `/soul-journal`, and the memory skill know where to look.
 
 ## Technical
 
-- The soul directory and port depend on the setup mode (shared by default, isolated when 6310 is taken, or reuse of an existing server). See `~/.demarkus/plugin-memory.conf` for `SOUL_DIR`, `PORT`, and `MODE`.
+- Soul directory, port, and mode are in `~/.demarkus/plugin-memory.conf` (`SOUL_DIR`, `PORT`, `MODE`). Mode is `default` (shared at `~/.demarkus/soul/` on 6310), `isolated` (separate instance on 16310+), or `reuse` (adopting an existing `demarkus-server`).
 - The plugin's auth token is at `~/.demarkus/plugin-memory.token` (mode 0600).
 - Browse the same soul from the demarkus TUI using the port from the config: `demarkus-tui -host mark://localhost:$PORT`.
 - Run `/soul-init` in Claude Code to reconfigure (switch modes, adopt an existing server, etc.).

--- a/plugins/claude-code/seed/index.md
+++ b/plugins/claude-code/seed/index.md
@@ -1,0 +1,20 @@
+# My Soul
+
+Personal memory for Claude Code agents, served by a local demarkus server.
+
+Every document here is versioned — writes never destroy prior content. The agent can fetch, publish, append, archive, and walk the link graph via the `mark_*` MCP tools.
+
+## Sections
+
+- [Journal](/journal.md) — session notes, things that happened
+- [Notes](/notes.md) — anything worth remembering
+
+## How to Use
+
+Ask the agent to "remember X" or "what do I know about Y" and it will route through these tools. Mention a topic and it can create a dedicated page under `/topics/` or similar — the structure is entirely up to you.
+
+## Technical
+
+- Served from `~/.demarkus/soul/` on `mark://localhost:6310`
+- Token and server pid live under the same directory
+- Browse the same soul from the demarkus TUI: `demarkus-tui -host mark://localhost:6310`

--- a/plugins/claude-code/seed/index.md
+++ b/plugins/claude-code/seed/index.md
@@ -15,6 +15,7 @@ Ask the agent to "remember X" or "what do I know about Y" and it will route thro
 
 ## Technical
 
-- Served from `~/.demarkus/soul/` on `mark://localhost:6310`
-- Token and server pid live under the same directory
-- Browse the same soul from the demarkus TUI: `demarkus-tui -host mark://localhost:6310`
+- The soul directory and port depend on the setup mode (shared by default, isolated when 6310 is taken, or reuse of an existing server). See `~/.demarkus/plugin-memory.conf` for `SOUL_DIR`, `PORT`, and `MODE`.
+- The plugin's auth token is at `~/.demarkus/plugin-memory.token` (mode 0600).
+- Browse the same soul from the demarkus TUI using the port from the config: `demarkus-tui -host mark://localhost:$PORT`.
+- Run `/soul-init` in Claude Code to reconfigure (switch modes, adopt an existing server, etc.).

--- a/plugins/claude-code/skills/memory/SKILL.md
+++ b/plugins/claude-code/skills/memory/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: memory
-description: Use when the user wants to remember, save, recall, or query personal notes that should persist across Claude Code sessions. Routes through the demarkus-memory MCP tools against a local versioned markdown store.
+description: Use when the user wants to remember, save, recall, or query personal notes that should persist across Claude Code sessions. Routes through the demarkus-memory MCP tools against a local versioned markdown store organized by project.
 ---
 
 # Memory
 
-This skill routes "remember" / "recall" intents through the `demarkus-memory` MCP server (a local demarkus-server), which provides a versioned, link-graph-aware personal memory store.
+This skill routes "remember" / "recall" intents through the `demarkus-memory` MCP server (a local demarkus-server), which provides a versioned, link-graph-aware personal memory store. The store is organized by project: top-level `/index.md` is a project list, and each project lives at `/<slug>/` with a consistent internal structure.
 
 ## When to trigger
 
 Trigger on phrases and intents like:
+
 - "remember this", "save to memory", "note that", "jot down"
 - "what do I know about X", "do I have notes on Y", "recall Z"
 - "add this to my notes", "put this in my soul"
@@ -17,37 +18,58 @@ Trigger on phrases and intents like:
 
 Do NOT trigger for ephemeral context ("remember that in this conversation we're using Python 3.12") — that belongs in the current session, not the persistent store.
 
+## Determining the current project
+
+Before reading or writing, resolve the project slug:
+
+1. Use the basename of `CLAUDE_PROJECT_DIR` env var (via the Bash tool: `basename "$CLAUDE_PROJECT_DIR"`). Convert to a lowercase slug if needed (spaces → hyphens).
+2. If `CLAUDE_PROJECT_DIR` is unset or the user is clearly asking about a different project, ask which project.
+3. If the project doesn't yet exist in the soul (no `/<slug>/` subtree), create it on first write by publishing the relevant file(s) and adding a link to `/index.md`.
+
+## Per-project structure
+
+Each `/<project>/` subtree has a fixed layout:
+
+- `/<project>/plan/tasks.md` — active work, priorities, what's in flight
+- `/<project>/architecture.md` — system design, module boundaries, key decisions
+- `/<project>/patterns.md` — code patterns, conventions, idioms
+- `/<project>/roadmap.md` — done, next, not prioritized
+- `/<project>/adr/<NNNN>-<slug>.md` — Architecture Decision Records (one per decision, zero-padded 4-digit sequence)
+- `/<project>/journal/<YYYY-MM-DD>.md` — dated session notes, one file per day
+
 ## Tool routing
 
-Read intents → start with `mark_fetch` on the most likely path. If the user is exploring ("what do I know about X"):
-1. Fetch `/index.md` first to see what structure exists
-2. If there is a topic page matching the query (e.g. `/topics/x.md`), fetch it
-3. Consider `mark_backlinks` or `mark_graph` to surface related documents
+Read intents → start with `mark_fetch`:
+
+1. Fetch `/index.md` to see the project list
+2. Fetch `/<project>/` (directory listing) or a specific file under it
+3. Use `mark_backlinks` or `mark_graph` to surface related documents across projects
 4. If nothing relevant is found, say so honestly rather than fabricating
 
-Write intents — decide between append and publish:
-- **Append** (`mark_append /notes.md`, `expected_version` left unset to auto-resolve): quick notes, observations, one-liners, fleeting thoughts. If `/notes.md` does not exist yet, create it first with `mark_publish` and `expected_version: 0`, then append on subsequent calls.
-- **Publish** (`mark_publish`): when the content is structured enough to deserve its own page — a topic, a person, an ongoing project. Suggest a path like `/topics/<slug>.md` or `/projects/<slug>.md` and ask the user if unsure. Use `expected_version: 0` for new documents; fetch first to get the version when updating existing pages.
-- **Journal** (`mark_append /journal.md`): dated session notes, "today I learned" entries. Prefix with a `## YYYY-MM-DD` heading when starting a new day. If `/journal.md` is missing, create it with `mark_publish` (`expected_version: 0`) before appending — or just use the `/soul-journal` command which handles this.
+Write intents — route to the right file for the content type:
 
-Always reference what you saved by path so the user can find it again.
+- **Fleeting observation / daily note** → append to today's `/<project>/journal/<YYYY-MM-DD>.md`. If the file does not exist yet, create it with `mark_publish` (`expected_version: 0`) and a header like `# <Project> journal — <YYYY-MM-DD>`, then append on subsequent calls. The `/soul-journal` command handles this automatically.
+- **Architecture decision** → create a new ADR at `/<project>/adr/<NNNN>-<slug>.md` with `mark_publish` (`expected_version: 0`). Pick the next sequence number by listing the `adr/` directory. Standard ADR template: `# <NNNN>. <Title>`, `## Status`, `## Context`, `## Decision`, `## Consequences`.
+- **Pattern / convention learned** → append to `/<project>/patterns.md`. Fetch first if updating an existing section; otherwise `mark_append` with `expected_version` unset.
+- **Architecture change** → fetch `/<project>/architecture.md`, update the relevant section, publish with the correct `expected_version`.
+- **Task / todo** → fetch and update `/<project>/plan/tasks.md`.
+- **Roadmap item** → fetch and update `/<project>/roadmap.md`.
+- **Cross-project or global note** → if it does not fit a project, ask the user where it belongs. Do not create ad-hoc top-level files.
 
-## Structure conventions
+Always reference what you saved by full path so the user can find it again.
 
-The soul starts with a minimal `/index.md`. As it grows, encourage lightweight structure:
+## Creating a new project
 
-- `/index.md` — hub page with links to everything else
-- `/notes.md` — append-only catch-all for fleeting notes
-- `/journal.md` — dated entries
-- `/topics/<slug>.md` — one page per topic
-- `/projects/<slug>.md` — one page per project
-- `/people/<slug>.md` — one page per person
+When the user wants to start memory for a project that does not exist in `/index.md` yet:
 
-When you create a new topic/project/person page, add a link to it from `/index.md` (fetch the index, add the link, publish with the correct `expected_version`).
+1. Confirm the slug (basename of `CLAUDE_PROJECT_DIR`, lowercased, spaces → hyphens)
+2. Create the first relevant file (e.g. today's journal entry, or `architecture.md` stub) with `mark_publish` `expected_version: 0`
+3. Fetch `/index.md`, add a bullet `- [<Project Name>](/<slug>/)` under the project list, and publish with the correct `expected_version`
 
 ## Don't
 
-- Don't fabricate memory. If `mark_fetch` returns 404, the document does not exist — say so.
+- Don't fabricate memory. If `mark_fetch` returns `not-found`, the document does not exist — say so.
 - Don't invent expected_versions. Use 0 for new documents; fetch first when updating.
 - Don't bypass the MCP tools with shell commands — the soul is the source of truth.
+- Don't create top-level files outside `/<project>/` subtrees except for `/index.md` itself.
 - Don't save secrets, credentials, or anything the user has not explicitly authorized.

--- a/plugins/claude-code/skills/memory/SKILL.md
+++ b/plugins/claude-code/skills/memory/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: memory
+description: Use when the user wants to remember, save, recall, or query personal notes that should persist across Claude Code sessions. Routes through the demarkus-memory MCP tools against a local versioned markdown store.
+---
+
+# Memory
+
+This skill routes "remember" / "recall" intents through the `demarkus-memory` MCP server (a local demarkus-server), which provides a versioned, link-graph-aware personal memory store.
+
+## When to trigger
+
+Trigger on phrases and intents like:
+- "remember this", "save to memory", "note that", "jot down"
+- "what do I know about X", "do I have notes on Y", "recall Z"
+- "add this to my notes", "put this in my soul"
+- "find anything about ...", "what have I saved about ..."
+
+Do NOT trigger for ephemeral context ("remember that in this conversation we're using Python 3.12") — that belongs in the current session, not the persistent store.
+
+## Tool routing
+
+Read intents → start with `mark_fetch` on the most likely path. If the user is exploring ("what do I know about X"):
+1. Fetch `/index.md` first to see what structure exists
+2. If there is a topic page matching the query (e.g. `/topics/x.md`), fetch it
+3. Consider `mark_backlinks` or `mark_graph` to surface related documents
+4. If nothing relevant is found, say so honestly rather than fabricating
+
+Write intents — decide between append and publish:
+- **Append** (`mark_append /notes.md`, `expected_version` left unset to auto-resolve): quick notes, observations, one-liners, fleeting thoughts
+- **Publish** (`mark_publish`): when the content is structured enough to deserve its own page — a topic, a person, an ongoing project. Suggest a path like `/topics/<slug>.md` or `/projects/<slug>.md` and ask the user if unsure. Use `expected_version: 0` for new documents; fetch first to get the version when updating existing pages
+- **Journal** (`mark_append /journal.md`): dated session notes, "today I learned" entries. Prefix with a `## YYYY-MM-DD` heading when starting a new day
+
+Always reference what you saved by path so the user can find it again.
+
+## Structure conventions
+
+The soul starts with a minimal `/index.md`. As it grows, encourage lightweight structure:
+
+- `/index.md` — hub page with links to everything else
+- `/notes.md` — append-only catch-all for fleeting notes
+- `/journal.md` — dated entries
+- `/topics/<slug>.md` — one page per topic
+- `/projects/<slug>.md` — one page per project
+- `/people/<slug>.md` — one page per person
+
+When you create a new topic/project/person page, add a link to it from `/index.md` (fetch the index, add the link, publish with the correct `expected_version`).
+
+## Don't
+
+- Don't fabricate memory. If `mark_fetch` returns 404, the document does not exist — say so.
+- Don't invent expected_versions. Use 0 for new documents; fetch first when updating.
+- Don't bypass the MCP tools with shell commands — the soul is the source of truth.
+- Don't save secrets, credentials, or anything the user has not explicitly authorized.

--- a/plugins/claude-code/skills/memory/SKILL.md
+++ b/plugins/claude-code/skills/memory/SKILL.md
@@ -26,9 +26,9 @@ Read intents → start with `mark_fetch` on the most likely path. If the user is
 4. If nothing relevant is found, say so honestly rather than fabricating
 
 Write intents — decide between append and publish:
-- **Append** (`mark_append /notes.md`, `expected_version` left unset to auto-resolve): quick notes, observations, one-liners, fleeting thoughts
-- **Publish** (`mark_publish`): when the content is structured enough to deserve its own page — a topic, a person, an ongoing project. Suggest a path like `/topics/<slug>.md` or `/projects/<slug>.md` and ask the user if unsure. Use `expected_version: 0` for new documents; fetch first to get the version when updating existing pages
-- **Journal** (`mark_append /journal.md`): dated session notes, "today I learned" entries. Prefix with a `## YYYY-MM-DD` heading when starting a new day
+- **Append** (`mark_append /notes.md`, `expected_version` left unset to auto-resolve): quick notes, observations, one-liners, fleeting thoughts. If `/notes.md` does not exist yet, create it first with `mark_publish` and `expected_version: 0`, then append on subsequent calls.
+- **Publish** (`mark_publish`): when the content is structured enough to deserve its own page — a topic, a person, an ongoing project. Suggest a path like `/topics/<slug>.md` or `/projects/<slug>.md` and ask the user if unsure. Use `expected_version: 0` for new documents; fetch first to get the version when updating existing pages.
+- **Journal** (`mark_append /journal.md`): dated session notes, "today I learned" entries. Prefix with a `## YYYY-MM-DD` heading when starting a new day. If `/journal.md` is missing, create it with `mark_publish` (`expected_version: 0`) before appending — or just use the `/soul-journal` command which handles this.
 
 Always reference what you saved by path so the user can find it again.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a persistent personal-memory plugin for Claude Code with setup modes (default/isolated/reuse), automatic session initialization, and a wrapper to access the local memory server.
  * Adds commands to initialize the memory soul, display the soul index, and append dated journal entries.

* **Documentation**
  * Adds user guides for setup, soul management, journaling, seeded index, and the memory skill that routes remember/recall actions to the local store.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->