### PR TITLE
fix(tools):  Add OIDC group membership and multi-dimensional authorization

### DIFF
--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -197,42 +197,65 @@ func (c *Config) validate() error {
 	seen := make(map[string]bool, len(c.Worlds))
 	for i := range c.Worlds {
 		w := &c.Worlds[i]
-		switch {
-		case w.Name == "":
-			return fmt.Errorf("worlds[%d]: name is required", i)
-		case seen[w.Name]:
+		if err := validateWorld(i, w); err != nil {
+			return err
+		}
+		if seen[w.Name] {
 			return fmt.Errorf("worlds[%d]: duplicate name %q", i, w.Name)
-		case w.Namespace == "":
-			return fmt.Errorf("worlds[%d] (%s): namespace is required", i, w.Name)
-		case w.TokensSecret == "":
-			return fmt.Errorf("worlds[%d] (%s): tokensSecret is required", i, w.Name)
-		case len(w.DefaultToken.Paths) == 0:
-			return fmt.Errorf("worlds[%d] (%s): defaultToken.paths is required", i, w.Name)
-		case len(w.DefaultToken.Operations) == 0:
-			return fmt.Errorf("worlds[%d] (%s): defaultToken.operations is required", i, w.Name)
-		case w.DefaultToken.ExpiresAfter <= 0:
-			return fmt.Errorf("worlds[%d] (%s): defaultToken.expiresAfter must be > 0", i, w.Name)
-		}
-		// Normalize Allow.Domains and Allow.Emails to lowercase+trim so
-		// authorizedWorlds can do plain string compares on every login.
-		// Reject empty entries here rather than silently never matching;
-		// an empty list entry is always a config typo, and surfacing it
-		// at load time blames the right person.
-		for j, d := range w.Allow.Domains {
-			norm := strings.ToLower(strings.TrimSpace(d))
-			if norm == "" {
-				return fmt.Errorf("worlds[%d] (%s): allow.domains[%d] is empty", i, w.Name, j)
-			}
-			w.Allow.Domains[j] = norm
-		}
-		for j, e := range w.Allow.Emails {
-			norm := strings.ToLower(strings.TrimSpace(e))
-			if norm == "" {
-				return fmt.Errorf("worlds[%d] (%s): allow.emails[%d] is empty", i, w.Name, j)
-			}
-			w.Allow.Emails[j] = norm
 		}
 		seen[w.Name] = true
+	}
+	return nil
+}
+
+// validateWorld enforces the per-world invariants and normalizes the
+// AllowConfig string lists in place. Split out of validate() so the
+// gocyclo budget on each function stays inside the linter threshold;
+// the outer loop owns cross-world checks (duplicates), the helper owns
+// single-world checks.
+func validateWorld(i int, w *WorldConfig) error {
+	switch {
+	case w.Name == "":
+		return fmt.Errorf("worlds[%d]: name is required", i)
+	case w.Namespace == "":
+		return fmt.Errorf("worlds[%d] (%s): namespace is required", i, w.Name)
+	case w.TokensSecret == "":
+		return fmt.Errorf("worlds[%d] (%s): tokensSecret is required", i, w.Name)
+	case len(w.DefaultToken.Paths) == 0:
+		return fmt.Errorf("worlds[%d] (%s): defaultToken.paths is required", i, w.Name)
+	case len(w.DefaultToken.Operations) == 0:
+		return fmt.Errorf("worlds[%d] (%s): defaultToken.operations is required", i, w.Name)
+	case w.DefaultToken.ExpiresAfter <= 0:
+		return fmt.Errorf("worlds[%d] (%s): defaultToken.expiresAfter must be > 0", i, w.Name)
+	}
+	// Domains and Emails are lowercased+trimmed so authorizedWorlds can
+	// do plain string compares on every login. Groups are trim-only
+	// because group-name case sensitivity is IdP-dependent (Okta can
+	// hold distinct "Engineering" / "engineering" entities, Entra ID
+	// preserves case for display, Google's directory is
+	// case-insensitive); groupsMatch uses EqualFold at runtime so case
+	// differences still match, but we keep the configured case for
+	// debug-log readability. Empty entries are always config typos and
+	// surface here at load time rather than silently never matching.
+	if err := normalizeAllowList(i, w.Name, "domains", w.Allow.Domains, true); err != nil {
+		return err
+	}
+	if err := normalizeAllowList(i, w.Name, "emails", w.Allow.Emails, true); err != nil {
+		return err
+	}
+	return normalizeAllowList(i, w.Name, "groups", w.Allow.Groups, false)
+}
+
+func normalizeAllowList(worldIdx int, worldName, field string, list []string, lower bool) error {
+	for j, s := range list {
+		norm := strings.TrimSpace(s)
+		if lower {
+			norm = strings.ToLower(norm)
+		}
+		if norm == "" {
+			return fmt.Errorf("worlds[%d] (%s): allow.%s[%d] is empty", worldIdx, worldName, field, j)
+		}
+		list[j] = norm
 	}
 	return nil
 }

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -213,11 +213,18 @@ func (c *Config) validate() error {
 		case w.DefaultToken.ExpiresAfter <= 0:
 			return fmt.Errorf("worlds[%d] (%s): defaultToken.expiresAfter must be > 0", i, w.Name)
 		}
-		// Normalize Allow.Emails to lowercase+trim so authorizedWorlds can
-		// do a plain string compare on every login. Reject empty entries
-		// here rather than silently matching the empty-email reject path
-		// inside Mint — that fails for the right reason but blames the
-		// caller for a config bug.
+		// Normalize Allow.Domains and Allow.Emails to lowercase+trim so
+		// authorizedWorlds can do plain string compares on every login.
+		// Reject empty entries here rather than silently never matching;
+		// an empty list entry is always a config typo, and surfacing it
+		// at load time blames the right person.
+		for j, d := range w.Allow.Domains {
+			norm := strings.ToLower(strings.TrimSpace(d))
+			if norm == "" {
+				return fmt.Errorf("worlds[%d] (%s): allow.domains[%d] is empty", i, w.Name, j)
+			}
+			w.Allow.Domains[j] = norm
+		}
 		for j, e := range w.Allow.Emails {
 			norm := strings.ToLower(strings.TrimSpace(e))
 			if norm == "" {

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -107,11 +107,16 @@ type AllowConfig struct {
 	Domains []string `yaml:"domains"`
 	// Groups is the OIDC `groups`-claim allowlist. The identity must
 	// have at least one group in this list for the domain-and-groups
-	// predicate to match. IdP-specific: Okta and Auth0 emit `groups` in
-	// the ID token when configured; Entra needs the optional `groups`
-	// claim enabled; Google does not surface groups in the ID token
-	// (use Emails as a carve-out, or wait for a userinfo-based Verifier
-	// — backlogged).
+	// predicate to match. Match is case-insensitive: entries are
+	// lowercased+trimmed at config load, and groupsMatch lowercases the
+	// claim's groups for compare. Our validated IdP set (Google, Okta,
+	// Entra ID, Auth0) treats group names case-insensitively; case-
+	// sensitive providers like Keycloak with deliberately distinct
+	// case-variant groups are out of scope. IdP-specific: Okta and
+	// Auth0 emit `groups` in the ID token when configured; Entra needs
+	// the optional `groups` claim enabled; Google does not surface
+	// groups in the ID token (use Emails as a carve-out, or wait for a
+	// userinfo-based Verifier — backlogged).
 	Groups []string `yaml:"groups"`
 	// Emails is the per-user carve-out. A login whose verified email
 	// matches an entry here qualifies regardless of Domains and Groups.
@@ -228,30 +233,28 @@ func validateWorld(i int, w *WorldConfig) error {
 	case w.DefaultToken.ExpiresAfter <= 0:
 		return fmt.Errorf("worlds[%d] (%s): defaultToken.expiresAfter must be > 0", i, w.Name)
 	}
-	// Domains and Emails are lowercased+trimmed so authorizedWorlds can
-	// do plain string compares on every login. Groups are trim-only
-	// because group-name case sensitivity is IdP-dependent (Okta can
-	// hold distinct "Engineering" / "engineering" entities, Entra ID
-	// preserves case for display, Google's directory is
-	// case-insensitive); groupsMatch uses EqualFold at runtime so case
-	// differences still match, but we keep the configured case for
-	// debug-log readability. Empty entries are always config typos and
+	// All three lists are lowercased+trimmed at load so authorizedWorlds
+	// can do plain string compares on every login. Group-name match is
+	// case-insensitive because our validated IdP set (Google, Okta,
+	// Entra ID, Auth0) enforces case-insensitive group-name uniqueness;
+	// an operator writing "Engineering" while the IdP emits
+	// "engineering" after upstream normalization would otherwise fail
+	// silently. Case-sensitive providers like Keycloak with
+	// deliberately distinct case-variant groups are out of scope; revisit
+	// if a customer asks. Empty entries are always config typos and
 	// surface here at load time rather than silently never matching.
-	if err := normalizeAllowList(i, w.Name, "domains", w.Allow.Domains, true); err != nil {
+	if err := normalizeAllowList(i, w.Name, "domains", w.Allow.Domains); err != nil {
 		return err
 	}
-	if err := normalizeAllowList(i, w.Name, "emails", w.Allow.Emails, true); err != nil {
+	if err := normalizeAllowList(i, w.Name, "emails", w.Allow.Emails); err != nil {
 		return err
 	}
-	return normalizeAllowList(i, w.Name, "groups", w.Allow.Groups, false)
+	return normalizeAllowList(i, w.Name, "groups", w.Allow.Groups)
 }
 
-func normalizeAllowList(worldIdx int, worldName, field string, list []string, lower bool) error {
+func normalizeAllowList(worldIdx int, worldName, field string, list []string) error {
 	for j, s := range list {
-		norm := strings.TrimSpace(s)
-		if lower {
-			norm = strings.ToLower(norm)
-		}
+		norm := strings.ToLower(strings.TrimSpace(s))
 		if norm == "" {
 			return fmt.Errorf("worlds[%d] (%s): allow.%s[%d] is empty", worldIdx, worldName, field, j)
 		}

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -60,7 +61,7 @@ type OIDCConfig struct {
 
 // WorldConfig describes one demarkus world the broker is authorized to
 // mint tokens for. Authorization is per-world; an OIDC identity may
-// qualify for some worlds and not others depending on AllowDomains.
+// qualify for some worlds and not others depending on Allow.
 type WorldConfig struct {
 	// Name is the world's logical name (also the value in the
 	// "world" field of issuances records).
@@ -70,16 +71,53 @@ type WorldConfig struct {
 	// TokensSecret is the name of the world's tokens.toml Secret. The
 	// broker requires get/patch on this Secret in that namespace.
 	TokensSecret string `yaml:"tokensSecret"`
-	// AllowDomains is the email-domain allowlist used for authorization
-	// in Slice B. A login's id_token.email must end with one of these
-	// domains for the broker to mint a token for this world. Empty list
-	// = no domain restriction (any verified user qualifies); the operator
-	// must opt out explicitly to avoid surprise authorization.
-	AllowDomains []string `yaml:"allowDomains"`
+	// Allow is the per-world authorization predicate. See AllowConfig for
+	// the rules. When every list is empty the world accepts any verified
+	// identity (back-compat with pre-Slice-C configs that had only
+	// AllowDomains and left it empty).
+	Allow AllowConfig `yaml:"allow"`
 	// DefaultToken describes the capabilities of every token minted for
 	// this world. Slice B treats DefaultToken as the only scope; per-call
 	// narrowing is a Slice C feature.
 	DefaultToken TokenScope `yaml:"defaultToken"`
+}
+
+// AllowConfig describes who qualifies for tokens against a given world.
+// Predicate (Slice C.1):
+//
+//  1. If Domains, Groups, and Emails are all empty, any verified identity
+//     qualifies. This preserves the pre-Slice-C "no allowlist = open
+//     world" behavior so existing configs upgrade without surprise.
+//  2. Otherwise the identity qualifies if its email is in Emails (the
+//     per-user carve-out), OR if its email matches Domains and its
+//     groups intersect Groups. Either Domains or Groups may be empty
+//     individually; an empty list in that dimension means "no
+//     restriction on that dimension." But at least one of {Domains,
+//     Groups, Emails} must match for the world to authorize.
+//
+// Emails exists so worlds can grant access to specific users when the
+// IdP doesn't surface usable groups in the ID token (Google Workspace,
+// some Entra configs). Groups exists so RBAC can live in the IdP
+// instead of the broker config.
+type AllowConfig struct {
+	// Domains is the email-domain allowlist. A login's id_token.email
+	// must end with one of these (case-insensitive) for the
+	// domain-and-groups predicate to match. Empty disables this
+	// dimension only — see the AllowConfig doc for the full rule.
+	Domains []string `yaml:"domains"`
+	// Groups is the OIDC `groups`-claim allowlist. The identity must
+	// have at least one group in this list for the domain-and-groups
+	// predicate to match. IdP-specific: Okta and Auth0 emit `groups` in
+	// the ID token when configured; Entra needs the optional `groups`
+	// claim enabled; Google does not surface groups in the ID token
+	// (use Emails as a carve-out, or wait for a userinfo-based Verifier
+	// — backlogged).
+	Groups []string `yaml:"groups"`
+	// Emails is the per-user carve-out. A login whose verified email
+	// matches an entry here qualifies regardless of Domains and Groups.
+	// Entries are lowercased + trimmed at config load so the runtime
+	// compare is case-insensitive without per-call normalization.
+	Emails []string `yaml:"emails"`
 }
 
 // TokenScope is the capability bundle every token minted for a given
@@ -174,6 +212,18 @@ func (c *Config) validate() error {
 			return fmt.Errorf("worlds[%d] (%s): defaultToken.operations is required", i, w.Name)
 		case w.DefaultToken.ExpiresAfter <= 0:
 			return fmt.Errorf("worlds[%d] (%s): defaultToken.expiresAfter must be > 0", i, w.Name)
+		}
+		// Normalize Allow.Emails to lowercase+trim so authorizedWorlds can
+		// do a plain string compare on every login. Reject empty entries
+		// here rather than silently matching the empty-email reject path
+		// inside Mint — that fails for the right reason but blames the
+		// caller for a config bug.
+		for j, e := range w.Allow.Emails {
+			norm := strings.ToLower(strings.TrimSpace(e))
+			if norm == "" {
+				return fmt.Errorf("worlds[%d] (%s): allow.emails[%d] is empty", i, w.Name, j)
+			}
+			w.Allow.Emails[j] = norm
 		}
 		seen[w.Name] = true
 	}

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -190,25 +190,25 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "allow.groups trimmed but case preserved",
-			// Groups are trim-only at load (no lowercase) because
-			// group-name case sensitivity is IdP-dependent — keep the
-			// configured case for debug-log readability while still
-			// catching whitespace typos.
+			name: "allow.groups normalized to lowercase",
+			// Groups are lowercased+trimmed at load, same as domains and
+			// emails. Match is case-insensitive because our target IdP
+			// set treats group-name uniqueness case-insensitively;
+			// see the AllowConfig.Groups doc for why.
 			body: strings.Replace(validConfig,
 				`allow:
       domains: ["example.com"]`,
 				`allow:
-      groups: ["  Engineering  ", " ops"]`, 1),
+      groups: ["  Engineering  ", " OPS"]`, 1),
 			validate: func(t *testing.T, c *Config) {
 				got := c.Worlds[0].Allow.Groups
-				want := []string{"Engineering", "ops"}
+				want := []string{"engineering", "ops"}
 				if len(got) != len(want) {
 					t.Fatalf("groups = %v, want %v", got, want)
 				}
 				for j, g := range got {
 					if g != want[j] {
-						t.Errorf("groups[%d] = %q, want %q (trim only, case preserved)", j, g, want[j])
+						t.Errorf("groups[%d] = %q, want %q (must be lowercased + trimmed at load)", j, g, want[j])
 					}
 				}
 			},

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -189,6 +189,39 @@ func TestLoadConfig(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "allow.groups trimmed but case preserved",
+			// Groups are trim-only at load (no lowercase) because
+			// group-name case sensitivity is IdP-dependent — keep the
+			// configured case for debug-log readability while still
+			// catching whitespace typos.
+			body: strings.Replace(validConfig,
+				`allow:
+      domains: ["example.com"]`,
+				`allow:
+      groups: ["  Engineering  ", " ops"]`, 1),
+			validate: func(t *testing.T, c *Config) {
+				got := c.Worlds[0].Allow.Groups
+				want := []string{"Engineering", "ops"}
+				if len(got) != len(want) {
+					t.Fatalf("groups = %v, want %v", got, want)
+				}
+				for j, g := range got {
+					if g != want[j] {
+						t.Errorf("groups[%d] = %q, want %q (trim only, case preserved)", j, g, want[j])
+					}
+				}
+			},
+		},
+		{
+			name: "allow.groups empty entry rejected",
+			body: strings.Replace(validConfig,
+				`allow:
+      domains: ["example.com"]`,
+				`allow:
+      groups: ["engineering", "   "]`, 1),
+			wantErr: "allow.groups[1] is empty",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -117,6 +117,35 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: "field extraField not found",
 		},
 		{
+			name: "allow.domains normalized to lowercase",
+			body: strings.Replace(validConfig,
+				`allow:
+      domains: ["example.com"]`,
+				`allow:
+      domains: ["  Example.COM  ", "OTHER.example"]`, 1),
+			validate: func(t *testing.T, c *Config) {
+				got := c.Worlds[0].Allow.Domains
+				want := []string{"example.com", "other.example"}
+				if len(got) != len(want) {
+					t.Fatalf("domains = %v, want %v", got, want)
+				}
+				for j, d := range got {
+					if d != want[j] {
+						t.Errorf("domains[%d] = %q, want %q (must be lowercased + trimmed at load)", j, d, want[j])
+					}
+				}
+			},
+		},
+		{
+			name: "allow.domains empty entry rejected",
+			body: strings.Replace(validConfig,
+				`allow:
+      domains: ["example.com"]`,
+				`allow:
+      domains: ["example.com", ""]`, 1),
+			wantErr: "allow.domains[1] is empty",
+		},
+		{
 			name: "allow.emails normalized to lowercase",
 			body: strings.Replace(validConfig,
 				`allow:

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -22,7 +22,20 @@ worlds:
   - name: team-a
     namespace: team-a
     tokensSecret: team-a-tokens
-    allowDomains: ["example.com"]
+    allow:
+      domains: ["example.com"]
+    defaultToken:
+      paths: ["/team-a/*"]
+      operations: ["read", "publish"]
+      expiresAfter: 24h
+`
+
+const validWorldBlock = `worlds:
+  - name: team-a
+    namespace: team-a
+    tokensSecret: team-a-tokens
+    allow:
+      domains: ["example.com"]
     defaultToken:
       paths: ["/team-a/*"]
       operations: ["read", "publish"]
@@ -75,7 +88,7 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			name:    "no worlds",
-			body:    strings.Replace(validConfig, "worlds:\n  - name: team-a\n    namespace: team-a\n    tokensSecret: team-a-tokens\n    allowDomains: [\"example.com\"]\n    defaultToken:\n      paths: [\"/team-a/*\"]\n      operations: [\"read\", \"publish\"]\n      expiresAfter: 24h\n", "worlds: []\n", 1),
+			body:    strings.Replace(validConfig, validWorldBlock, "worlds: []\n", 1),
 			wantErr: "at least one world is required",
 		},
 		{
@@ -102,6 +115,50 @@ func TestLoadConfig(t *testing.T) {
 			name:    "unknown field caught",
 			body:    validConfig + "extraField: oops\n",
 			wantErr: "field extraField not found",
+		},
+		{
+			name: "allow.emails normalized to lowercase",
+			body: strings.Replace(validConfig,
+				`allow:
+      domains: ["example.com"]`,
+				`allow:
+      emails: ["  Alice@Example.COM  ", "BOB@example.com"]`, 1),
+			validate: func(t *testing.T, c *Config) {
+				got := c.Worlds[0].Allow.Emails
+				want := []string{"alice@example.com", "bob@example.com"}
+				if len(got) != len(want) {
+					t.Fatalf("emails = %v, want %v", got, want)
+				}
+				for j, e := range got {
+					if e != want[j] {
+						t.Errorf("emails[%d] = %q, want %q (must be lowercased + trimmed at load)", j, e, want[j])
+					}
+				}
+			},
+		},
+		{
+			name: "allow.emails empty entry rejected",
+			body: strings.Replace(validConfig,
+				`allow:
+      domains: ["example.com"]`,
+				`allow:
+      emails: ["alice@example.com", "   "]`, 1),
+			wantErr: "allow.emails[1] is empty",
+		},
+		{
+			name: "allow.groups accepted",
+			body: strings.Replace(validConfig,
+				`allow:
+      domains: ["example.com"]`,
+				`allow:
+      domains: ["example.com"]
+      groups: ["engineering", "ops"]`, 1),
+			validate: func(t *testing.T, c *Config) {
+				got := c.Worlds[0].Allow.Groups
+				if len(got) != 2 || got[0] != "engineering" || got[1] != "ops" {
+					t.Errorf("groups = %v, want [engineering ops]", got)
+				}
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/tools/demarkus-broker/internal/broker/issuer.go
+++ b/tools/demarkus-broker/internal/broker/issuer.go
@@ -115,13 +115,24 @@ func (i *Issuer) Mint(ctx context.Context, claims Claims) ([]MintResult, error) 
 	if !claims.EmailVerified {
 		return nil, ErrEmailUnverified
 	}
-	// An empty (or whitespace-only) email evades domain authorization
-	// because a world with every Allow list empty qualifies any verified
-	// identity (back-compat). Worse, the empty string would land as the
-	// "owner" of the issuance record, collapsing every future caller
-	// with no email into the same identity for List/Revoke. Reject
-	// explicitly at this boundary, before authorizedWorlds runs.
-	if strings.TrimSpace(claims.Email) == "" {
+	// Canonicalize the email once at the boundary: trim + lowercase, then
+	// reject empty. Reasons to do this here, not in the leaf helpers:
+	//
+	//  - An untrimmed email (e.g. "alice@example.com ") evades
+	//    domainMatches because LastIndex("@") splits the local-part from
+	//    the domain *including the trailing whitespace*, and the
+	//    config-side allowlist is trim+lowercase normalized.
+	//  - The canonicalized value is what lands in the issuances Secret
+	//    as the owner. Without normalization here, two logins of the
+	//    same user with different IdP-side casing produce two distinct
+	//    "owners" for List/Revoke, even though EqualFold compares paper
+	//    over the difference on the read path.
+	//  - The empty-email guard prevents the empty string from becoming a
+	//    shared "no identity" owner across every future no-email caller,
+	//    in the path where every Allow list is empty (back-compat
+	//    "any verified user" worlds).
+	claims.Email = strings.ToLower(strings.TrimSpace(claims.Email))
+	if claims.Email == "" {
 		return nil, ErrNotAuthorized
 	}
 	worlds := i.authorizedWorlds(claims)

--- a/tools/demarkus-broker/internal/broker/issuer.go
+++ b/tools/demarkus-broker/internal/broker/issuer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -115,15 +116,15 @@ func (i *Issuer) Mint(ctx context.Context, claims Claims) ([]MintResult, error) 
 		return nil, ErrEmailUnverified
 	}
 	// An empty (or whitespace-only) email evades domain authorization
-	// because domainMatches short-circuits to true when a world's
-	// AllowDomains is empty. Worse, the empty string would land as the
+	// because a world with every Allow list empty qualifies any verified
+	// identity (back-compat). Worse, the empty string would land as the
 	// "owner" of the issuance record, collapsing every future caller
 	// with no email into the same identity for List/Revoke. Reject
-	// explicitly at this boundary.
+	// explicitly at this boundary, before authorizedWorlds runs.
 	if strings.TrimSpace(claims.Email) == "" {
 		return nil, ErrNotAuthorized
 	}
-	worlds := i.authorizedWorlds(claims.Email)
+	worlds := i.authorizedWorlds(claims)
 	if len(worlds) == 0 {
 		return nil, ErrNotAuthorized
 	}
@@ -139,17 +140,56 @@ func (i *Issuer) Mint(ctx context.Context, claims Claims) ([]MintResult, error) 
 	return results, nil
 }
 
-func (i *Issuer) authorizedWorlds(email string) []*WorldConfig {
+func (i *Issuer) authorizedWorlds(claims Claims) []*WorldConfig {
 	out := make([]*WorldConfig, 0, len(i.cfg.Worlds))
 	for j := range i.cfg.Worlds {
 		w := &i.cfg.Worlds[j]
-		if domainMatches(email, w.AllowDomains) {
+		if worldAllows(&w.Allow, claims) {
 			out = append(out, w)
 		}
 	}
 	return out
 }
 
+// worldAllows is the AllowConfig predicate. See the AllowConfig doc on
+// config.go for the human-readable rule; the order of checks here is:
+//
+//  1. All three lists empty → match (back-compat for worlds with no
+//     allowlist configured, same as the pre-Slice-C behavior).
+//  2. Email-in-Emails → match (per-user carve-out bypasses both
+//     domain and group requirements).
+//  3. Domains+Groups predicate, where an empty list on either dimension
+//     means "no restriction on that dimension." But if only Emails was
+//     set and Step 2 didn't match, Step 3 must reject — otherwise
+//     `emails: [alice@x]` with no other allowlist would silently mean
+//     "everyone plus alice." Detected as `len(Domains)+len(Groups)==0`
+//     when we get here.
+func worldAllows(a *AllowConfig, claims Claims) bool {
+	if len(a.Domains) == 0 && len(a.Groups) == 0 && len(a.Emails) == 0 {
+		return true
+	}
+	if emailMatches(claims.Email, a.Emails) {
+		return true
+	}
+	if len(a.Domains) == 0 && len(a.Groups) == 0 {
+		return false
+	}
+	return domainMatches(claims.Email, a.Domains) && groupsMatch(claims.Groups, a.Groups)
+}
+
+// emailMatches reports whether the lowercased+trimmed identity email is
+// in the (already-normalized at config load) Emails list.
+func emailMatches(email string, allowed []string) bool {
+	if len(allowed) == 0 {
+		return false
+	}
+	want := strings.ToLower(strings.TrimSpace(email))
+	return slices.Contains(allowed, want)
+}
+
+// domainMatches reports whether the identity email's domain part is in
+// the allowlist. Returns true on an empty allowlist — the "no
+// restriction on the domain dimension" semantic worldAllows depends on.
 func domainMatches(email string, allowed []string) bool {
 	if len(allowed) == 0 {
 		return true
@@ -162,6 +202,26 @@ func domainMatches(email string, allowed []string) bool {
 	for _, d := range allowed {
 		if strings.EqualFold(d, domain) {
 			return true
+		}
+	}
+	return false
+}
+
+// groupsMatch reports whether the identity has at least one group in
+// the allowlist. Returns true on an empty allowlist — the "no
+// restriction on the group dimension" semantic worldAllows depends on.
+// IdPs that don't surface groups in the ID token send a nil claims.Groups;
+// in that case the match fails (unless the allowlist is also empty),
+// which is the operator's signal to use AllowEmails as a carve-out.
+func groupsMatch(have, allowed []string) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	for _, g := range have {
+		for _, want := range allowed {
+			if strings.EqualFold(g, want) {
+				return true
+			}
 		}
 	}
 	return false

--- a/tools/demarkus-broker/internal/broker/issuer.go
+++ b/tools/demarkus-broker/internal/broker/issuer.go
@@ -223,15 +223,18 @@ func domainMatches(email string, allowed []string) bool {
 // IdPs that don't surface groups in the ID token send a nil claims.Groups;
 // in that case the match fails (unless the allowlist is also empty),
 // which is the operator's signal to use AllowEmails as a carve-out.
+//
+// Match is case-insensitive: the allowlist is lowercased at config load
+// (validate in config.go) and the claim's groups are lowercased here.
+// See the AllowConfig.Groups doc for why our target IdPs (Google, Okta,
+// Entra ID, Auth0) make case-insensitive the safe default.
 func groupsMatch(have, allowed []string) bool {
 	if len(allowed) == 0 {
 		return true
 	}
 	for _, g := range have {
-		for _, want := range allowed {
-			if strings.EqualFold(g, want) {
-				return true
-			}
+		if slices.Contains(allowed, strings.ToLower(g)) {
+			return true
 		}
 	}
 	return false

--- a/tools/demarkus-broker/internal/broker/issuer.go
+++ b/tools/demarkus-broker/internal/broker/issuer.go
@@ -190,6 +190,10 @@ func emailMatches(email string, allowed []string) bool {
 // domainMatches reports whether the identity email's domain part is in
 // the allowlist. Returns true on an empty allowlist — the "no
 // restriction on the domain dimension" semantic worldAllows depends on.
+//
+// The allowlist is lowercased+trimmed at config load (validate in
+// config.go), so a plain compare against the lowercased domain part of
+// the email is sufficient — no EqualFold needed on the hot path.
 func domainMatches(email string, allowed []string) bool {
 	if len(allowed) == 0 {
 		return true
@@ -199,12 +203,7 @@ func domainMatches(email string, allowed []string) bool {
 		return false
 	}
 	domain := strings.ToLower(email[at+1:])
-	for _, d := range allowed {
-		if strings.EqualFold(d, domain) {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(allowed, domain)
 }
 
 // groupsMatch reports whether the identity has at least one group in

--- a/tools/demarkus-broker/internal/broker/issuer_test.go
+++ b/tools/demarkus-broker/internal/broker/issuer_test.go
@@ -318,6 +318,21 @@ func TestMintAuthorizationPredicate(t *testing.T) {
 			accept: false,
 		},
 		{
+			name: "groups_case_insensitive_claim_side",
+			// The allowlist arrives pre-normalized (lowercased+trimmed)
+			// from config load — see TestLoadConfig/allow.groups_normalized_to_lowercase
+			// for the load-side half. This row asserts the runtime half:
+			// the IdP can emit any case in the claim and still match.
+			// Together the two cover the end-to-end "operator writes
+			// any case, IdP emits any case" story. Regressing this to a
+			// case-sensitive compare would silently break the common
+			// case where Okta/Entra/Auth0 normalize group casing
+			// upstream and must fail this test.
+			allow:  AllowConfig{Groups: []string{"engineering"}},
+			claims: Claims{Email: "any@anywhere.test", EmailVerified: true, Groups: []string{"Engineering"}},
+			accept: true,
+		},
+		{
 			name:   "domain_and_groups_both_match",
 			allow:  AllowConfig{Domains: []string{"example.com"}, Groups: []string{"engineering"}},
 			claims: Claims{Email: "alice@example.com", EmailVerified: true, Groups: []string{"engineering"}},

--- a/tools/demarkus-broker/internal/broker/issuer_test.go
+++ b/tools/demarkus-broker/internal/broker/issuer_test.go
@@ -42,7 +42,7 @@ func testConfig() *Config {
 				Name:         "team-a",
 				Namespace:    "team-a",
 				TokensSecret: "team-a-tokens",
-				AllowDomains: []string{"example.com"},
+				Allow:        AllowConfig{Domains: []string{"example.com"}},
 				DefaultToken: TokenScope{
 					Paths:        []string{"/team-a/*"},
 					Operations:   []string{"read", "publish"},
@@ -161,7 +161,7 @@ func TestMintRejectsEmptyEmail(t *testing.T) {
 	// with no identity into the same "owner" in the issuances Secret.
 	// Mint must refuse before that ownership record is written.
 	cfg := testConfig()
-	cfg.Worlds[0].AllowDomains = nil
+	cfg.Worlds[0].Allow = AllowConfig{}
 	for _, email := range []string{"", "   ", "\t"} {
 		k8s := fake.NewSimpleClientset()
 		i := newIssuer(t, cfg, k8s)
@@ -193,7 +193,7 @@ func TestMintMultipleWorldsOnlyAuthorizedReceive(t *testing.T) {
 		Name:         "team-b",
 		Namespace:    "team-b",
 		TokensSecret: "team-b-tokens",
-		AllowDomains: []string{"other.example"},
+		Allow:        AllowConfig{Domains: []string{"other.example"}},
 		DefaultToken: TokenScope{
 			Paths:        []string{"/team-b/*"},
 			Operations:   []string{"read"},
@@ -215,14 +215,162 @@ func TestMintMultipleWorldsOnlyAuthorizedReceive(t *testing.T) {
 	}
 }
 
-func TestMintDomainAllowlistEmptyMatchesAll(t *testing.T) {
+func TestMintAllAllowlistsEmptyMatchesAll(t *testing.T) {
+	// Back-compat: a world with no allowlist (the pre-Slice-C default
+	// when an operator omitted allowDomains) keeps the "any verified
+	// user qualifies" behavior. Slice C.1 must not tighten this — only
+	// rendering AllowConfig non-empty switches into restricted mode.
 	cfg := testConfig()
-	cfg.Worlds[0].AllowDomains = nil
+	cfg.Worlds[0].Allow = AllowConfig{}
 	k8s := fake.NewSimpleClientset()
 	i := newIssuer(t, cfg, k8s)
 
 	if _, err := i.Mint(context.Background(), Claims{Email: "anyone@anywhere.test", EmailVerified: true}); err != nil {
 		t.Errorf("Mint: %v", err)
+	}
+}
+
+// TestMintAuthorizationPredicate is the Slice C.1 authorization table.
+// Each row pins one AllowConfig shape and asserts whether a given
+// Claims qualifies. Mint is the public surface; reaching ErrNotAuthorized
+// means the world rejected, while a single MintResult means it accepted.
+// The "expect" column is the world-A accept decision; rejections also
+// verify no Secrets were written (caught by the partial-mint regression
+// guard from Slice B).
+func TestMintAuthorizationPredicate(t *testing.T) {
+	tests := []struct {
+		name   string
+		allow  AllowConfig
+		claims Claims
+		accept bool
+	}{
+		{
+			name:   "all_empty_back_compat_accept",
+			allow:  AllowConfig{},
+			claims: Claims{Email: "any@anywhere.test", EmailVerified: true},
+			accept: true,
+		},
+		{
+			name:   "domain_only_match",
+			allow:  AllowConfig{Domains: []string{"example.com"}},
+			claims: Claims{Email: "alice@example.com", EmailVerified: true},
+			accept: true,
+		},
+		{
+			name:   "domain_only_reject",
+			allow:  AllowConfig{Domains: []string{"example.com"}},
+			claims: Claims{Email: "alice@evil.example", EmailVerified: true},
+			accept: false,
+		},
+		{
+			name:   "groups_only_match",
+			allow:  AllowConfig{Groups: []string{"engineering"}},
+			claims: Claims{Email: "any@anywhere.test", EmailVerified: true, Groups: []string{"engineering", "ops"}},
+			accept: true,
+		},
+		{
+			name: "groups_only_reject_no_group_claim",
+			// The IdP did not surface a `groups` claim at all (Groups nil).
+			// AllowGroups is non-empty so groupsMatch returns false.
+			// The operator's escape hatch is to add Emails — covered below.
+			allow:  AllowConfig{Groups: []string{"engineering"}},
+			claims: Claims{Email: "any@anywhere.test", EmailVerified: true},
+			accept: false,
+		},
+		{
+			name:   "groups_only_reject_wrong_group",
+			allow:  AllowConfig{Groups: []string{"engineering"}},
+			claims: Claims{Email: "any@anywhere.test", EmailVerified: true, Groups: []string{"marketing"}},
+			accept: false,
+		},
+		{
+			name:   "domain_and_groups_both_match",
+			allow:  AllowConfig{Domains: []string{"example.com"}, Groups: []string{"engineering"}},
+			claims: Claims{Email: "alice@example.com", EmailVerified: true, Groups: []string{"engineering"}},
+			accept: true,
+		},
+		{
+			name: "domain_and_groups_domain_fails",
+			// Predicate is AND between domains and groups, so a domain
+			// miss rejects even with a matching group. This is the
+			// "groups intersect domains" semantics — RBAC inside an org,
+			// not across orgs.
+			allow:  AllowConfig{Domains: []string{"example.com"}, Groups: []string{"engineering"}},
+			claims: Claims{Email: "alice@partner.test", EmailVerified: true, Groups: []string{"engineering"}},
+			accept: false,
+		},
+		{
+			name:   "domain_and_groups_groups_fails",
+			allow:  AllowConfig{Domains: []string{"example.com"}, Groups: []string{"engineering"}},
+			claims: Claims{Email: "alice@example.com", EmailVerified: true, Groups: []string{"marketing"}},
+			accept: false,
+		},
+		{
+			name:   "emails_carve_out_bypasses_domain",
+			allow:  AllowConfig{Domains: []string{"example.com"}, Emails: []string{"alice@partner.test"}},
+			claims: Claims{Email: "alice@partner.test", EmailVerified: true},
+			accept: true,
+		},
+		{
+			name: "emails_carve_out_bypasses_groups",
+			// The whole point of Emails: the user lacks a matching
+			// group (or any groups at all), but is on the carve-out
+			// list. Mint must accept regardless.
+			allow:  AllowConfig{Groups: []string{"engineering"}, Emails: []string{"contractor@example.com"}},
+			claims: Claims{Email: "contractor@example.com", EmailVerified: true},
+			accept: true,
+		},
+		{
+			name: "emails_only_no_match_rejects",
+			// The "only AllowEmails" subtlety: an empty Domains+Groups
+			// would normally evaluate to true on the AND predicate, but
+			// worldAllows refuses to fall through to that branch when
+			// only Emails was configured. Otherwise `allow.emails:
+			// [alice]` with nothing else would silently mean "everyone
+			// plus alice."
+			allow:  AllowConfig{Emails: []string{"alice@example.com"}},
+			claims: Claims{Email: "bob@example.com", EmailVerified: true},
+			accept: false,
+		},
+		{
+			name:   "emails_only_match",
+			allow:  AllowConfig{Emails: []string{"alice@example.com"}},
+			claims: Claims{Email: "alice@example.com", EmailVerified: true},
+			accept: true,
+		},
+		{
+			name: "emails_case_insensitive",
+			// AllowConfig.Emails is normalized at config load
+			// (lowercased + trimmed). The runtime compare lowercases
+			// the claim's email too; a claim with uppercase characters
+			// must still match a lowercased entry.
+			allow:  AllowConfig{Emails: []string{"alice@example.com"}},
+			claims: Claims{Email: "Alice@Example.COM", EmailVerified: true},
+			accept: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfig()
+			cfg.Worlds[0].Allow = tt.allow
+			k8s := fake.NewSimpleClientset()
+			i := newIssuer(t, cfg, k8s)
+
+			results, err := i.Mint(context.Background(), tt.claims)
+			if tt.accept {
+				if err != nil {
+					t.Fatalf("Mint: %v, want accept", err)
+				}
+				if len(results) != 1 {
+					t.Errorf("got %d results, want 1", len(results))
+				}
+				return
+			}
+			if !errors.Is(err, ErrNotAuthorized) {
+				t.Errorf("err = %v, want ErrNotAuthorized", err)
+			}
+			assertNoSecretsWritten(t, k8s)
+		})
 	}
 }
 
@@ -309,7 +457,7 @@ func TestMintCrossWorldLabelCollisionRetries(t *testing.T) {
 		Name:         "team-b",
 		Namespace:    "team-b",
 		TokensSecret: "team-b-tokens",
-		AllowDomains: []string{"example.com"},
+		Allow:        AllowConfig{Domains: []string{"example.com"}},
 		DefaultToken: TokenScope{
 			Paths:        []string{"/team-b/*"},
 			Operations:   []string{"read"},
@@ -390,7 +538,7 @@ func TestListFiltersByEmail(t *testing.T) {
 		Name:         "team-b",
 		Namespace:    "team-b",
 		TokensSecret: "team-b-tokens",
-		AllowDomains: []string{"example.com"},
+		Allow:        AllowConfig{Domains: []string{"example.com"}},
 		DefaultToken: TokenScope{
 			Paths:        []string{"/team-b/*"},
 			Operations:   []string{"read"},

--- a/tools/demarkus-broker/internal/broker/issuer_test.go
+++ b/tools/demarkus-broker/internal/broker/issuer_test.go
@@ -173,6 +173,40 @@ func TestMintRejectsEmptyEmail(t *testing.T) {
 	}
 }
 
+func TestMintCanonicalizesEmail(t *testing.T) {
+	// Mint trims and lowercases claims.Email once before authorization
+	// and persistence. Without that, a domain match on the right side
+	// of the email could be silently dropped because LastIndex("@")
+	// keeps trailing whitespace in the domain slice; and two logins of
+	// the same user with different IdP-side casing would land as two
+	// distinct "owner" records in the issuances Secret. Asserting the
+	// final state covers both halves: domain match succeeded (single
+	// MintResult returned) and the persisted owner is canonical.
+	k8s := fake.NewSimpleClientset()
+	i := newIssuer(t, testConfig(), k8s)
+
+	results, err := i.Mint(context.Background(), Claims{
+		Email:         "  Alice@Example.COM\t",
+		EmailVerified: true,
+	})
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	got, err := i.List(context.Background(), "alice@example.com")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("List got %d, want 1", len(got))
+	}
+	if got[0].Email != "alice@example.com" {
+		t.Errorf("issuance Email = %q, want canonical %q", got[0].Email, "alice@example.com")
+	}
+}
+
 // assertNoSecretsWritten verifies the rejection paths leave both the
 // world namespace and the broker namespace untouched. Bug regressions
 // that write the issuances Secret before returning an error would

--- a/tools/demarkus-broker/internal/broker/oidc.go
+++ b/tools/demarkus-broker/internal/broker/oidc.go
@@ -10,12 +10,15 @@ import (
 )
 
 // Claims is the subset of OIDC ID-token claims the broker actually consumes.
-// Slice B uses only Subject + Email + EmailVerified. Groups will be added
-// in Slice C; left out for now so the surface area is minimal.
+// Subject + Email + EmailVerified are required to mint. Groups is optional
+// and used by the per-world group allowlist (Slice C.1); IdPs that don't
+// surface groups in the ID token (or aren't configured to) leave it nil
+// and the operator falls back to AllowDomains or per-email carve-outs.
 type Claims struct {
 	Subject       string
 	Email         string
 	EmailVerified bool
+	Groups        []string
 }
 
 // Verifier is the broker's abstraction over an OIDC provider. The
@@ -45,8 +48,8 @@ var ErrNoIDToken = errors.New("broker: oidc token response missing id_token")
 
 // ErrEmailUnverified is returned when the IdP did not assert
 // email_verified=true. The broker refuses to mint for unverified emails
-// because the world authorization decision (allowDomains) is meaningless
-// on an unverified address.
+// because the world authorization decisions (allow.domains / allow.emails)
+// are meaningless on an unverified address.
 var ErrEmailUnverified = errors.New("broker: id_token email not verified")
 
 type oidcVerifier struct {
@@ -99,8 +102,9 @@ func (v *oidcVerifier) VerifyIDToken(ctx context.Context, rawIDToken string) (Cl
 		return Claims{}, fmt.Errorf("broker: verify id_token: %w", err)
 	}
 	var raw struct {
-		Email         string `json:"email"`
-		EmailVerified bool   `json:"email_verified"`
+		Email         string   `json:"email"`
+		EmailVerified bool     `json:"email_verified"`
+		Groups        []string `json:"groups"`
 	}
 	if err := idTok.Claims(&raw); err != nil {
 		return Claims{}, fmt.Errorf("broker: read id_token claims: %w", err)
@@ -112,5 +116,6 @@ func (v *oidcVerifier) VerifyIDToken(ctx context.Context, rawIDToken string) (Cl
 		Subject:       idTok.Subject,
 		Email:         raw.Email,
 		EmailVerified: raw.EmailVerified,
+		Groups:        raw.Groups,
 	}, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authorization config now supports nested allow lists for domains, groups, and emails; empty allow lists remain permissive (back-compat)
  * ID token groups are now recognized and used in authorization decisions

* **Bug Fixes / Behavior**
  * Email, domain, and group entries are normalized (trimmed, lowercased); empty/invalid entries fail validation
  * Minting canonicalizes emails and rejects empty/whitespace-only emails

* **Tests**
  * Expanded tests for allow-list combinations, normalization, and authorization semantics

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/110)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->