### PR TITLE
feat(client): Add on_conflict option to mark_publish with merge as default

### DIFF
--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -220,7 +220,7 @@ func markPublishTool(host string) mcp.Tool {
 			mcp.Description("version number from a prior fetch for conflict detection; use 0 when creating a new document"),
 		),
 		mcp.WithString("on_conflict",
-			mcp.Description("conflict behavior: \"fail\" (default) or \"merge\" (diff3 merge with retry, escalates to git-style markers on overlap)"),
+			mcp.Description("conflict behavior: \"merge\" (default) returns a structurally-merged candidate body the agent verifies and republishes; \"fail\" opts out and returns the raw conflict status"),
 		),
 	)
 }

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -201,10 +201,11 @@ func markPublishTool(host string) mcp.Tool {
 				"Use 0 when creating a new document. "+
 				"on_conflict controls behavior when the version check fails. Default \"merge\" "+
 				"returns a structurally-merged candidate body (with git-style conflict markers "+
-				"if both sides edited the same lines) for the agent to semantically verify and "+
-				"republish at publish-at-version — preventing the silent content loss that "+
-				"happens when callers naively republish their stale body. Pass \"fail\" to opt "+
-				"out and get the strict conflict response with no merge attempt. "+
+				"if both sides edited the same lines) for the agent to semantically verify, "+
+				"then call mark_publish again with expected_version set to the returned "+
+				"publish-at-version. This prevents the silent content loss that happens when "+
+				"callers naively republish their stale body. Pass \"fail\" to opt out and get "+
+				"the strict conflict response with no merge attempt. "+
 				urlHint(host),
 		),
 		mcp.WithString("url",
@@ -220,7 +221,7 @@ func markPublishTool(host string) mcp.Tool {
 			mcp.Description("version number from a prior fetch for conflict detection; use 0 when creating a new document"),
 		),
 		mcp.WithString("on_conflict",
-			mcp.Description("conflict behavior: \"merge\" (default) returns a structurally-merged candidate body the agent verifies and republishes; \"fail\" opts out and returns the raw conflict status"),
+			mcp.Description("conflict behavior: \"merge\" (default) returns a merge-candidate body; the agent reviews it (resolving any conflict markers) and calls mark_publish again with expected_version set to the returned publish-at-version. \"fail\" opts out and returns the raw conflict status."),
 		),
 	)
 }

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -456,6 +456,12 @@ func (h *handler) markPublish(ctx context.Context, req mcp.CallToolRequest) (*mc
 	if err != nil {
 		return mcp.NewToolResultError("expected_version is required"), nil
 	}
+	// Validate before the on_conflict switch so both branches (merge and
+	// fail) reject invalid input the same way and surface a clear local
+	// error rather than forwarding it to the server.
+	if expectedVersion < 0 {
+		return mcp.NewToolResultError("expected_version must be >= 0"), nil
+	}
 
 	// Default is "merge": on conflict, return a structurally-merged candidate
 	// for the agent to verify and republish. Callers wanting the strict

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -468,8 +468,14 @@ func (h *handler) markPublish(ctx context.Context, req mcp.CallToolRequest) (*mc
 	// optimistic-concurrency behavior (a hard conflict response with no merge
 	// attempt) opt out with on_conflict: "fail". Default flipped because the
 	// whole point of the feature is preventing content loss; "fail" left as
-	// default would mean naive callers never benefit.
-	onConflict := req.GetString("on_conflict", "merge")
+	// default would mean naive callers never benefit. An explicit empty or
+	// whitespace-only value is normalized to the default — MCP clients
+	// commonly send blank strings for optional fields, and rejecting them
+	// would turn the default path into a needless tool error.
+	onConflict := strings.TrimSpace(req.GetString("on_conflict", "merge"))
+	if onConflict == "" {
+		onConflict = "merge"
+	}
 	switch onConflict {
 	case "fail":
 		// fall through to plain publish

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -199,10 +199,12 @@ func markPublishTool(host string) mcp.Tool {
 				"number from a prior fetch to detect conflicts. If the document has been "+
 				"modified since that version, the server returns a conflict status. "+
 				"Use 0 when creating a new document. "+
-				"on_conflict controls behavior when the version check fails: \"fail\" (default) "+
-				"returns the conflict as today; \"merge\" returns a structurally-merged candidate "+
-				"body (with git-style conflict markers if both sides edited the same lines) for "+
-				"the agent to semantically verify and republish at publish-at-version. "+
+				"on_conflict controls behavior when the version check fails. Default \"merge\" "+
+				"returns a structurally-merged candidate body (with git-style conflict markers "+
+				"if both sides edited the same lines) for the agent to semantically verify and "+
+				"republish at publish-at-version — preventing the silent content loss that "+
+				"happens when callers naively republish their stale body. Pass \"fail\" to opt "+
+				"out and get the strict conflict response with no merge attempt. "+
 				urlHint(host),
 		),
 		mcp.WithString("url",
@@ -454,7 +456,13 @@ func (h *handler) markPublish(ctx context.Context, req mcp.CallToolRequest) (*mc
 		return mcp.NewToolResultError("expected_version is required"), nil
 	}
 
-	onConflict := req.GetString("on_conflict", "fail")
+	// Default is "merge": on conflict, return a structurally-merged candidate
+	// for the agent to verify and republish. Callers wanting the strict
+	// optimistic-concurrency behavior (a hard conflict response with no merge
+	// attempt) opt out with on_conflict: "fail". Default flipped because the
+	// whole point of the feature is preventing content loss; "fail" left as
+	// default would mean naive callers never benefit.
+	onConflict := req.GetString("on_conflict", "merge")
 	switch onConflict {
 	case "fail":
 		// fall through to plain publish

--- a/client/cmd/demarkus-mcp/main_test.go
+++ b/client/cmd/demarkus-mcp/main_test.go
@@ -1395,6 +1395,97 @@ func TestHandlerMarkPublish_OnConflictInvalid(t *testing.T) {
 	assertIsToolError(t, result, "invalid on_conflict")
 }
 
+func TestHandlerMarkPublish_DefaultIsMerge(t *testing.T) {
+	// Omitting on_conflict should follow the merge path: a server conflict
+	// returns a structurally-merged candidate, not a flat conflict response.
+	// This is the default-flip in v0.12.26 — protective behavior by default.
+	sc := &stubClient{
+		fetchFn: func(_, path, _ string) (fetch.Result, error) {
+			switch path {
+			case "/doc.md/v5":
+				return fetch.Result{Response: protocol.Response{
+					Status:   protocol.StatusOK,
+					Metadata: map[string]string{"version": "5"},
+					Body:     "a\nb\nc\n",
+				}}, nil
+			case "/doc.md":
+				return fetch.Result{Response: protocol.Response{
+					Status:   protocol.StatusOK,
+					Metadata: map[string]string{"version": "6"},
+					Body:     "a\nb\nC\n",
+				}}, nil
+			}
+			return fetch.Result{}, nil
+		},
+		publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusConflict,
+				Metadata: map[string]string{"server-version": "6"},
+			}}, nil
+		},
+	}
+
+	h := &handler{client: sc, token: "test"}
+	result, err := h.markPublish(context.Background(), newCallToolRequest(map[string]any{
+		"url":              "mark://example.com/doc.md",
+		"body":             "a\nB\nc\n",
+		"expected_version": float64(5),
+		// on_conflict deliberately omitted — default should be merge.
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, "status: merge-candidate") {
+		t.Errorf("default behavior should be merge, got:\n%s", text)
+	}
+}
+
+func TestHandlerMarkPublish_OnConflictFail_OptOut(t *testing.T) {
+	// Explicit on_conflict: "fail" preserves strict optimistic-concurrency
+	// semantics — a server conflict reaches the agent verbatim, no diff3.
+	var fetchCalls int
+	sc := &stubClient{
+		fetchFn: func(_, _, _ string) (fetch.Result, error) {
+			fetchCalls++
+			return fetch.Result{}, nil
+		},
+		publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusConflict,
+				Metadata: map[string]string{"server-version": "6", "your-version": "5"},
+			}}, nil
+		},
+	}
+
+	h := &handler{client: sc, token: "test"}
+	result, err := h.markPublish(context.Background(), newCallToolRequest(map[string]any{
+		"url":              "mark://example.com/doc.md",
+		"body":             "x",
+		"expected_version": float64(5),
+		"on_conflict":      "fail",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	if fetchCalls != 0 {
+		t.Errorf("fail mode must not fetch base/current; saw %d fetches", fetchCalls)
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, "status: conflict") {
+		t.Errorf("fail mode should surface raw conflict status, got:\n%s", text)
+	}
+	if strings.Contains(text, "merge-candidate") {
+		t.Errorf("fail mode must not produce a merge candidate, got:\n%s", text)
+	}
+}
+
 func TestHandlerMarkPublish_OnConflictMergeFirstTrySuccess(t *testing.T) {
 	// When the initial publish succeeds, the merge path returns a plain
 	// success — no candidate, no markers, no diff3 invoked.

--- a/client/cmd/demarkus-mcp/main_test.go
+++ b/client/cmd/demarkus-mcp/main_test.go
@@ -1395,6 +1395,31 @@ func TestHandlerMarkPublish_OnConflictInvalid(t *testing.T) {
 	assertIsToolError(t, result, "invalid on_conflict")
 }
 
+func TestHandlerMarkPublish_NegativeExpectedVersionRejected(t *testing.T) {
+	// expected_version < 0 must be rejected at the handler level on both
+	// the merge path (where merge.Candidate would catch it) and the fail
+	// path (which would otherwise forward the invalid value to the server).
+	// Same input, same error, regardless of on_conflict.
+	for _, onConflict := range []string{"", "merge", "fail"} {
+		t.Run("on_conflict="+onConflict, func(t *testing.T) {
+			args := map[string]any{
+				"url":              "mark://example.com/doc.md",
+				"body":             "x",
+				"expected_version": float64(-1),
+			}
+			if onConflict != "" {
+				args["on_conflict"] = onConflict
+			}
+			h := &handler{client: &stubClient{}, token: "test"}
+			result, err := h.markPublish(context.Background(), newCallToolRequest(args))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			assertIsToolError(t, result, "expected_version must be >= 0")
+		})
+	}
+}
+
 func TestHandlerMarkPublish_DefaultIsMerge(t *testing.T) {
 	// Omitting on_conflict should follow the merge path: a server conflict
 	// returns a structurally-merged candidate, not a flat conflict response.

--- a/client/cmd/demarkus-mcp/main_test.go
+++ b/client/cmd/demarkus-mcp/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -1416,6 +1417,41 @@ func TestHandlerMarkPublish_NegativeExpectedVersionRejected(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertIsToolError(t, result, "expected_version must be >= 0")
+		})
+	}
+}
+
+func TestHandlerMarkPublish_BlankOnConflictUsesDefault(t *testing.T) {
+	// MCP clients commonly send blank strings for optional fields. An
+	// explicit empty or whitespace-only on_conflict should behave like
+	// omission (default "merge"), not produce an invalid-value error.
+	for _, blank := range []string{"", " ", "\t"} {
+		t.Run(fmt.Sprintf("on_conflict=%q", blank), func(t *testing.T) {
+			sc := &stubClient{
+				publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
+					// Return ok so we don't need fetch fixtures — we just
+					// want to verify the request was routed to the merge
+					// branch (which short-circuits to OutcomeOK on success)
+					// rather than rejected as invalid.
+					return fetch.Result{Response: protocol.Response{
+						Status:   protocol.StatusCreated,
+						Metadata: map[string]string{"version": "1"},
+					}}, nil
+				},
+			}
+			h := &handler{client: sc, token: "test"}
+			result, err := h.markPublish(context.Background(), newCallToolRequest(map[string]any{
+				"url":              "mark://example.com/doc.md",
+				"body":             "x",
+				"expected_version": float64(0),
+				"on_conflict":      blank,
+			}))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("blank on_conflict should not error; got: %v", result.Content)
+			}
 		})
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conflict-aware publish flow: conflicts now produce a merge candidate by default (on_conflict default: "merge"); set on_conflict="fail" to opt out and receive a plain conflict result.
  * Preserves server-provided metadata through the merge/publish flow.

* **Bug Fixes**
  * Rejects negative expected_version values at the handler level.

* **Tests**
  * Added tests for default merge behavior, explicit fail opt-out, successful publish flows, metadata preservation, and negative expected_version validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->