### PR TITLE
fix(agent):  Add Helm chart for demarkus-agent Kubernetes workload

### DIFF
--- a/deploy/helm/demarkus-agent/.helmignore
+++ b/deploy/helm/demarkus-agent/.helmignore
@@ -1,0 +1,12 @@
+# Patterns to ignore when building Helm packages.
+.DS_Store
+.git/
+.gitignore
+.idea/
+.vscode/
+*.swp
+*.tmp
+*.bak
+*.orig
+*.tgz
+tests/

--- a/deploy/helm/demarkus-agent/Chart.yaml
+++ b/deploy/helm/demarkus-agent/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: demarkus-agent
+description: |
+  Federation crawler for the Mark Protocol. Discovers servers, collects content
+  hashes, and publishes aggregated or per-server indexes to one or more hubs.
+type: application
+version: 0.1.0
+appVersion: "0.7.1"
+keywords:
+  - demarkus
+  - mark-protocol
+  - federation
+  - crawler
+home: https://demarkus.io
+sources:
+  - https://github.com/latebit-io/demarkus
+maintainers:
+  - name: latebit-io
+    url: https://github.com/latebit-io

--- a/deploy/helm/demarkus-agent/README.md
+++ b/deploy/helm/demarkus-agent/README.md
@@ -1,0 +1,95 @@
+# demarkus-agent Helm chart
+
+Deploys [demarkus-agent](https://github.com/latebit-io/demarkus) as a federation crawler in Kubernetes. The agent crawls a list of seed Mark Protocol servers, collects content hashes, and publishes aggregated (or per-server) indexes to one or more hubs on a schedule.
+
+## Quick start
+
+```bash
+helm install agent ./deploy/helm/demarkus-agent \
+  --set 'config.seeds[0]=mark://team-a.example.com:6309' \
+  --set 'config.seeds[1]=mark://team-b.example.com:6309' \
+  --set 'config.hubs[0]=mark://hub.example.com:6309' \
+  --set 'tokens.inline.hub\.example\.com:6309=<write-token>' \
+  --set config.schedule.interval=15m
+```
+
+For private seeds (read-auth enabled), add a token entry for that host as well.
+
+## Values
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `image.repository` | string | `ghcr.io/latebit-io/demarkus-agent` | Container image |
+| `image.tag` | string | `""` (uses `.Chart.AppVersion`) | Image tag |
+| `image.pullPolicy` | string | `IfNotPresent` | |
+| `replicaCount` | int | `1` | Keep at 1 — multiple replicas re-do the same crawl |
+| `config.seeds` | list | `[]` | `mark://` URLs to crawl. **Required.** |
+| `config.hubs` | list | `[]` | `mark://` URLs to publish indexes to. Empty = crawl-only mode |
+| `config.crawl.maxDepth` | int | `2` | Max link hops per server |
+| `config.crawl.maxServers` | int | `50` | Max servers to discover per run |
+| `config.crawl.maxDocuments` | int | `1000` | Max documents per crawl run |
+| `config.crawl.workers` | int | `5` | Concurrent fetch goroutines |
+| `config.schedule.interval` | duration | `6h` | Time between crawl runs |
+| `config.politeness.requestDelay` | duration | `100ms` | Delay between requests to same server |
+| `config.politeness.perServerConcurrency` | int | `2` | Max concurrent requests per server |
+| `perServer` | bool | `false` | `true` → one index per server at `/index/<host>.md`; `false` → single aggregated `/index.md` |
+| `insecure` | bool | `false` | Skip TLS cert verification (self-signed dev clusters only) |
+| `tokens.existingSecret` | string | `""` | Name of an existing Secret with key `tokens.toml`. Takes precedence over `tokens.inline` |
+| `tokens.inline` | map | `{}` | Inline `host:port → token` map. Generates `<release>-tokens` Secret |
+| `state.persistent` | bool | `false` | If true, mount a PVC for the crawl-politeness state file |
+| `state.storageClassName` | string | `""` | StorageClass for the state PVC |
+| `state.size` | string | `1Gi` | PVC size |
+| `resources` | object | `50m/64Mi → 500m/256Mi` | Resource requests/limits |
+| `serviceAccount.create` | bool | `true` | |
+| `serviceAccount.name` | string | `""` (auto) | |
+| `serviceAccount.workloadIdentity.gsa` | string | `""` | GKE Workload Identity GSA binding |
+| `podSecurityContext` | object | non-root user 65532 | Pod-level security |
+| `securityContext` | object | read-only root FS, drop all caps | Container-level security |
+
+## How auth is wired
+
+The agent uses the protocol-client tokens convention. On startup it calls `tokens.LoadDefault()` which reads `~/.mark/tokens.toml`. The chart mounts the tokens Secret at `/home/demarkus/.mark/tokens.toml` and sets `HOME=/home/demarkus`, so the existing code path Just Works.
+
+For a single hub with a single token, you can also set the `DEMARKUS_AUTH` env var via `podAnnotations` or by patching the Deployment — but the file path is preferred for multi-host setups.
+
+## How publishing modes interact
+
+| Setting | What the agent publishes |
+|---|---|
+| `hubs: []` | Nothing. Crawl-only. State is updated. |
+| `hubs: [X]`, `perServer: false` | Single aggregated `/index.md` to each hub |
+| `hubs: [X]`, `perServer: true` | One `/index/<server>.md` per discovered seed, to each hub |
+
+Re-publishing is idempotent: the agent uses `expected_version=-1` (no check), and the server's no-op-on-duplicate-content prevents version churn when the computed index is unchanged.
+
+## Probes
+
+Intentionally omitted. The agent is an outbound scheduled job, not a service. Kubernetes restarts on process exit — the daemon loop logs and continues on transient crawl errors and exits only on configuration / unrecoverable failures. An exec probe would only verify the binary, not crawl health, so it's misleading.
+
+## Persistence
+
+The agent's state file holds per-URL `etag` and last-seen timestamps for crawl politeness (conditional FETCH). It is not authoritative content — losing it just means a fresh crawl on the next tick, no data loss on hubs. Default is ephemeral (`emptyDir`). Set `state.persistent: true` only if you crawl very large universes where the etag cache is worth preserving across restarts.
+
+## Image
+
+The image `ghcr.io/latebit-io/demarkus-agent` is published as part of the release pipeline (see Phase 6.7 in `/plans/universe-deployment.md`). For local development, build with:
+
+```bash
+cd client && go build -o ../demarkus-agent ./cmd/demarkus-agent
+# Build a container image with that binary as ENTRYPOINT
+```
+
+## Tests
+
+Helm unit tests are in `tests/`. Install [helm-unittest](https://github.com/helm-unittest/helm-unittest) and run:
+
+```bash
+helm unittest deploy/helm/demarkus-agent/
+```
+
+## See also
+
+- `/plans/universe-deployment.md` — full Phase 6 plan
+- `/architecture.md#agent-driven-hash-discovery` — federation pattern
+- `client/cmd/demarkus-agent/main.go` — agent CLI
+- `client/internal/fedcrawl/` — crawl + index + publish core

--- a/deploy/helm/demarkus-agent/README.md
+++ b/deploy/helm/demarkus-agent/README.md
@@ -50,7 +50,7 @@ For private seeds (read-auth enabled), add a token entry for that host as well.
 
 The agent uses the protocol-client tokens convention. On startup it calls `tokens.LoadDefault()` which reads `~/.mark/tokens.toml`. The chart mounts the tokens Secret at `/home/demarkus/.mark/tokens.toml` and sets `HOME=/home/demarkus`, so the existing code path Just Works.
 
-For a single hub with a single token, you can also set the `DEMARKUS_AUTH` env var via `podAnnotations` or by patching the Deployment — but the file path is preferred for multi-host setups.
+For a single hub with a single token, you can also set the `DEMARKUS_AUTH` env var by patching the Deployment container `env` — but the file path is preferred for multi-host setups.
 
 ## How publishing modes interact
 

--- a/deploy/helm/demarkus-agent/templates/_helpers.tpl
+++ b/deploy/helm/demarkus-agent/templates/_helpers.tpl
@@ -1,0 +1,71 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "demarkus-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name. Truncated at 63 chars per DNS-1123.
+*/}}
+{{- define "demarkus-agent.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart name and version, used by chart label.
+*/}}
+{{- define "demarkus-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels applied to every resource.
+*/}}
+{{- define "demarkus-agent.labels" -}}
+helm.sh/chart: {{ include "demarkus-agent.chart" . }}
+{{ include "demarkus-agent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels (subset of common labels used for matchLabels / selectors).
+*/}}
+{{- define "demarkus-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "demarkus-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+ServiceAccount name. Defaults to fullname when create=true and name is unset.
+*/}}
+{{- define "demarkus-agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "demarkus-agent.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Tokens Secret name. Either the user-provided existingSecret or <fullname>-tokens.
+*/}}
+{{- define "demarkus-agent.tokensSecretName" -}}
+{{- if .Values.tokens.existingSecret -}}
+{{- .Values.tokens.existingSecret -}}
+{{- else -}}
+{{- printf "%s-tokens" (include "demarkus-agent.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/demarkus-agent/templates/configmap.yaml
+++ b/deploy/helm/demarkus-agent/templates/configmap.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "demarkus-agent.fullname" . }}-config
+  labels:
+    {{- include "demarkus-agent.labels" . | nindent 4 }}
+data:
+  agent.toml: |
+    {{- if .Values.config.seeds }}
+    seeds = [
+      {{- range .Values.config.seeds }}
+      {{ . | quote }},
+      {{- end }}
+    ]
+    {{- else }}
+    seeds = []
+    {{- end }}
+
+    {{- if .Values.config.hubs }}
+    hubs = [
+      {{- range .Values.config.hubs }}
+      {{ . | quote }},
+      {{- end }}
+    ]
+    {{- else }}
+    hubs = []
+    {{- end }}
+
+    [crawl]
+    max_depth = {{ .Values.config.crawl.maxDepth }}
+    max_servers = {{ .Values.config.crawl.maxServers }}
+    max_documents = {{ .Values.config.crawl.maxDocuments }}
+    workers = {{ .Values.config.crawl.workers }}
+
+    [schedule]
+    interval = {{ .Values.config.schedule.interval | quote }}
+
+    [politeness]
+    request_delay = {{ .Values.config.politeness.requestDelay | quote }}
+    per_server_concurrency = {{ .Values.config.politeness.perServerConcurrency }}

--- a/deploy/helm/demarkus-agent/templates/deployment.yaml
+++ b/deploy/helm/demarkus-agent/templates/deployment.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "demarkus-agent.fullname" . }}
+  labels:
+    {{- include "demarkus-agent.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "demarkus-agent.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "demarkus-agent.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if or (not .Values.tokens.existingSecret) .Values.tokens.inline }}
+        checksum/tokens: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "demarkus-agent.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: agent
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          args:
+            - daemon
+            - --config
+            - /etc/demarkus/agent.toml
+            - --state
+            - /var/lib/demarkus/state.json
+            {{- if .Values.config.hubs }}
+            - --publish
+            {{- end }}
+            {{- if .Values.perServer }}
+            - --per-server
+            {{- end }}
+            {{- if .Values.insecure }}
+            - --insecure
+            {{- end }}
+          env:
+            # Ensure tokens.LoadDefault() finds the mounted Secret at ~/.mark/tokens.toml.
+            - name: HOME
+              value: /home/demarkus
+          volumeMounts:
+            - name: config
+              mountPath: /etc/demarkus
+              readOnly: true
+            - name: tokens
+              mountPath: /home/demarkus/.mark
+              readOnly: true
+            - name: state
+              mountPath: /var/lib/demarkus
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "demarkus-agent.fullname" . }}-config
+        - name: tokens
+          secret:
+            secretName: {{ include "demarkus-agent.tokensSecretName" . }}
+            optional: true
+        - name: tmp
+          emptyDir: {}
+        {{- if .Values.state.persistent }}
+        - name: state
+          persistentVolumeClaim:
+            claimName: {{ include "demarkus-agent.fullname" . }}-state
+        {{- else }}
+        - name: state
+          emptyDir: {}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- if .Values.state.persistent }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "demarkus-agent.fullname" . }}-state
+  labels:
+    {{- include "demarkus-agent.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.state.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.state.size }}
+  {{- if .Values.state.storageClassName }}
+  storageClassName: {{ .Values.state.storageClassName | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/demarkus-agent/templates/secret.yaml
+++ b/deploy/helm/demarkus-agent/templates/secret.yaml
@@ -11,5 +11,5 @@ stringData:
     {{- range $hostPort, $token := .Values.tokens.inline }}
     [{{ $hostPort | quote }}]
     token = {{ $token | quote }}
-    {{ end }}
+    {{- end }}
 {{- end }}

--- a/deploy/helm/demarkus-agent/templates/secret.yaml
+++ b/deploy/helm/demarkus-agent/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- if and (not .Values.tokens.existingSecret) .Values.tokens.inline }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "demarkus-agent.tokensSecretName" . }}
+  labels:
+    {{- include "demarkus-agent.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  tokens.toml: |
+    {{- range $hostPort, $token := .Values.tokens.inline }}
+    [{{ $hostPort | quote }}]
+    token = {{ $token | quote }}
+    {{ end }}
+{{- end }}

--- a/deploy/helm/demarkus-agent/templates/secret.yaml
+++ b/deploy/helm/demarkus-agent/templates/secret.yaml
@@ -8,7 +8,8 @@ metadata:
 type: Opaque
 stringData:
   tokens.toml: |
-    {{- range $hostPort, $token := .Values.tokens.inline }}
+    {{- range $hostPort := keys .Values.tokens.inline | sortAlpha }}
+    {{- $token := index $.Values.tokens.inline $hostPort }}
     [{{ $hostPort | quote }}]
     token = {{ $token | quote }}
     {{- end }}

--- a/deploy/helm/demarkus-agent/templates/serviceaccount.yaml
+++ b/deploy/helm/demarkus-agent/templates/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "demarkus-agent.labels" . | nindent 4 }}
   {{- $extraAnnotations := .Values.serviceAccount.annotations | default dict }}
   {{- if .Values.serviceAccount.workloadIdentity.gsa }}
-  {{- $extraAnnotations = merge $extraAnnotations (dict "iam.gke.io/gcp-service-account" .Values.serviceAccount.workloadIdentity.gsa) }}
+  {{- $extraAnnotations = mergeOverwrite $extraAnnotations (dict "iam.gke.io/gcp-service-account" .Values.serviceAccount.workloadIdentity.gsa) }}
   {{- end }}
   {{- if $extraAnnotations }}
   annotations:

--- a/deploy/helm/demarkus-agent/templates/serviceaccount.yaml
+++ b/deploy/helm/demarkus-agent/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "demarkus-agent.serviceAccountName" . }}
+  labels:
+    {{- include "demarkus-agent.labels" . | nindent 4 }}
+  {{- $extraAnnotations := .Values.serviceAccount.annotations | default dict }}
+  {{- if .Values.serviceAccount.workloadIdentity.gsa }}
+  {{- $extraAnnotations = merge $extraAnnotations (dict "iam.gke.io/gcp-service-account" .Values.serviceAccount.workloadIdentity.gsa) }}
+  {{- end }}
+  {{- if $extraAnnotations }}
+  annotations:
+    {{- toYaml $extraAnnotations | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/demarkus-agent/tests/configmap_test.yaml
+++ b/deploy/helm/demarkus-agent/tests/configmap_test.yaml
@@ -1,0 +1,50 @@
+suite: configmap
+templates:
+  - configmap.yaml
+tests:
+  - it: renders agent.toml with seeds and hubs
+    set:
+      config.seeds:
+        - mark://team-a:6309
+        - mark://team-b:6309
+      config.hubs:
+        - mark://hub:6309
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["agent.toml"]
+          pattern: 'seeds = \['
+      - matchRegex:
+          path: data["agent.toml"]
+          pattern: '"mark://team-a:6309"'
+      - matchRegex:
+          path: data["agent.toml"]
+          pattern: '"mark://hub:6309"'
+
+  - it: renders crawl + schedule + politeness blocks with defaults
+    set:
+      config.seeds:
+        - mark://team-a:6309
+    asserts:
+      - matchRegex:
+          path: data["agent.toml"]
+          pattern: 'max_workers? = 5|workers = 5'
+      - matchRegex:
+          path: data["agent.toml"]
+          pattern: 'interval = "6h"'
+      - matchRegex:
+          path: data["agent.toml"]
+          pattern: 'request_delay = "100ms"'
+
+  - it: emits empty arrays when no seeds/hubs configured
+    set:
+      config.seeds: []
+      config.hubs: []
+    asserts:
+      - matchRegex:
+          path: data["agent.toml"]
+          pattern: 'seeds = \[\]'
+      - matchRegex:
+          path: data["agent.toml"]
+          pattern: 'hubs = \[\]'

--- a/deploy/helm/demarkus-agent/tests/configmap_test.yaml
+++ b/deploy/helm/demarkus-agent/tests/configmap_test.yaml
@@ -29,7 +29,7 @@ tests:
     asserts:
       - matchRegex:
           path: data["agent.toml"]
-          pattern: 'max_workers? = 5|workers = 5'
+          pattern: 'workers = 5'
       - matchRegex:
           path: data["agent.toml"]
           pattern: 'interval = "6h"'

--- a/deploy/helm/demarkus-agent/tests/deployment_test.yaml
+++ b/deploy/helm/demarkus-agent/tests/deployment_test.yaml
@@ -1,0 +1,157 @@
+suite: deployment
+templates:
+  - deployment.yaml
+tests:
+  - it: renders a Deployment with correct name and labels
+    set:
+      config.seeds:
+        - mark://team-a:6309
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-demarkus-agent
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: omits --publish when no hubs configured
+    set:
+      config.seeds:
+        - mark://team-a:6309
+      config.hubs: []
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --publish
+
+  - it: includes --publish when hubs configured
+    set:
+      config.seeds:
+        - mark://team-a:6309
+      config.hubs:
+        - mark://hub:6309
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --publish
+
+  - it: includes --per-server when perServer=true
+    set:
+      config.seeds:
+        - mark://team-a:6309
+      config.hubs:
+        - mark://hub:6309
+      perServer: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --per-server
+
+  - it: includes --insecure when insecure=true
+    set:
+      config.seeds:
+        - mark://team-a:6309
+      insecure: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --insecure
+
+  - it: state volume is emptyDir by default
+    set:
+      config.seeds:
+        - mark://team-a:6309
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - exists:
+          path: spec.template.spec.volumes[?(@.name=="state")].emptyDir
+      - notExists:
+          path: spec.template.spec.volumes[?(@.name=="state")].persistentVolumeClaim
+
+  - it: state volume is PVC when persistent=true and emits PVC document
+    set:
+      config.seeds:
+        - mark://team-a:6309
+      state.persistent: true
+      state.storageClassName: premium-rwo
+      state.size: 5Gi
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 1
+        isKind:
+          of: PersistentVolumeClaim
+      - documentIndex: 1
+        equal:
+          path: spec.resources.requests.storage
+          value: 5Gi
+      - documentIndex: 1
+        equal:
+          path: spec.storageClassName
+          value: premium-rwo
+
+  - it: pod-level securityContext only contains pod-supported fields
+    set:
+      config.seeds:
+        - mark://team-a:6309
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - notExists:
+          path: spec.template.spec.securityContext.readOnlyRootFilesystem
+      - notExists:
+          path: spec.template.spec.securityContext.allowPrivilegeEscalation
+
+  - it: container-level securityContext locks down the container
+    set:
+      config.seeds:
+        - mark://team-a:6309
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: tokens volume mounts at /home/demarkus/.mark for tokens.LoadDefault
+    set:
+      config.seeds:
+        - mark://team-a:6309
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tokens
+            mountPath: /home/demarkus/.mark
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HOME
+            value: /home/demarkus

--- a/deploy/helm/demarkus-agent/tests/deployment_test.yaml
+++ b/deploy/helm/demarkus-agent/tests/deployment_test.yaml
@@ -113,6 +113,9 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.runAsNonRoot
           value: true
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
       - notExists:
           path: spec.template.spec.securityContext.readOnlyRootFilesystem
       - notExists:

--- a/deploy/helm/demarkus-agent/tests/secret_test.yaml
+++ b/deploy/helm/demarkus-agent/tests/secret_test.yaml
@@ -1,0 +1,39 @@
+suite: tokens secret
+templates:
+  - secret.yaml
+tests:
+  - it: not rendered when no inline tokens and no existingSecret
+    set:
+      tokens.inline: {}
+      tokens.existingSecret: ""
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: not rendered when existingSecret is set (user-managed)
+    set:
+      tokens.existingSecret: my-tokens
+      tokens.inline:
+        "hub.example.com:6309": tok
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: rendered with TOML structure when inline tokens provided
+    set:
+      tokens.inline:
+        "hub.example.com:6309": secrettoken
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: type
+          value: Opaque
+      - matchRegex:
+          path: stringData["tokens.toml"]
+          pattern: '\["hub.example.com:6309"\]'
+      - matchRegex:
+          path: stringData["tokens.toml"]
+          pattern: 'token = "secrettoken"'

--- a/deploy/helm/demarkus-agent/tests/serviceaccount_test.yaml
+++ b/deploy/helm/demarkus-agent/tests/serviceaccount_test.yaml
@@ -28,9 +28,9 @@ tests:
           path: metadata.annotations["iam.gke.io/gcp-service-account"]
           value: agent@my-project.iam.gserviceaccount.com
 
-  - it: no annotations when none configured
+  - it: no Workload Identity annotation when gsa unset
     set:
       serviceAccount.create: true
     asserts:
       - notExists:
-          path: metadata.annotations
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]

--- a/deploy/helm/demarkus-agent/tests/serviceaccount_test.yaml
+++ b/deploy/helm/demarkus-agent/tests/serviceaccount_test.yaml
@@ -1,0 +1,36 @@
+suite: service account
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: not rendered when serviceAccount.create=false
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: rendered with default name when serviceAccount.create=true
+    set:
+      serviceAccount.create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-demarkus-agent
+
+  - it: Workload Identity annotation added when gsa is set
+    set:
+      serviceAccount.create: true
+      serviceAccount.workloadIdentity.gsa: agent@my-project.iam.gserviceaccount.com
+    asserts:
+      - equal:
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]
+          value: agent@my-project.iam.gserviceaccount.com
+
+  - it: no annotations when none configured
+    set:
+      serviceAccount.create: true
+    asserts:
+      - notExists:
+          path: metadata.annotations

