### PR TITLE
fix: Refactor ParseRequest with helper functions and conditional parsing

### DIFF
--- a/protocol/request.go
+++ b/protocol/request.go
@@ -27,107 +27,144 @@ const MaxRequestFrontmatterLength = 65536 // 64KB
 // MaxBodyLength is the maximum allowed size for a document body (1 MiB).
 const MaxBodyLength = 1 * 1024 * 1024
 
+// Frontmatter delimiters as they appear on the wire.
+const (
+	// frontmatterOpen marks the start of a YAML frontmatter block.
+	frontmatterOpen = "---\n"
+	// frontmatterClose marks the end of a frontmatter block when a body follows
+	// (leading newline from prior content + "---\n").
+	frontmatterClose = "\n---\n"
+	// frontmatterTrim matches a closing "---" at end-of-input, no trailing newline.
+	frontmatterTrim = "\n---"
+)
+
 // ParseRequest reads a request from r.
 // Format: "VERB /path\n" followed by optional YAML frontmatter and body.
 // The body is read as raw bytes to preserve content verbatim.
 func ParseRequest(r io.Reader) (Request, error) {
 	br := bufio.NewReader(r)
 
-	// Read the request line.
-	line, err := readLine(br)
+	verb, path, err := parseRequestLine(br)
 	if err != nil {
-		return Request{}, fmt.Errorf("reading request: %w", err)
-	}
-	if len(line) > MaxRequestLineLength {
-		return Request{}, fmt.Errorf("request line exceeds limit: %d > %d bytes", len(line), MaxRequestLineLength)
-	}
-
-	verb, path, ok := strings.Cut(line, " ")
-	if !ok {
-		return Request{}, fmt.Errorf("malformed request: %q", line)
-	}
-
-	// Validate verb is non-empty and is a known verb
-	if verb == "" {
-		return Request{}, fmt.Errorf("empty verb")
-	}
-	if !IsValidVerb(verb) {
-		return Request{}, fmt.Errorf("unknown verb: %q", verb)
-	}
-
-	// Validate path is non-empty and starts with /
-	if path == "" || !strings.HasPrefix(path, "/") {
-		return Request{}, fmt.Errorf("invalid path: %q", path)
-	}
-	// Reject null bytes and control characters in paths.
-	if containsControlChars(path) {
-		return Request{}, fmt.Errorf("invalid path: contains control characters")
+		return Request{}, err
 	}
 
 	req := Request{Verb: verb, Path: path, Metadata: make(map[string]string)}
 
-	// Read remaining bytes with a size limit to prevent unbounded allocation.
-	// The limit accounts for frontmatter overhead on top of the body.
-	maxRequest := int64(MaxRequestFrontmatterLength + MaxBodyLength + 64) // 64 bytes for delimiters
-	rest, err := io.ReadAll(io.LimitReader(br, maxRequest+1))
+	rest, err := readBoundedPayload(br)
 	if err != nil {
-		return Request{}, fmt.Errorf("reading request body: %w", err)
-	}
-	if int64(len(rest)) > maxRequest {
-		return Request{}, fmt.Errorf("request payload exceeds limit: %d bytes", len(rest))
+		return Request{}, err
 	}
 	if len(rest) == 0 {
 		return req, nil
 	}
 
-	// Check for frontmatter opening delimiter.
-	if !bytes.HasPrefix(rest, []byte("---\n")) {
-		if len(rest) > MaxBodyLength {
-			return Request{}, fmt.Errorf("body exceeds limit: %d > %d bytes", len(rest), MaxBodyLength)
-		}
-		req.Body = string(rest)
-		return req, nil
+	fm, body, err := splitFrontmatterAndBody(rest)
+	if err != nil {
+		return Request{}, err
 	}
 
-	// Strip the opening --- and parse frontmatter until closing ---.
-	rest = rest[4:] // skip "---\n"
-	closeIdx := bytes.Index(rest, []byte("\n---\n"))
-	if closeIdx == -1 {
-		// Check for closing --- at end of input (no trailing newline after ---).
-		if bytes.HasSuffix(rest, []byte("\n---")) {
-			closeIdx = len(rest) - 3
-		} else {
-			return Request{}, fmt.Errorf("malformed request: unclosed frontmatter")
+	if len(fm) > 0 {
+		meta, err := decodeFrontmatter(fm)
+		if err != nil {
+			return Request{}, err
 		}
+		req.Metadata = meta
 	}
 
-	fmBytes := rest[:closeIdx]
-	if len(fmBytes) > MaxRequestFrontmatterLength {
-		return Request{}, fmt.Errorf("request metadata exceeds limit: %d > %d bytes", len(fmBytes), MaxRequestFrontmatterLength)
+	if len(body) > MaxBodyLength {
+		return Request{}, fmt.Errorf("body exceeds limit: %d > %d bytes", len(body), MaxBodyLength)
 	}
-
-	if len(fmBytes) > 0 {
-		var raw map[string]string
-		if err := yaml.Unmarshal(fmBytes, &raw); err != nil {
-			return Request{}, fmt.Errorf("parsing request metadata: %w", err)
-		}
-		req.Metadata = raw
-	}
-
-	// Body is everything after the closing "---\n".
-	afterClose := rest[closeIdx:]
-	if bytes.HasPrefix(afterClose, []byte("\n---\n")) {
-		body := afterClose[5:] // skip "\n---\n"
-		if len(body) > MaxBodyLength {
-			return Request{}, fmt.Errorf("body exceeds limit: %d > %d bytes", len(body), MaxBodyLength)
-		}
-		req.Body = string(body)
-	} else {
-		// Closing --- was at end of input with no body.
-		req.Body = ""
-	}
+	req.Body = string(body)
 
 	return req, nil
+}
+
+// parseRequestLine reads and validates the request line ("VERB /path\n").
+func parseRequestLine(br *bufio.Reader) (verb, path string, err error) {
+	line, err := readLine(br)
+	if err != nil {
+		return "", "", fmt.Errorf("reading request: %w", err)
+	}
+	if len(line) > MaxRequestLineLength {
+		return "", "", fmt.Errorf("request line exceeds limit: %d > %d bytes", len(line), MaxRequestLineLength)
+	}
+
+	verb, path, ok := strings.Cut(line, " ")
+	if !ok {
+		return "", "", fmt.Errorf("malformed request: %q", line)
+	}
+
+	if verb == "" {
+		return "", "", fmt.Errorf("empty verb")
+	}
+	if !IsValidVerb(verb) {
+		return "", "", fmt.Errorf("unknown verb: %q", verb)
+	}
+
+	if path == "" || !strings.HasPrefix(path, "/") {
+		return "", "", fmt.Errorf("invalid path: %q", path)
+	}
+	if containsControlChars(path) {
+		return "", "", fmt.Errorf("invalid path: contains control characters")
+	}
+
+	return verb, path, nil
+}
+
+// readBoundedPayload reads everything after the request line, rejecting payloads
+// that would exceed the combined frontmatter + body + delimiter budget.
+func readBoundedPayload(br *bufio.Reader) ([]byte, error) {
+	limit := int64(MaxRequestFrontmatterLength + MaxBodyLength + 64) // 64 bytes for delimiters
+	rest, err := io.ReadAll(io.LimitReader(br, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading request body: %w", err)
+	}
+	if int64(len(rest)) > limit {
+		return nil, fmt.Errorf("request payload exceeds limit: %d bytes", len(rest))
+	}
+	return rest, nil
+}
+
+// splitFrontmatterAndBody separates a request payload into its frontmatter and
+// body components. When no frontmatter is present the whole payload is the body.
+// The frontmatter length is checked against MaxRequestFrontmatterLength here;
+// the body length is checked by the caller against MaxBodyLength.
+func splitFrontmatterAndBody(data []byte) (fm, body []byte, err error) {
+	if !bytes.HasPrefix(data, []byte(frontmatterOpen)) {
+		return nil, data, nil
+	}
+
+	inner := data[len(frontmatterOpen):]
+
+	// Closing form 1: "\n---\n" with possibly more bytes after (the body).
+	// Closing form 2: "\n---" at end of input, no body.
+	var fmEnd, bodyStart int
+	if idx := bytes.Index(inner, []byte(frontmatterClose)); idx >= 0 {
+		fmEnd = idx
+		bodyStart = idx + len(frontmatterClose)
+	} else if bytes.HasSuffix(inner, []byte(frontmatterTrim)) {
+		fmEnd = len(inner) - len(frontmatterTrim)
+		bodyStart = len(inner)
+	} else {
+		return nil, nil, fmt.Errorf("malformed request: unclosed frontmatter")
+	}
+
+	fm = inner[:fmEnd]
+	if len(fm) > MaxRequestFrontmatterLength {
+		return nil, nil, fmt.Errorf("request metadata exceeds limit: %d > %d bytes", len(fm), MaxRequestFrontmatterLength)
+	}
+	body = inner[bodyStart:]
+	return fm, body, nil
+}
+
+// decodeFrontmatter parses a YAML frontmatter block into a string-to-string map.
+func decodeFrontmatter(fm []byte) (map[string]string, error) {
+	var meta map[string]string
+	if err := yaml.Unmarshal(fm, &meta); err != nil {
+		return nil, fmt.Errorf("parsing request metadata: %w", err)
+	}
+	return meta, nil
 }
 
 // readLine reads a single newline-terminated line from a bufio.Reader,

--- a/protocol/request.go
+++ b/protocol/request.go
@@ -27,13 +27,18 @@ const MaxRequestFrontmatterLength = 65536 // 64KB
 // MaxBodyLength is the maximum allowed size for a document body (1 MiB).
 const MaxBodyLength = 1 * 1024 * 1024
 
-// Frontmatter delimiters as they appear on the wire.
+// Frontmatter delimiters as they appear on the wire. Parser and serializer
+// share these so the two sides of the wire format cannot drift.
 const (
-	// frontmatterOpen marks the start of a YAML frontmatter block.
-	frontmatterOpen = "---\n"
-	// frontmatterClose marks the end of a frontmatter block when a body follows
-	// (leading newline from prior content + "---\n").
-	frontmatterClose = "\n---\n"
+	// frontmatterFence is the bare fence line that opens and closes a
+	// YAML frontmatter block on the wire.
+	frontmatterFence = "---\n"
+	// frontmatterOpen is the opening delimiter at the start of a request
+	// payload (no leading newline).
+	frontmatterOpen = frontmatterFence
+	// frontmatterClose is the closing delimiter with a body following
+	// (leading newline from prior content + fence).
+	frontmatterClose = "\n" + frontmatterFence
 	// frontmatterTrim matches a closing "---" at end-of-input, no trailing newline.
 	frontmatterTrim = "\n---"
 )
@@ -210,9 +215,9 @@ func (req Request) WriteTo(w io.Writer) (int64, error) {
 		if err != nil {
 			return 0, fmt.Errorf("encoding request metadata: %w", err)
 		}
-		buf.WriteString("---\n")
+		buf.WriteString(frontmatterFence)
 		buf.Write(yamlBytes)
-		buf.WriteString("---\n")
+		buf.WriteString(frontmatterFence)
 	}
 
 	if req.Body != "" {

--- a/protocol/request.go
+++ b/protocol/request.go
@@ -159,10 +159,15 @@ func splitFrontmatterAndBody(data []byte) (fm, body []byte, err error) {
 }
 
 // decodeFrontmatter parses a YAML frontmatter block into a string-to-string map.
+// Always returns a non-nil map on success; YAML with no key-value pairs (e.g. a
+// comment-only block) yields an empty map rather than nil.
 func decodeFrontmatter(fm []byte) (map[string]string, error) {
 	var meta map[string]string
 	if err := yaml.Unmarshal(fm, &meta); err != nil {
 		return nil, fmt.Errorf("parsing request metadata: %w", err)
+	}
+	if meta == nil {
+		meta = make(map[string]string)
 	}
 	return meta, nil
 }

--- a/protocol/request.go
+++ b/protocol/request.go
@@ -94,12 +94,9 @@ func ParseRequest(r io.Reader) (Request, error) {
 
 // parseRequestLine reads and validates the request line ("VERB /path\n").
 func parseRequestLine(br *bufio.Reader) (verb, path string, err error) {
-	line, err := readLine(br)
+	line, err := readLineLimited(br, MaxRequestLineLength)
 	if err != nil {
 		return "", "", fmt.Errorf("reading request: %w", err)
-	}
-	if len(line) > MaxRequestLineLength {
-		return "", "", fmt.Errorf("request line exceeds limit: %d > %d bytes", len(line), MaxRequestLineLength)
 	}
 
 	verb, path, ok := strings.Cut(line, " ")
@@ -184,13 +181,17 @@ func decodeFrontmatter(fm []byte) (map[string]string, error) {
 	return meta, nil
 }
 
-// readLine reads a single newline-terminated line from a bufio.Reader,
-// returning the line without the trailing newline. Returns io.EOF if no
-// data is available.
-func readLine(br *bufio.Reader) (string, error) {
+// readLineLimited reads a single newline-terminated line from a bufio.Reader,
+// rejecting any line that would exceed maxBytes before the full line is
+// accumulated. Returns the line without the trailing newline. Returns io.EOF
+// if no data is available.
+func readLineLimited(br *bufio.Reader, maxBytes int) (string, error) {
 	var line []byte
 	for {
 		fragment, isPrefix, err := br.ReadLine()
+		if len(line)+len(fragment) > maxBytes {
+			return "", fmt.Errorf("request line exceeds limit: %d > %d bytes", len(line)+len(fragment), maxBytes)
+		}
 		line = append(line, fragment...)
 		if err != nil {
 			if len(line) > 0 {

--- a/protocol/request.go
+++ b/protocol/request.go
@@ -38,6 +38,13 @@ const (
 	frontmatterTrim = "\n---"
 )
 
+// requestWireOverhead is generous slack allowed above the frontmatter and body
+// limits when reading the request payload, so we get a clean
+// "payload exceeds limit" error rather than truncating mid-read. The real
+// budgets are MaxRequestFrontmatterLength and MaxBodyLength; this covers
+// delimiter bytes plus any trailing bytes the client may send.
+const requestWireOverhead = 64
+
 // ParseRequest reads a request from r.
 // Format: "VERB /path\n" followed by optional YAML frontmatter and body.
 // The body is read as raw bytes to preserve content verbatim.
@@ -115,7 +122,7 @@ func parseRequestLine(br *bufio.Reader) (verb, path string, err error) {
 // readBoundedPayload reads everything after the request line, rejecting payloads
 // that would exceed the combined frontmatter + body + delimiter budget.
 func readBoundedPayload(br *bufio.Reader) ([]byte, error) {
-	limit := int64(MaxRequestFrontmatterLength + MaxBodyLength + 64) // 64 bytes for delimiters
+	limit := int64(MaxRequestFrontmatterLength + MaxBodyLength + requestWireOverhead)
 	rest, err := io.ReadAll(io.LimitReader(br, limit+1))
 	if err != nil {
 		return nil, fmt.Errorf("reading request body: %w", err)

--- a/protocol/request_test.go
+++ b/protocol/request_test.go
@@ -190,6 +190,21 @@ func TestParseRequestUnclosedFrontmatter(t *testing.T) {
 	}
 }
 
+func TestParseRequestLineExceedsLimit(t *testing.T) {
+	// A pathological long "line" (no newline) should be rejected by the
+	// bounded reader without accumulating all the input in memory.
+	// We send MaxRequestLineLength+1 bytes of non-newline data.
+	input := strings.Repeat("A", MaxRequestLineLength+1)
+
+	_, err := ParseRequest(strings.NewReader(input))
+	if err == nil {
+		t.Fatal("expected error for oversized request line, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds limit") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
 func TestParseRequestFrontmatterCommentOnly(t *testing.T) {
 	// Valid YAML with no key-value pairs (comment only) must still yield a
 	// non-nil Metadata map so callers can safely write to it.

--- a/protocol/request_test.go
+++ b/protocol/request_test.go
@@ -190,6 +190,23 @@ func TestParseRequestUnclosedFrontmatter(t *testing.T) {
 	}
 }
 
+func TestParseRequestFrontmatterNoTrailingNewline(t *testing.T) {
+	// Frontmatter closed with "---" at end-of-input (no trailing newline, no body).
+	// This path hits the frontmatterTrim branch in splitFrontmatterAndBody.
+	input := "FETCH /index.md\n---\nkey: value\n---"
+
+	req, err := ParseRequest(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Metadata["key"] != "value" {
+		t.Errorf("metadata: got %q, want %q", req.Metadata["key"], "value")
+	}
+	if req.Body != "" {
+		t.Errorf("body: got %q, want empty", req.Body)
+	}
+}
+
 func TestParseRequestFrontmatterTooLarge(t *testing.T) {
 	// Build frontmatter that exceeds MaxRequestFrontmatterLength.
 	// Each line is "key: value\n" — repeat enough to exceed 64KB.

--- a/protocol/request_test.go
+++ b/protocol/request_test.go
@@ -205,6 +205,23 @@ func TestParseRequestLineExceedsLimit(t *testing.T) {
 	}
 }
 
+func TestParseRequestRejectsTouchingFenceEmptyFrontmatter(t *testing.T) {
+	// `---\n---\n` with zero bytes between the fences is intentionally rejected
+	// (the canonical empty form is `---\n\n---\n`). This matches response.go's
+	// parser — both sides of the wire agree that some content, even just a
+	// newline, must appear between the delimiters. Pin it so future parser
+	// tweaks can't silently widen the accepted set.
+	input := "FETCH /index.md\n---\n---\n"
+
+	_, err := ParseRequest(strings.NewReader(input))
+	if err == nil {
+		t.Fatal("expected error for touching-fence empty frontmatter, got nil")
+	}
+	if !strings.Contains(err.Error(), "unclosed frontmatter") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
 func TestParseRequestFrontmatterCommentOnly(t *testing.T) {
 	// Valid YAML with no key-value pairs (comment only) must still yield a
 	// non-nil Metadata map so callers can safely write to it.

--- a/protocol/request_test.go
+++ b/protocol/request_test.go
@@ -190,6 +190,25 @@ func TestParseRequestUnclosedFrontmatter(t *testing.T) {
 	}
 }
 
+func TestParseRequestFrontmatterCommentOnly(t *testing.T) {
+	// Valid YAML with no key-value pairs (comment only) must still yield a
+	// non-nil Metadata map so callers can safely write to it.
+	input := "FETCH /index.md\n---\n# just a comment\n---\n"
+
+	req, err := ParseRequest(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Metadata == nil {
+		t.Fatal("Metadata is nil; expected a non-nil empty map")
+	}
+	if len(req.Metadata) != 0 {
+		t.Errorf("Metadata: expected empty, got %v", req.Metadata)
+	}
+	// Writing to the returned map must not panic.
+	req.Metadata["added-by-caller"] = "ok"
+}
+
 func TestParseRequestFrontmatterNoTrailingNewline(t *testing.T) {
 	// Frontmatter closed with "---" at end-of-input (no trailing newline, no body).
 	// This path hits the frontmatterTrim branch in splitFrontmatterAndBody.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request parsing: enforces request-line and combined frontmatter/body size limits, returns immediately for empty payloads, handles frontmatter that ends at end-of-input, and ensures metadata is present (empty when frontmatter has only comments).
* **Tests**
  * Added tests covering oversized request-line rejection, frontmatter-at-EOF, and frontmatter-with-only-comments edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->