### PR TITLE
feat(client): semantic merge conflicts in mark_publish

### DIFF
--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -200,9 +200,9 @@ func markPublishTool(host string) mcp.Tool {
 				"modified since that version, the server returns a conflict status. "+
 				"Use 0 when creating a new document. "+
 				"on_conflict controls behavior when the version check fails: \"fail\" (default) "+
-				"returns the conflict; \"merge\" runs a three-way diff3 merge against the latest "+
-				"version and republishes if changes are disjoint, or returns a body with git-style "+
-				"conflict markers if they overlap. "+
+				"returns the conflict as today; \"merge\" returns a structurally-merged candidate "+
+				"body (with git-style conflict markers if both sides edited the same lines) for "+
+				"the agent to semantically verify and republish at publish-at-version. "+
 				urlHint(host),
 		),
 		mcp.WithString("url",
@@ -428,10 +428,6 @@ func (h *handler) markVersions(_ context.Context, req mcp.CallToolRequest) (*mcp
 	return mcp.NewToolResultText(formatResult(result, "total", "current", "chain-valid", "chain-error")), nil
 }
 
-// mergeMaxRetries is how many times the diff3 merge loop retries before
-// giving up with a contention conflict. See /plans/conflict-merge.md.
-const mergeMaxRetries = 3
-
 func (h *handler) markPublish(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go
 	rawURL, err := req.RequireString("url")
 	if err != nil {
@@ -464,7 +460,7 @@ func (h *handler) markPublish(ctx context.Context, req mcp.CallToolRequest) (*mc
 		// fall through to plain publish
 	case "merge":
 		adapter := &mergeClientAdapter{inner: h.client, host: host, token: token}
-		outcome, mErr := merge.MergeAndPublish(adapter, path, body, expectedVersion, mergeMaxRetries, agentMeta(ctx))
+		outcome, mErr := merge.Candidate(adapter, path, body, expectedVersion, agentMeta(ctx))
 		if mErr != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("publish failed: %v", mErr)), nil
 		}
@@ -562,9 +558,10 @@ func optionalInt(meta map[string]string, key string) (int, error) {
 	return n, nil
 }
 
-// formatOutcome renders a MergeAndPublish outcome in the same key:value text
-// shape as formatResult. Conflict and contention outcomes carry the merged
-// body or marker payload after a blank line.
+// formatOutcome renders a Candidate outcome in the same key:value text
+// shape as formatResult. The candidate body (with or without conflict
+// markers) follows the metadata after a blank line; the agent uses
+// publish-at-version for the follow-up publish.
 func formatOutcome(o *merge.Outcome) string {
 	var b strings.Builder
 	switch o.Status {
@@ -579,33 +576,14 @@ func formatOutcome(o *merge.Outcome) string {
 		if ch, ok := o.Publish.Metadata["content-hash"]; ok {
 			fmt.Fprintf(&b, "content-hash: %s\n", ch)
 		}
-		if o.Merged {
-			b.WriteString("merged: true\n")
-			fmt.Fprintf(&b, "base-version: %d\n", o.BaseVersion)
-			fmt.Fprintf(&b, "their-version: %d\n", o.TheirVersion)
-			fmt.Fprintf(&b, "retries: %d\n", o.Retries)
-		}
-	case merge.OutcomeConflict:
-		b.WriteString("status: conflict\n")
-		b.WriteString("mergeable: false\n")
+	case merge.OutcomeCandidate:
+		b.WriteString("status: merge-candidate\n")
 		fmt.Fprintf(&b, "your-version: %d\n", o.BaseVersion)
-		if o.TheirVersion > 0 {
-			fmt.Fprintf(&b, "current-version: %d\n", o.TheirVersion)
-		}
-		if o.Merged {
-			b.WriteString("merged: true\n")
-			b.WriteString("\n")
-			b.WriteString(o.ConflictBody)
-		}
-	case merge.OutcomeContention:
-		b.WriteString("status: conflict\n")
-		b.WriteString("reason: contention\n")
-		fmt.Fprintf(&b, "retries: %d\n", o.Retries)
-		fmt.Fprintf(&b, "your-version: %d\n", o.BaseVersion)
-		if o.TheirVersion > 0 {
-			fmt.Fprintf(&b, "current-version: %d\n", o.TheirVersion)
-		}
-		b.WriteString("mergeable: false\n")
+		fmt.Fprintf(&b, "current-version: %d\n", o.TheirVersion)
+		fmt.Fprintf(&b, "publish-at-version: %d\n", o.PublishAtVersion)
+		fmt.Fprintf(&b, "has-markers: %t\n", o.HasMarkers)
+		b.WriteString("\n")
+		b.WriteString(o.Body)
 	}
 	return b.String()
 }

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -558,25 +558,23 @@ func optionalInt(meta map[string]string, key string) (int, error) {
 	return n, nil
 }
 
-// formatOutcome renders a Candidate outcome in the same key:value text
-// shape as formatResult. The candidate body (with or without conflict
-// markers) follows the metadata after a blank line; the agent uses
-// publish-at-version for the follow-up publish.
+// formatOutcome renders a merge.Candidate outcome in the same key:value text
+// shape as formatResult. On OutcomeOK it delegates to formatResult so the
+// success response is byte-for-byte identical to a plain mark_publish — the
+// on_conflict=merge opt-in does not change the success contract. On
+// OutcomeCandidate it surfaces merge metadata followed by the candidate body
+// (with or without conflict markers) after a blank line.
 func formatOutcome(o *merge.Outcome) string {
-	var b strings.Builder
 	switch o.Status {
 	case merge.OutcomeOK:
-		fmt.Fprintf(&b, "status: %s\n", o.Publish.Status)
-		if v, ok := o.Publish.Metadata["version"]; ok {
-			fmt.Fprintf(&b, "version: %s\n", v)
-		}
-		if mod, ok := o.Publish.Metadata["modified"]; ok {
-			fmt.Fprintf(&b, "modified: %s\n", mod)
-		}
-		if ch, ok := o.Publish.Metadata["content-hash"]; ok {
-			fmt.Fprintf(&b, "content-hash: %s\n", ch)
-		}
+		return formatResult(fetch.Result{
+			Response: protocol.Response{
+				Status:   o.Publish.Status,
+				Metadata: o.Publish.Metadata,
+			},
+		}, "version", "modified", "server-version")
 	case merge.OutcomeCandidate:
+		var b strings.Builder
 		b.WriteString("status: merge-candidate\n")
 		fmt.Fprintf(&b, "your-version: %d\n", o.BaseVersion)
 		fmt.Fprintf(&b, "current-version: %d\n", o.TheirVersion)
@@ -584,8 +582,9 @@ func formatOutcome(o *merge.Outcome) string {
 		fmt.Fprintf(&b, "has-markers: %t\n", o.HasMarkers)
 		b.WriteString("\n")
 		b.WriteString(o.Body)
+		return b.String()
 	}
-	return b.String()
+	return ""
 }
 
 func (h *handler) markArchive(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/latebit/demarkus/client/internal/graphstore"
 	"github.com/latebit/demarkus/client/internal/index"
 	"github.com/latebit/demarkus/client/internal/links"
+	"github.com/latebit/demarkus/client/internal/merge"
 	"github.com/latebit/demarkus/client/internal/tokens"
 	"github.com/latebit/demarkus/protocol"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -198,6 +199,10 @@ func markPublishTool(host string) mcp.Tool {
 				"number from a prior fetch to detect conflicts. If the document has been "+
 				"modified since that version, the server returns a conflict status. "+
 				"Use 0 when creating a new document. "+
+				"on_conflict controls behavior when the version check fails: \"fail\" (default) "+
+				"returns the conflict; \"merge\" runs a three-way diff3 merge against the latest "+
+				"version and republishes if changes are disjoint, or returns a body with git-style "+
+				"conflict markers if they overlap. "+
 				urlHint(host),
 		),
 		mcp.WithString("url",
@@ -211,6 +216,9 @@ func markPublishTool(host string) mcp.Tool {
 		mcp.WithNumber("expected_version",
 			mcp.Required(),
 			mcp.Description("version number from a prior fetch for conflict detection; use 0 when creating a new document"),
+		),
+		mcp.WithString("on_conflict",
+			mcp.Description("conflict behavior: \"fail\" (default) or \"merge\" (diff3 merge with retry, escalates to git-style markers on overlap)"),
 		),
 	)
 }
@@ -420,6 +428,10 @@ func (h *handler) markVersions(_ context.Context, req mcp.CallToolRequest) (*mcp
 	return mcp.NewToolResultText(formatResult(result, "total", "current", "chain-valid", "chain-error")), nil
 }
 
+// mergeMaxRetries is how many times the diff3 merge loop retries before
+// giving up with a contention conflict. See /plans/conflict-merge.md.
+const mergeMaxRetries = 3
+
 func (h *handler) markPublish(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go
 	rawURL, err := req.RequireString("url")
 	if err != nil {
@@ -446,12 +458,125 @@ func (h *handler) markPublish(ctx context.Context, req mcp.CallToolRequest) (*mc
 		return mcp.NewToolResultError("expected_version is required"), nil
 	}
 
+	onConflict := req.GetString("on_conflict", "fail")
+	switch onConflict {
+	case "fail":
+		// fall through to plain publish
+	case "merge":
+		adapter := &mergeClientAdapter{inner: h.client, host: host, token: token}
+		outcome, mErr := merge.MergeAndPublish(adapter, path, body, expectedVersion, mergeMaxRetries, agentMeta(ctx))
+		if mErr != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("publish failed: %v", mErr)), nil
+		}
+		return mcp.NewToolResultText(formatOutcome(&outcome)), nil
+	default:
+		return mcp.NewToolResultError(fmt.Sprintf("invalid on_conflict %q: expected \"fail\" or \"merge\"", onConflict)), nil
+	}
+
 	result, err := h.client.Publish(host, path, body, token, expectedVersion, agentMeta(ctx))
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("publish failed: %v", err)), nil
 	}
 
 	return mcp.NewToolResultText(formatResult(result, "version", "modified", "server-version")), nil
+}
+
+// mergeClientAdapter exposes the markClient interface as a merge.Client. It
+// turns versioned fetches into the path/vN suffix the server understands and
+// extracts version metadata from the protocol response.
+type mergeClientAdapter struct {
+	inner markClient
+	host  string
+	token string
+}
+
+func (a *mergeClientAdapter) FetchVersion(path string, version int) (merge.Doc, error) {
+	versionedPath := strings.TrimRight(path, "/") + "/v" + strconv.Itoa(version)
+	r, err := a.inner.Fetch(a.host, versionedPath, a.token)
+	if err != nil {
+		return merge.Doc{}, err
+	}
+	return docFromResponse(r), nil
+}
+
+func (a *mergeClientAdapter) FetchCurrent(path string) (merge.Doc, error) {
+	r, err := a.inner.Fetch(a.host, path, a.token)
+	if err != nil {
+		return merge.Doc{}, err
+	}
+	return docFromResponse(r), nil
+}
+
+func (a *mergeClientAdapter) Publish(path, body string, expectedVersion int, meta map[string]string) (merge.PublishResult, error) {
+	r, err := a.inner.Publish(a.host, path, body, a.token, expectedVersion, meta)
+	if err != nil {
+		return merge.PublishResult{}, err
+	}
+	v, _ := strconv.Atoi(r.Response.Metadata["version"])
+	sv, _ := strconv.Atoi(r.Response.Metadata["server-version"])
+	return merge.PublishResult{
+		Status:        r.Response.Status,
+		Version:       v,
+		ServerVersion: sv,
+		Metadata:      r.Response.Metadata,
+	}, nil
+}
+
+func docFromResponse(r fetch.Result) merge.Doc {
+	v, _ := strconv.Atoi(r.Response.Metadata["version"])
+	return merge.Doc{
+		Status:  r.Response.Status,
+		Body:    r.Response.Body,
+		Version: v,
+	}
+}
+
+// formatOutcome renders a MergeAndPublish outcome in the same key:value text
+// shape as formatResult. Conflict and contention outcomes carry the merged
+// body or marker payload after a blank line.
+func formatOutcome(o *merge.Outcome) string {
+	var b strings.Builder
+	switch o.Status {
+	case merge.OutcomeOK:
+		fmt.Fprintf(&b, "status: %s\n", o.Publish.Status)
+		if v, ok := o.Publish.Metadata["version"]; ok {
+			fmt.Fprintf(&b, "version: %s\n", v)
+		}
+		if mod, ok := o.Publish.Metadata["modified"]; ok {
+			fmt.Fprintf(&b, "modified: %s\n", mod)
+		}
+		if ch, ok := o.Publish.Metadata["content-hash"]; ok {
+			fmt.Fprintf(&b, "content-hash: %s\n", ch)
+		}
+		if o.Merged {
+			b.WriteString("merged: true\n")
+			fmt.Fprintf(&b, "base-version: %d\n", o.BaseVersion)
+			fmt.Fprintf(&b, "their-version: %d\n", o.TheirVersion)
+			fmt.Fprintf(&b, "retries: %d\n", o.Retries)
+		}
+	case merge.OutcomeConflict:
+		b.WriteString("status: conflict\n")
+		b.WriteString("mergeable: false\n")
+		fmt.Fprintf(&b, "your-version: %d\n", o.BaseVersion)
+		if o.TheirVersion > 0 {
+			fmt.Fprintf(&b, "current-version: %d\n", o.TheirVersion)
+		}
+		if o.Merged {
+			b.WriteString("merged: true\n")
+			b.WriteString("\n")
+			b.WriteString(o.ConflictBody)
+		}
+	case merge.OutcomeContention:
+		b.WriteString("status: conflict\n")
+		b.WriteString("reason: contention\n")
+		fmt.Fprintf(&b, "retries: %d\n", o.Retries)
+		fmt.Fprintf(&b, "your-version: %d\n", o.BaseVersion)
+		if o.TheirVersion > 0 {
+			fmt.Fprintf(&b, "current-version: %d\n", o.TheirVersion)
+		}
+		b.WriteString("mergeable: false\n")
+	}
+	return b.String()
 }
 
 func (h *handler) markArchive(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -490,30 +490,40 @@ type mergeClientAdapter struct {
 	token string
 }
 
+// FetchVersion fetches a specific historical version via the /path/vN route.
 func (a *mergeClientAdapter) FetchVersion(path string, version int) (merge.Doc, error) {
 	versionedPath := strings.TrimRight(path, "/") + "/v" + strconv.Itoa(version)
 	r, err := a.inner.Fetch(a.host, versionedPath, a.token)
 	if err != nil {
 		return merge.Doc{}, err
 	}
-	return docFromResponse(r), nil
+	return docFromResponse(r)
 }
 
+// FetchCurrent fetches the current head version of path.
 func (a *mergeClientAdapter) FetchCurrent(path string) (merge.Doc, error) {
 	r, err := a.inner.Fetch(a.host, path, a.token)
 	if err != nil {
 		return merge.Doc{}, err
 	}
-	return docFromResponse(r), nil
+	return docFromResponse(r)
 }
 
+// Publish forwards to the underlying client and lifts the protocol response
+// into a merge.PublishResult, parsing version and server-version metadata.
 func (a *mergeClientAdapter) Publish(path, body string, expectedVersion int, meta map[string]string) (merge.PublishResult, error) {
 	r, err := a.inner.Publish(a.host, path, body, a.token, expectedVersion, meta)
 	if err != nil {
 		return merge.PublishResult{}, err
 	}
-	v, _ := strconv.Atoi(r.Response.Metadata["version"])
-	sv, _ := strconv.Atoi(r.Response.Metadata["server-version"])
+	v, err := optionalInt(r.Response.Metadata, "version")
+	if err != nil {
+		return merge.PublishResult{}, err
+	}
+	sv, err := optionalInt(r.Response.Metadata, "server-version")
+	if err != nil {
+		return merge.PublishResult{}, err
+	}
 	return merge.PublishResult{
 		Status:        r.Response.Status,
 		Version:       v,
@@ -522,13 +532,34 @@ func (a *mergeClientAdapter) Publish(path, body string, expectedVersion int, met
 	}, nil
 }
 
-func docFromResponse(r fetch.Result) merge.Doc {
-	v, _ := strconv.Atoi(r.Response.Metadata["version"])
+// docFromResponse converts a fetch.Result into the merge package's Doc type,
+// extracting the integer version from response metadata.
+func docFromResponse(r fetch.Result) (merge.Doc, error) {
+	v, err := optionalInt(r.Response.Metadata, "version")
+	if err != nil {
+		return merge.Doc{}, err
+	}
 	return merge.Doc{
 		Status:  r.Response.Status,
 		Body:    r.Response.Body,
 		Version: v,
+	}, nil
+}
+
+// optionalInt parses metadata[key] as an int. A missing or empty value
+// returns 0 with no error (the natural sentinel for absent versions). A
+// present but malformed value returns a wrapped parse error so the caller
+// surfaces server-side corruption rather than silently treating it as 0.
+func optionalInt(meta map[string]string, key string) (int, error) {
+	s, ok := meta[key]
+	if !ok || s == "" {
+		return 0, nil
 	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("response metadata %q = %q: %w", key, s, err)
+	}
+	return n, nil
 }
 
 // formatOutcome renders a MergeAndPublish outcome in the same key:value text

--- a/client/cmd/demarkus-mcp/main_test.go
+++ b/client/cmd/demarkus-mcp/main_test.go
@@ -1429,6 +1429,53 @@ func TestHandlerMarkPublish_OnConflictMergeFirstTrySuccess(t *testing.T) {
 	}
 }
 
+func TestHandlerMarkPublish_OnConflictMergeFirstTrySuccess_PreservesAllMetadata(t *testing.T) {
+	// on_conflict=merge must not change the success contract — every
+	// metadata key the server returned should reach the agent, just like a
+	// plain mark_publish would do via formatResult.
+	sc := &stubClient{
+		publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status: protocol.StatusCreated,
+				Metadata: map[string]string{
+					"version":      "6",
+					"modified":     "2026-05-05T00:00:00Z",
+					"content-hash": "sha256-deadbeef",
+					"etag":         "abc123",
+					"custom-key":   "preserved",
+				},
+			}}, nil
+		},
+	}
+
+	h := &handler{client: sc, token: "test"}
+	result, err := h.markPublish(context.Background(), newCallToolRequest(map[string]any{
+		"url":              "mark://example.com/doc.md",
+		"body":             "x",
+		"expected_version": float64(5),
+		"on_conflict":      "merge",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	for _, want := range []string{
+		"status: created",
+		"version: 6",
+		"modified: 2026-05-05T00:00:00Z",
+		"content-hash: sha256-deadbeef",
+		"etag: abc123",
+		"custom-key: preserved",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("response missing %q\n%s", want, text)
+		}
+	}
+}
+
 // assertIsToolError checks that a CallToolResult is an error containing the given substring.
 func assertIsToolError(t *testing.T, result *mcp.CallToolResult, substr string) {
 	t.Helper()

--- a/client/cmd/demarkus-mcp/main_test.go
+++ b/client/cmd/demarkus-mcp/main_test.go
@@ -1260,7 +1260,8 @@ func TestHandlerMarkGraphPublish_NoToken(t *testing.T) {
 
 func TestHandlerMarkPublish_OnConflictMergeDisjoint(t *testing.T) {
 	// Agent edited base v5 ("a\nb\nc\n") into "a\nB\nc\n".
-	// Latest is v6 ("a\nb\nC\n"). diff3 produces "a\nB\nC\n", republish at v6 succeeds.
+	// Latest is v6 ("a\nb\nC\n"). Tool returns a clean diff3 candidate at v6;
+	// it does NOT auto-publish — the agent verifies semantically and republishes.
 	var publishCalls int
 	sc := &stubClient{
 		fetchFn: func(_, path, _ string) (fetch.Result, error) {
@@ -1280,23 +1281,11 @@ func TestHandlerMarkPublish_OnConflictMergeDisjoint(t *testing.T) {
 			}
 			return fetch.Result{}, nil
 		},
-		publishFn: func(_, _, body, _ string, expectedVersion int, _ map[string]string) (fetch.Result, error) {
+		publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
 			publishCalls++
-			if publishCalls == 1 {
-				return fetch.Result{Response: protocol.Response{
-					Status:   protocol.StatusConflict,
-					Metadata: map[string]string{"server-version": "6"},
-				}}, nil
-			}
-			if expectedVersion != 6 {
-				t.Errorf("merged publish expected_version = %d, want 6", expectedVersion)
-			}
-			if body != "a\nB\nC\n" {
-				t.Errorf("merged body = %q, want %q", body, "a\nB\nC\n")
-			}
 			return fetch.Result{Response: protocol.Response{
-				Status:   protocol.StatusCreated,
-				Metadata: map[string]string{"version": "7", "modified": "2026-05-05T00:00:00Z"},
+				Status:   protocol.StatusConflict,
+				Metadata: map[string]string{"server-version": "6"},
 			}}, nil
 		},
 	}
@@ -1314,8 +1303,18 @@ func TestHandlerMarkPublish_OnConflictMergeDisjoint(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected tool error: %v", result.Content)
 	}
+	if publishCalls != 1 {
+		t.Errorf("want exactly 1 publish call (no auto-publish), got %d", publishCalls)
+	}
 	text := result.Content[0].(mcp.TextContent).Text
-	for _, want := range []string{"status: created", "version: 7", "merged: true", "base-version: 5", "their-version: 6"} {
+	for _, want := range []string{
+		"status: merge-candidate",
+		"your-version: 5",
+		"current-version: 6",
+		"publish-at-version: 6",
+		"has-markers: false",
+		"a\nB\nC\n",
+	} {
 		if !strings.Contains(text, want) {
 			t.Errorf("response missing %q\n%s", want, text)
 		}
@@ -1366,10 +1365,11 @@ func TestHandlerMarkPublish_OnConflictMergeOverlap(t *testing.T) {
 	}
 	text := result.Content[0].(mcp.TextContent).Text
 	for _, want := range []string{
-		"status: conflict",
-		"mergeable: false",
+		"status: merge-candidate",
+		"has-markers: true",
 		"your-version: 5",
 		"current-version: 6",
+		"publish-at-version: 6",
 		"<<<<<<< ours",
 		">>>>>>> theirs",
 		"B",
@@ -1397,7 +1397,7 @@ func TestHandlerMarkPublish_OnConflictInvalid(t *testing.T) {
 
 func TestHandlerMarkPublish_OnConflictMergeFirstTrySuccess(t *testing.T) {
 	// When the initial publish succeeds, the merge path returns a plain
-	// success without merged metadata.
+	// success — no candidate, no markers, no diff3 invoked.
 	sc := &stubClient{
 		publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
 			return fetch.Result{Response: protocol.Response{
@@ -1424,8 +1424,8 @@ func TestHandlerMarkPublish_OnConflictMergeFirstTrySuccess(t *testing.T) {
 	if !strings.Contains(text, "status: created") || !strings.Contains(text, "version: 6") {
 		t.Errorf("response missing expected fields\n%s", text)
 	}
-	if strings.Contains(text, "merged: true") {
-		t.Errorf("first-try success should not be marked merged\n%s", text)
+	if strings.Contains(text, "merge-candidate") {
+		t.Errorf("first-try success should not produce a candidate\n%s", text)
 	}
 }
 

--- a/client/cmd/demarkus-mcp/main_test.go
+++ b/client/cmd/demarkus-mcp/main_test.go
@@ -1258,6 +1258,177 @@ func TestHandlerMarkGraphPublish_NoToken(t *testing.T) {
 	assertIsToolError(t, result, "requires a token")
 }
 
+func TestHandlerMarkPublish_OnConflictMergeDisjoint(t *testing.T) {
+	// Agent edited base v5 ("a\nb\nc\n") into "a\nB\nc\n".
+	// Latest is v6 ("a\nb\nC\n"). diff3 produces "a\nB\nC\n", republish at v6 succeeds.
+	var publishCalls int
+	sc := &stubClient{
+		fetchFn: func(_, path, _ string) (fetch.Result, error) {
+			switch path {
+			case "/doc.md/v5":
+				return fetch.Result{Response: protocol.Response{
+					Status:   protocol.StatusOK,
+					Metadata: map[string]string{"version": "5"},
+					Body:     "a\nb\nc\n",
+				}}, nil
+			case "/doc.md":
+				return fetch.Result{Response: protocol.Response{
+					Status:   protocol.StatusOK,
+					Metadata: map[string]string{"version": "6"},
+					Body:     "a\nb\nC\n",
+				}}, nil
+			}
+			return fetch.Result{}, nil
+		},
+		publishFn: func(_, _, body, _ string, expectedVersion int, _ map[string]string) (fetch.Result, error) {
+			publishCalls++
+			if publishCalls == 1 {
+				return fetch.Result{Response: protocol.Response{
+					Status:   protocol.StatusConflict,
+					Metadata: map[string]string{"server-version": "6"},
+				}}, nil
+			}
+			if expectedVersion != 6 {
+				t.Errorf("merged publish expected_version = %d, want 6", expectedVersion)
+			}
+			if body != "a\nB\nC\n" {
+				t.Errorf("merged body = %q, want %q", body, "a\nB\nC\n")
+			}
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusCreated,
+				Metadata: map[string]string{"version": "7", "modified": "2026-05-05T00:00:00Z"},
+			}}, nil
+		},
+	}
+
+	h := &handler{client: sc, token: "test"}
+	result, err := h.markPublish(context.Background(), newCallToolRequest(map[string]any{
+		"url":              "mark://example.com/doc.md",
+		"body":             "a\nB\nc\n",
+		"expected_version": float64(5),
+		"on_conflict":      "merge",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	for _, want := range []string{"status: created", "version: 7", "merged: true", "base-version: 5", "their-version: 6"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("response missing %q\n%s", want, text)
+		}
+	}
+}
+
+func TestHandlerMarkPublish_OnConflictMergeOverlap(t *testing.T) {
+	// Agent edited base v5 ("a\nb\nc\n") into "a\nB\nc\n".
+	// Latest is v6 ("a\nXX\nc\n"). diff3 produces conflict markers.
+	sc := &stubClient{
+		fetchFn: func(_, path, _ string) (fetch.Result, error) {
+			switch path {
+			case "/doc.md/v5":
+				return fetch.Result{Response: protocol.Response{
+					Status:   protocol.StatusOK,
+					Metadata: map[string]string{"version": "5"},
+					Body:     "a\nb\nc\n",
+				}}, nil
+			case "/doc.md":
+				return fetch.Result{Response: protocol.Response{
+					Status:   protocol.StatusOK,
+					Metadata: map[string]string{"version": "6"},
+					Body:     "a\nXX\nc\n",
+				}}, nil
+			}
+			return fetch.Result{}, nil
+		},
+		publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusConflict,
+				Metadata: map[string]string{"server-version": "6"},
+			}}, nil
+		},
+	}
+
+	h := &handler{client: sc, token: "test"}
+	result, err := h.markPublish(context.Background(), newCallToolRequest(map[string]any{
+		"url":              "mark://example.com/doc.md",
+		"body":             "a\nB\nc\n",
+		"expected_version": float64(5),
+		"on_conflict":      "merge",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	for _, want := range []string{
+		"status: conflict",
+		"mergeable: false",
+		"your-version: 5",
+		"current-version: 6",
+		"<<<<<<< ours",
+		">>>>>>> theirs",
+		"B",
+		"XX",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("response missing %q\n%s", want, text)
+		}
+	}
+}
+
+func TestHandlerMarkPublish_OnConflictInvalid(t *testing.T) {
+	h := &handler{client: &stubClient{}, token: "test"}
+	result, err := h.markPublish(context.Background(), newCallToolRequest(map[string]any{
+		"url":              "mark://example.com/doc.md",
+		"body":             "x",
+		"expected_version": float64(1),
+		"on_conflict":      "bogus",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertIsToolError(t, result, "invalid on_conflict")
+}
+
+func TestHandlerMarkPublish_OnConflictMergeFirstTrySuccess(t *testing.T) {
+	// When the initial publish succeeds, the merge path returns a plain
+	// success without merged metadata.
+	sc := &stubClient{
+		publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusCreated,
+				Metadata: map[string]string{"version": "6", "modified": "2026-05-05T00:00:00Z"},
+			}}, nil
+		},
+	}
+
+	h := &handler{client: sc, token: "test"}
+	result, err := h.markPublish(context.Background(), newCallToolRequest(map[string]any{
+		"url":              "mark://example.com/doc.md",
+		"body":             "x",
+		"expected_version": float64(5),
+		"on_conflict":      "merge",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, "status: created") || !strings.Contains(text, "version: 6") {
+		t.Errorf("response missing expected fields\n%s", text)
+	}
+	if strings.Contains(text, "merged: true") {
+		t.Errorf("first-try success should not be marked merged\n%s", text)
+	}
+}
+
 // assertIsToolError checks that a CallToolResult is an error containing the given substring.
 func assertIsToolError(t *testing.T, result *mcp.CallToolResult, substr string) {
 	t.Helper()

--- a/client/internal/merge/diff3.go
+++ b/client/internal/merge/diff3.go
@@ -165,6 +165,7 @@ func editHunks(base, side []string) []editHunk {
 	return hunks
 }
 
+// lineMatch records that base[baseIdx] equals side[sideIdx] in an LCS pairing.
 type lineMatch struct{ baseIdx, sideIdx int }
 
 // lcsMatches returns the longest common subsequence of base and side as
@@ -214,7 +215,9 @@ func lcsMatches(base, side []string) []lineMatch {
 
 // emitChunk merges a single unstable region of base/ours/theirs and writes
 // the result to out. If both sides made conflicting edits, conflict markers
-// are written and *conflict is set.
+// are written and *conflict is set. Stable-merge paths emit lines verbatim
+// (preserving the input's trailing-newline state); the conflict path pads
+// each side's chunk with a newline so the marker line stays line-aligned.
 func emitChunk(baseChunk, oursChunk, theirsChunk []string, out *strings.Builder, conflict *bool) {
 	oursEqualsBase := equalLines(oursChunk, baseChunk)
 	theirsEqualsBase := equalLines(theirsChunk, baseChunk)
@@ -231,33 +234,38 @@ func emitChunk(baseChunk, oursChunk, theirsChunk []string, out *strings.Builder,
 	default:
 		*conflict = true
 		out.WriteString("<<<<<<< ours\n")
-		writeLines(out, oursChunk)
-		ensureNewline(out)
+		writeLinesPadded(out, oursChunk)
 		out.WriteString("=======\n")
-		writeLines(out, theirsChunk)
-		ensureNewline(out)
+		writeLinesPadded(out, theirsChunk)
 		out.WriteString(">>>>>>> theirs\n")
 	}
 }
 
+// writeLines writes lines verbatim, preserving each line's original line
+// ending (or lack of one).
 func writeLines(out *strings.Builder, lines []string) {
 	for _, l := range lines {
 		out.WriteString(l)
 	}
 }
 
-// ensureNewline appends a newline if the buffer does not already end with one.
-// Conflict markers must start at the beginning of a line, so a chunk whose
-// last line is missing its trailing newline would otherwise run into the
-// next marker.
-func ensureNewline(out *strings.Builder) {
-	s := out.String()
-	if s == "" || s[len(s)-1] == '\n' {
+// writeLinesPadded writes lines and ensures the result ends with a newline.
+// Used inside conflict marker blocks so the next marker starts at column 0
+// even when the chunk's last line lacks a trailing newline. Inspecting the
+// chunk directly is clearer than reading state back from the builder.
+func writeLinesPadded(out *strings.Builder, lines []string) {
+	writeLines(out, lines)
+	if len(lines) == 0 {
+		return
+	}
+	last := lines[len(lines)-1]
+	if last == "" || last[len(last)-1] == '\n' {
 		return
 	}
 	out.WriteByte('\n')
 }
 
+// equalLines reports whether a and b have the same length and matching elements.
 func equalLines(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/client/internal/merge/diff3.go
+++ b/client/internal/merge/diff3.go
@@ -1,0 +1,271 @@
+// Package merge implements three-way line-based merge for Mark Protocol clients.
+// The diff3 algorithm here is used by the MCP `mark_publish` handler to
+// reconcile concurrent writes without an LLM round trip when changes are
+// disjoint, and to surface git-style conflict markers when they overlap.
+package merge
+
+import "strings"
+
+// Result holds the output of a three-way merge.
+type Result struct {
+	Body     string
+	Conflict bool
+}
+
+// Diff3 performs a line-based three-way merge of base, ours, and theirs.
+// Lines that only one side changed are taken from that side. Lines that both
+// sides changed identically collapse into a single copy. Lines that both
+// sides changed differently are emitted with git-style conflict markers and
+// Conflict is set to true.
+func Diff3(base, ours, theirs string) Result {
+	baseLines := splitLines(base)
+	oursLines := splitLines(ours)
+	theirsLines := splitLines(theirs)
+
+	hunksO := editHunks(baseLines, oursLines)
+	hunksT := editHunks(baseLines, theirsLines)
+
+	var out strings.Builder
+	conflict := false
+
+	bPos, oPos, tPos := 0, 0, 0
+	oi, ti := 0, 0
+
+	for bPos < len(baseLines) || oi < len(hunksO) || ti < len(hunksT) {
+		oAtPos := oi < len(hunksO) && hunksO[oi].baseLo == bPos
+		tAtPos := ti < len(hunksT) && hunksT[ti].baseLo == bPos
+
+		if !oAtPos && !tAtPos {
+			// Stable region: emit base lines until the next hunk starts
+			// or we reach the end.
+			stableEnd := len(baseLines)
+			if oi < len(hunksO) {
+				stableEnd = min(stableEnd, hunksO[oi].baseLo)
+			}
+			if ti < len(hunksT) {
+				stableEnd = min(stableEnd, hunksT[ti].baseLo)
+			}
+			n := stableEnd - bPos
+			for k := range n {
+				out.WriteString(baseLines[bPos+k])
+			}
+			bPos += n
+			oPos += n
+			tPos += n
+			continue
+		}
+
+		// Unstable chunk. Consume any hunks anchored at bPos, then extend
+		// to absorb hunks that start strictly inside the chunk.
+		bLo, oLo, tLo := bPos, oPos, tPos
+		bHi := bPos
+		lastOBaseHi, lastOSideHi := bLo, oLo
+		lastTBaseHi, lastTSideHi := bLo, tLo
+
+		if oAtPos {
+			h := hunksO[oi]
+			if h.baseHi > bHi {
+				bHi = h.baseHi
+			}
+			lastOBaseHi, lastOSideHi = h.baseHi, h.sideHi
+			oi++
+		}
+		if tAtPos {
+			h := hunksT[ti]
+			if h.baseHi > bHi {
+				bHi = h.baseHi
+			}
+			lastTBaseHi, lastTSideHi = h.baseHi, h.sideHi
+			ti++
+		}
+
+		for {
+			extended := false
+			if oi < len(hunksO) && hunksO[oi].baseLo < bHi {
+				h := hunksO[oi]
+				if h.baseHi > bHi {
+					bHi = h.baseHi
+				}
+				lastOBaseHi, lastOSideHi = h.baseHi, h.sideHi
+				oi++
+				extended = true
+			}
+			if ti < len(hunksT) && hunksT[ti].baseLo < bHi {
+				h := hunksT[ti]
+				if h.baseHi > bHi {
+					bHi = h.baseHi
+				}
+				lastTBaseHi, lastTSideHi = h.baseHi, h.sideHi
+				ti++
+				extended = true
+			}
+			if !extended {
+				break
+			}
+		}
+
+		// Trailing-stable extension: between the last consumed hunk and
+		// bHi, ours and theirs match base 1-to-1, so the side ranges
+		// extend by the remaining base count.
+		oHi := lastOSideHi + (bHi - lastOBaseHi)
+		tHi := lastTSideHi + (bHi - lastTBaseHi)
+
+		emitChunk(
+			baseLines[bLo:bHi],
+			oursLines[oLo:oHi],
+			theirsLines[tLo:tHi],
+			&out, &conflict,
+		)
+		bPos, oPos, tPos = bHi, oHi, tHi
+	}
+
+	return Result{Body: out.String(), Conflict: conflict}
+}
+
+// splitLines splits s on newlines while preserving the trailing newline on
+// each line. The explicit nil for empty input keeps callers from special-
+// casing length.
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.SplitAfter(s, "\n")
+}
+
+// editHunk describes a region where base differs from one side. base[baseLo:baseHi]
+// is replaced by side[sideLo:sideHi]. Either range may be empty (pure
+// insertion or deletion).
+type editHunk struct {
+	baseLo, baseHi int
+	sideLo, sideHi int
+}
+
+// editHunks computes the diff between base and side as an ordered list of
+// replacement hunks, derived from the LCS of the two line sequences.
+func editHunks(base, side []string) []editHunk {
+	matches := lcsMatches(base, side)
+	var hunks []editHunk
+	bPrev, sPrev := 0, 0
+	for _, m := range matches {
+		if m.baseIdx > bPrev || m.sideIdx > sPrev {
+			hunks = append(hunks, editHunk{
+				baseLo: bPrev, baseHi: m.baseIdx,
+				sideLo: sPrev, sideHi: m.sideIdx,
+			})
+		}
+		bPrev = m.baseIdx + 1
+		sPrev = m.sideIdx + 1
+	}
+	if bPrev < len(base) || sPrev < len(side) {
+		hunks = append(hunks, editHunk{
+			baseLo: bPrev, baseHi: len(base),
+			sideLo: sPrev, sideHi: len(side),
+		})
+	}
+	return hunks
+}
+
+type lineMatch struct{ baseIdx, sideIdx int }
+
+// lcsMatches returns the longest common subsequence of base and side as
+// (baseIdx, sideIdx) pairs in ascending order. O(n*m) time and space; for
+// markdown documents under the 1 MiB body limit this is microseconds.
+func lcsMatches(base, side []string) []lineMatch {
+	m, n := len(base), len(side)
+	if m == 0 || n == 0 {
+		return nil
+	}
+	dp := make([][]int, m+1)
+	for i := range dp {
+		dp[i] = make([]int, n+1)
+	}
+	for i := 1; i <= m; i++ {
+		for j := 1; j <= n; j++ {
+			switch {
+			case base[i-1] == side[j-1]:
+				dp[i][j] = dp[i-1][j-1] + 1
+			case dp[i-1][j] >= dp[i][j-1]:
+				dp[i][j] = dp[i-1][j]
+			default:
+				dp[i][j] = dp[i][j-1]
+			}
+		}
+	}
+
+	matches := make([]lineMatch, 0, dp[m][n])
+	i, j := m, n
+	for i > 0 && j > 0 {
+		switch {
+		case base[i-1] == side[j-1]:
+			matches = append(matches, lineMatch{baseIdx: i - 1, sideIdx: j - 1})
+			i--
+			j--
+		case dp[i-1][j] >= dp[i][j-1]:
+			i--
+		default:
+			j--
+		}
+	}
+	for l, r := 0, len(matches)-1; l < r; l, r = l+1, r-1 {
+		matches[l], matches[r] = matches[r], matches[l]
+	}
+	return matches
+}
+
+// emitChunk merges a single unstable region of base/ours/theirs and writes
+// the result to out. If both sides made conflicting edits, conflict markers
+// are written and *conflict is set.
+func emitChunk(baseChunk, oursChunk, theirsChunk []string, out *strings.Builder, conflict *bool) {
+	oursEqualsBase := equalLines(oursChunk, baseChunk)
+	theirsEqualsBase := equalLines(theirsChunk, baseChunk)
+
+	switch {
+	case oursEqualsBase && theirsEqualsBase:
+		writeLines(out, baseChunk)
+	case oursEqualsBase:
+		writeLines(out, theirsChunk)
+	case theirsEqualsBase:
+		writeLines(out, oursChunk)
+	case equalLines(oursChunk, theirsChunk):
+		writeLines(out, oursChunk)
+	default:
+		*conflict = true
+		out.WriteString("<<<<<<< ours\n")
+		writeLines(out, oursChunk)
+		ensureNewline(out)
+		out.WriteString("=======\n")
+		writeLines(out, theirsChunk)
+		ensureNewline(out)
+		out.WriteString(">>>>>>> theirs\n")
+	}
+}
+
+func writeLines(out *strings.Builder, lines []string) {
+	for _, l := range lines {
+		out.WriteString(l)
+	}
+}
+
+// ensureNewline appends a newline if the buffer does not already end with one.
+// Conflict markers must start at the beginning of a line, so a chunk whose
+// last line is missing its trailing newline would otherwise run into the
+// next marker.
+func ensureNewline(out *strings.Builder) {
+	s := out.String()
+	if s == "" || s[len(s)-1] == '\n' {
+		return
+	}
+	out.WriteByte('\n')
+}
+
+func equalLines(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/client/internal/merge/diff3.go
+++ b/client/internal/merge/diff3.go
@@ -168,12 +168,24 @@ func editHunks(base, side []string) []editHunk {
 // lineMatch records that base[baseIdx] equals side[sideIdx] in an LCS pairing.
 type lineMatch struct{ baseIdx, sideIdx int }
 
+// maxLCSCells caps the LCS dp table at ~16 MB (2M ints × 8 bytes) to bound
+// memory use on pathological inputs (e.g. 100K short lines, which would
+// otherwise allocate gigabytes). Inputs that exceed the cap fall through to
+// a single-hunk merge: editHunks treats the entire range as one replacement,
+// which diff3 surfaces as one big conflict block — coarser than line-level
+// granularity but still correct, and the agent can resolve manually.
+const maxLCSCells = 2_000_000
+
 // lcsMatches returns the longest common subsequence of base and side as
-// (baseIdx, sideIdx) pairs in ascending order. O(n*m) time and space; for
-// markdown documents under the 1 MiB body limit this is microseconds.
+// (baseIdx, sideIdx) pairs in ascending order. O(m*n) time and space.
+// Returns nil when m*n would exceed maxLCSCells, leaving callers to fall
+// back to whole-range hunk semantics.
 func lcsMatches(base, side []string) []lineMatch {
 	m, n := len(base), len(side)
 	if m == 0 || n == 0 {
+		return nil
+	}
+	if int64(m)*int64(n) > maxLCSCells {
 		return nil
 	}
 	dp := make([][]int, m+1)

--- a/client/internal/merge/diff3_test.go
+++ b/client/internal/merge/diff3_test.go
@@ -1,6 +1,7 @@
 package merge
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -147,6 +148,47 @@ func TestDiff3(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDiff3_OversizedInputsFallBackToSingleHunk(t *testing.T) {
+	// Build inputs whose product exceeds maxLCSCells. lcsMatches returns nil,
+	// editHunks emits a single whole-range hunk, and diff3 then handles the
+	// chunk normally — identical inputs collapse to base, divergent inputs
+	// produce one big conflict block. Either way, no allocation explosion.
+	side := func(line string, n int) string {
+		var b strings.Builder
+		for i := range n {
+			fmt.Fprintf(&b, "%s %d\n", line, i)
+		}
+		return b.String()
+	}
+	// 1500 * 1500 = 2.25M > maxLCSCells (2M).
+	const n = 1500
+
+	t.Run("identical large inputs merge cleanly", func(t *testing.T) {
+		body := side("line", n)
+		got := Diff3(body, body, body)
+		if got.Conflict {
+			t.Error("identical inputs should never conflict")
+		}
+		if got.Body != body {
+			t.Errorf("identical merge corrupted body (len got=%d want=%d)", len(got.Body), len(body))
+		}
+	})
+
+	t.Run("divergent large inputs yield one conflict block", func(t *testing.T) {
+		base := side("base", n)
+		ours := side("ours", n)
+		theirs := side("theirs", n)
+		got := Diff3(base, ours, theirs)
+		if !got.Conflict {
+			t.Error("divergent inputs should conflict")
+		}
+		// Exactly one conflict block since the fallback emits one big hunk.
+		if c := strings.Count(got.Body, "<<<<<<< ours"); c != 1 {
+			t.Errorf("want exactly 1 conflict block, got %d", c)
+		}
+	})
 }
 
 func TestDiff3_NoConflictsHaveMarkers(t *testing.T) {

--- a/client/internal/merge/diff3_test.go
+++ b/client/internal/merge/diff3_test.go
@@ -1,0 +1,165 @@
+package merge
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDiff3(t *testing.T) {
+	tests := []struct {
+		name         string
+		base         string
+		ours         string
+		theirs       string
+		wantBody     string
+		wantConflict bool
+	}{
+		{
+			name:         "all identical",
+			base:         "a\nb\nc\n",
+			ours:         "a\nb\nc\n",
+			theirs:       "a\nb\nc\n",
+			wantBody:     "a\nb\nc\n",
+			wantConflict: false,
+		},
+		{
+			name:         "only ours changed",
+			base:         "a\nb\nc\n",
+			ours:         "a\nB\nc\n",
+			theirs:       "a\nb\nc\n",
+			wantBody:     "a\nB\nc\n",
+			wantConflict: false,
+		},
+		{
+			name:         "only theirs changed",
+			base:         "a\nb\nc\n",
+			ours:         "a\nb\nc\n",
+			theirs:       "a\nb\nC\n",
+			wantBody:     "a\nb\nC\n",
+			wantConflict: false,
+		},
+		{
+			name:         "both sides changed identically",
+			base:         "a\nb\nc\n",
+			ours:         "a\nB\nc\n",
+			theirs:       "a\nB\nc\n",
+			wantBody:     "a\nB\nc\n",
+			wantConflict: false,
+		},
+		{
+			name:         "disjoint paragraph edits merge cleanly",
+			base:         "para1\n\npara2\n\npara3\n",
+			ours:         "PARA1\n\npara2\n\npara3\n",
+			theirs:       "para1\n\npara2\n\nPARA3\n",
+			wantBody:     "PARA1\n\npara2\n\nPARA3\n",
+			wantConflict: false,
+		},
+		{
+			name:         "same line changed differently produces conflict",
+			base:         "a\nb\nc\n",
+			ours:         "a\nB\nc\n",
+			theirs:       "a\nXX\nc\n",
+			wantBody:     "a\n<<<<<<< ours\nB\n=======\nXX\n>>>>>>> theirs\nc\n",
+			wantConflict: true,
+		},
+		{
+			name:         "ours inserts, theirs untouched",
+			base:         "a\nc\n",
+			ours:         "a\nb\nc\n",
+			theirs:       "a\nc\n",
+			wantBody:     "a\nb\nc\n",
+			wantConflict: false,
+		},
+		{
+			name:         "ours appends, theirs appends elsewhere",
+			base:         "head\nmiddle\ntail\n",
+			ours:         "head\nmiddle\ntail\nours-end\n",
+			theirs:       "theirs-start\nhead\nmiddle\ntail\n",
+			wantBody:     "theirs-start\nhead\nmiddle\ntail\nours-end\n",
+			wantConflict: false,
+		},
+		{
+			name:         "ours deletes, theirs untouched",
+			base:         "a\nb\nc\n",
+			ours:         "a\nc\n",
+			theirs:       "a\nb\nc\n",
+			wantBody:     "a\nc\n",
+			wantConflict: false,
+		},
+		{
+			name:         "empty base, both add same content",
+			base:         "",
+			ours:         "added\n",
+			theirs:       "added\n",
+			wantBody:     "added\n",
+			wantConflict: false,
+		},
+		{
+			name:         "empty base, both add different content conflicts",
+			base:         "",
+			ours:         "ours-only\n",
+			theirs:       "theirs-only\n",
+			wantBody:     "<<<<<<< ours\nours-only\n=======\ntheirs-only\n>>>>>>> theirs\n",
+			wantConflict: true,
+		},
+		{
+			name:         "all empty",
+			base:         "",
+			ours:         "",
+			theirs:       "",
+			wantBody:     "",
+			wantConflict: false,
+		},
+		{
+			name:         "ours empty, theirs unchanged means delete-vs-keep wins as delete",
+			base:         "a\nb\n",
+			ours:         "",
+			theirs:       "a\nb\n",
+			wantBody:     "",
+			wantConflict: false,
+		},
+		{
+			name:         "missing trailing newline still gets clean conflict markers",
+			base:         "a\nb\nc",
+			ours:         "a\nB\nc",
+			theirs:       "a\nXX\nc",
+			wantBody:     "a\n<<<<<<< ours\nB\n=======\nXX\n>>>>>>> theirs\nc",
+			wantConflict: true,
+		},
+		{
+			name:         "adjacent line edits do not over-conflict",
+			base:         "a\nb\nc\nd\ne\n",
+			ours:         "a\nB\nc\nd\ne\n",
+			theirs:       "a\nb\nc\nD\ne\n",
+			wantBody:     "a\nB\nc\nD\ne\n",
+			wantConflict: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Diff3(tt.base, tt.ours, tt.theirs)
+			if got.Body != tt.wantBody {
+				t.Errorf("body mismatch\n  want: %q\n  got:  %q", tt.wantBody, got.Body)
+			}
+			if got.Conflict != tt.wantConflict {
+				t.Errorf("conflict mismatch: want %v, got %v", tt.wantConflict, got.Conflict)
+			}
+		})
+	}
+}
+
+func TestDiff3_NoConflictsHaveMarkers(t *testing.T) {
+	// Property: if Conflict is false, the merged body must not contain
+	// any conflict markers — agents downstream rely on this to decide
+	// whether to invoke an LLM.
+	got := Diff3("a\nb\nc\n", "a\nB\nc\n", "a\nb\nC\n")
+	if got.Conflict {
+		t.Fatal("expected clean merge")
+	}
+	for _, marker := range []string{"<<<<<<<", "=======", ">>>>>>>"} {
+		if strings.Contains(got.Body, marker) {
+			t.Errorf("clean merge body contains marker %q: %q", marker, got.Body)
+		}
+	}
+}

--- a/client/internal/merge/merge.go
+++ b/client/internal/merge/merge.go
@@ -22,7 +22,7 @@ type PublishResult struct {
 	Metadata      map[string]string
 }
 
-// Client is the subset of fetch.Client operations MergeAndPublish needs.
+// Client is the subset of fetch.Client operations Candidate needs.
 // Defined here so the merge package is testable without QUIC.
 type Client interface {
 	FetchVersion(path string, version int) (Doc, error)
@@ -30,30 +30,29 @@ type Client interface {
 	Publish(path, body string, expectedVersion int, meta map[string]string) (PublishResult, error)
 }
 
-// OutcomeStatus describes the final state of a MergeAndPublish call.
+// OutcomeStatus describes the result of a Candidate call.
 type OutcomeStatus string
 
 const (
-	// OutcomeOK means the publish succeeded. Merged is true if a diff3
-	// merge happened along the way.
+	// OutcomeOK means the initial publish succeeded — no merge was needed.
 	OutcomeOK OutcomeStatus = "ok"
-	// OutcomeConflict means diff3 produced conflict markers and the
-	// caller's LLM must resolve them. ConflictBody holds the marked merge.
-	OutcomeConflict OutcomeStatus = "conflict"
-	// OutcomeContention means the merge loop exhausted maxRetries against
-	// a path that kept advancing. The caller may retry.
-	OutcomeContention OutcomeStatus = "contention"
+	// OutcomeCandidate means the publish conflicted and the tool produced a
+	// diff3 merge candidate. The agent should semantically review the body
+	// (resolving any markers) and republish at PublishAtVersion.
+	OutcomeCandidate OutcomeStatus = "merge-candidate"
 )
 
-// Outcome is the result of a MergeAndPublish call.
+// Outcome is the result of a Candidate call. Fields are populated based
+// on Status — Publish on OutcomeOK; Body, HasMarkers, BaseVersion,
+// TheirVersion, and PublishAtVersion on OutcomeCandidate.
 type Outcome struct {
-	Status       OutcomeStatus
-	Publish      PublishResult // populated when Status == OutcomeOK
-	Merged       bool          // true when at least one diff3 merge happened
-	BaseVersion  int           // the version we merged from (Status != OutcomeOK or Merged)
-	TheirVersion int           // the latest version we merged against
-	ConflictBody string        // diff3 output with markers (Status == OutcomeConflict)
-	Retries      int           // number of merge attempts (0 if first publish succeeded)
+	Status           OutcomeStatus
+	Publish          PublishResult
+	Body             string
+	HasMarkers       bool
+	BaseVersion      int
+	TheirVersion     int
+	PublishAtVersion int
 }
 
 // ErrInvalidExpectedVersion is returned when expectedVersion is < 0.
@@ -66,103 +65,61 @@ const statusConflict = "conflict"
 // statusOK matches protocol.StatusOK for fetch responses.
 const statusOK = "ok"
 
-// MergeAndPublish publishes body to path with optimistic concurrency. On
-// version conflict, it fetches the base version (the one the agent edited
-// from) and the current version, runs diff3, and republishes the merged
-// body. It retries up to maxRetries times when the republish itself
-// conflicts (a third writer slipped in). Returns OutcomeConflict if diff3
-// produces markers; OutcomeContention when retries are exhausted.
+// Candidate publishes body to path with optimistic concurrency. On a
+// version mismatch it produces a diff3 merge candidate (base = the version
+// the agent edited from, theirs = the current latest, ours = body) and
+// returns it for the agent to semantically verify and republish. The tool
+// never auto-publishes the merge — line-level disjoint ≠ semantically
+// disjoint, so the agent must always inspect the candidate before it
+// becomes the new head.
 //
-// expectedVersion = 0 means create-only, identical to fetch.Client.Publish.
-// In that mode, conflicts are not eligible for diff3 merge — there is no
-// base to merge from — and the conflict is returned as-is.
+// Iteration is the agent's responsibility: if the agent's follow-up publish
+// itself conflicts (a third writer slipped in), the agent simply calls
+// Candidate again with the new body and version.
 //
-//nolint:revive // MergeAndPublish reads more clearly at call sites than merge.AndPublish or merge.Publish.
-func MergeAndPublish(c Client, path, body string, expectedVersion, maxRetries int, meta map[string]string) (Outcome, error) {
+// expectedVersion = 0 means create-only. Conflicts in that mode merge
+// against an empty base — non-overlapping insertions on both sides make it
+// through cleanly; overlapping insertions get markers.
+func Candidate(c Client, path, body string, expectedVersion int, meta map[string]string) (Outcome, error) {
 	if expectedVersion < 0 {
 		return Outcome{}, ErrInvalidExpectedVersion
 	}
 
-	first, err := c.Publish(path, body, expectedVersion, meta)
+	pub, err := c.Publish(path, body, expectedVersion, meta)
 	if err != nil {
-		return Outcome{}, fmt.Errorf("initial publish: %w", err)
+		return Outcome{}, fmt.Errorf("publish: %w", err)
 	}
-	if first.Status != statusConflict {
-		return Outcome{Status: OutcomeOK, Publish: first}, nil
-	}
-	// expectedVersion == 0 means "create only". A conflict here means the
-	// document already exists; there is no base to merge from.
-	if expectedVersion == 0 {
-		return Outcome{
-			Status:       OutcomeConflict,
-			TheirVersion: first.ServerVersion,
-		}, nil
+	if pub.Status != statusConflict {
+		return Outcome{Status: OutcomeOK, Publish: pub}, nil
 	}
 
-	base, err := c.FetchVersion(path, expectedVersion)
+	base := ""
+	if expectedVersion > 0 {
+		baseDoc, err := c.FetchVersion(path, expectedVersion)
+		if err != nil {
+			return Outcome{}, fmt.Errorf("fetch base v%d: %w", expectedVersion, err)
+		}
+		if baseDoc.Status != statusOK {
+			return Outcome{}, fmt.Errorf("fetch base v%d: status %s", expectedVersion, baseDoc.Status)
+		}
+		base = baseDoc.Body
+	}
+
+	latest, err := c.FetchCurrent(path)
 	if err != nil {
-		return Outcome{}, fmt.Errorf("fetch base v%d: %w", expectedVersion, err)
+		return Outcome{}, fmt.Errorf("fetch current: %w", err)
 	}
-	if base.Status != statusOK {
-		return Outcome{}, fmt.Errorf("fetch base v%d: status %s", expectedVersion, base.Status)
-	}
-
-	// mergeBase advances forward with each retry: after a successful diff3
-	// the merged body is "based on" whatever latest we just merged with,
-	// so the next iteration uses that as base. Otherwise we'd re-conflict
-	// on the prior iteration's already-resolved changes.
-	mergeBase := base.Body
-	mergeOurs := body
-	merged := false
-	lastLatestVersion := 0
-
-	for attempt := range maxRetries {
-		latest, err := c.FetchCurrent(path)
-		if err != nil {
-			return Outcome{}, fmt.Errorf("fetch latest: %w", err)
-		}
-		if latest.Status != statusOK {
-			return Outcome{}, fmt.Errorf("fetch latest: status %s", latest.Status)
-		}
-		lastLatestVersion = latest.Version
-
-		mergeRes := Diff3(mergeBase, mergeOurs, latest.Body)
-		merged = true
-		if mergeRes.Conflict {
-			return Outcome{
-				Status:       OutcomeConflict,
-				Merged:       true,
-				BaseVersion:  expectedVersion,
-				TheirVersion: latest.Version,
-				ConflictBody: mergeRes.Body,
-				Retries:      attempt,
-			}, nil
-		}
-
-		next, err := c.Publish(path, mergeRes.Body, latest.Version, meta)
-		if err != nil {
-			return Outcome{}, fmt.Errorf("publish merged (attempt %d): %w", attempt+1, err)
-		}
-		if next.Status != statusConflict {
-			return Outcome{
-				Status:       OutcomeOK,
-				Publish:      next,
-				Merged:       merged,
-				BaseVersion:  expectedVersion,
-				TheirVersion: latest.Version,
-				Retries:      attempt + 1,
-			}, nil
-		}
-
-		mergeBase = latest.Body
-		mergeOurs = mergeRes.Body
+	if latest.Status != statusOK {
+		return Outcome{}, fmt.Errorf("fetch current: status %s", latest.Status)
 	}
 
+	merged := Diff3(base, body, latest.Body)
 	return Outcome{
-		Status:       OutcomeContention,
-		Merged:       merged,
-		BaseVersion:  expectedVersion,
-		TheirVersion: lastLatestVersion,
-		Retries:      maxRetries,
+		Status:           OutcomeCandidate,
+		Body:             merged.Body,
+		HasMarkers:       merged.Conflict,
+		BaseVersion:      expectedVersion,
+		TheirVersion:     latest.Version,
+		PublishAtVersion: latest.Version,
 	}, nil
 }

--- a/client/internal/merge/merge.go
+++ b/client/internal/merge/merge.go
@@ -1,0 +1,168 @@
+package merge
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Doc is a fetched document used as input to a merge.
+type Doc struct {
+	Status  string
+	Body    string
+	Version int
+}
+
+// PublishResult is what a publish returns. Status is the raw protocol status
+// ("ok", "created", "conflict", etc). On a version conflict, ServerVersion
+// holds the server's current version; otherwise it is zero.
+type PublishResult struct {
+	Status        string
+	Version       int
+	ServerVersion int
+	Metadata      map[string]string
+}
+
+// Client is the subset of fetch.Client operations MergeAndPublish needs.
+// Defined here so the merge package is testable without QUIC.
+type Client interface {
+	FetchVersion(path string, version int) (Doc, error)
+	FetchCurrent(path string) (Doc, error)
+	Publish(path, body string, expectedVersion int, meta map[string]string) (PublishResult, error)
+}
+
+// OutcomeStatus describes the final state of a MergeAndPublish call.
+type OutcomeStatus string
+
+const (
+	// OutcomeOK means the publish succeeded. Merged is true if a diff3
+	// merge happened along the way.
+	OutcomeOK OutcomeStatus = "ok"
+	// OutcomeConflict means diff3 produced conflict markers and the
+	// caller's LLM must resolve them. ConflictBody holds the marked merge.
+	OutcomeConflict OutcomeStatus = "conflict"
+	// OutcomeContention means the merge loop exhausted maxRetries against
+	// a path that kept advancing. The caller may retry.
+	OutcomeContention OutcomeStatus = "contention"
+)
+
+// Outcome is the result of a MergeAndPublish call.
+type Outcome struct {
+	Status       OutcomeStatus
+	Publish      PublishResult // populated when Status == OutcomeOK
+	Merged       bool          // true when at least one diff3 merge happened
+	BaseVersion  int           // the version we merged from (Status != OutcomeOK or Merged)
+	TheirVersion int           // the latest version we merged against
+	ConflictBody string        // diff3 output with markers (Status == OutcomeConflict)
+	Retries      int           // number of merge attempts (0 if first publish succeeded)
+}
+
+// ErrInvalidExpectedVersion is returned when expectedVersion is < 0.
+var ErrInvalidExpectedVersion = errors.New("expected_version must be >= 0")
+
+// statusConflict matches protocol.StatusConflict. Compared as a raw string
+// so this package does not depend on the protocol package.
+const statusConflict = "conflict"
+
+// statusOK matches protocol.StatusOK for fetch responses.
+const statusOK = "ok"
+
+// MergeAndPublish publishes body to path with optimistic concurrency. On
+// version conflict, it fetches the base version (the one the agent edited
+// from) and the current version, runs diff3, and republishes the merged
+// body. It retries up to maxRetries times when the republish itself
+// conflicts (a third writer slipped in). Returns OutcomeConflict if diff3
+// produces markers; OutcomeContention when retries are exhausted.
+//
+// expectedVersion = 0 means create-only, identical to fetch.Client.Publish.
+// In that mode, conflicts are not eligible for diff3 merge — there is no
+// base to merge from — and the conflict is returned as-is.
+//
+//nolint:revive // MergeAndPublish reads more clearly at call sites than merge.AndPublish or merge.Publish.
+func MergeAndPublish(c Client, path, body string, expectedVersion, maxRetries int, meta map[string]string) (Outcome, error) {
+	if expectedVersion < 0 {
+		return Outcome{}, ErrInvalidExpectedVersion
+	}
+
+	first, err := c.Publish(path, body, expectedVersion, meta)
+	if err != nil {
+		return Outcome{}, fmt.Errorf("initial publish: %w", err)
+	}
+	if first.Status != statusConflict {
+		return Outcome{Status: OutcomeOK, Publish: first}, nil
+	}
+	// expectedVersion == 0 means "create only". A conflict here means the
+	// document already exists; there is no base to merge from.
+	if expectedVersion == 0 {
+		return Outcome{
+			Status:       OutcomeConflict,
+			TheirVersion: first.ServerVersion,
+		}, nil
+	}
+
+	base, err := c.FetchVersion(path, expectedVersion)
+	if err != nil {
+		return Outcome{}, fmt.Errorf("fetch base v%d: %w", expectedVersion, err)
+	}
+	if base.Status != statusOK {
+		return Outcome{}, fmt.Errorf("fetch base v%d: status %s", expectedVersion, base.Status)
+	}
+
+	// mergeBase advances forward with each retry: after a successful diff3
+	// the merged body is "based on" whatever latest we just merged with,
+	// so the next iteration uses that as base. Otherwise we'd re-conflict
+	// on the prior iteration's already-resolved changes.
+	mergeBase := base.Body
+	mergeOurs := body
+	merged := false
+	lastLatestVersion := 0
+
+	for attempt := range maxRetries {
+		latest, err := c.FetchCurrent(path)
+		if err != nil {
+			return Outcome{}, fmt.Errorf("fetch latest: %w", err)
+		}
+		if latest.Status != statusOK {
+			return Outcome{}, fmt.Errorf("fetch latest: status %s", latest.Status)
+		}
+		lastLatestVersion = latest.Version
+
+		mergeRes := Diff3(mergeBase, mergeOurs, latest.Body)
+		merged = true
+		if mergeRes.Conflict {
+			return Outcome{
+				Status:       OutcomeConflict,
+				Merged:       true,
+				BaseVersion:  expectedVersion,
+				TheirVersion: latest.Version,
+				ConflictBody: mergeRes.Body,
+				Retries:      attempt,
+			}, nil
+		}
+
+		next, err := c.Publish(path, mergeRes.Body, latest.Version, meta)
+		if err != nil {
+			return Outcome{}, fmt.Errorf("publish merged (attempt %d): %w", attempt+1, err)
+		}
+		if next.Status != statusConflict {
+			return Outcome{
+				Status:       OutcomeOK,
+				Publish:      next,
+				Merged:       merged,
+				BaseVersion:  expectedVersion,
+				TheirVersion: latest.Version,
+				Retries:      attempt + 1,
+			}, nil
+		}
+
+		mergeBase = latest.Body
+		mergeOurs = mergeRes.Body
+	}
+
+	return Outcome{
+		Status:       OutcomeContention,
+		Merged:       merged,
+		BaseVersion:  expectedVersion,
+		TheirVersion: lastLatestVersion,
+		Retries:      maxRetries,
+	}, nil
+}

--- a/client/internal/merge/merge.go
+++ b/client/internal/merge/merge.go
@@ -112,6 +112,13 @@ func Candidate(c Client, path, body string, expectedVersion int, meta map[string
 	if latest.Status != statusOK {
 		return Outcome{}, fmt.Errorf("fetch current: status %s", latest.Status)
 	}
+	// A candidate without a real head version would force the agent's
+	// follow-up publish into create-only semantics (expected_version=0),
+	// which would either silently change behavior or fail at the server.
+	// Fail fast instead of returning an unusable PublishAtVersion.
+	if latest.Version <= 0 {
+		return Outcome{}, fmt.Errorf("fetch current: missing or invalid version metadata")
+	}
 
 	merged := Diff3(base, body, latest.Body)
 	return Outcome{

--- a/client/internal/merge/merge_test.go
+++ b/client/internal/merge/merge_test.go
@@ -1,0 +1,281 @@
+package merge
+
+import (
+	"errors"
+	"testing"
+)
+
+// stubClient is a programmable Client for tests. Each Publish call advances
+// through publishResults; each FetchCurrent through currentDocs.
+type stubClient struct {
+	versionedDocs  map[int]Doc     // FetchVersion lookups
+	currentDocs    []Doc           // FetchCurrent returns these in order
+	publishResults []PublishResult // Publish returns these in order
+	publishErrs    []error         // optional errors aligned with publishResults
+	fetchErr       error           // returned by FetchVersion if non-nil
+	currentErr     error           // returned by FetchCurrent if non-nil
+	publishedBody  []string        // bodies seen by Publish, in order
+	publishedMeta  []map[string]string
+	publishedExp   []int
+	currentIdx     int
+	publishIdx     int
+}
+
+func (s *stubClient) FetchVersion(_ string, version int) (Doc, error) {
+	if s.fetchErr != nil {
+		return Doc{}, s.fetchErr
+	}
+	d, ok := s.versionedDocs[version]
+	if !ok {
+		return Doc{Status: "not-found"}, nil
+	}
+	return d, nil
+}
+
+func (s *stubClient) FetchCurrent(_ string) (Doc, error) {
+	if s.currentErr != nil {
+		return Doc{}, s.currentErr
+	}
+	if s.currentIdx >= len(s.currentDocs) {
+		return Doc{}, errors.New("stub: no more current docs")
+	}
+	d := s.currentDocs[s.currentIdx]
+	s.currentIdx++
+	return d, nil
+}
+
+func (s *stubClient) Publish(_, body string, expectedVersion int, meta map[string]string) (PublishResult, error) {
+	s.publishedBody = append(s.publishedBody, body)
+	s.publishedMeta = append(s.publishedMeta, meta)
+	s.publishedExp = append(s.publishedExp, expectedVersion)
+	if s.publishIdx < len(s.publishErrs) && s.publishErrs[s.publishIdx] != nil {
+		err := s.publishErrs[s.publishIdx]
+		s.publishIdx++
+		return PublishResult{}, err
+	}
+	if s.publishIdx >= len(s.publishResults) {
+		return PublishResult{}, errors.New("stub: no more publish results")
+	}
+	r := s.publishResults[s.publishIdx]
+	s.publishIdx++
+	return r, nil
+}
+
+func TestMergeAndPublish(t *testing.T) {
+	t.Run("first publish succeeds without merge", func(t *testing.T) {
+		c := &stubClient{
+			publishResults: []PublishResult{{Status: "ok", Version: 6}},
+		}
+		out, err := MergeAndPublish(c, "/p", "body", 5, 3, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out.Status != OutcomeOK {
+			t.Errorf("want OutcomeOK, got %s", out.Status)
+		}
+		if out.Merged {
+			t.Error("Merged should be false on first-try success")
+		}
+		if out.Publish.Version != 6 {
+			t.Errorf("want version 6, got %d", out.Publish.Version)
+		}
+	})
+
+	t.Run("disjoint changes merge cleanly on retry", func(t *testing.T) {
+		// Agent edited base v5 ("a\nb\nc\n") into "a\nB\nc\n".
+		// Meanwhile latest is v6 ("a\nb\nC\n").
+		// diff3 should merge to "a\nB\nC\n".
+		c := &stubClient{
+			versionedDocs: map[int]Doc{
+				5: {Status: "ok", Body: "a\nb\nc\n", Version: 5},
+			},
+			currentDocs: []Doc{
+				{Status: "ok", Body: "a\nb\nC\n", Version: 6},
+			},
+			publishResults: []PublishResult{
+				{Status: "conflict", ServerVersion: 6}, // first try
+				{Status: "ok", Version: 7},             // merged publish
+			},
+		}
+		out, err := MergeAndPublish(c, "/p", "a\nB\nc\n", 5, 3, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out.Status != OutcomeOK {
+			t.Errorf("want OutcomeOK, got %s", out.Status)
+		}
+		if !out.Merged {
+			t.Error("Merged should be true")
+		}
+		if out.Publish.Version != 7 {
+			t.Errorf("want version 7, got %d", out.Publish.Version)
+		}
+		if got := c.publishedBody[1]; got != "a\nB\nC\n" {
+			t.Errorf("merged body: want %q, got %q", "a\nB\nC\n", got)
+		}
+		if got := c.publishedExp[1]; got != 6 {
+			t.Errorf("publish expected_version: want 6, got %d", got)
+		}
+		if out.Retries != 1 {
+			t.Errorf("want Retries=1, got %d", out.Retries)
+		}
+	})
+
+	t.Run("overlapping changes return OutcomeConflict with marked body", func(t *testing.T) {
+		c := &stubClient{
+			versionedDocs: map[int]Doc{
+				5: {Status: "ok", Body: "a\nb\nc\n", Version: 5},
+			},
+			currentDocs: []Doc{
+				{Status: "ok", Body: "a\nXX\nc\n", Version: 6},
+			},
+			publishResults: []PublishResult{
+				{Status: "conflict", ServerVersion: 6},
+			},
+		}
+		out, err := MergeAndPublish(c, "/p", "a\nB\nc\n", 5, 3, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out.Status != OutcomeConflict {
+			t.Fatalf("want OutcomeConflict, got %s", out.Status)
+		}
+		if !out.Merged {
+			t.Error("Merged should be true")
+		}
+		if out.BaseVersion != 5 || out.TheirVersion != 6 {
+			t.Errorf("versions: want base=5 their=6, got base=%d their=%d", out.BaseVersion, out.TheirVersion)
+		}
+		want := "a\n<<<<<<< ours\nB\n=======\nXX\n>>>>>>> theirs\nc\n"
+		if out.ConflictBody != want {
+			t.Errorf("conflict body mismatch\n  want: %q\n  got:  %q", want, out.ConflictBody)
+		}
+		// Only one publish (the initial) — merged version was never sent.
+		if len(c.publishedBody) != 1 {
+			t.Errorf("want 1 publish call, got %d", len(c.publishedBody))
+		}
+	})
+
+	t.Run("third writer slips in, merge loop resolves", func(t *testing.T) {
+		// Agent edits v5 → "a\nB\nc\n".
+		// Latest is v6 ("a\nb\nC\n"). First merge yields "a\nB\nC\n", republish.
+		// Third writer pushed v7 ("a\nb\nC\nadded\n") in the meantime.
+		// Republish conflicts. Re-merge: base=v6, ours="a\nB\nC\n", theirs=v7.
+		// diff3 yields "a\nB\nC\nadded\n". Republish at v7 succeeds.
+		c := &stubClient{
+			versionedDocs: map[int]Doc{
+				5: {Status: "ok", Body: "a\nb\nc\n", Version: 5},
+			},
+			currentDocs: []Doc{
+				{Status: "ok", Body: "a\nb\nC\n", Version: 6},
+				{Status: "ok", Body: "a\nb\nC\nadded\n", Version: 7},
+			},
+			publishResults: []PublishResult{
+				{Status: "conflict", ServerVersion: 6}, // initial
+				{Status: "conflict", ServerVersion: 7}, // first merged retry
+				{Status: "ok", Version: 8},             // second merged retry
+			},
+		}
+		out, err := MergeAndPublish(c, "/p", "a\nB\nc\n", 5, 3, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out.Status != OutcomeOK {
+			t.Fatalf("want OutcomeOK, got %s", out.Status)
+		}
+		if out.Retries != 2 {
+			t.Errorf("want Retries=2, got %d", out.Retries)
+		}
+		if got := c.publishedBody[2]; got != "a\nB\nC\nadded\n" {
+			t.Errorf("final body: want %q, got %q", "a\nB\nC\nadded\n", got)
+		}
+		if got := c.publishedExp[2]; got != 7 {
+			t.Errorf("final publish expected_version: want 7, got %d", got)
+		}
+	})
+
+	t.Run("contention exhausts retries", func(t *testing.T) {
+		c := &stubClient{
+			versionedDocs: map[int]Doc{
+				5: {Status: "ok", Body: "x\n", Version: 5},
+			},
+			currentDocs: []Doc{
+				{Status: "ok", Body: "x\n", Version: 6},
+				{Status: "ok", Body: "x\n", Version: 7},
+				{Status: "ok", Body: "x\n", Version: 8},
+			},
+			publishResults: []PublishResult{
+				{Status: "conflict", ServerVersion: 6}, // initial
+				{Status: "conflict", ServerVersion: 7},
+				{Status: "conflict", ServerVersion: 8},
+				{Status: "conflict", ServerVersion: 9},
+			},
+		}
+		out, err := MergeAndPublish(c, "/p", "y\n", 5, 3, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out.Status != OutcomeContention {
+			t.Errorf("want OutcomeContention, got %s", out.Status)
+		}
+		if out.Retries != 3 {
+			t.Errorf("want Retries=3, got %d", out.Retries)
+		}
+		if out.TheirVersion != 8 {
+			t.Errorf("want TheirVersion=8 (last fetched), got %d", out.TheirVersion)
+		}
+	})
+
+	t.Run("create-only conflict returns OutcomeConflict without merge", func(t *testing.T) {
+		c := &stubClient{
+			publishResults: []PublishResult{
+				{Status: "conflict", ServerVersion: 3},
+			},
+		}
+		out, err := MergeAndPublish(c, "/p", "body", 0, 3, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out.Status != OutcomeConflict {
+			t.Errorf("want OutcomeConflict, got %s", out.Status)
+		}
+		if out.Merged {
+			t.Error("expected_version=0 path should never merge")
+		}
+		if out.TheirVersion != 3 {
+			t.Errorf("want TheirVersion=3, got %d", out.TheirVersion)
+		}
+	})
+
+	t.Run("invalid expected_version", func(t *testing.T) {
+		_, err := MergeAndPublish(&stubClient{}, "/p", "b", -1, 3, nil)
+		if !errors.Is(err, ErrInvalidExpectedVersion) {
+			t.Errorf("want ErrInvalidExpectedVersion, got %v", err)
+		}
+	})
+
+	t.Run("metadata is forwarded on every publish", func(t *testing.T) {
+		c := &stubClient{
+			versionedDocs: map[int]Doc{
+				5: {Status: "ok", Body: "a\n"},
+			},
+			currentDocs: []Doc{
+				{Status: "ok", Body: "a\nB\n", Version: 6},
+			},
+			publishResults: []PublishResult{
+				{Status: "conflict", ServerVersion: 6},
+				{Status: "ok", Version: 7},
+			},
+		}
+		meta := map[string]string{"agent": "test"}
+		_, err := MergeAndPublish(c, "/p", "a\n", 5, 3, meta)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for i, m := range c.publishedMeta {
+			if m["agent"] != "test" {
+				t.Errorf("publish #%d: agent metadata lost: %v", i, m)
+			}
+		}
+	})
+}

--- a/client/internal/merge/merge_test.go
+++ b/client/internal/merge/merge_test.go
@@ -2,6 +2,7 @@ package merge
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -194,6 +195,30 @@ func TestCandidate(t *testing.T) {
 		}
 		if got := c.publishedMeta[0]["agent"]; got != "test" {
 			t.Errorf("agent metadata lost: %q", got)
+		}
+	})
+
+	t.Run("missing head version is rejected", func(t *testing.T) {
+		// FetchCurrent returns ok with no version metadata. A candidate with
+		// PublishAtVersion=0 would silently switch the agent's follow-up
+		// publish to create-only mode, so we fail fast.
+		c := &stubClient{
+			versionedDocs: map[int]Doc{
+				5: {Status: "ok", Body: "x\n", Version: 5},
+			},
+			currentDocs: []Doc{
+				{Status: "ok", Body: "x\n", Version: 0},
+			},
+			publishResults: []PublishResult{
+				{Status: "conflict", ServerVersion: 6},
+			},
+		}
+		_, err := Candidate(c, "/p", "x\nB\n", 5, nil)
+		if err == nil {
+			t.Fatal("expected error for missing head version")
+		}
+		if !strings.Contains(err.Error(), "version metadata") {
+			t.Errorf("error should mention version metadata, got: %v", err)
 		}
 	})
 

--- a/client/internal/merge/merge_test.go
+++ b/client/internal/merge/merge_test.go
@@ -61,30 +61,32 @@ func (s *stubClient) Publish(_, body string, expectedVersion int, meta map[strin
 	return r, nil
 }
 
-func TestMergeAndPublish(t *testing.T) {
-	t.Run("first publish succeeds without merge", func(t *testing.T) {
+func TestCandidate(t *testing.T) {
+	t.Run("first publish succeeds", func(t *testing.T) {
 		c := &stubClient{
 			publishResults: []PublishResult{{Status: "ok", Version: 6}},
 		}
-		out, err := MergeAndPublish(c, "/p", "body", 5, 3, nil)
+		out, err := Candidate(c, "/p", "body", 5, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if out.Status != OutcomeOK {
 			t.Errorf("want OutcomeOK, got %s", out.Status)
 		}
-		if out.Merged {
-			t.Error("Merged should be false on first-try success")
-		}
 		if out.Publish.Version != 6 {
 			t.Errorf("want version 6, got %d", out.Publish.Version)
 		}
+		if out.Body != "" {
+			t.Errorf("OutcomeOK should have empty Body, got %q", out.Body)
+		}
+		if len(c.publishedBody) != 1 {
+			t.Errorf("want 1 publish call, got %d", len(c.publishedBody))
+		}
 	})
 
-	t.Run("disjoint changes merge cleanly on retry", func(t *testing.T) {
+	t.Run("disjoint conflict produces clean candidate", func(t *testing.T) {
 		// Agent edited base v5 ("a\nb\nc\n") into "a\nB\nc\n".
-		// Meanwhile latest is v6 ("a\nb\nC\n").
-		// diff3 should merge to "a\nB\nC\n".
+		// Latest is v6 ("a\nb\nC\n"). diff3 produces "a\nB\nC\n".
 		c := &stubClient{
 			versionedDocs: map[int]Doc{
 				5: {Status: "ok", Body: "a\nb\nc\n", Version: 5},
@@ -93,35 +95,33 @@ func TestMergeAndPublish(t *testing.T) {
 				{Status: "ok", Body: "a\nb\nC\n", Version: 6},
 			},
 			publishResults: []PublishResult{
-				{Status: "conflict", ServerVersion: 6}, // first try
-				{Status: "ok", Version: 7},             // merged publish
+				{Status: "conflict", ServerVersion: 6},
 			},
 		}
-		out, err := MergeAndPublish(c, "/p", "a\nB\nc\n", 5, 3, nil)
+		out, err := Candidate(c, "/p", "a\nB\nc\n", 5, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if out.Status != OutcomeOK {
-			t.Errorf("want OutcomeOK, got %s", out.Status)
+		if out.Status != OutcomeCandidate {
+			t.Errorf("want OutcomeCandidate, got %s", out.Status)
 		}
-		if !out.Merged {
-			t.Error("Merged should be true")
+		if out.HasMarkers {
+			t.Error("want HasMarkers=false")
 		}
-		if out.Publish.Version != 7 {
-			t.Errorf("want version 7, got %d", out.Publish.Version)
+		if out.Body != "a\nB\nC\n" {
+			t.Errorf("candidate body: want %q, got %q", "a\nB\nC\n", out.Body)
 		}
-		if got := c.publishedBody[1]; got != "a\nB\nC\n" {
-			t.Errorf("merged body: want %q, got %q", "a\nB\nC\n", got)
+		if out.BaseVersion != 5 || out.TheirVersion != 6 || out.PublishAtVersion != 6 {
+			t.Errorf("versions: want base=5 their=6 publishAt=6, got base=%d their=%d publishAt=%d",
+				out.BaseVersion, out.TheirVersion, out.PublishAtVersion)
 		}
-		if got := c.publishedExp[1]; got != 6 {
-			t.Errorf("publish expected_version: want 6, got %d", got)
-		}
-		if out.Retries != 1 {
-			t.Errorf("want Retries=1, got %d", out.Retries)
+		// Tool never auto-publishes — only the initial attempt happened.
+		if len(c.publishedBody) != 1 {
+			t.Errorf("want exactly 1 publish call (no auto-publish of merge), got %d", len(c.publishedBody))
 		}
 	})
 
-	t.Run("overlapping changes return OutcomeConflict with marked body", func(t *testing.T) {
+	t.Run("overlapping conflict produces candidate with markers", func(t *testing.T) {
 		c := &stubClient{
 			versionedDocs: map[int]Doc{
 				5: {Status: "ok", Body: "a\nb\nc\n", Version: 5},
@@ -133,149 +133,123 @@ func TestMergeAndPublish(t *testing.T) {
 				{Status: "conflict", ServerVersion: 6},
 			},
 		}
-		out, err := MergeAndPublish(c, "/p", "a\nB\nc\n", 5, 3, nil)
+		out, err := Candidate(c, "/p", "a\nB\nc\n", 5, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if out.Status != OutcomeConflict {
-			t.Fatalf("want OutcomeConflict, got %s", out.Status)
+		if out.Status != OutcomeCandidate {
+			t.Errorf("want OutcomeCandidate, got %s", out.Status)
 		}
-		if !out.Merged {
-			t.Error("Merged should be true")
-		}
-		if out.BaseVersion != 5 || out.TheirVersion != 6 {
-			t.Errorf("versions: want base=5 their=6, got base=%d their=%d", out.BaseVersion, out.TheirVersion)
+		if !out.HasMarkers {
+			t.Error("want HasMarkers=true")
 		}
 		want := "a\n<<<<<<< ours\nB\n=======\nXX\n>>>>>>> theirs\nc\n"
-		if out.ConflictBody != want {
-			t.Errorf("conflict body mismatch\n  want: %q\n  got:  %q", want, out.ConflictBody)
-		}
-		// Only one publish (the initial) — merged version was never sent.
-		if len(c.publishedBody) != 1 {
-			t.Errorf("want 1 publish call, got %d", len(c.publishedBody))
+		if out.Body != want {
+			t.Errorf("body mismatch\n  want: %q\n  got:  %q", want, out.Body)
 		}
 	})
 
-	t.Run("third writer slips in, merge loop resolves", func(t *testing.T) {
-		// Agent edits v5 → "a\nB\nc\n".
-		// Latest is v6 ("a\nb\nC\n"). First merge yields "a\nB\nC\n", republish.
-		// Third writer pushed v7 ("a\nb\nC\nadded\n") in the meantime.
-		// Republish conflicts. Re-merge: base=v6, ours="a\nB\nC\n", theirs=v7.
-		// diff3 yields "a\nB\nC\nadded\n". Republish at v7 succeeds.
+	t.Run("create-only conflict merges against empty base", func(t *testing.T) {
+		// Agent tries to create with body "x\ny\n", but doc already exists
+		// at v3 with body "x\nz\n". With empty base, ours and theirs both
+		// add lines starting from nothing — diff3 detects overlap.
+		c := &stubClient{
+			currentDocs: []Doc{
+				{Status: "ok", Body: "x\nz\n", Version: 3},
+			},
+			publishResults: []PublishResult{
+				{Status: "conflict", ServerVersion: 3},
+			},
+		}
+		out, err := Candidate(c, "/p", "x\ny\n", 0, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out.Status != OutcomeCandidate {
+			t.Errorf("want OutcomeCandidate, got %s", out.Status)
+		}
+		if out.BaseVersion != 0 {
+			t.Errorf("want BaseVersion=0, got %d", out.BaseVersion)
+		}
+		if out.PublishAtVersion != 3 {
+			t.Errorf("want PublishAtVersion=3, got %d", out.PublishAtVersion)
+		}
+	})
+
+	t.Run("invalid expected_version", func(t *testing.T) {
+		_, err := Candidate(&stubClient{}, "/p", "b", -1, nil)
+		if !errors.Is(err, ErrInvalidExpectedVersion) {
+			t.Errorf("want ErrInvalidExpectedVersion, got %v", err)
+		}
+	})
+
+	t.Run("metadata is forwarded on publish", func(t *testing.T) {
+		c := &stubClient{
+			publishResults: []PublishResult{{Status: "ok", Version: 6}},
+		}
+		meta := map[string]string{"agent": "test"}
+		_, err := Candidate(c, "/p", "body", 5, meta)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := c.publishedMeta[0]["agent"]; got != "test" {
+			t.Errorf("agent metadata lost: %q", got)
+		}
+	})
+
+	t.Run("base fetch failure propagates", func(t *testing.T) {
+		c := &stubClient{
+			publishResults: []PublishResult{
+				{Status: "conflict", ServerVersion: 6},
+			},
+			fetchErr: errors.New("network down"),
+		}
+		_, err := Candidate(c, "/p", "body", 5, nil)
+		if err == nil {
+			t.Fatal("expected error from base fetch")
+		}
+	})
+
+	t.Run("agent loop simulation: re-call with candidate body succeeds", func(t *testing.T) {
+		// Round 1: publish v5 → conflict, get candidate at v6.
+		// Round 2: agent reviews candidate, calls Candidate again
+		// with the candidate body and PublishAtVersion=6 → succeeds.
 		c := &stubClient{
 			versionedDocs: map[int]Doc{
 				5: {Status: "ok", Body: "a\nb\nc\n", Version: 5},
 			},
 			currentDocs: []Doc{
 				{Status: "ok", Body: "a\nb\nC\n", Version: 6},
-				{Status: "ok", Body: "a\nb\nC\nadded\n", Version: 7},
-			},
-			publishResults: []PublishResult{
-				{Status: "conflict", ServerVersion: 6}, // initial
-				{Status: "conflict", ServerVersion: 7}, // first merged retry
-				{Status: "ok", Version: 8},             // second merged retry
-			},
-		}
-		out, err := MergeAndPublish(c, "/p", "a\nB\nc\n", 5, 3, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if out.Status != OutcomeOK {
-			t.Fatalf("want OutcomeOK, got %s", out.Status)
-		}
-		if out.Retries != 2 {
-			t.Errorf("want Retries=2, got %d", out.Retries)
-		}
-		if got := c.publishedBody[2]; got != "a\nB\nC\nadded\n" {
-			t.Errorf("final body: want %q, got %q", "a\nB\nC\nadded\n", got)
-		}
-		if got := c.publishedExp[2]; got != 7 {
-			t.Errorf("final publish expected_version: want 7, got %d", got)
-		}
-	})
-
-	t.Run("contention exhausts retries", func(t *testing.T) {
-		c := &stubClient{
-			versionedDocs: map[int]Doc{
-				5: {Status: "ok", Body: "x\n", Version: 5},
-			},
-			currentDocs: []Doc{
-				{Status: "ok", Body: "x\n", Version: 6},
-				{Status: "ok", Body: "x\n", Version: 7},
-				{Status: "ok", Body: "x\n", Version: 8},
-			},
-			publishResults: []PublishResult{
-				{Status: "conflict", ServerVersion: 6}, // initial
-				{Status: "conflict", ServerVersion: 7},
-				{Status: "conflict", ServerVersion: 8},
-				{Status: "conflict", ServerVersion: 9},
-			},
-		}
-		out, err := MergeAndPublish(c, "/p", "y\n", 5, 3, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if out.Status != OutcomeContention {
-			t.Errorf("want OutcomeContention, got %s", out.Status)
-		}
-		if out.Retries != 3 {
-			t.Errorf("want Retries=3, got %d", out.Retries)
-		}
-		if out.TheirVersion != 8 {
-			t.Errorf("want TheirVersion=8 (last fetched), got %d", out.TheirVersion)
-		}
-	})
-
-	t.Run("create-only conflict returns OutcomeConflict without merge", func(t *testing.T) {
-		c := &stubClient{
-			publishResults: []PublishResult{
-				{Status: "conflict", ServerVersion: 3},
-			},
-		}
-		out, err := MergeAndPublish(c, "/p", "body", 0, 3, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if out.Status != OutcomeConflict {
-			t.Errorf("want OutcomeConflict, got %s", out.Status)
-		}
-		if out.Merged {
-			t.Error("expected_version=0 path should never merge")
-		}
-		if out.TheirVersion != 3 {
-			t.Errorf("want TheirVersion=3, got %d", out.TheirVersion)
-		}
-	})
-
-	t.Run("invalid expected_version", func(t *testing.T) {
-		_, err := MergeAndPublish(&stubClient{}, "/p", "b", -1, 3, nil)
-		if !errors.Is(err, ErrInvalidExpectedVersion) {
-			t.Errorf("want ErrInvalidExpectedVersion, got %v", err)
-		}
-	})
-
-	t.Run("metadata is forwarded on every publish", func(t *testing.T) {
-		c := &stubClient{
-			versionedDocs: map[int]Doc{
-				5: {Status: "ok", Body: "a\n"},
-			},
-			currentDocs: []Doc{
-				{Status: "ok", Body: "a\nB\n", Version: 6},
 			},
 			publishResults: []PublishResult{
 				{Status: "conflict", ServerVersion: 6},
 				{Status: "ok", Version: 7},
 			},
 		}
-		meta := map[string]string{"agent": "test"}
-		_, err := MergeAndPublish(c, "/p", "a\n", 5, 3, meta)
+		out1, err := Candidate(c, "/p", "a\nB\nc\n", 5, nil)
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatalf("round 1: %v", err)
 		}
-		for i, m := range c.publishedMeta {
-			if m["agent"] != "test" {
-				t.Errorf("publish #%d: agent metadata lost: %v", i, m)
-			}
+		if out1.Status != OutcomeCandidate {
+			t.Fatalf("round 1: want OutcomeCandidate, got %s", out1.Status)
+		}
+
+		// Agent's semantic verification is a no-op for this test.
+		out2, err := Candidate(c, "/p", out1.Body, out1.PublishAtVersion, nil)
+		if err != nil {
+			t.Fatalf("round 2: %v", err)
+		}
+		if out2.Status != OutcomeOK {
+			t.Errorf("round 2: want OutcomeOK, got %s", out2.Status)
+		}
+		if out2.Publish.Version != 7 {
+			t.Errorf("round 2: want version 7, got %d", out2.Publish.Version)
+		}
+		if got := c.publishedExp[1]; got != 6 {
+			t.Errorf("round 2: expected_version sent = %d, want 6", got)
+		}
+		if got := c.publishedBody[1]; got != "a\nB\nC\n" {
+			t.Errorf("round 2: body sent = %q, want %q", got, "a\nB\nC\n")
 		}
 	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * mark_publish gains an on_conflict="merge" option that performs automatic three-way merges and surfaces merged content.
  * Merge outcomes include merged body, conflict markers (when present), and version details (base/their/published).

* **Bug Fixes**
  * Invalid on_conflict values now return a clear tool error.
  * Server-returned metadata is preserved and shown in publish results.

* **Documentation**
  * mark_publish docs updated to describe on_conflict choices, retry behavior, and conflict-marker semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->