### PR TITLE
fix(tools): Add periodic token expiry sweeper to brokerai

### DIFF
--- a/protocol/token/bytes_test.go
+++ b/protocol/token/bytes_test.go
@@ -114,3 +114,63 @@ func TestRemoveBytesEmpty(t *testing.T) {
 		t.Errorf("expected nil, got %q", got)
 	}
 }
+
+func TestParseBytesEmpty(t *testing.T) {
+	f, err := ParseBytes(nil)
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	// Tokens map must be non-nil so membership checks (`_, ok := f.Tokens[label]`)
+	// don't need to special-case the empty input — symmetric with ReadFile.
+	if f.Tokens == nil {
+		t.Error("Tokens map nil on empty input")
+	}
+	if len(f.Tokens) != 0 {
+		t.Errorf("Tokens populated on empty input: %+v", f.Tokens)
+	}
+}
+
+func TestParseBytesPopulated(t *testing.T) {
+	existing := []byte("[tokens.admin]\nhash = \"sha256-aaa\"\npaths = [\"/\"]\noperations = [\"read\"]\n\n[tokens.user1]\nhash = \"sha256-bbb\"\npaths = [\"/team-a/*\"]\noperations = [\"read\", \"publish\"]\nexpires = \"2026-05-12T12:00:00Z\"\n")
+	f, err := ParseBytes(existing)
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	if len(f.Tokens) != 2 {
+		t.Fatalf("got %d entries, want 2: %+v", len(f.Tokens), f.Tokens)
+	}
+	admin, ok := f.Tokens["admin"]
+	if !ok {
+		t.Fatalf("admin missing")
+	}
+	if admin.Hash != "sha256-aaa" {
+		t.Errorf("admin.Hash = %q", admin.Hash)
+	}
+	user1, ok := f.Tokens["user1"]
+	if !ok {
+		t.Fatalf("user1 missing")
+	}
+	if user1.Expires != "2026-05-12T12:00:00Z" {
+		t.Errorf("user1.Expires = %q", user1.Expires)
+	}
+}
+
+func TestParseBytesQuotedLabel(t *testing.T) {
+	// Labels that need quoting in TOML (dots, plus signs) must round-trip
+	// through ParseBytes intact — the broker's drift sweep relies on a
+	// labels-map lookup, not a substring search on the serialized form.
+	existing := []byte(`[tokens."alice@example.com"]` + "\nhash = \"sha256-aaa\"\npaths = [\"/\"]\noperations = [\"read\"]\n")
+	f, err := ParseBytes(existing)
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	if _, ok := f.Tokens["alice@example.com"]; !ok {
+		t.Errorf("quoted label missing: %+v", f.Tokens)
+	}
+}
+
+func TestParseBytesMalformed(t *testing.T) {
+	if _, err := ParseBytes([]byte("not = [")); err == nil {
+		t.Error("expected error on malformed TOML")
+	}
+}

--- a/protocol/token/tomlio.go
+++ b/protocol/token/tomlio.go
@@ -87,6 +87,27 @@ func AppendEntry(path, label string, entry *Entry) error {
 	})
 }
 
+// ParseBytes decodes tokens.toml bytes into a File. An empty input
+// returns an empty File with Tokens initialized to a non-nil map, the
+// same convention ReadFile uses. The broker calls this to inspect a
+// world's tokens Secret directly — drift detection in the expiry
+// sweeper compares broker-side issuance labels against the labels
+// actually present in the world's TOML, and a quoted-key parse here is
+// safer than a substring search on the serialized bytes.
+func ParseBytes(existing []byte) (File, error) {
+	f := File{Tokens: make(map[string]Entry)}
+	if len(existing) == 0 {
+		return f, nil
+	}
+	if err := toml.Unmarshal(existing, &f); err != nil {
+		return File{}, fmt.Errorf("decode tokens bytes: %w", err)
+	}
+	if f.Tokens == nil {
+		f.Tokens = make(map[string]Entry)
+	}
+	return f, nil
+}
+
 // AppendBytes is the in-memory analogue of AppendEntry: given existing
 // tokens.toml bytes (possibly empty), it returns the bytes with a new
 // labeled entry appended. Used by the demarkus-broker, which writes to a

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -241,18 +241,32 @@ func (c *Config) validate() error {
 	// Sweeper defaults. Disabled is the zero-value opt-out — see the
 	// SweeperConfig doc for why it's named "Disabled" rather than
 	// "Enabled". Interval and LeaseName get production-safe defaults
-	// when omitted; negative Interval is a config typo.
+	// when omitted; negative Interval is a config typo, and an
+	// interval longer than the typical 24h token lifetime would let
+	// expired tokens linger past their `defaultToken.expiresAfter`
+	// window — defeating the short-lived-tokens identity-lifecycle
+	// model (see plan §Revocation §3).
 	if c.Sweeper.Interval == 0 {
 		c.Sweeper.Interval = 5 * time.Minute
 	}
 	if c.Sweeper.Interval < 0 {
 		return fmt.Errorf("sweeper.interval must be > 0 (got %s)", c.Sweeper.Interval)
 	}
+	if c.Sweeper.Interval > maxSweeperInterval {
+		return fmt.Errorf("sweeper.interval must be <= %s (got %s); intervals longer than a token lifetime defeat expiry-driven revocation", maxSweeperInterval, c.Sweeper.Interval)
+	}
 	if c.Sweeper.LeaseName == "" {
 		c.Sweeper.LeaseName = "demarkus-broker-sweeper"
 	}
 	return nil
 }