--- a/deploy/helm/demarkus-agent/values.yaml
+++ b/deploy/helm/demarkus-agent/values.yaml
@@ -9,8 +9,8 @@ image:
 
 imagePullSecrets: []
 
-# Pod count. The agent is stateless modulo its on-disk crawl-politeness cache;
-# multiple replicas would re-do the same work. Keep at 1.
+# Pod count. The agent maintains a crawl-politeness cache on disk;
+# multiple replicas would duplicate work. Keep at 1.
 replicaCount: 1
 
 # Crawler config. Becomes the contents of /etc/demarkus/agent.toml.
@@ -101,6 +101,8 @@ podSecurityContext:
   runAsUser: 65532
   runAsGroup: 65532
   fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
 
 # Container-level securityContext (the agent container).
 securityContext:

--- a/deploy/helm/demarkus-agent/values.yaml
+++ b/deploy/helm/demarkus-agent/values.yaml
@@ -1,0 +1,110 @@
+# Default values for demarkus-agent.
+# Override with --values or --set on `helm install`.
+
+image:
+  repository: ghcr.io/latebit-io/demarkus-agent
+  # tag defaults to .Chart.appVersion when empty
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# Pod count. The agent is stateless modulo its on-disk crawl-politeness cache;
+# multiple replicas would re-do the same work. Keep at 1.
+replicaCount: 1
+
+# Crawler config. Becomes the contents of /etc/demarkus/agent.toml.
+# See client/internal/fedcrawl/config.go for the full schema.
+config:
+  # mark:// URLs of servers to crawl from on each tick. Required.
+  seeds: []
+  #  - mark://team-a.example.com:6309
+  #  - mark://team-b.example.com:6309
+
+  # mark:// URLs of hubs to publish indexes to. Empty means crawl only.
+  hubs: []
+  #  - mark://hub.example.com:6309
+
+  crawl:
+    maxDepth: 2
+    maxServers: 50
+    maxDocuments: 1000
+    workers: 5
+  schedule:
+    interval: 6h
+  politeness:
+    requestDelay: 100ms
+    perServerConcurrency: 2
+
+# Publishing mode. false = single aggregated /index.md per hub.
+# true = one index per discovered server at /index/<host>.md.
+perServer: false
+
+# Skip TLS certificate verification on outbound mark:// connections.
+# Useful for self-signed dev clusters. Leave false in production.
+insecure: false
+
+# Tokens for publishing to hubs / reading private servers.
+# Mounted as ~/.mark/tokens.toml inside the container.
+# Provide either an existing Secret name OR an inline tokens map.
+tokens:
+  # Name of an existing Secret with a "tokens.toml" key. If set, takes precedence.
+  existingSecret: ""
+
+  # Inline tokens, generates Secret <release>-tokens with key tokens.toml.
+  # Format: hostPort -> raw token.
+  inline: {}
+  #   "hub.example.com:6309": "abc123..."
+
+# Persist the crawl-politeness state file across pod restarts.
+# Losing it just means a fresh crawl on next tick — no data loss on the hub.
+# Default: ephemeral (emptyDir).
+state:
+  persistent: false
+  storageClassName: ""
+  size: 1Gi
+  accessMode: ReadWriteOnce
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+# Pod-level overrides.
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}
+podLabels: {}
+
+# Liveness/readiness probes are intentionally omitted: the agent is an outbound
+# scheduled job, not a service. K8s restarts on process exit, which is the
+# correct behavior — the daemon loop logs and continues on transient crawl
+# errors, and exits only on configuration/unrecoverable failures.
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  # GKE Workload Identity: when set, annotates the SA with the GCP service
+  # account binding. Not needed for the agent unless your hubs require it.
+  workloadIdentity:
+    gsa: ""
+
+# Pod-level securityContext (applies to all containers, supports a limited
+# subset of fields: runAs*, fsGroup, seccompProfile, etc.).
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+
+# Container-level securityContext (the agent container).
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Helm chart for demarkus-agent with configurable seeds/hubs, crawl and publish settings, token handling, optional persistent state, service account creation, Workload Identity support, and hardened pod/container security.

* **Documentation**
  * Added a deployment guide with quick-start, token/state configuration, and local development notes.

* **Tests**
  * Added unit tests validating chart templates and conditional rendering.

* **Chores**
  * Added Helm packaging ignore rules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/106)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->