### PR TITLE
fix(server):  Add Helm chart for demarkus-server Kubernetes deployment

### DIFF
--- a/deploy/helm/demarkus-server/.helmignore
+++ b/deploy/helm/demarkus-server/.helmignore
@@ -1,0 +1,11 @@
+.DS_Store
+.git/
+.gitignore
+.idea/
+.vscode/
+*.swp
+*.tmp
+*.bak
+*.orig
+*.tgz
+tests/

--- a/deploy/helm/demarkus-server/Chart.yaml
+++ b/deploy/helm/demarkus-server/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: demarkus-server
+description: |
+  Mark Protocol server. Serves markdown over QUIC, with capability-based auth,
+  versioned content store, and TLS. One Helm release = one world.
+type: application
+version: 0.1.0
+appVersion: "0.7.1"
+keywords:
+  - demarkus
+  - mark-protocol
+  - markdown
+  - quic
+home: https://demarkus.io
+sources:
+  - https://github.com/latebit-io/demarkus
+maintainers:
+  - name: latebit-io
+    url: https://github.com/latebit-io

--- a/deploy/helm/demarkus-server/README.md
+++ b/deploy/helm/demarkus-server/README.md
@@ -1,0 +1,144 @@
+# demarkus-server Helm chart
+
+Deploys one [demarkus](https://github.com/latebit-io/demarkus) world on Kubernetes — a Mark Protocol server serving versioned markdown over QUIC, with capability-based auth and TLS. One Helm release = one world.
+
+## Quick start
+
+```bash
+helm install team-a ./deploy/helm/demarkus-server \
+  --set storage.className=premium-rwo
+```
+
+That's enough to get a working world with:
+- A `LoadBalancer` Service on UDP/6309 (cloud-provider provisions an external IP)
+- A 5 GiB content PVC
+- A self-signed dev TLS cert (good for testing; replace with cert-manager or a real Secret for production)
+- An auto-generated `admin` token, preserved across upgrades
+
+Read the admin token after install:
+
+```bash
+kubectl get secret team-a-demarkus-server-token-values \
+  -o jsonpath='{.data.admin}' | base64 -d
+```
+
+## Production install (GKE example)
+
+```bash
+helm install team-a ./deploy/helm/demarkus-server \
+  --set storage.className=premium-rwo \
+  --set storage.size=20Gi \
+  --set tls.certManager.enabled=true \
+  --set 'tls.certManager.dnsNames[0]=team-a.library.example.com' \
+  --set 'tls.certManager.issuerRef.name=letsencrypt-prod' \
+  --set 'service.annotations.cloud\.google\.com/neg=\{"exposed_ports":\{"6309":\{\}\}\}'
+```
+
+## Values
+
+### Image
+| Key | Default | Notes |
+|---|---|---|
+| `image.repository` | `ghcr.io/latebit-io/demarkus-server` | Must contain `demarkus-server`, `demarkus` (CLI for probes), and `demarkus-token` |
+| `image.tag` | `""` (uses `.Chart.AppVersion`) | |
+| `image.pullPolicy` | `IfNotPresent` | |
+
+### Server
+| Key | Default | Notes |
+|---|---|---|
+| `server.udpPort` | `6309` | Override to `443` for VPN/middlebox-hostile networks (Warp Zero Trust, etc.) |
+| `server.readOnly` | `false` | When true, rejects all writes with `not-permitted` |
+| `server.extraArgs` | `[]` | Appended to the server command line |
+
+### Service
+| Key | Default | Notes |
+|---|---|---|
+| `service.type` | `LoadBalancer` | `LoadBalancer` for prod; `ClusterIP`/`NodePort` for local dev |
+| `service.loadBalancerIP` | `""` | Pin LB to a specific external IP (if your cloud supports it) |
+| `service.annotations` | `{}` | E.g. `service.beta.kubernetes.io/aws-load-balancer-type: nlb` |
+
+### Storage
+| Key | Default | Notes |
+|---|---|---|
+| `storage.className` | `""` (cluster default) | Often `premium-rwo` (GKE), `gp3` (EKS), etc. |
+| `storage.size` | `5Gi` | |
+| `storage.accessMode` | `ReadWriteOnce` | Don't change — Phase 7 territory |
+
+### TLS
+
+Three modes — pick one:
+
+1. **`tls.existingSecret`** — reference a pre-existing Secret with `tls.crt` and `tls.key` (made by cert-manager elsewhere, kustomize, or `kubectl create secret tls`).
+2. **`tls.certManager.enabled: true`** — chart provisions a cert-manager `Certificate` resource targeting the configured `issuerRef`. Use **DNS-01** for issuers like Let's Encrypt (HTTP-01 cannot validate a QUIC-only service).
+3. **Neither set** — the server auto-generates a self-signed dev cert at startup. Good for tests, not for production.
+
+### Auth tokens
+
+| Key | Default | Notes |
+|---|---|---|
+| `tokens.admin.label` | `admin` | TOML `[tokens.<label>]` |
+| `tokens.admin.paths` | `["/*"]` | Path globs the token may operate on |
+| `tokens.admin.operations` | `["publish", "read"]` | |
+| `tokens.admin.token` | `""` (auto-generated) | Set to a literal raw token to skip auto-generation |
+| `tokens.emitRawValues` | `true` | Emit the raw-token Secret for broker discovery |
+
+**How it works.** The chart writes **two Secrets**:
+
+- `<release>-tokens` — TOML `tokens.toml` with the SHA-256 *hash* of the admin token. Mounted into the server pod. The server never sees the raw token.
+- `<release>-token-values` — the raw admin token, base64-encoded under key `<label>`. Annotated `demarkus.io/raw-tokens: "true"` so the future broker can discover and revoke. Server does not mount this Secret.
+
+On `helm upgrade`, the chart uses `lookup` to read the existing `-token-values` and preserves the admin token — no churn, no surprise rotation.
+
+### Probes
+Liveness/readiness exec `demarkus -insecure -no-cache mark://localhost:<port>/.well-known/agent-manifest.md`. The manifest is always public per `/architecture.md`. Probe disabled root-fs writes via `-no-cache`. The image must include the `demarkus` CLI binary.
+
+### Security defaults
+Pod runs as non-root user 65532, with `seccompProfile: RuntimeDefault`. Container has read-only root filesystem, no privilege escalation, all capabilities dropped. `/tmp` and `/home/demarkus` are emptyDir for writable scratch space.
+
+### Workload Identity (GKE)
+Set `serviceAccount.workloadIdentity.gsa` to the GCP service account email. The chart annotates the ServiceAccount with `iam.gke.io/gcp-service-account: <gsa>`. Use `mergeOverwrite`, so this binding wins over any user-supplied annotations.
+
+## Auth bootstrap walkthrough
+
+The first administrator gets the token from the raw-values Secret and uses it to configure other clients (or as input to the broker):
+
+```bash
+# Read the admin token
+TOKEN=$(kubectl get secret team-a-demarkus-server-token-values \
+  -o jsonpath='{.data.admin}' | base64 -d)
+
+# Use it from a laptop
+demarkus -auth "$TOKEN" mark://team-a.library.example.com:6309/index.md
+```
+
+For production, the recommended path is:
+
+1. Install the chart — get the bootstrap admin token from the Secret.
+2. Install the broker (Phase 6.3) pointing at this world.
+3. Use the broker to mint per-user tokens via OIDC.
+4. Once verified, the bootstrap admin token can be revoked or rotated.
+
+## Image requirement
+
+`ghcr.io/latebit-io/demarkus-server` must be a multi-binary image containing:
+
+- `/demarkus-server` (the server, ENTRYPOINT)
+- `/demarkus` (CLI, used by exec probes)
+- `/demarkus-token` (token mint utility, used by future broker integrations)
+
+The current `server/Dockerfile` ships only `demarkus-server`. Building the multi-binary image is part of Phase 6.7 (release pipeline). For local testing in the meantime, build the image manually with all three binaries.
+
+## Tests
+
+helm-unittest suites live in `tests/`:
+
+```bash
+helm plugin install https://github.com/helm-unittest/helm-unittest
+helm unittest deploy/helm/demarkus-server/
+```
+
+## See also
+
+- `/plans/universe-deployment.md` — full Phase 6 plan
+- `/architecture.md` — Mark Protocol architecture (capability auth, versioned store, content-addressed fetch)
+- `deploy/helm/demarkus-agent/` — federation crawler chart (Phase 6.0)

--- a/deploy/helm/demarkus-server/README.md
+++ b/deploy/helm/demarkus-server/README.md
@@ -37,6 +37,7 @@ helm install team-a ./deploy/helm/demarkus-server \
 ## Values
 
 ### Image
+
 | Key | Default | Notes |
 |---|---|---|
 | `image.repository` | `ghcr.io/latebit-io/demarkus-server` | Must contain `demarkus-server`, `demarkus` (CLI for probes), and `demarkus-token` |
@@ -44,6 +45,7 @@ helm install team-a ./deploy/helm/demarkus-server \
 | `image.pullPolicy` | `IfNotPresent` | |
 
 ### Server
+
 | Key | Default | Notes |
 |---|---|---|
 | `server.udpPort` | `6309` | Override to `443` for VPN/middlebox-hostile networks (Warp Zero Trust, etc.) |
@@ -51,6 +53,7 @@ helm install team-a ./deploy/helm/demarkus-server \
 | `server.extraArgs` | `[]` | Appended to the server command line |
 
 ### Service
+
 | Key | Default | Notes |
 |---|---|---|
 | `service.type` | `LoadBalancer` | `LoadBalancer` for prod; `ClusterIP`/`NodePort` for local dev |
@@ -58,6 +61,7 @@ helm install team-a ./deploy/helm/demarkus-server \
 | `service.annotations` | `{}` | E.g. `service.beta.kubernetes.io/aws-load-balancer-type: nlb` |
 
 ### Storage
+
 | Key | Default | Notes |
 |---|---|---|
 | `storage.className` | `""` (cluster default) | Often `premium-rwo` (GKE), `gp3` (EKS), etc. |
@@ -90,12 +94,15 @@ Three modes — pick one:
 On `helm upgrade`, the chart uses `lookup` to read the existing `-token-values` and preserves the admin token — no churn, no surprise rotation.
 
 ### Probes
+
 Liveness/readiness exec `demarkus -insecure -no-cache mark://localhost:<port>/.well-known/agent-manifest.md`. The manifest is always public per `/architecture.md`. Probe disabled root-fs writes via `-no-cache`. The image must include the `demarkus` CLI binary.
 
 ### Security defaults
+
 Pod runs as non-root user 65532, with `seccompProfile: RuntimeDefault`. Container has read-only root filesystem, no privilege escalation, all capabilities dropped. `/tmp` and `/home/demarkus` are emptyDir for writable scratch space.
 
 ### Workload Identity (GKE)
+
 Set `serviceAccount.workloadIdentity.gsa` to the GCP service account email. The chart annotates the ServiceAccount with `iam.gke.io/gcp-service-account: <gsa>`. Use `mergeOverwrite`, so this binding wins over any user-supplied annotations.
 
 ## Auth bootstrap walkthrough

--- a/deploy/helm/demarkus-server/templates/_helpers.tpl
+++ b/deploy/helm/demarkus-server/templates/_helpers.tpl
@@ -1,0 +1,97 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "demarkus-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name.
+*/}}
+{{- define "demarkus-server.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "demarkus-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "demarkus-server.labels" -}}
+helm.sh/chart: {{ include "demarkus-server.chart" . }}
+{{ include "demarkus-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "demarkus-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "demarkus-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "demarkus-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "demarkus-server.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Names for the two token Secrets.
+*/}}
+{{- define "demarkus-server.tokensSecretName" -}}
+{{- printf "%s-tokens" (include "demarkus-server.fullname" .) -}}
+{{- end -}}
+
+{{- define "demarkus-server.tokenValuesSecretName" -}}
+{{- printf "%s-token-values" (include "demarkus-server.fullname" .) -}}
+{{- end -}}
+
+{{/*
+TLS Secret name. Either user-provided or chart-generated via cert-manager.
+*/}}
+{{- define "demarkus-server.tlsSecretName" -}}
+{{- if .Values.tls.existingSecret -}}
+{{- .Values.tls.existingSecret -}}
+{{- else if .Values.tls.certManager.enabled -}}
+{{- printf "%s-tls" (include "demarkus-server.fullname" .) -}}
+{{- else -}}
+{{- /* No external TLS configured; server auto-generates a dev cert. */ -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Admin token resolution. Order of precedence:
+  1. .Values.tokens.admin.token (user-provided literal)
+  2. Existing <release>-token-values Secret (preserves token across upgrades)
+  3. Freshly generated randAlphaNum 64
+
+This helper is called from tokens.yaml where both Secrets render in the same
+template pass, so $rawToken is computed once and reused across both Secrets.
+
+NOTE: `lookup` returns nil during `helm template` (no cluster context). Tests
+should not assert on exact token values, only on structure.
+*/}}
+{{- define "demarkus-server.resolveAdminToken" -}}
+{{- if .Values.tokens.admin.token -}}
+{{- .Values.tokens.admin.token -}}
+{{- else -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "demarkus-server.tokenValuesSecretName" .) -}}
+{{- if and $existing $existing.data.admin -}}
+{{- $existing.data.admin | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 64 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/demarkus-server/templates/_helpers.tpl
+++ b/deploy/helm/demarkus-server/templates/_helpers.tpl
@@ -88,8 +88,9 @@ should not assert on exact token values, only on structure.
 {{- .Values.tokens.admin.token -}}
 {{- else -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace (include "demarkus-server.tokenValuesSecretName" .) -}}
-{{- if and $existing $existing.data.admin -}}
-{{- $existing.data.admin | b64dec -}}
+{{- $label := .Values.tokens.admin.label -}}
+{{- if and $existing (index $existing.data $label) -}}
+{{- index $existing.data $label | b64dec -}}
 {{- else -}}
 {{- randAlphaNum 64 -}}
 {{- end -}}

--- a/deploy/helm/demarkus-server/templates/certificate.yaml
+++ b/deploy/helm/demarkus-server/templates/certificate.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.tls.certManager.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "demarkus-server.fullname" . }}-tls
+  labels:
+    {{- include "demarkus-server.labels" . | nindent 4 }}
+  {{- with .Values.tls.certManager.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  secretName: {{ include "demarkus-server.tlsSecretName" . }}
+  issuerRef:
+    kind: {{ .Values.tls.certManager.issuerRef.kind }}
+    name: {{ .Values.tls.certManager.issuerRef.name }}
+  dnsNames:
+    {{- if .Values.tls.certManager.dnsNames }}
+    {{- toYaml .Values.tls.certManager.dnsNames | nindent 4 }}
+    {{- else }}
+    - {{ printf "%s.%s.svc.cluster.local" (include "demarkus-server.fullname" .) .Release.Namespace | quote }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/demarkus-server/templates/service.yaml
+++ b/deploy/helm/demarkus-server/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "demarkus-server.fullname" . }}
+  labels:
+    {{- include "demarkus-server.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP | quote }}
+  {{- end }}
+  selector:
+    {{- include "demarkus-server.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: mark
+      protocol: UDP
+      port: {{ .Values.server.udpPort }}
+      targetPort: mark

--- a/deploy/helm/demarkus-server/templates/serviceaccount.yaml
+++ b/deploy/helm/demarkus-server/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "demarkus-server.serviceAccountName" . }}
+  labels:
+    {{- include "demarkus-server.labels" . | nindent 4 }}
+  {{- $extraAnnotations := .Values.serviceAccount.annotations | default dict }}
+  {{- if .Values.serviceAccount.workloadIdentity.gsa }}
+  {{- $extraAnnotations = mergeOverwrite $extraAnnotations (dict "iam.gke.io/gcp-service-account" .Values.serviceAccount.workloadIdentity.gsa) }}
+  {{- end }}
+  {{- if $extraAnnotations }}
+  annotations:
+    {{- toYaml $extraAnnotations | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/demarkus-server/templates/statefulset.yaml
+++ b/deploy/helm/demarkus-server/templates/statefulset.yaml
@@ -1,0 +1,146 @@
+{{- $tlsSecret := include "demarkus-server.tlsSecretName" . -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "demarkus-server.fullname" . }}
+  labels:
+    {{- include "demarkus-server.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "demarkus-server.fullname" . }}
+  replicas: {{ .Values.replicaCount }}
+  podManagementPolicy: OrderedReady
+  selector:
+    matchLabels:
+      {{- include "demarkus-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "demarkus-server.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/tokens: {{ include (print $.Template.BasePath "/tokens.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "demarkus-server.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: server
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          args:
+            - -port
+            - {{ .Values.server.udpPort | quote }}
+            - -root
+            - /var/lib/demarkus/content
+            - -tokens
+            - /etc/demarkus/tokens/tokens.toml
+            {{- if $tlsSecret }}
+            - -tls-cert
+            - /etc/demarkus/tls/tls.crt
+            - -tls-key
+            - /etc/demarkus/tls/tls.key
+            {{- end }}
+            {{- if .Values.server.readOnly }}
+            - -read-only
+            {{- end }}
+            {{- with .Values.server.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          env:
+            - name: HOME
+              value: /home/demarkus
+          ports:
+            - name: mark
+              protocol: UDP
+              containerPort: {{ .Values.server.udpPort }}
+          {{- if .Values.probes.enabled }}
+          livenessProbe:
+            exec:
+              command:
+                - /demarkus
+                - -insecure
+                - -no-cache
+                - {{ printf "mark://localhost:%d/.well-known/agent-manifest.md" (int .Values.server.udpPort) | quote }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            exec:
+              command:
+                - /demarkus
+                - -insecure
+                - -no-cache
+                - {{ printf "mark://localhost:%d/.well-known/agent-manifest.md" (int .Values.server.udpPort) | quote }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+            - name: content
+              mountPath: /var/lib/demarkus/content
+            - name: tokens
+              mountPath: /etc/demarkus/tokens
+              readOnly: true
+            {{- if $tlsSecret }}
+            - name: tls
+              mountPath: /etc/demarkus/tls
+              readOnly: true
+            {{- end }}
+            - name: tmp
+              mountPath: /tmp
+            - name: home
+              mountPath: /home/demarkus
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: tokens
+          secret:
+            secretName: {{ include "demarkus-server.tokensSecretName" . }}
+        {{- if $tlsSecret }}
+        - name: tls
+          secret:
+            secretName: {{ $tlsSecret }}
+        {{- end }}
+        - name: tmp
+          emptyDir: {}
+        - name: home
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: content
+        labels:
+          {{- include "demarkus-server.labels" . | nindent 10 }}
+      spec:
+        accessModes:
+          - {{ .Values.storage.accessMode }}
+        resources:
+          requests:
+            storage: {{ .Values.storage.size }}
+        {{- if .Values.storage.className }}
+        storageClassName: {{ .Values.storage.className | quote }}
+        {{- end }}

--- a/deploy/helm/demarkus-server/templates/tokens.yaml
+++ b/deploy/helm/demarkus-server/templates/tokens.yaml
@@ -1,0 +1,41 @@
+{{/*
+Both token Secrets are emitted from one file so a single $rawToken value flows
+into both (within the same template render pass). This avoids the trap where
+randAlphaNum runs separately per file and produces mismatched raw/hash.
+*/}}
+{{- $rawToken := include "demarkus-server.resolveAdminToken" . -}}
+{{- $hash := printf "sha256-%s" (sha256sum $rawToken) -}}
+{{- $admin := .Values.tokens.admin -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "demarkus-server.tokensSecretName" . }}
+  labels:
+    {{- include "demarkus-server.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  tokens.toml: |
+    [tokens.{{ $admin.label }}]
+    hash = {{ $hash | quote }}
+    paths = [
+      {{- range $i, $p := $admin.paths }}{{ if $i }}, {{ end }}{{ $p | quote }}{{ end -}}
+    ]
+    operations = [
+      {{- range $i, $o := $admin.operations }}{{ if $i }}, {{ end }}{{ $o | quote }}{{ end -}}
+    ]
+{{- if .Values.tokens.emitRawValues }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "demarkus-server.tokenValuesSecretName" . }}
+  labels:
+    {{- include "demarkus-server.labels" . | nindent 4 }}
+  annotations:
+    # This Secret contains raw tokens. Intended for broker consumption (read +
+    # revoke). The server never mounts this Secret.
+    demarkus.io/raw-tokens: "true"
+type: Opaque
+data:
+  {{ $admin.label }}: {{ $rawToken | b64enc }}
+{{- end }}

--- a/deploy/helm/demarkus-server/tests/certificate_test.yaml
+++ b/deploy/helm/demarkus-server/tests/certificate_test.yaml
@@ -1,0 +1,56 @@
+suite: certificate
+templates:
+  - certificate.yaml
+tests:
+  - it: not rendered when certManager.enabled=false (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: rendered with default dnsName when enabled
+    set:
+      tls.certManager.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Certificate
+      - equal:
+          path: spec.secretName
+          value: RELEASE-NAME-demarkus-server-tls
+      - equal:
+          path: spec.issuerRef.kind
+          value: ClusterIssuer
+      - equal:
+          path: spec.issuerRef.name
+          value: letsencrypt-prod
+      - contains:
+          path: spec.dnsNames
+          content: RELEASE-NAME-demarkus-server.NAMESPACE.svc.cluster.local
+
+  - it: dnsNames override when configured
+    set:
+      tls.certManager.enabled: true
+      tls.certManager.dnsNames:
+        - team-a.library.example.com
+        - team-a-alt.library.example.com
+    asserts:
+      - contains:
+          path: spec.dnsNames
+          content: team-a.library.example.com
+      - contains:
+          path: spec.dnsNames
+          content: team-a-alt.library.example.com
+
+  - it: custom issuerRef propagates
+    set:
+      tls.certManager.enabled: true
+      tls.certManager.issuerRef.kind: Issuer
+      tls.certManager.issuerRef.name: corp-ca
+    asserts:
+      - equal:
+          path: spec.issuerRef.kind
+          value: Issuer
+      - equal:
+          path: spec.issuerRef.name
+          value: corp-ca

--- a/deploy/helm/demarkus-server/tests/service_test.yaml
+++ b/deploy/helm/demarkus-server/tests/service_test.yaml
@@ -1,0 +1,43 @@
+suite: service
+templates:
+  - service.yaml
+tests:
+  - it: renders a LoadBalancer UDP Service by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.ports[0].port
+          value: 6309
+      - equal:
+          path: spec.ports[0].protocol
+          value: UDP
+
+  - it: service.type override switches to ClusterIP
+    set:
+      service.type: ClusterIP
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: loadBalancerIP set when type is LoadBalancer and IP provided
+    set:
+      service.loadBalancerIP: 34.10.20.30
+    asserts:
+      - equal:
+          path: spec.loadBalancerIP
+          value: 34.10.20.30
+
+  - it: cloud annotations propagate
+    set:
+      service.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-type: nlb
+    asserts:
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-type"]
+          value: nlb

--- a/deploy/helm/demarkus-server/tests/serviceaccount_test.yaml
+++ b/deploy/helm/demarkus-server/tests/serviceaccount_test.yaml
@@ -1,0 +1,40 @@
+suite: service account
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: not rendered when serviceAccount.create=false
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: rendered with default name
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-demarkus-server
+
+  - it: Workload Identity annotation added when gsa set
+    set:
+      serviceAccount.workloadIdentity.gsa: server@my-project.iam.gserviceaccount.com
+    asserts:
+      - equal:
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]
+          value: server@my-project.iam.gserviceaccount.com
+
+  - it: workloadIdentity wins over user-supplied annotation (mergeOverwrite)
+    set:
+      serviceAccount.annotations.iam\.gke\.io/gcp-service-account: user-set-value
+      serviceAccount.workloadIdentity.gsa: should-win@my-project.iam.gserviceaccount.com
+    asserts:
+      - equal:
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]
+          value: should-win@my-project.iam.gserviceaccount.com
+
+  - it: no Workload Identity annotation when gsa unset
+    asserts:
+      - notExists:
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]

--- a/deploy/helm/demarkus-server/tests/statefulset_test.yaml
+++ b/deploy/helm/demarkus-server/tests/statefulset_test.yaml
@@ -1,0 +1,159 @@
+suite: statefulset
+templates:
+  - statefulset.yaml
+tests:
+  - it: renders a StatefulSet with correct name + replicas
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-demarkus-server
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-demarkus-server
+
+  - it: container args include -port and -root by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "-port"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "6309"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "-root"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: /var/lib/demarkus/content
+
+  - it: -read-only added when server.readOnly=true
+    set:
+      server.readOnly: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "-read-only"
+
+  - it: -read-only absent when server.readOnly=false (default)
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "-read-only"
+
+  - it: TLS args + volume absent when no TLS configured
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "-tls-cert"
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: tls
+            secret:
+              secretName: RELEASE-NAME-demarkus-server-tls
+
+  - it: TLS args + volume present when cert-manager enabled
+    set:
+      tls.certManager.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "-tls-cert"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: /etc/demarkus/tls/tls.crt
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tls
+            secret:
+              secretName: RELEASE-NAME-demarkus-server-tls
+
+  - it: TLS uses existingSecret when set
+    set:
+      tls.existingSecret: my-corp-tls
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tls
+            secret:
+              secretName: my-corp-tls
+
+  - it: udpPort knob propagates to args and port
+    set:
+      server.udpPort: 443
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "443"
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 443
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].protocol
+          value: UDP
+
+  - it: pod-level securityContext has runAsNonRoot + seccompProfile
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: container-level securityContext locks down container
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: probes disabled when probes.enabled=false
+    set:
+      probes.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: probes use demarkus CLI fetching agent-manifest
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
+          content: "/demarkus"
+      - contains:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
+          content: "-no-cache"
+      - contains:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
+          content: "mark://localhost:6309/.well-known/agent-manifest.md"
+
+  - it: volumeClaimTemplates provisions content PVC
+    set:
+      storage.className: premium-rwo
+      storage.size: 10Gi
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: content
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 10Gi
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: premium-rwo

--- a/deploy/helm/demarkus-server/tests/tokens_test.yaml
+++ b/deploy/helm/demarkus-server/tests/tokens_test.yaml
@@ -1,0 +1,94 @@
+suite: tokens
+templates:
+  - tokens.yaml
+tests:
+  - it: renders both tokens.toml hash Secret and raw token-values Secret by default
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        isKind:
+          of: Secret
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-demarkus-server-tokens
+      - documentIndex: 1
+        isKind:
+          of: Secret
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-demarkus-server-token-values
+
+  - it: tokens.toml uses configured admin label
+    set:
+      tokens.admin.label: bootstrap-admin
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-demarkus-server-tokens
+    asserts:
+      - matchRegex:
+          path: stringData["tokens.toml"]
+          pattern: '\[tokens\.bootstrap-admin\]'
+
+  - it: tokens.toml stores hash with sha256- prefix
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-demarkus-server-tokens
+    asserts:
+      - matchRegex:
+          path: stringData["tokens.toml"]
+          pattern: 'hash = "sha256-[0-9a-f]{64}"'
+
+  - it: tokens.toml includes paths and operations from values
+    set:
+      tokens.admin.paths: ["/docs/**", "/public/**"]
+      tokens.admin.operations: ["publish", "read"]
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-demarkus-server-tokens
+    asserts:
+      - matchRegex:
+          path: stringData["tokens.toml"]
+          pattern: '"/docs/\*\*"'
+      - matchRegex:
+          path: stringData["tokens.toml"]
+          pattern: '"/public/\*\*"'
+      - matchRegex:
+          path: stringData["tokens.toml"]
+          pattern: '"publish"'
+      - matchRegex:
+          path: stringData["tokens.toml"]
+          pattern: '"read"'
+
+  - it: token-values Secret omitted when emitRawValues=false
+    set:
+      tokens.emitRawValues: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-demarkus-server-tokens
+
+  - it: token-values Secret has raw-tokens annotation for broker discovery
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-demarkus-server-token-values
+    asserts:
+      - equal:
+          path: metadata.annotations["demarkus.io/raw-tokens"]
+          value: "true"
+
+  - it: user-supplied admin token is used as-is
+    set:
+      tokens.admin.token: my-literal-raw-token
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-demarkus-server-token-values
+    asserts:
+      - equal:
+          path: data.admin
+          value: bXktbGl0ZXJhbC1yYXctdG9rZW4=  # base64 of "my-literal-raw-token"

--- a/deploy/helm/demarkus-server/values.yaml
+++ b/deploy/helm/demarkus-server/values.yaml
@@ -1,0 +1,130 @@
+# Default values for demarkus-server.
+# Override with --values or --set on `helm install`.
+
+image:
+  # Must include demarkus-server, demarkus (CLI for probes), and demarkus-token.
+  repository: ghcr.io/latebit-io/demarkus-server
+  # tag defaults to .Chart.appVersion when empty
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# Pod count. Multi-replica with shared content is a Phase 7 concern; keep at 1.
+replicaCount: 1
+
+server:
+  # UDP port the server listens on. Default protocol port. Override to 443 for
+  # VPN/middlebox-hostile networks (Cloudflare Warp, corp firewalls that filter
+  # non-standard UDP).
+  udpPort: 6309
+
+  # Reject all write operations (FETCH/LIST/VERSIONS only).
+  readOnly: false
+
+  # Extra args appended to the server command line.
+  extraArgs: []
+
+# Service exposing the server. LoadBalancer with protocol UDP is the standard
+# path on managed Kubernetes (GKE, EKS); use ClusterIP/NodePort for local dev.
+service:
+  type: LoadBalancer
+  # Optional: bind LB to a specific external IP (if your cloud supports it).
+  loadBalancerIP: ""
+  # Cloud-specific Service annotations (e.g. AWS NLB selection).
+  annotations: {}
+  #   service.beta.kubernetes.io/aws-load-balancer-type: nlb
+
+# Persistent storage for the versioned content store.
+storage:
+  className: ""        # cluster-default if empty
+  size: 5Gi
+  accessMode: ReadWriteOnce
+
+# TLS — server speaks QUIC, so TLS is mandatory. Three modes:
+#   1. existingSecret: reference a pre-existing tls Secret (cert-manager, etc.)
+#   2. certManager.enabled=true: chart provisions a cert-manager Certificate
+#   3. neither set: server auto-generates a self-signed dev cert at startup
+tls:
+  existingSecret: ""
+
+  certManager:
+    enabled: false
+    issuerRef:
+      kind: ClusterIssuer
+      name: letsencrypt-prod
+    # If empty, defaults to <release>.<namespace>.svc.cluster.local
+    dnsNames: []
+    # Annotations on the Certificate resource.
+    annotations: {}
+
+# Initial admin token.
+# - If you provide tokens.admin.token (raw), the chart uses it as-is.
+# - Otherwise the chart auto-generates one on first install and preserves it
+#   across helm upgrades via `lookup` on the existing Secret.
+# - The chart writes TWO Secrets:
+#     <release>-tokens         server-mounted, contains TOML with hash only
+#     <release>-token-values   raw token, for the broker to read/revoke
+#   These are kept separate so the server never mounts raw token bytes.
+tokens:
+  admin:
+    label: admin
+    paths: ["/*"]
+    operations: ["publish", "read"]
+    # Explicit token value; if empty, auto-generated on first install.
+    token: ""
+
+  # When true, also emit the <release>-token-values Secret with the raw value.
+  # Required when the broker manages this world. Default true.
+  emitRawValues: true
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 512Mi
+
+# Liveness + readiness use the demarkus CLI fetching /.well-known/agent-manifest.md
+# (always public per /architecture.md). Cache disabled via -no-cache so probe
+# does not write to the read-only root filesystem.
+probes:
+  enabled: true
+  liveness:
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 5
+  readiness:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  workloadIdentity:
+    gsa: ""
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}
+podLabels: {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Helm chart for deploying the server with configurable storage, UDP service, TLS (cert-manager or existing secret), probes, Workload Identity, and hardened security defaults.
  * Admin token management with optional raw-token emission and stable token lookup across upgrades.

* **Documentation**
  * Comprehensive chart README with quick start, production examples, values and auth/bootstrap guidance.

* **Tests**
  * Chart test suites validating certificate, service, service account, statefulset and token rendering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/107)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->