+
+// maxSweeperInterval caps Sweeper.Interval at 24h — the canonical
+// short-lived-token lifetime in plan §Revocation. Intervals longer
+// than this leave expired tokens accepted past their ExpiresAt for
+// up to a whole sweep cycle, breaking the contract that callers
+// expect "expires" to mean.
+const maxSweeperInterval = 24 * time.Hour
 
 // validateWorld enforces the per-world invariants and normalizes the
 // AllowConfig string lists in place. Split out of validate() so the

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -15,9 +15,10 @@ import (
 // is authorized to mint tokens for. The world Tokens Secrets live in each
 // world's namespace; the issuances Secret lives in the broker's namespace.
 type Config struct {
-	Server ServerConfig  `yaml:"server"`
-	OIDC   OIDCConfig    `yaml:"oidc"`
-	Worlds []WorldConfig `yaml:"worlds"`
+	Server  ServerConfig  `yaml:"server"`
+	OIDC    OIDCConfig    `yaml:"oidc"`
+	Worlds  []WorldConfig `yaml:"worlds"`
+	Sweeper SweeperConfig `yaml:"sweeper"`
 }
 
 // ServerConfig holds the broker's own runtime settings — listen address,
@@ -125,6 +126,33 @@ type AllowConfig struct {
 	Emails []string `yaml:"emails"`
 }
 
+// SweeperConfig knobs control the broker's periodic expiry+drift
+// janitor (Slice C.2). The sweeper runs by default in every broker;
+// multi-replica deployments need it so expired tokens age out and
+// operator hand-edits of world tokens.toml propagate back into the
+// issuances Secret. Leader election timings are not yet exposed —
+// client-go defaults (15s lease, 10s renew, 2s retry) suffice for our
+// failover budget and revisit only if a customer needs faster failover.
+type SweeperConfig struct {
+	// Disabled is the opt-out switch. Omitting the block in YAML
+	// (zero-value false) gives the production-correct behavior: the
+	// sweeper runs. Set to true only in dev configs where the operator
+	// wants expired tokens to linger for inspection, or in a
+	// single-replica deployment that wants to skip the leader-election
+	// overhead. Named "Disabled" rather than "Enabled" so the
+	// zero-value default is the safe one.
+	Disabled bool `yaml:"disabled"`
+	// Interval is the time between sweep passes. Default 5m. Shorter
+	// values shrink the worst-case window between token expiry and the
+	// world Secret reflecting it, at the cost of more k8s API churn.
+	Interval time.Duration `yaml:"interval"`
+	// LeaseName is the coordination.k8s.io/Lease object the broker
+	// replicas race for, in Server.BrokerNamespace. Default
+	// "demarkus-broker-sweeper". Override only when running multiple
+	// independent broker deployments in the same namespace (rare).
+	LeaseName string `yaml:"leaseName"`
+}
+
 // TokenScope is the capability bundle every token minted for a given
 // world carries. Paths + Operations are written verbatim into the server-
 // readable tokens.toml; ExpiresAfter is the lifetime applied to each
@@ -209,6 +237,19 @@ func (c *Config) validate() error {
 			return fmt.Errorf("worlds[%d]: duplicate name %q", i, w.Name)
 		}
 		seen[w.Name] = true
+	}
+	// Sweeper defaults. Disabled is the zero-value opt-out — see the
+	// SweeperConfig doc for why it's named "Disabled" rather than
+	// "Enabled". Interval and LeaseName get production-safe defaults
+	// when omitted; negative Interval is a config typo.
+	if c.Sweeper.Interval == 0 {
+		c.Sweeper.Interval = 5 * time.Minute
+	}
+	if c.Sweeper.Interval < 0 {
+		return fmt.Errorf("sweeper.interval must be > 0 (got %s)", c.Sweeper.Interval)
+	}
+	if c.Sweeper.LeaseName == "" {
+		c.Sweeper.LeaseName = "demarkus-broker-sweeper"
 	}
 	return nil
 }

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -117,6 +117,11 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: "sweeper.interval must be <= 24h0m0s",
 		},
 		{
+			name:    "sweeper.interval negative rejected",
+			body:    validConfig + "sweeper:\n  interval: -1m\n",
+			wantErr: "sweeper.interval must be > 0",
+		},
+		{
 			name: "sweeper.interval defaults to 5m when omitted",
 			body: validConfig,
 			validate: func(t *testing.T, c *Config) {

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -112,6 +112,26 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: "server.stateTTL must be > 0",
 		},
 		{
+			name:    "sweeper.interval over 24h rejected",
+			body:    validConfig + "sweeper:\n  interval: 48h\n",
+			wantErr: "sweeper.interval must be <= 24h0m0s",
+		},
+		{
+			name: "sweeper.interval defaults to 5m when omitted",
+			body: validConfig,
+			validate: func(t *testing.T, c *Config) {
+				if c.Sweeper.Interval != 5*time.Minute {
+					t.Errorf("sweeper.interval default = %s, want 5m", c.Sweeper.Interval)
+				}
+				if c.Sweeper.LeaseName != "demarkus-broker-sweeper" {
+					t.Errorf("sweeper.leaseName default = %q, want demarkus-broker-sweeper", c.Sweeper.LeaseName)
+				}
+				if c.Sweeper.Disabled {
+					t.Error("sweeper.disabled = true, want false default")
+				}
+			},
+		},
+		{
 			name:    "unknown field caught",
 			body:    validConfig + "extraField: oops\n",
 			wantErr: "field extraField not found",

--- a/tools/demarkus-broker/internal/broker/issuer.go
+++ b/tools/demarkus-broker/internal/broker/issuer.go
@@ -325,12 +325,8 @@ func (i *Issuer) List(ctx context.Context, email string) ([]Issuance, error) {
 // Revoke removes a label from both the world's tokens Secret and the
 // broker's issuances Secret. Returns ErrNotFound if the label has no
 // issuance record, ErrNotOwner if the caller's email does not match the
-// issuance.
-//
-// World Secret is removed first so the token stops working immediately;
-// the issuance entry is the second write, which means a transient failure
-// between the two writes leaves an orphan in issuances. The Slice D
-// sweeper prunes such orphans by comparing both Secrets every tick.
+// issuance. User-initiated revocation path; the sweeper uses
+// revokeIssuance directly (no owner check, already holds the entry).
 func (i *Issuer) Revoke(ctx context.Context, callerEmail, label string) error {
 	all, err := i.readIssuances(ctx)
 	if err != nil {
@@ -349,18 +345,29 @@ func (i *Issuer) Revoke(ctx context.Context, callerEmail, label string) error {
 	if !strings.EqualFold(found.Email, callerEmail) {
 		return ErrNotOwner
 	}
-	world := i.lookupWorld(found.World)
+	return i.revokeIssuance(ctx, found)
+}
+
+// revokeIssuance executes the two-Secret mutation that retires a token:
+// remove from the world's tokens Secret first so the token stops working
+// immediately, then remove from the broker's issuances Secret. A
+// transient failure between the two writes leaves an orphan in
+// issuances; the expiry sweeper's drift-pruning catches those next tick
+// by comparing both Secrets.
+//
+// Shared between Revoke (after the owner check) and the sweeper (which
+// already holds the entry from its iteration). Surfaces the
+// world-not-configured case as an explicit error so silently dropping
+// the issuance can't leave a still-valid token in an orphaned world.
+func (i *Issuer) revokeIssuance(ctx context.Context, iss *Issuance) error {
+	world := i.lookupWorld(iss.World)
 	if world == nil {
-		// The issuance points at a world the broker is no longer
-		// configured for. Silently dropping the issuance entry would
-		// report success while leaving a still-valid token in that
-		// world's tokens Secret. Surface the misconfiguration instead.
-		return fmt.Errorf("world %q not configured for label %q", found.World, label)
+		return fmt.Errorf("world %q not configured for label %q", iss.World, iss.Label)
 	}
-	if err := i.removeFromWorldSecret(ctx, world, label); err != nil {
+	if err := i.removeFromWorldSecret(ctx, world, iss.Label); err != nil {
 		return fmt.Errorf("remove from world %s: %w", world.Name, err)
 	}
-	return i.removeIssuance(ctx, label)
+	return i.removeIssuance(ctx, iss.Label)
 }
 
 func (i *Issuer) lookupWorld(name string) *WorldConfig {

--- a/tools/demarkus-broker/internal/broker/issuer_test.go
+++ b/tools/demarkus-broker/internal/broker/issuer_test.go
@@ -723,3 +723,87 @@ func TestTokenStoredHashMatchesProtocolContract(t *testing.T) {
 		t.Errorf("stored hash does not match HashToken(raw):\n%s", secret.Data[TokensSecretKey])
 	}
 }
+
+func TestMintRBACDeniedNoPartialState(t *testing.T) {
+	// Slice C.2 RBAC-denied guard. Multi-world config: alice qualifies
+	// for team-a and team-b. The broker SA has write permission on
+	// team-a's tokens Secret but is denied on team-b's. Mint must
+	// return partial results (team-a) plus an error, AND leave team-b
+	// with zero state in either the world Secret or the issuances
+	// Secret. The latter is the "no partial state" property the plan
+	// §6.2 partial-mint edge case promises: a failed world's mint
+	// rolls back any half-written state before returning.
+	//
+	// Implementation detail: we pre-seed team-b's tokens Secret with
+	// empty data so mutateSecret takes the Update path (rather than
+	// Create), which matches the real-world RBAC failure mode of "SA
+	// can patch but only on the listed Secrets in its Role." Deny the
+	// update via a fake.Clientset reactor returning Forbidden.
+	cfg := testConfig()
+	cfg.Worlds = append(cfg.Worlds, WorldConfig{
+		Name:         "team-b",
+		Namespace:    "team-b",
+		TokensSecret: "team-b-tokens",
+		Allow:        AllowConfig{Domains: []string{"example.com"}},
+		DefaultToken: TokenScope{
+			Paths:        []string{"/team-b/*"},
+			Operations:   []string{"read"},
+			ExpiresAfter: 12 * time.Hour,
+		},
+	})
+	k8s := fake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-b-tokens", Namespace: "team-b"},
+		Data:       map[string][]byte{TokensSecretKey: {}},
+	})
+	k8s.PrependReactor("update", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ua, ok := action.(k8stesting.UpdateAction)
+		if !ok || ua.GetNamespace() != "team-b" {
+			return false, nil, nil
+		}
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Resource: "secrets"},
+			"team-b-tokens",
+			errors.New("broker SA lacks update on team-b/team-b-tokens"),
+		)
+	})
+	i := newIssuer(t, cfg, k8s)
+
+	results, err := i.Mint(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true})
+	if err == nil {
+		t.Fatal("Mint returned nil err, want RBAC-denied")
+	}
+	if len(results) != 1 || results[0].World != "team-a" {
+		t.Fatalf("results = %+v, want only team-a (partial mint)", results)
+	}
+	if !strings.Contains(err.Error(), "team-b") {
+		t.Errorf("err %q does not name the failing world team-b", err)
+	}
+
+	// team-b's tokens Secret was seeded empty and must STAY empty —
+	// every Update was Forbidden, so neither the initial write nor any
+	// retry could land. (mutateSecret's optimistic-concurrency retry
+	// only re-fires on Conflict, not Forbidden, so the budget isn't
+	// burned and the call returns promptly.)
+	teamB, err := k8s.CoreV1().Secrets("team-b").Get(context.Background(), "team-b-tokens", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get team-b Secret: %v", err)
+	}
+	if len(teamB.Data[TokensSecretKey]) != 0 {
+		t.Errorf("team-b tokens Secret leaked data despite RBAC denial:\n%s", teamB.Data[TokensSecretKey])
+	}
+
+	// Issuances Secret records team-a only — team-b never made it
+	// past the world-Secret write, so the per-world rollback in
+	// mintForWorld (which only fires after a successful world write
+	// followed by a failed issuance append) didn't even need to run.
+	live, err := i.List(context.Background(), "alice@example.com")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(live) != 1 {
+		t.Fatalf("issuances after RBAC denial = %d, want 1 (team-a)", len(live))
+	}
+	if live[0].World != "team-a" {
+		t.Errorf("issuance world = %q, want team-a", live[0].World)
+	}
+}

