### PR TITLE
fix(claude): Replace trap cleanup with inline rm -rf in ensure_binaries

### DIFF
--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -107,36 +107,36 @@ ensure_binaries() {
   local plat
   plat=$(detect_platform)
 
-  local tmp
-  tmp=$(mktemp -d)
-  # NOTE: We deliberately don't install a RETURN trap here. Bash RETURN traps
-  # persist globally by default (without the functrace option) and fire for
-  # every subsequent function return in the calling chain, which would hit
-  # `tmp: unbound variable` under set -u once the local goes out of scope.
-  # We clean up inline after install; if `die` fires partway through, the
-  # OS cleans its temp dir eventually — no data or security risk.
+  # Download + verify + extract + install happens inside a subshell so the
+  # EXIT trap cleans up the tmpdir deterministically on any failure path
+  # (curl/tar/sha256 failure, die, etc.). RETURN traps can't be used here:
+  # bash's default RETURN traps persist globally and would fire for every
+  # subsequent function return with `tmp` out of scope.
+  (
+    local tmp
+    tmp=$(mktemp -d)
+    trap 'rm -rf "${tmp}"' EXIT
 
-  log "downloading demarkus binaries (server v${SERVER_VERSION}, client v${CLIENT_VERSION}, ${plat})"
+    log "downloading demarkus binaries (server v${SERVER_VERSION}, client v${CLIENT_VERSION}, ${plat})"
 
-  local server_archive="demarkus-server_${SERVER_VERSION}_${plat}.tar.gz"
-  local server_base="https://github.com/latebit-io/demarkus/releases/download/server%2Fv${SERVER_VERSION}"
-  curl -fsSL -o "${tmp}/${server_archive}"    "${server_base}/${server_archive}"              || die "download ${server_archive}"
-  curl -fsSL -o "${tmp}/server_checksums.txt" "${server_base}/demarkus-server_checksums.txt"  || die "download server checksums"
-  (cd "${tmp}" && sha256_verify server_checksums.txt "${server_archive}")
-  tar -xzf "${tmp}/${server_archive}" -C "${tmp}"
+    local server_archive="demarkus-server_${SERVER_VERSION}_${plat}.tar.gz"
+    local server_base="https://github.com/latebit-io/demarkus/releases/download/server%2Fv${SERVER_VERSION}"
+    curl -fsSL -o "${tmp}/${server_archive}"    "${server_base}/${server_archive}"              || die "download ${server_archive}"
+    curl -fsSL -o "${tmp}/server_checksums.txt" "${server_base}/demarkus-server_checksums.txt"  || die "download server checksums"
+    (cd "${tmp}" && sha256_verify server_checksums.txt "${server_archive}")
+    tar -xzf "${tmp}/${server_archive}" -C "${tmp}"
 
-  local mcp_archive="demarkus-mcp_${CLIENT_VERSION}_${plat}.tar.gz"
-  local client_base="https://github.com/latebit-io/demarkus/releases/download/client%2Fv${CLIENT_VERSION}"
-  curl -fsSL -o "${tmp}/${mcp_archive}"       "${client_base}/${mcp_archive}"                 || die "download ${mcp_archive}"
-  curl -fsSL -o "${tmp}/client_checksums.txt" "${client_base}/demarkus-client_checksums.txt"  || die "download client checksums"
-  (cd "${tmp}" && sha256_verify client_checksums.txt "${mcp_archive}")
-  tar -xzf "${tmp}/${mcp_archive}" -C "${tmp}"
+    local mcp_archive="demarkus-mcp_${CLIENT_VERSION}_${plat}.tar.gz"
+    local client_base="https://github.com/latebit-io/demarkus/releases/download/client%2Fv${CLIENT_VERSION}"
+    curl -fsSL -o "${tmp}/${mcp_archive}"       "${client_base}/${mcp_archive}"                 || die "download ${mcp_archive}"
+    curl -fsSL -o "${tmp}/client_checksums.txt" "${client_base}/demarkus-client_checksums.txt"  || die "download client checksums"
+    (cd "${tmp}" && sha256_verify client_checksums.txt "${mcp_archive}")
+    tar -xzf "${tmp}/${mcp_archive}" -C "${tmp}"
 
-  install -m 0755 "${tmp}/demarkus-server" "${PLUGIN_BIN_DIR}/demarkus-server"
-  install -m 0755 "${tmp}/demarkus-token"  "${PLUGIN_BIN_DIR}/demarkus-token"
-  install -m 0755 "${tmp}/demarkus-mcp"    "${PLUGIN_BIN_DIR}/demarkus-mcp"
-
-  rm -rf "${tmp}"
+    install -m 0755 "${tmp}/demarkus-server" "${PLUGIN_BIN_DIR}/demarkus-server"
+    install -m 0755 "${tmp}/demarkus-token"  "${PLUGIN_BIN_DIR}/demarkus-token"
+    install -m 0755 "${tmp}/demarkus-mcp"    "${PLUGIN_BIN_DIR}/demarkus-mcp"
+  )
   log "binaries installed to ${PLUGIN_BIN_DIR}"
 }
 

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -109,7 +109,12 @@ ensure_binaries() {
 
   local tmp
   tmp=$(mktemp -d)
-  trap 'rm -rf "${tmp}"' RETURN
+  # NOTE: We deliberately don't install a RETURN trap here. Bash RETURN traps
+  # persist globally by default (without the functrace option) and fire for
+  # every subsequent function return in the calling chain, which would hit
+  # `tmp: unbound variable` under set -u once the local goes out of scope.
+  # We clean up inline after install; if `die` fires partway through, the
+  # OS cleans its temp dir eventually — no data or security risk.
 
   log "downloading demarkus binaries (server v${SERVER_VERSION}, client v${CLIENT_VERSION}, ${plat})"
 
@@ -130,6 +135,8 @@ ensure_binaries() {
   install -m 0755 "${tmp}/demarkus-server" "${PLUGIN_BIN_DIR}/demarkus-server"
   install -m 0755 "${tmp}/demarkus-token"  "${PLUGIN_BIN_DIR}/demarkus-token"
   install -m 0755 "${tmp}/demarkus-mcp"    "${PLUGIN_BIN_DIR}/demarkus-mcp"
+
+  rm -rf "${tmp}"
   log "binaries installed to ${PLUGIN_BIN_DIR}"
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed binary installation cleanup to reliably remove temporary files on both success and failure.
  * Prevented premature or stray cleanup from occurring after nested install steps, ensuring logs and final install state remain accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->