### PR TITLE
fix(client):  Implement idempotent hub index publishing semantics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,8 @@ client: protocol
 	cd client && go build -o bin/demarkus ./cmd/demarkus
 	cd client && go build -o bin/demarkus-tui ./cmd/demarkus-tui
 	cd client && go build -ldflags "-X main.version=$(VERSION)" -o bin/demarkus-mcp ./cmd/demarkus-mcp
-	@echo "✓ Client built: client/bin/demarkus, client/bin/demarkus-tui, client/bin/demarkus-mcp"
+	cd client && go build -ldflags "-X main.version=$(VERSION)" -o bin/demarkus-agent ./cmd/demarkus-agent
+	@echo "✓ Client built: client/bin/demarkus, client/bin/demarkus-tui, client/bin/demarkus-mcp, client/bin/demarkus-agent"
 
 # Build tools
 tools:

--- a/client/internal/fedcrawl/crawl.go
+++ b/client/internal/fedcrawl/crawl.go
@@ -456,23 +456,25 @@ type PublishClient interface {
 }
 
 // publishIndex publishes a single index document to a hub.
+// Hub indexes are regenerated whole-doc each crawl cycle, so we use
+// expected_version=-1 (no check) for idempotent re-publish. The server's
+// no-op-on-duplicate-content behavior prevents version churn when the
+// computed index is identical to the previous run.
 func (c *Crawler) publishIndex(ctx context.Context, client PublishClient, host, path, body, token string) error {
-	// Check context
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
 
-	// For now, we create new indexes (expected_version=0)
-	// In the future, we could fetch existing and merge
-	result, err := client.Publish(host, path, body, token, 0, map[string]string{
+	result, err := client.Publish(host, path, body, token, -1, map[string]string{
 		"agent": "demarkus-agent",
 	})
 	if err != nil {
 		return err
 	}
 
-	if result.Response.Status != protocol.StatusOK {
-		return fmt.Errorf("publish returned %s", result.Response.Status)
+	status := result.Response.Status
+	if status != protocol.StatusOK && status != protocol.StatusCreated {
+		return fmt.Errorf("publish returned %s", status)
 	}
 
 	return nil

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -18,7 +18,8 @@ type mockClient struct {
 	calls []string
 
 	// publishStatuses overrides the default created-on-publish behavior.
-	// Map from path -> status returned by Publish.
+	// Keyed by host+path so multi-hub tests can model per-hub status differences
+	// when several hubs share the same target path (e.g. /index.md).
 	publishStatuses map[string]string
 	publishes       []publishCall
 }
@@ -57,7 +58,7 @@ func (m *mockClient) Publish(host, path, body, token string, expectedVersion int
 		ExpectedVersion: expectedVersion,
 	})
 	status := protocol.StatusCreated
-	if s, ok := m.publishStatuses[path]; ok {
+	if s, ok := m.publishStatuses[host+path]; ok {
 		status = s
 	}
 	return fetch.Result{Response: protocol.Response{Status: status}}, nil
@@ -397,7 +398,7 @@ func TestPublishIndex(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := newMockClient()
-			client.publishStatuses["/index.md"] = tt.status
+			client.publishStatuses["hub.example.com:6309/index.md"] = tt.status
 
 			crawler := NewCrawler(DefaultConfig(), client, nil, nil)
 			err := crawler.publishIndex(context.Background(), client, "hub.example.com:6309", "/index.md", "# Index\n", "tok")
@@ -443,7 +444,7 @@ func TestPublishIndexRePublish(t *testing.T) {
 	}
 
 	client.mu.Lock()
-	client.publishStatuses["/index.md"] = protocol.StatusOK
+	client.publishStatuses["hub.example.com:6309/index.md"] = protocol.StatusOK
 	client.mu.Unlock()
 
 	if err := crawler.publishIndex(context.Background(), client, "hub.example.com:6309", "/index.md", "# v2\n", "tok"); err != nil {
@@ -528,6 +529,14 @@ func TestPublishToHubs(t *testing.T) {
 		}
 		if count != 2 {
 			t.Errorf("count = %d, want 2", count)
+		}
+		if len(client.publishes) != 2 {
+			t.Fatalf("expected 2 publishes, got %d", len(client.publishes))
+		}
+		for i, call := range client.publishes {
+			if call.ExpectedVersion != -1 {
+				t.Errorf("publishes[%d].ExpectedVersion = %d, want -1 (no-check)", i, call.ExpectedVersion)
+			}
 		}
 	})
 }

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -453,6 +453,11 @@ func TestPublishIndexRePublish(t *testing.T) {
 	if len(client.publishes) != 2 {
 		t.Fatalf("expected 2 publishes, got %d", len(client.publishes))
 	}
+	for i, call := range client.publishes {
+		if call.ExpectedVersion != -1 {
+			t.Errorf("publishes[%d].ExpectedVersion = %d, want -1 (no-check) for idempotent re-publish", i, call.ExpectedVersion)
+		}
+	}
 }
 
 func TestPublishToHubs(t *testing.T) {

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -10,12 +10,17 @@ import (
 	"github.com/latebit/demarkus/protocol"
 )
 
-// mockClient implements FetchClient for testing.
+// mockClient implements FetchClient and PublishClient for testing.
 type mockClient struct {
 	mu    sync.Mutex
 	pages map[string]mockPage // keyed by "host/path"
 	lists map[string]mockPage // keyed by "host/path" for LIST results
 	calls []string
+
+	// publishStatuses overrides the default created-on-publish behavior.
+	// Map from path -> status returned by Publish.
+	publishStatuses map[string]string
+	publishes       []publishCall
 }
 
 type mockPage struct {
@@ -24,11 +29,38 @@ type mockPage struct {
 	metadata map[string]string
 }
 
+type publishCall struct {
+	Host            string
+	Path            string
+	Body            string
+	Token           string
+	ExpectedVersion int
+}
+
 func newMockClient() *mockClient {
 	return &mockClient{
-		pages: make(map[string]mockPage),
-		lists: make(map[string]mockPage),
+		pages:           make(map[string]mockPage),
+		lists:           make(map[string]mockPage),
+		publishStatuses: make(map[string]string),
 	}
+}
+
+func (m *mockClient) Publish(host, path, body, token string, expectedVersion int, _ map[string]string) (fetch.Result, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, "PUBLISH "+host+path)
+	m.publishes = append(m.publishes, publishCall{
+		Host:            host,
+		Path:            path,
+		Body:            body,
+		Token:           token,
+		ExpectedVersion: expectedVersion,
+	})
+	status := protocol.StatusCreated
+	if s, ok := m.publishStatuses[path]; ok {
+		status = s
+	}
+	return fetch.Result{Response: protocol.Response{Status: status}}, nil
 }
 
 func (m *mockClient) addDoc(host, path, body, hash string) {
@@ -347,6 +379,152 @@ func TestCrawlerWithState(t *testing.T) {
 	if u.ContentHash != "sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
 		t.Errorf("ContentHash = %q, want sha256-aaa...", u.ContentHash)
 	}
+}
+
+func TestPublishIndex(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     string
+		wantErr    bool
+		wantErrSub string
+	}{
+		{name: "created status accepted (first publish)", status: protocol.StatusCreated},
+		{name: "ok status accepted (re-publish or no-op)", status: protocol.StatusOK},
+		{name: "conflict status surfaces error", status: protocol.StatusConflict, wantErr: true, wantErrSub: "conflict"},
+		{name: "not-found status surfaces error", status: protocol.StatusNotFound, wantErr: true, wantErrSub: "not-found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newMockClient()
+			client.publishStatuses["/index.md"] = tt.status
+
+			crawler := NewCrawler(DefaultConfig(), client, nil, nil)
+			err := crawler.publishIndex(context.Background(), client, "hub.example.com:6309", "/index.md", "# Index\n", "tok")
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.wantErrSub != "" && !containsMiddle(err.Error(), tt.wantErrSub) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(client.publishes) != 1 {
+				t.Fatalf("expected 1 publish, got %d", len(client.publishes))
+			}
+			call := client.publishes[0]
+			if call.ExpectedVersion != -1 {
+				t.Errorf("ExpectedVersion = %d, want -1 (no-check) for idempotent re-publish", call.ExpectedVersion)
+			}
+			if call.Path != "/index.md" {
+				t.Errorf("Path = %q, want /index.md", call.Path)
+			}
+			if call.Token != "tok" {
+				t.Errorf("Token = %q, want tok", call.Token)
+			}
+		})
+	}
+}
+
+func TestPublishIndexRePublish(t *testing.T) {
+	// Two consecutive publishes to the same path: first returns created,
+	// second returns ok. Both must succeed (the daemon-mode case).
+	client := newMockClient()
+	crawler := NewCrawler(DefaultConfig(), client, nil, nil)
+
+	if err := crawler.publishIndex(context.Background(), client, "hub.example.com:6309", "/index.md", "# v1\n", "tok"); err != nil {
+		t.Fatalf("first publish: %v", err)
+	}
+
+	client.mu.Lock()
+	client.publishStatuses["/index.md"] = protocol.StatusOK
+	client.mu.Unlock()
+
+	if err := crawler.publishIndex(context.Background(), client, "hub.example.com:6309", "/index.md", "# v2\n", "tok"); err != nil {
+		t.Fatalf("second publish: %v", err)
+	}
+
+	if len(client.publishes) != 2 {
+		t.Fatalf("expected 2 publishes, got %d", len(client.publishes))
+	}
+}
+
+func TestPublishToHubs(t *testing.T) {
+	t.Run("no hubs returns zero publishes", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Seeds = []string{"mark://example.com"}
+		// no hubs configured
+		client := newMockClient()
+		crawler := NewCrawler(cfg, client, nil, nil)
+		count, err := crawler.PublishToHubs(context.Background(), client, false)
+		if err != nil {
+			t.Fatalf("PublishToHubs() error: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("count = %d, want 0", count)
+		}
+		if len(client.publishes) != 0 {
+			t.Errorf("expected 0 publishes, got %d", len(client.publishes))
+		}
+	})
+
+	t.Run("aggregated mode publishes single /index.md", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Seeds = []string{"mark://example.com"}
+		cfg.Hubs = []string{"mark://hub.example.com"}
+
+		client := newMockClient()
+		client.addList("example.com:6309", "/", "- [a.md](a.md)\n")
+		client.addDoc("example.com:6309", "/a.md", "# A", "sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+		crawler := NewCrawler(cfg, client, nil, nil)
+		if _, err := crawler.Run(context.Background()); err != nil {
+			t.Fatalf("Run() error: %v", err)
+		}
+		count, err := crawler.PublishToHubs(context.Background(), client, false)
+		if err != nil {
+			t.Fatalf("PublishToHubs() error: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("count = %d, want 1", count)
+		}
+		if len(client.publishes) != 1 {
+			t.Fatalf("expected 1 publish, got %d", len(client.publishes))
+		}
+		if client.publishes[0].Path != "/index.md" {
+			t.Errorf("publish path = %q, want /index.md", client.publishes[0].Path)
+		}
+	})
+
+	t.Run("per-server mode publishes one index per discovered server", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Seeds = []string{"mark://a.example.com", "mark://b.example.com"}
+		cfg.Hubs = []string{"mark://hub.example.com"}
+
+		client := newMockClient()
+		client.addList("a.example.com:6309", "/", "- [doc.md](doc.md)\n")
+		client.addDoc("a.example.com:6309", "/doc.md", "# A", "sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+		client.addList("b.example.com:6309", "/", "- [doc.md](doc.md)\n")
+		client.addDoc("b.example.com:6309", "/doc.md", "# B", "sha256-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+		crawler := NewCrawler(cfg, client, nil, nil)
+		if _, err := crawler.Run(context.Background()); err != nil {
+			t.Fatalf("Run() error: %v", err)
+		}
+		count, err := crawler.PublishToHubs(context.Background(), client, true)
+		if err != nil {
+			t.Fatalf("PublishToHubs() error: %v", err)
+		}
+		if count != 2 {
+			t.Errorf("count = %d, want 2", count)
+		}
+	})
 }
 
 func contains(s, substr string) bool {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  - Client build now produces an additional agent binary and updates the build success message.
  - Index publishing treats both "created" and "ok" as success and surfaces clearer error messages on failure.
* **Bug Fixes**
  - Re-publishes use idempotent semantics to avoid version conflicts.
* **Tests**
  - Added tests covering publish semantics, re-publish behavior, and hub publishing modes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/105)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->