--- a/tools/demarkus-broker/internal/broker/issuer_test.go
+++ b/tools/demarkus-broker/internal/broker/issuer_test.go
@@ -757,14 +757,17 @@ func TestMintRBACDeniedNoPartialState(t *testing.T) {
 	})
 	k8s.PrependReactor("update", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		ua, ok := action.(k8stesting.UpdateAction)
-		if !ok || ua.GetNamespace() != "team-b" {
+		if !ok {
 			return false, nil, nil
 		}
-		return true, nil, apierrors.NewForbidden(
-			schema.GroupResource{Resource: "secrets"},
-			"team-b-tokens",
-			errors.New("broker SA lacks update on team-b/team-b-tokens"),
-		)
+		if ua.GetNamespace() == "team-b" {
+			return true, nil, apierrors.NewForbidden(
+				schema.GroupResource{Resource: "secrets"},
+				"team-b-tokens",
+				errors.New("broker SA lacks update on team-b/team-b-tokens"),
+			)
+		}
+		return false, nil, nil
 	})
 	i := newIssuer(t, cfg, k8s)
 

--- a/tools/demarkus-broker/internal/broker/sweeper.go
+++ b/tools/demarkus-broker/internal/broker/sweeper.go
@@ -132,6 +132,17 @@ func (s *Sweeper) runOnce(ctx context.Context) {
 // sweep performs one cleanup pass. Returns an error only when the
 // top-level issuances read fails — every other failure is logged in
 // place and the loop continues with the remaining entries.
+//
+// Memory: the full issuances list is loaded into memory each tick.
+// The implicit upper bound is the Kubernetes Secret size limit (~1MB
+// after etcd encoding), which works out to roughly 5000–7000
+// issuance records at ~150 bytes apiece. Long before sweep memory
+// becomes a problem, the issuances Secret itself stops being
+// writable — which is the actual scaling wall for this design.
+// Pagination would address neither failure mode (Secrets aren't a
+// paginated resource), so the right Phase-7 fix is a different
+// backing store (CRD, namespaced ConfigMap-per-user, etc.), not a
+// streaming sweep.
 func (s *Sweeper) sweep(ctx context.Context) error {
 	all, err := s.issuer.readIssuances(ctx)
 	if err != nil {

--- a/tools/demarkus-broker/internal/broker/sweeper.go
+++ b/tools/demarkus-broker/internal/broker/sweeper.go
@@ -1,0 +1,228 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+
+	"github.com/latebit/demarkus/protocol/token"
+)
+
+// Sweeper is the broker's periodic janitor. Each tick it walks the
+// issuances Secret and retires entries that fall into either bucket:
+//
+//   - Expired: now > issuance.ExpiresAt. The primary revocation
+//     mechanism for short-lived tokens per the plan §Revocation §2.
+//   - Drifted: the issuance record points at a label that's no longer
+//     in the world's tokens Secret. Causes: an operator hand-edited
+//     the world Secret, or a prior Revoke failed midway between the
+//     two-Secret writes leaving an orphan in issuances. Pruning
+//     these keeps List/Revoke and the issuances-Secret-as-index
+//     consistent with the world Secret as source of truth.
+//
+// One pass per tick: a single read of the issuances Secret, grouped by
+// world; each affected world's tokens Secret is read at most once for
+// drift detection. Concurrent mints and revokes on the same Secrets are
+// handled by mutateSecret's optimistic-concurrency retry — no extra
+// locking is needed here.
+//
+// Across broker replicas, RunLeaderElected ensures only the holder of a
+// coordination.k8s.io/Lease runs the sweep loop. The other replicas
+// keep serving Mint/List/Revoke (those don't need a leader).
+type Sweeper struct {
+	issuer   *Issuer
+	interval time.Duration
+	clock    func() time.Time
+	log      *slog.Logger
+	// sweepHook fires after each sweep pass when non-nil. Test-only
+	// observability point so the leader-election test can count which
+	// replica's loop is running without scraping logs or polling the
+	// Lease object. Production code never sets it.
+	sweepHook func()
+}
+
+// NewSweeper builds a Sweeper. interval is the cadence between sweep
+// passes when running (5 min default from config); leader-election
+// timings live in RunLeaderElected. A nil logger falls back to slog
+// default so callers building one for ad-hoc tests don't have to plumb
+// a handler through.
+func NewSweeper(i *Issuer, interval time.Duration, log *slog.Logger) *Sweeper {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Sweeper{issuer: i, interval: interval, clock: time.Now, log: log}
+}
+
+// RunLeaderElected blocks until ctx is canceled, running the sweep loop
+// only while this replica holds the named Lease in namespace. Multi-
+// replica deployments must pass the same leaseName + namespace so all
+// replicas race for the one Lease. identity is the holder field that
+// shows up in the Lease object (read from POD_NAME with a hostname
+// fallback in production wiring).
+//
+// LeaseDuration/RenewDeadline/RetryPeriod use the client-go defaults
+// (15s/10s/2s) — failover budget is roughly the LeaseDuration. Lease
+// is released on graceful context cancel so the successor takes over
+// in milliseconds rather than waiting out the expiry.
+func (s *Sweeper) RunLeaderElected(ctx context.Context, leaseName, namespace, identity string) {
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta:  metav1.ObjectMeta{Name: leaseName, Namespace: namespace},
+		Client:     s.issuer.k8s.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{Identity: identity},
+	}
+	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		LeaseDuration:   15 * time.Second,
+		RenewDeadline:   10 * time.Second,
+		RetryPeriod:     2 * time.Second,
+		ReleaseOnCancel: true,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: s.runLoop,
+			OnStoppedLeading: func() {
+				s.log.Info("broker: sweeper lost leadership", "identity", identity)
+			},
+			OnNewLeader: func(id string) {
+				if id != identity {
+					s.log.Info("broker: sweeper observing new leader", "leader", id, "self", identity)
+				}
+			},
+		},
+	})
+}
+
+// runLoop runs an initial sweep then ticks every Sweeper.interval until
+// ctx is canceled. The eager first pass means a freshly-elected leader
+// doesn't have to wait a full interval before pruning expired entries
+// from a slow takeover — important when LeaseDuration > Interval on
+// rollouts. Test entry point: tests drive runLoop directly without
+// leader-election plumbing.
+func (s *Sweeper) runLoop(ctx context.Context) {
+	s.runOnce(ctx)
+	t := time.NewTicker(s.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.runOnce(ctx)
+		}
+	}
+}
+
+// runOnce is the per-tick boundary: swallow + log sweep errors so the
+// loop survives transient k8s API blips. Per-entry failures inside
+// sweep are also non-fatal (logged and skipped) so one stuck label
+// can't starve the rest.
+func (s *Sweeper) runOnce(ctx context.Context) {
+	if err := s.sweep(ctx); err != nil {
+		s.log.ErrorContext(ctx, "broker: sweep failed", "err", err)
+	}
+	if s.sweepHook != nil {
+		s.sweepHook()
+	}
+}
+
+// sweep performs one cleanup pass. Returns an error only when the
+// top-level issuances read fails — every other failure is logged in
+// place and the loop continues with the remaining entries.
+func (s *Sweeper) sweep(ctx context.Context) error {
+	all, err := s.issuer.readIssuances(ctx)
+	if err != nil {
+		return fmt.Errorf("read issuances: %w", err)
+	}
+	if len(all.Entries) == 0 {
+		return nil
+	}
+	now := s.clock()
+
+	// Two-pass collection so drift detection only fetches a world's
+	// tokens Secret once even when multiple issuances point at it.
+	// Expired entries skip the drift check — they're getting retired
+	// either way and revokeIssuance is idempotent if the label is
+	// already absent from the world Secret.
+	var toRevoke []Issuance
+	perWorld := make(map[string][]Issuance)
+	for j := range all.Entries {
+		iss := all.Entries[j]
+		if !iss.ExpiresAt.IsZero() && now.After(iss.ExpiresAt) {
+			toRevoke = append(toRevoke, iss)
+			continue
+		}
+		perWorld[iss.World] = append(perWorld[iss.World], iss)
+	}
+
+	for worldName, isses := range perWorld {
+		world := s.issuer.lookupWorld(worldName)
+		if world == nil {
+			// Same conservative posture as Revoke: don't silently
+			// drop issuance records for a world the broker is no
+			// longer configured for. The operator either intended
+			// to remove the world (and needs to clean up issuances
+			// explicitly) or the config is in flight; either way,
+			// we surface and skip.
+			s.log.WarnContext(ctx, "broker: sweep skipped issuances for unconfigured world",
+				"world", worldName, "count", len(isses))
+			continue
+		}
+		labels, err := s.readWorldLabels(ctx, world)
+		if err != nil {
+			s.log.ErrorContext(ctx, "broker: sweep read world tokens secret failed",
+				"world", worldName, "err", err)
+			continue
+		}
+		for j := range isses {
+			if _, present := labels[isses[j].Label]; !present {
+				toRevoke = append(toRevoke, isses[j])
+			}
+		}
+	}
+
+	for j := range toRevoke {
+		iss := &toRevoke[j]
+		reason := "drift"
+		if !iss.ExpiresAt.IsZero() && now.After(iss.ExpiresAt) {
+			reason = "expired"
+		}
+		if err := s.issuer.revokeIssuance(ctx, iss); err != nil {
+			s.log.ErrorContext(ctx, "broker: sweep revoke failed",
+				"label", iss.Label, "world", iss.World, "reason", reason, "err", err)
+			continue
+		}
+		s.log.InfoContext(ctx, "broker: swept",
+			"label", iss.Label, "world", iss.World,
+			"subject", hashSubject(iss.Email), "reason", reason)
+	}
+	return nil
+}
+
+// readWorldLabels fetches a world's tokens Secret and returns its label
+// set. A missing Secret yields an empty (non-nil) set; from drift's
+// point of view that's "no labels present" — every issuance against
+// that world has effectively drifted (probably operator
+// pre-deployment state, but the right thing is still to prune the
+// stale issuances).
+func (s *Sweeper) readWorldLabels(ctx context.Context, w *WorldConfig) (map[string]struct{}, error) {
+	secret, err := s.issuer.k8s.CoreV1().Secrets(w.Namespace).Get(ctx, w.TokensSecret, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return map[string]struct{}{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get tokens secret %s/%s: %w", w.Namespace, w.TokensSecret, err)
+	}
+	f, err := token.ParseBytes(secret.Data[TokensSecretKey])
+	if err != nil {
+		return nil, fmt.Errorf("parse tokens secret %s/%s: %w", w.Namespace, w.TokensSecret, err)
+	}
+	labels := make(map[string]struct{}, len(f.Tokens))
+	for label := range f.Tokens {
+		labels[label] = struct{}{}
+	}
+	return labels, nil
+}

--- a/tools/demarkus-broker/internal/broker/sweeper_test.go
+++ b/tools/demarkus-broker/internal/broker/sweeper_test.go
@@ -1,0 +1,373 @@
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/latebit/demarkus/protocol/token"
+)
+
+// seedIssuance writes a single issuance record into the broker
+// namespace alongside an entry in the world's tokens Secret. Bypasses
+// Mint so individual sweeper tests can manipulate ExpiresAt directly.
+// Multi-call: subsequent calls against the same world append to the
+// existing TOML rather than replacing it.
+func seedIssuance(t *testing.T, k8s *fake.Clientset, iss *Issuance) {
+	t.Helper()
+	world := worldByName(t, iss.World)
+	tokensSecret, getErr := k8s.CoreV1().Secrets(world.Namespace).Get(context.Background(), world.TokensSecret, metav1.GetOptions{})
+	notFound := apierrors.IsNotFound(getErr)
+	if !notFound && getErr != nil {
+		t.Fatalf("get world tokens secret: %v", getErr)
+	}
+	if notFound {
+		tokensSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: world.TokensSecret, Namespace: world.Namespace},
+			Data:       map[string][]byte{},
+		}
+	}
+	updated, err := token.AppendBytes(tokensSecret.Data[TokensSecretKey], iss.Label, &token.Entry{
+		Hash:       "sha256-seeded",
+		Paths:      iss.Paths,
+		Operations: iss.Operations,
+		Expires:    iss.ExpiresAt.UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("seed AppendBytes: %v", err)
+	}
+	if tokensSecret.Data == nil {
+		tokensSecret.Data = map[string][]byte{}
+	}
+	tokensSecret.Data[TokensSecretKey] = updated
+	if notFound {
+		if _, err := k8s.CoreV1().Secrets(world.Namespace).Create(context.Background(), tokensSecret, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("create world tokens secret: %v", err)
+		}
+	} else {
+		if _, err := k8s.CoreV1().Secrets(world.Namespace).Update(context.Background(), tokensSecret, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("update world tokens secret: %v", err)
+		}
+	}
+	seedIssuanceRecord(t, k8s, iss)
+}
+
+// seedIssuanceRecord adds only the broker-side issuance entry without
+// touching any world Secret. Used by drift tests to simulate the
+// orphan-in-issuances state (label present in broker state, absent
+// from world Secret).
+func seedIssuanceRecord(t *testing.T, k8s *fake.Clientset, iss *Issuance) {
+	t.Helper()
+	brokerSecret, getErr := k8s.CoreV1().Secrets(testBrokerNS).Get(context.Background(), testIssuancesNS, metav1.GetOptions{})
+	notFound := apierrors.IsNotFound(getErr)
+	if !notFound && getErr != nil {
+		t.Fatalf("get issuances secret: %v", getErr)
+	}
+	var current Issuances
+	if notFound {
+		brokerSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: testIssuancesNS, Namespace: testBrokerNS},
+			Data:       map[string][]byte{},
+		}
+	} else if raw := brokerSecret.Data[IssuancesSecretKey]; len(raw) > 0 {
+		if err := json.Unmarshal(raw, &current); err != nil {
+			t.Fatalf("decode issuances seed: %v", err)
+		}
+	}
+	current.Entries = append(current.Entries, *iss)
+	payload, err := json.Marshal(current)
+	if err != nil {
+		t.Fatalf("marshal issuances seed: %v", err)
+	}
+	if brokerSecret.Data == nil {
+		brokerSecret.Data = map[string][]byte{}
+	}
+	brokerSecret.Data[IssuancesSecretKey] = payload
+	if notFound {
+		if _, err := k8s.CoreV1().Secrets(testBrokerNS).Create(context.Background(), brokerSecret, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("create issuances secret: %v", err)
+		}
+	} else {
+		if _, err := k8s.CoreV1().Secrets(testBrokerNS).Update(context.Background(), brokerSecret, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("update issuances secret: %v", err)
+		}
+	}
+}
+
+// worldByName returns the single-world testConfig() WorldConfig
+// matching name. Sweeper tests use the default config's team-a world;
+// tests that need multi-world fixtures construct the config inline.
+func worldByName(t *testing.T, name string) *WorldConfig {
+	t.Helper()
+	cfg := testConfig()
+	for i := range cfg.Worlds {
+		if cfg.Worlds[i].Name == name {
+			return &cfg.Worlds[i]
+		}
+	}
+	t.Fatalf("no world named %q in testConfig", name)
+	return nil
+}
+
+func TestSweepRetiresExpiredKeepsFresh(t *testing.T) {
+	// Two issuances against team-a. "stale" expired 5 minutes before
+	// the sweeper's clock; "fresh" expires 23 hours after. After one
+	// sweep pass, the stale entry must be gone from both Secrets and
+	// the fresh entry must be intact in both.
+	k8s := fake.NewSimpleClientset()
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	seedIssuance(t, k8s, &Issuance{
+		Label:      "usr_stale",
+		Email:      "alice@example.com",
+		World:      "team-a",
+		Paths:      []string{"/team-a/*"},
+		Operations: []string{"read"},
+		IssuedAt:   now.Add(-24 * time.Hour),
+		ExpiresAt:  now.Add(-5 * time.Minute),
+	})
+	seedIssuance(t, k8s, &Issuance{
+		Label:      "usr_fresh",
+		Email:      "alice@example.com",
+		World:      "team-a",
+		Paths:      []string{"/team-a/*"},
+		Operations: []string{"read"},
+		IssuedAt:   now.Add(-1 * time.Hour),
+		ExpiresAt:  now.Add(23 * time.Hour),
+	})
+
+	issuer := newIssuer(t, testConfig(), k8s)
+	s := NewSweeper(issuer, time.Hour, nil)
+	s.clock = func() time.Time { return now }
+
+	if err := s.sweep(context.Background()); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+
+	worldSecret, _ := k8s.CoreV1().Secrets("team-a").Get(context.Background(), "team-a-tokens", metav1.GetOptions{})
+	gotTOML := string(worldSecret.Data[TokensSecretKey])
+	if strings.Contains(gotTOML, "usr_stale") {
+		t.Errorf("stale label still in world Secret:\n%s", gotTOML)
+	}
+	if !strings.Contains(gotTOML, "usr_fresh") {
+		t.Errorf("fresh label missing from world Secret:\n%s", gotTOML)
+	}
+
+	live, err := issuer.List(context.Background(), "alice@example.com")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(live) != 1 || live[0].Label != "usr_fresh" {
+		t.Errorf("issuances after sweep = %+v, want only usr_fresh", live)
+	}
+}
+
+func TestSweepPrunesDrift(t *testing.T) {
+	// Two issuances against team-a, both fresh (not expired). One has
+	// no corresponding entry in the world's tokens Secret (operator
+	// hand-edit or prior partial-Revoke). The sweeper must prune the
+	// orphan from issuances; the other must stay intact in both
+	// Secrets.
+	k8s := fake.NewSimpleClientset()
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	seedIssuance(t, k8s, &Issuance{
+		Label:      "usr_present",
+		Email:      "alice@example.com",
+		World:      "team-a",
+		Paths:      []string{"/team-a/*"},
+		Operations: []string{"read"},
+		IssuedAt:   now,
+		ExpiresAt:  now.Add(24 * time.Hour),
+	})
+	// usr_orphan: only the issuance record exists; the world's tokens
+	// Secret does not contain its label. seedIssuanceRecord (broker
+	// side only) plus seedIssuance for usr_present above already gave
+	// us the world Secret with usr_present.
+	seedIssuanceRecord(t, k8s, &Issuance{
+		Label:      "usr_orphan",
+		Email:      "alice@example.com",
+		World:      "team-a",
+		Paths:      []string{"/team-a/*"},
+		Operations: []string{"read"},
+		IssuedAt:   now,
+		ExpiresAt:  now.Add(24 * time.Hour),
+	})
+
+	issuer := newIssuer(t, testConfig(), k8s)
+	s := NewSweeper(issuer, time.Hour, nil)
+	s.clock = func() time.Time { return now }
+
+	if err := s.sweep(context.Background()); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+
+	live, err := issuer.List(context.Background(), "alice@example.com")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(live) != 1 || live[0].Label != "usr_present" {
+		t.Errorf("issuances after drift sweep = %+v, want only usr_present", live)
+	}
+	worldSecret, _ := k8s.CoreV1().Secrets("team-a").Get(context.Background(), "team-a-tokens", metav1.GetOptions{})
+	if !strings.Contains(string(worldSecret.Data[TokensSecretKey]), "usr_present") {
+		t.Errorf("present label missing from world Secret after drift sweep:\n%s", worldSecret.Data[TokensSecretKey])
+	}
+}
+
+func TestSweepSkipsUnconfiguredWorld(t *testing.T) {
+	// Issuance points at a world the broker has no config for —
+	// admin removed the world between mint and sweep. Same
+	// conservative posture as Revoke: surface and skip; never silently
+	// drop. The issuance record must remain so an operator can
+	// investigate.
+	k8s := fake.NewSimpleClientset()
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	seedIssuanceRecord(t, k8s, &Issuance{
+		Label:      "usr_orphan",
+		Email:      "alice@example.com",
+		World:      "team-deleted",
+		Paths:      []string{"/x/*"},
+		Operations: []string{"read"},
+		IssuedAt:   now,
+		ExpiresAt:  now.Add(24 * time.Hour),
+	})
+
+	issuer := newIssuer(t, testConfig(), k8s)
+	s := NewSweeper(issuer, time.Hour, nil)
+	s.clock = func() time.Time { return now }
+
+	if err := s.sweep(context.Background()); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	live, err := issuer.List(context.Background(), "alice@example.com")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(live) != 1 || live[0].Label != "usr_orphan" {
+		t.Errorf("issuance dropped for unconfigured world: %+v", live)
+	}
+}
+
+func TestSweepEmptyIssuancesIsNoop(t *testing.T) {
+	// No issuances Secret exists yet — sweeper must return cleanly
+	// without panicking on the nil-data path inside readIssuances or
+	// touching any world Secret.
+	k8s := fake.NewSimpleClientset()
+	issuer := newIssuer(t, testConfig(), k8s)
+	s := NewSweeper(issuer, time.Hour, nil)
+	if err := s.sweep(context.Background()); err != nil {
+		t.Fatalf("sweep on empty state: %v", err)
+	}
+	// No Secrets should have been created.
+	if list, _ := k8s.CoreV1().Secrets("team-a").List(context.Background(), metav1.ListOptions{}); len(list.Items) != 0 {
+		t.Errorf("empty sweep created team-a Secrets: %d", len(list.Items))
+	}
+}
+
+func TestSweeperLeaderElection(t *testing.T) {
+	// Two Sweeper instances race for the same Lease in the same
+	// namespace against a shared fake clientset. Exactly one is
+	// elected and runs its loop; the follower stays dormant. Cancel
+	// the leader's context — ReleaseOnCancel hands the Lease back, the
+	// follower picks it up and starts sweeping. Validates
+	// RunLeaderElected as a singleton coordinator across replicas.
+	if testing.Short() {
+		t.Skip("skipping leader-election test in short mode")
+	}
+	k8s := fake.NewSimpleClientset()
+	cfg := testConfig()
+	// Two issuers backed by the same fake clientset so leader
+	// election state is shared. Each replica gets its own Sweeper
+	// with its own counter.
+	makeReplica := func(identity string) (*Sweeper, *atomic.Int32) {
+		var count atomic.Int32
+		s := NewSweeper(newIssuer(t, cfg, k8s), 30*time.Millisecond, nil)
+		s.sweepHook = func() { count.Add(1) }
+		_ = identity // wired into RunLeaderElected below
+		return s, &count
+	}
+	sweepA, countA := makeReplica("A")
+	sweepB, countB := makeReplica("B")
+
+	ctxA, cancelA := context.WithCancel(context.Background())
+	defer cancelA()
+	ctxB, cancelB := context.WithCancel(context.Background())
+	defer cancelB()
+
+	doneA := make(chan struct{})
+	doneB := make(chan struct{})
+	go func() {
+		defer close(doneA)
+		sweepA.RunLeaderElected(ctxA, "test-sweeper-lease", testBrokerNS, "A")
+	}()
+	go func() {
+		defer close(doneB)
+		sweepB.RunLeaderElected(ctxB, "test-sweeper-lease", testBrokerNS, "B")
+	}()
+
+	// Wait for exactly one to start sweeping.
+	leaderIsA := waitFor(t, 10*time.Second, func() bool {
+		return countA.Load() > 0 || countB.Load() > 0
+	}) && countA.Load() > 0
+	leaderIsB := countB.Load() > 0
+
+	if leaderIsA == leaderIsB {
+		t.Fatalf("both or neither swept: A=%d B=%d", countA.Load(), countB.Load())
+	}
+
+	// Hold for a few more ticks; the follower must remain at zero.
+	var (
+		leaderCount, followerCount   *atomic.Int32
+		cancelLeader, cancelFollower context.CancelFunc
+		doneLeader                   chan struct{}
+	)
+	if leaderIsA {
+		leaderCount, followerCount = countA, countB
+		cancelLeader, cancelFollower = cancelA, cancelB
+		doneLeader = doneA
+	} else {
+		leaderCount, followerCount = countB, countA
+		cancelLeader, cancelFollower = cancelB, cancelA
+		doneLeader = doneB
+	}
+	_ = cancelFollower
+
+	time.Sleep(200 * time.Millisecond)
+	if followerCount.Load() != 0 {
+		t.Errorf("follower swept while leader held lease: leader=%d follower=%d",
+			leaderCount.Load(), followerCount.Load())
+	}
+
+	// Cancel the leader. Its loop must unwind, releasing the Lease,
+	// and the follower must take over within a few hundred ms.
+	cancelLeader()
+	<-doneLeader
+	followerBaseline := followerCount.Load()
+	waitFor(t, 10*time.Second, func() bool {
+		return followerCount.Load() > followerBaseline
+	})
+}
+
+// waitFor polls cond every 10ms until it returns true or the timeout
+// elapses. Returns true on success, fails the test on timeout. Used by
+// the leader-election test to assert "eventually" conditions without
+// resorting to fixed sleeps that either over- or under-shoot.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %s", timeout)
+	return false
+}

--- a/tools/demarkus-broker/internal/broker/sweeper_test.go
+++ b/tools/demarkus-broker/internal/broker/sweeper_test.go
@@ -151,7 +151,10 @@ func TestSweepRetiresExpiredKeepsFresh(t *testing.T) {
 		t.Fatalf("sweep: %v", err)
 	}
 
-	worldSecret, _ := k8s.CoreV1().Secrets("team-a").Get(context.Background(), "team-a-tokens", metav1.GetOptions{})
+	worldSecret, err := k8s.CoreV1().Secrets("team-a").Get(context.Background(), "team-a-tokens", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get world tokens secret: %v", err)
+	}
 	gotTOML := string(worldSecret.Data[TokensSecretKey])
 	if strings.Contains(gotTOML, "usr_stale") {
 		t.Errorf("stale label still in world Secret:\n%s", gotTOML)
@@ -215,7 +218,10 @@ func TestSweepPrunesDrift(t *testing.T) {
 	if len(live) != 1 || live[0].Label != "usr_present" {
 		t.Errorf("issuances after drift sweep = %+v, want only usr_present", live)
 	}
-	worldSecret, _ := k8s.CoreV1().Secrets("team-a").Get(context.Background(), "team-a-tokens", metav1.GetOptions{})
+	worldSecret, err := k8s.CoreV1().Secrets("team-a").Get(context.Background(), "team-a-tokens", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get world tokens secret: %v", err)
+	}
 	if !strings.Contains(string(worldSecret.Data[TokensSecretKey]), "usr_present") {
 		t.Errorf("present label missing from world Secret after drift sweep:\n%s", worldSecret.Data[TokensSecretKey])
 	}
@@ -266,7 +272,11 @@ func TestSweepEmptyIssuancesIsNoop(t *testing.T) {
 		t.Fatalf("sweep on empty state: %v", err)
 	}
 	// No Secrets should have been created.
-	if list, _ := k8s.CoreV1().Secrets("team-a").List(context.Background(), metav1.ListOptions{}); len(list.Items) != 0 {
+	list, err := k8s.CoreV1().Secrets("team-a").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list team-a Secrets: %v", err)
+	}
+	if len(list.Items) != 0 {
 		t.Errorf("empty sweep created team-a Secrets: %d", len(list.Items))
 	}
 }
@@ -326,18 +336,17 @@ func TestSweeperLeaderElection(t *testing.T) {
 	var (
 		leaderCount, followerCount   *atomic.Int32
 		cancelLeader, cancelFollower context.CancelFunc
-		doneLeader                   chan struct{}
+		doneLeader, doneFollower     chan struct{}
 	)
 	if leaderIsA {
 		leaderCount, followerCount = countA, countB
 		cancelLeader, cancelFollower = cancelA, cancelB
-		doneLeader = doneA
+		doneLeader, doneFollower = doneA, doneB
 	} else {
 		leaderCount, followerCount = countB, countA
 		cancelLeader, cancelFollower = cancelB, cancelA
-		doneLeader = doneB
+		doneLeader, doneFollower = doneB, doneA
 	}
-	_ = cancelFollower
 
 	time.Sleep(200 * time.Millisecond)
 	if followerCount.Load() != 0 {
@@ -353,6 +362,14 @@ func TestSweeperLeaderElection(t *testing.T) {
 	waitFor(t, 10*time.Second, func() bool {
 		return followerCount.Load() > followerBaseline
 	})
+
+	// Cancel and wait for the follower too. The deferred cancels at
+	// the top of the test would eventually fire, but they fire on
+	// return — without an explicit join here the follower's renewal
+	// loop and the test's cleanup race, leaving the goroutine and
+	// fake-clientset Lease state to leak into the next test.
+	cancelFollower()
+	<-doneFollower
 }
 
 // waitFor polls cond every 10ms until it returns true or the timeout

--- a/tools/demarkus-broker/main.go
+++ b/tools/demarkus-broker/main.go
@@ -3,11 +3,12 @@
 // per-world Kubernetes Secrets while tracking ownership in its own
 // broker-namespace Secret.
 //
-// Slice B scope (this binary): single broker, multi-world support behind
-// per-world domain allowlists, browser code-flow for /auth/login +
-// /auth/callback, bearer-token (ID token) authentication for /tokens and
-// DELETE /tokens/:label. No expiry sweeper, no leader election, no
-// rotate, no rate limit — those land in Slice C/D.
+// Current scope: single broker, multi-world support with
+// domain/groups/emails allowlists (Slice C.1), browser code-flow for
+// /auth/login + /auth/callback, bearer-token (ID token) authentication
+// for /tokens and DELETE /tokens/:label, leader-elected expiry/drift
+// sweeper (Slice C.2). No rotate endpoint, no rate limit — Slice C.3
+// and C.4 respectively.
 package main
 
 import (
@@ -18,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -101,6 +103,27 @@ func run(configPath, kubeconfigPath string, log *slog.Logger) error {
 		errs <- nil
 	}()
 
+	// Sweeper runs alongside HTTP — leader election keeps it singleton
+	// across replicas. Its lifecycle hangs off sweepCtx so the signal
+	// path below can cancel it cleanly before HTTP shutdown begins.
+	// ReleaseOnCancel inside RunLeaderElected gives the lease back so a
+	// rolling restart's successor takes over in milliseconds.
+	sweepCtx, cancelSweep := context.WithCancel(context.Background())
+	defer cancelSweep()
+	var sweepWG sync.WaitGroup
+	if !cfg.Sweeper.Disabled {
+		sweeper := broker.NewSweeper(issuer, cfg.Sweeper.Interval, log)
+		identity := brokerIdentity()
+		log.Info("broker: starting sweeper",
+			"interval", cfg.Sweeper.Interval, "leaseName", cfg.Sweeper.LeaseName,
+			"namespace", cfg.Server.BrokerNamespace, "identity", identity)
+		sweepWG.Go(func() {
+			sweeper.RunLeaderElected(sweepCtx, cfg.Sweeper.LeaseName, cfg.Server.BrokerNamespace, identity)
+		})
+	} else {
+		log.Info("broker: sweeper disabled (sweeper.disabled=true)")
+	}
+
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 	select {
@@ -108,13 +131,33 @@ func run(configPath, kubeconfigPath string, log *slog.Logger) error {
 		log.Info("broker: received signal, shutting down", "signal", sig.String())
 	case err := <-errs:
 		if err != nil {
+			cancelSweep()
+			sweepWG.Wait()
 			return err
 		}
 	}
 
+	cancelSweep()
+	sweepWG.Wait()
+
 	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelShutdown()
 	return httpSrv.Shutdown(shutdownCtx)
+}
+
+// brokerIdentity returns the holder identity stamped onto the leader-
+// election Lease. In-cluster the operator wires POD_NAME via the
+// downward API; out-of-cluster runs fall back to the host's hostname,
+// or a literal "broker" string for unconfigured developer environments
+// where Hostname() can return empty.
+func brokerIdentity() string {
+	if v := os.Getenv("POD_NAME"); v != "" {
+		return v
+	}
+	if h, err := os.Hostname(); err == nil && h != "" {
+		return h
+	}
+	return "broker"
 }
 
 // newKubeClient builds a kubernetes client. When kubeconfigPath is empty

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -71,6 +71,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
 go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broker adds a configurable Sweeper that runs under leader election to retire expired issuances and prune drift; startup now launches the sweeper when enabled.
  * Added in-memory token parsing helper for decoding tokens TOML from bytes.

* **Configuration**
  * New sweeper settings: enabled/disabled, interval (defaults to 5m, max 24h), and lease name (default provided).

* **Tests**
  * Added tests for token parsing, sweeper behaviors (including leader election), and RBAC/no-partial-state minting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/111)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->