### PR TITLE
fix(tools):  Add token rotation with scope preservation

### DIFF
--- a/tools/demarkus-broker/internal/broker/issuer.go
+++ b/tools/demarkus-broker/internal/broker/issuer.go
@@ -401,6 +401,15 @@ func (i *Issuer) Revoke(ctx context.Context, callerEmail, label string) error {
 //     Callers detect via `result.Label != ""` and treat as 200 with a
 //     warn log. Matches the Slice B partial-mint convention.
 func (i *Issuer) RotateLabel(ctx context.Context, claims Claims, label string) (MintResult, error) {
+	// Defense in depth: mirror Mint's email-verified gate. The
+	// production Verifier rejects unverified ID tokens before they
+	// reach this layer, but a future Verifier impl (or a test
+	// double) might not — and rotation extends access, so the cost
+	// of an unverified-identity rotation slipping through is exactly
+	// the same as the original Mint footgun this guards against.
+	if !claims.EmailVerified {
+		return MintResult{}, ErrEmailUnverified
+	}
 	// Same canonicalization as Mint — the persisted issuance email
 	// is lowercase+trim, so the owner-check compare needs the
 	// caller's email in the same form.
@@ -422,7 +431,12 @@ func (i *Issuer) RotateLabel(ctx context.Context, claims Claims, label string) (
 	if found == nil {
 		return MintResult{}, ErrNotFound
 	}
-	if found.Email != claims.Email {
+	// EqualFold rather than == so admin-tooled or pre-canonicalization
+	// issuance rows still match a canonical caller email. Forward
+	// traffic from Mint always lands with canonical iss.Email so the
+	// two are equivalent; this is the defense-in-depth shape for
+	// non-canonical legacy entries, matching Revoke's owner check.
+	if !strings.EqualFold(found.Email, claims.Email) {
 		return MintResult{}, ErrNotOwner
 	}
 	world := i.lookupWorld(found.World)

--- a/tools/demarkus-broker/internal/broker/issuer.go
+++ b/tools/demarkus-broker/internal/broker/issuer.go
@@ -142,7 +142,7 @@ func (i *Issuer) Mint(ctx context.Context, claims Claims) ([]MintResult, error) 
 	now := i.clock()
 	results := make([]MintResult, 0, len(worlds))
 	for _, w := range worlds {
-		r, err := i.mintForWorld(ctx, w, claims, now)
+		r, err := i.mintForWorld(ctx, w, claims, now, w.DefaultToken.Paths, w.DefaultToken.Operations)
 		if err != nil {
 			return results, fmt.Errorf("mint for world %s: %w", w.Name, err)
 		}
@@ -240,13 +240,22 @@ func groupsMatch(have, allowed []string) bool {
 	return false
 }
 
-func (i *Issuer) mintForWorld(ctx context.Context, w *WorldConfig, claims Claims, now time.Time) (MintResult, error) {
+// mintForWorld issues one token against w with the given scope
+// (paths + operations) and the world's current expiry policy. Slice
+// B's Mint passes the world's DefaultToken scope; Slice C.3's
+// RotateLabel passes the issuance-recorded scope, deliberately
+// ignoring config-side scope changes between mint and rotate (see
+// plan §Routes — operator scope changes only take effect on next
+// `demarkus login`). Lifetime always uses the operator's current
+// DefaultToken.ExpiresAfter so config-side expiry tightening DOES
+// take effect on rotate; the asymmetry is intentional.
+func (i *Issuer) mintForWorld(ctx context.Context, w *WorldConfig, claims Claims, now time.Time, paths, operations []string) (MintResult, error) {
 	for range maxLabelRetries {
 		label, err := i.labelGen()
 		if err != nil {
 			return MintResult{}, err
 		}
-		minted, err := token.Generate(label, w.DefaultToken.Paths, w.DefaultToken.Operations)
+		minted, err := token.Generate(label, paths, operations)
 		if err != nil {
 			return MintResult{}, fmt.Errorf("generate token: %w", err)
 		}
@@ -267,8 +276,8 @@ func (i *Issuer) mintForWorld(ctx context.Context, w *WorldConfig, claims Claims
 			Label:      label,
 			Email:      claims.Email,
 			World:      w.Name,
-			Paths:      append([]string(nil), w.DefaultToken.Paths...),
-			Operations: append([]string(nil), w.DefaultToken.Operations...),
+			Paths:      append([]string(nil), paths...),
+			Operations: append([]string(nil), operations...),
 			IssuedAt:   now,
 			ExpiresAt:  expiresAt,
 		}
@@ -346,6 +355,105 @@ func (i *Issuer) Revoke(ctx context.Context, callerEmail, label string) error {
 		return ErrNotOwner
 	}
 	return i.revokeIssuance(ctx, found)
+}
+
+// RotateLabel issues a fresh token replacing label, returning the new
+// MintResult. Slice C.3.
+//
+// Authorization model (see plan §Routes "rotate"):
+//
+//  1. Owner check — caller's claims.Email must match the issuance's
+//     stored email. Same gate as Revoke; prevents one user from
+//     rotating another's token.
+//  2. Re-validation — the world's current Allow predicate must still
+//     accept the caller. A user removed from the world's allowlist
+//     between mint and rotate must NOT be able to extend access via
+//     rotation. This is the difference between rotation-as-refresh
+//     (would skip this check) and rotation-as-relogin (this
+//     implementation). The bearer ID-token verification at the HTTP
+//     layer already proves the IdP identity is still active; we add
+//     the per-world predicate to catch in-org permission changes.
+//
+// Scope vs. lifetime asymmetry:
+//
+//   - Scope (paths + operations) stays frozen to the issuance record.
+//     Operator narrowing of DefaultToken.Paths between mint and rotate
+//     does NOT shrink the rotated token's reach; the user re-logs in to
+//     pick up new scope.
+//   - Lifetime resets to now + DefaultToken.ExpiresAfter. Operator
+//     tightening of expiry DOES apply on rotate — the operator's
+//     security tightening trumps the user's lifetime expectation.
+//
+// Sequence: mint new first, then revoke old. On revoke failure the
+// new token is returned anyway and the soft error wraps the revoke
+// failure — the sweeper catches the orphan on expiry. Picked over
+// revoke-then-mint because the alternative leaves the user with no
+// token if mint then fails (which forces a full re-login), worse UX
+// than the briefly-two-valid-tokens window.
+//
+// Returns:
+//   - (minted, nil) on full success.
+//   - (zero MintResult, ErrNotFound/ErrNotOwner/ErrNotAuthorized) on
+//     hard authz failures, BEFORE any state change.
+//   - (zero MintResult, other err) on hard mint failures, also no
+//     state change.
+//   - (minted, err) when new mint succeeded but old revoke failed.
+//     Callers detect via `result.Label != ""` and treat as 200 with a
+//     warn log. Matches the Slice B partial-mint convention.
+func (i *Issuer) RotateLabel(ctx context.Context, claims Claims, label string) (MintResult, error) {
+	// Same canonicalization as Mint — the persisted issuance email
+	// is lowercase+trim, so the owner-check compare needs the
+	// caller's email in the same form.
+	claims.Email = strings.ToLower(strings.TrimSpace(claims.Email))
+	if claims.Email == "" {
+		return MintResult{}, ErrNotAuthorized
+	}
+	all, err := i.readIssuances(ctx)
+	if err != nil {
+		return MintResult{}, err
+	}
+	var found *Issuance
+	for j := range all.Entries {
+		if all.Entries[j].Label == label {
+			found = &all.Entries[j]
+			break
+		}
+	}
+	if found == nil {
+		return MintResult{}, ErrNotFound
+	}
+	if found.Email != claims.Email {
+		return MintResult{}, ErrNotOwner
+	}
+	world := i.lookupWorld(found.World)
+	if world == nil {
+		return MintResult{}, fmt.Errorf("world %q not configured for label %q", found.World, label)
+	}
+	if !worldAllows(&world.Allow, claims) {
+		return MintResult{}, ErrNotAuthorized
+	}
+	now := i.clock()
+	minted, err := i.mintForWorld(ctx, world, claims, now, found.Paths, found.Operations)
+	if err != nil {
+		return MintResult{}, fmt.Errorf("mint replacement for %s: %w", label, err)
+	}
+	// Snapshot of the old label before mutation; revokeIssuance
+	// removes by iss.Label so passing found directly is safe, but
+	// reading it back from `all.Entries` post-mint would race with
+	// a fresh-mint that re-added it (impossible in practice since
+	// labels are opaque random IDs, but the snapshot makes the
+	// data-flow obvious).
+	oldLabel := found.Label
+	if err := i.revokeIssuance(ctx, found); err != nil {
+		// Partial success: the new token is live and recorded.
+		// The old label stays both in the world Secret and the
+		// issuances Secret; sweep will retire it on expiry (or
+		// drift, if the operator hand-edits the world Secret in
+		// the meantime). Return the new mint plus the wrapped
+		// error so the HTTP layer can log-warn-and-200.
+		return minted, fmt.Errorf("revoke old label %s: %w", oldLabel, err)
+	}
+	return minted, nil
 }
 
 // revokeIssuance executes the two-Secret mutation that retires a token:

--- a/tools/demarkus-broker/internal/broker/issuer_test.go
+++ b/tools/demarkus-broker/internal/broker/issuer_test.go
@@ -870,6 +870,36 @@ func TestRotateLabelHappyPath(t *testing.T) {
 	}
 }
 
+func TestRotateLabelRejectsUnverifiedEmail(t *testing.T) {
+	// Defense-in-depth gate mirrored from Mint. The production
+	// Verifier short-circuits unverified ID tokens before they reach
+	// RotateLabel, but a test double or a future Verifier impl might
+	// not, and rotation extends access — so an unverified rotation
+	// is the same threat as an unverified mint. ErrEmailUnverified
+	// returned, original token left untouched.
+	k8s := fake.NewSimpleClientset()
+	issuer := newIssuer(t, testConfig(), k8s)
+	minted, err := issuer.Mint(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true})
+	if err != nil {
+		t.Fatalf("seed Mint: %v", err)
+	}
+
+	_, err = issuer.RotateLabel(context.Background(), Claims{Email: "alice@example.com", EmailVerified: false}, minted[0].Label)
+	if !errors.Is(err, ErrEmailUnverified) {
+		t.Errorf("err = %v, want ErrEmailUnverified", err)
+	}
+	// Original token still alive in both Secrets — no state
+	// mutation on the unverified-reject path.
+	worldSecret, _ := k8s.CoreV1().Secrets("team-a").Get(context.Background(), "team-a-tokens", metav1.GetOptions{})
+	if !strings.Contains(string(worldSecret.Data[TokensSecretKey]), minted[0].Label) {
+		t.Errorf("original label removed from world Secret after unverified-reject rotate")
+	}
+	live, _ := issuer.List(context.Background(), "alice@example.com")
+	if len(live) != 1 || live[0].Label != minted[0].Label {
+		t.Errorf("issuances mutated by unverified-reject rotate: %+v", live)
+	}
+}
+
 func TestRotateLabelNotOwner(t *testing.T) {
 	// Alice mints, mallory tries to rotate. Same gate as Revoke's
 	// owner-check: ErrNotOwner, no state change in either Secret.

--- a/tools/demarkus-broker/internal/broker/issuer_test.go
+++ b/tools/demarkus-broker/internal/broker/issuer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -808,5 +809,258 @@ func TestMintRBACDeniedNoPartialState(t *testing.T) {
 	}
 	if live[0].World != "team-a" {
 		t.Errorf("issuance world = %q, want team-a", live[0].World)
+	}
+}
+
+func TestRotateLabelHappyPath(t *testing.T) {
+	// End-to-end: mint via Issuer.Mint, rotate the resulting label,
+	// assert the new MintResult is well-formed and the world/issuance
+	// Secrets reflect exactly the new label (old gone from both).
+	// This pins the basic "mint new, revoke old" sequence on the
+	// happy path.
+	k8s := fake.NewSimpleClientset()
+	issuer := newIssuer(t, testConfig(), k8s)
+	minted, err := issuer.Mint(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true})
+	if err != nil {
+		t.Fatalf("seed Mint: %v", err)
+	}
+	oldLabel := minted[0].Label
+	oldToken := minted[0].RawToken
+
+	rotated, err := issuer.RotateLabel(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true}, oldLabel)
+	if err != nil {
+		t.Fatalf("RotateLabel: %v", err)
+	}
+	if rotated.Label == "" || rotated.Label == oldLabel {
+		t.Errorf("new label = %q, want non-empty and != old %q", rotated.Label, oldLabel)
+	}
+	if rotated.RawToken == "" || rotated.RawToken == oldToken {
+		t.Errorf("new RawToken empty or unchanged from old")
+	}
+	if rotated.World != "team-a" {
+		t.Errorf("world = %q, want team-a", rotated.World)
+	}
+
+	// World Secret: only the new label present.
+	worldSecret, err := k8s.CoreV1().Secrets("team-a").Get(context.Background(), "team-a-tokens", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get world Secret: %v", err)
+	}
+	gotTOML := string(worldSecret.Data[TokensSecretKey])
+	if strings.Contains(gotTOML, oldLabel) {
+		t.Errorf("old label still in world Secret after rotate:\n%s", gotTOML)
+	}
+	if !strings.Contains(gotTOML, rotated.Label) {
+		t.Errorf("new label missing from world Secret:\n%s", gotTOML)
+	}
+
+	// Issuances Secret: only the new label, with same scope, same email.
+	live, err := issuer.List(context.Background(), "alice@example.com")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(live) != 1 {
+		t.Fatalf("issuances after rotate = %d, want 1", len(live))
+	}
+	if live[0].Label != rotated.Label {
+		t.Errorf("issuance label = %q, want rotated label %q", live[0].Label, rotated.Label)
+	}
+	if live[0].Email != "alice@example.com" {
+		t.Errorf("issuance email = %q, want alice@example.com (canonical)", live[0].Email)
+	}
+}
+
+func TestRotateLabelNotOwner(t *testing.T) {
+	// Alice mints, mallory tries to rotate. Same gate as Revoke's
+	// owner-check: ErrNotOwner, no state change in either Secret.
+	k8s := fake.NewSimpleClientset()
+	issuer := newIssuer(t, testConfig(), k8s)
+	minted, err := issuer.Mint(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true})
+	if err != nil {
+		t.Fatalf("seed Mint: %v", err)
+	}
+	oldLabel := minted[0].Label
+
+	_, err = issuer.RotateLabel(context.Background(), Claims{Email: "mallory@example.com", EmailVerified: true}, oldLabel)
+	if !errors.Is(err, ErrNotOwner) {
+		t.Fatalf("err = %v, want ErrNotOwner", err)
+	}
+
+	// Alice's token must still be intact in both Secrets.
+	worldSecret, _ := k8s.CoreV1().Secrets("team-a").Get(context.Background(), "team-a-tokens", metav1.GetOptions{})
+	if !strings.Contains(string(worldSecret.Data[TokensSecretKey]), oldLabel) {
+		t.Errorf("alice's label vanished from world Secret after mallory's failed rotate")
+	}
+	live, _ := issuer.List(context.Background(), "alice@example.com")
+	if len(live) != 1 || live[0].Label != oldLabel {
+		t.Errorf("alice's issuance changed after mallory's failed rotate: %+v", live)
+	}
+}
+
+func TestRotateLabelUnknownLabel(t *testing.T) {
+	k8s := fake.NewSimpleClientset()
+	issuer := newIssuer(t, testConfig(), k8s)
+
+	_, err := issuer.RotateLabel(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true}, "usr_nope")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestRotateLabelPreservesIssuanceScope(t *testing.T) {
+	// The plan's central rotate semantic: scope (paths + operations)
+	// stays frozen to the issuance record across rotation. Operator
+	// narrowing of DefaultToken.Paths between mint and rotate must
+	// NOT shrink the rotated token's reach — that only happens on
+	// next demarkus login. Lifetime, by contrast, DOES update to the
+	// operator's current DefaultToken.ExpiresAfter (separate test
+	// below would cover the lifetime side; here we only need to pin
+	// scope).
+	cfg := testConfig()
+	cfg.Worlds[0].DefaultToken.Paths = []string{"/team-a/wide/*", "/team-a/other/*"}
+	cfg.Worlds[0].DefaultToken.Operations = []string{"read", "publish"}
+	k8s := fake.NewSimpleClientset()
+	issuer := newIssuer(t, cfg, k8s)
+	minted, err := issuer.Mint(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true})
+	if err != nil {
+		t.Fatalf("seed Mint: %v", err)
+	}
+	oldLabel := minted[0].Label
+
+	// Operator narrows DefaultToken between mint and rotate.
+	// (Mutating the shared config is fine here — newIssuer captured
+	// the same *Config pointer, but the issuance record's scope was
+	// snapshot at mint time and stored in the issuances Secret.)
+	cfg.Worlds[0].DefaultToken.Paths = []string{"/team-a/narrow/*"}
+	cfg.Worlds[0].DefaultToken.Operations = []string{"read"}
+
+	rotated, err := issuer.RotateLabel(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true}, oldLabel)
+	if err != nil {
+		t.Fatalf("RotateLabel: %v", err)
+	}
+
+	// New issuance record carries the ORIGINAL scope, not the
+	// narrowed DefaultToken.
+	live, _ := issuer.List(context.Background(), "alice@example.com")
+	if len(live) != 1 || live[0].Label != rotated.Label {
+		t.Fatalf("issuances = %+v, want one entry matching rotated", live)
+	}
+	wantPaths := []string{"/team-a/wide/*", "/team-a/other/*"}
+	if !slices.Equal(live[0].Paths, wantPaths) {
+		t.Errorf("paths = %v, want %v (issuance-frozen, not config-current)", live[0].Paths, wantPaths)
+	}
+	wantOps := []string{"read", "publish"}
+	if !slices.Equal(live[0].Operations, wantOps) {
+		t.Errorf("operations = %v, want %v (issuance-frozen)", live[0].Operations, wantOps)
+	}
+
+	// World Secret entry for the new label carries the original
+	// scope too — the server is the one that enforces paths/ops, so
+	// what's written here is what the user can actually do.
+	worldSecret, _ := k8s.CoreV1().Secrets("team-a").Get(context.Background(), "team-a-tokens", metav1.GetOptions{})
+	gotTOML := string(worldSecret.Data[TokensSecretKey])
+	if !strings.Contains(gotTOML, `paths = ["/team-a/wide/*", "/team-a/other/*"]`) {
+		t.Errorf("world Secret entry does not carry original paths:\n%s", gotTOML)
+	}
+}
+
+func TestRotateLabelLifetimeUpdatesToCurrentConfig(t *testing.T) {
+	// The other half of the scope-vs-lifetime asymmetry: lifetime
+	// resets to now + DefaultToken.ExpiresAfter on rotate, using the
+	// operator's CURRENT config. If the operator tightens expiry,
+	// rotation honors the new shorter lifetime — that's an explicit
+	// security-tightening lever and rotation must not bypass it.
+	cfg := testConfig()
+	cfg.Worlds[0].DefaultToken.ExpiresAfter = 24 * time.Hour
+	k8s := fake.NewSimpleClientset()
+	issuer := newIssuer(t, cfg, k8s)
+	minted, err := issuer.Mint(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true})
+	if err != nil {
+		t.Fatalf("seed Mint: %v", err)
+	}
+
+	// Tighten expiry to 1 hour and rotate.
+	cfg.Worlds[0].DefaultToken.ExpiresAfter = 1 * time.Hour
+
+	rotated, err := issuer.RotateLabel(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true}, minted[0].Label)
+	if err != nil {
+		t.Fatalf("RotateLabel: %v", err)
+	}
+
+	// newIssuer pins the clock to 2026-05-11 12:00 UTC; expect the
+	// new token to expire 1h later (the tightened lifetime), not 24h
+	// later (the original).
+	wantExpiry := time.Date(2026, 5, 11, 13, 0, 0, 0, time.UTC)
+	if !rotated.ExpiresAt.Equal(wantExpiry) {
+		t.Errorf("ExpiresAt = %v, want %v (1h after pinned clock — operator tightening must apply)",
+			rotated.ExpiresAt, wantExpiry)
+	}
+}
+
+func TestRotateLabelReauthorizesAgainstCurrentAllow(t *testing.T) {
+	// Rotate-as-relogin: if the user no longer qualifies under the
+	// world's current Allow predicate (operator removed their group,
+	// renamed their domain, took them off the email carve-out),
+	// rotation must reject. Without re-auth, a fired user could keep
+	// rotating forever as long as the IdP still issues ID tokens.
+	cfg := testConfig()
+	cfg.Worlds[0].Allow = AllowConfig{Domains: []string{"example.com"}}
+	k8s := fake.NewSimpleClientset()
+	issuer := newIssuer(t, cfg, k8s)
+	minted, err := issuer.Mint(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true})
+	if err != nil {
+		t.Fatalf("seed Mint: %v", err)
+	}
+
+	// Operator tightens the allowlist to a different domain. Alice's
+	// email no longer qualifies.
+	cfg.Worlds[0].Allow = AllowConfig{Domains: []string{"other.example"}}
+
+	_, err = issuer.RotateLabel(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true}, minted[0].Label)
+	if !errors.Is(err, ErrNotAuthorized) {
+		t.Errorf("err = %v, want ErrNotAuthorized", err)
+	}
+
+	// Alice's original token must remain intact — rotate failed
+	// before any state mutation. (No new label minted, no old label
+	// revoked.)
+	live, _ := issuer.List(context.Background(), "alice@example.com")
+	if len(live) != 1 || live[0].Label != minted[0].Label {
+		t.Errorf("issuances after denied rotate = %+v, want unchanged from original", live)
+	}
+}
+
+func TestRotateLabelMissingWorldErrors(t *testing.T) {
+	// Pre-seed an issuance pointing at a world the broker has no
+	// config for (admin removed the world between mint and rotate).
+	// RotateLabel must surface the misconfiguration rather than
+	// silently treating it as no-op or 5xx-swallowing; same
+	// conservative posture as Revoke.
+	cfg := testConfig()
+	orphan := Issuance{
+		Label:      "usr_orphan",
+		Email:      "alice@example.com",
+		World:      "team-removed",
+		Paths:      []string{"/team-removed/*"},
+		Operations: []string{"read"},
+		IssuedAt:   time.Date(2026, 5, 11, 10, 0, 0, 0, time.UTC),
+		ExpiresAt:  time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+	}
+	payload, err := json.Marshal(Issuances{Entries: []Issuance{orphan}})
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	k8s := fake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: testIssuancesNS, Namespace: testBrokerNS},
+		Data:       map[string][]byte{IssuancesSecretKey: payload},
+	})
+	issuer := newIssuer(t, cfg, k8s)
+
+	_, err = issuer.RotateLabel(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true}, "usr_orphan")
+	if err == nil {
+		t.Fatal("RotateLabel returned nil, want error for missing world")
+	}
+	if !strings.Contains(err.Error(), "team-removed") {
+		t.Errorf("error %q does not name the orphaned world", err)
 	}
 }

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -57,6 +57,7 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("GET /auth/callback", s.authCallback)
 	mux.HandleFunc("GET /tokens", s.listTokens)
 	mux.HandleFunc("DELETE /tokens/{label}", s.deleteToken)
+	mux.HandleFunc("POST /tokens/{label}/rotate", s.rotateToken)
 	return mux
 }
 
@@ -221,6 +222,56 @@ func (s *Server) deleteToken(w http.ResponseWriter, r *http.Request) {
 	default:
 		s.log.ErrorContext(r.Context(), "broker: revoke failed", "label", label, "err", err)
 		http.Error(w, "revoke failed", http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) rotateToken(w http.ResponseWriter, r *http.Request) {
+	claims, ok := s.authenticate(w, r)
+	if !ok {
+		return
+	}
+	label := r.PathValue("label")
+	if label == "" {
+		http.Error(w, "label is required", http.StatusBadRequest)
+		return
+	}
+	minted, err := s.issuer.RotateLabel(r.Context(), claims, label)
+	switch {
+	case err == nil:
+		s.log.InfoContext(r.Context(), "broker: rotate succeeded",
+			"old", label, "new", minted.Label,
+			"world", minted.World, "subject", hashSubject(claims.Subject))
+		writeJSON(w, http.StatusOK, minted)
+	case errors.Is(err, ErrNotFound):
+		http.Error(w, "label not found", http.StatusNotFound)
+	case errors.Is(err, ErrNotOwner):
+		s.log.WarnContext(r.Context(), "broker: rotate owner mismatch",
+			"label", label, "subject", hashSubject(claims.Subject))
+		http.Error(w, "not the token owner", http.StatusForbidden)
+	case errors.Is(err, ErrNotAuthorized):
+		// Caller's bearer token is valid but the world's Allow
+		// predicate no longer accepts them (group removed, domain
+		// renamed, email taken off carve-out). Same response shape
+		// as Mint's "no authorized worlds" path.
+		s.log.InfoContext(r.Context(), "broker: rotate denied — caller no longer authorized for world",
+			"label", label, "subject", hashSubject(claims.Subject))
+		http.Error(w, "no longer authorized for this world", http.StatusForbidden)
+	case minted.Label != "":
+		// Soft failure: the new token was minted and recorded
+		// successfully, but the old-label revoke failed (k8s API
+		// blip, transient RBAC issue, etc.). The user's rotation
+		// completed from their perspective — return 200 with the
+		// new token; the sweeper will retire the orphan old label
+		// on expiry or via drift if the operator hand-cleans.
+		// Logging at WARN so operators see the soft failure without
+		// it tripping HTTP error-rate alerts.
+		s.log.WarnContext(r.Context(), "broker: rotate partial — old label not revoked",
+			"old", label, "new", minted.Label,
+			"world", minted.World, "subject", hashSubject(claims.Subject), "err", err)
+		writeJSON(w, http.StatusOK, minted)
+	default:
+		s.log.ErrorContext(r.Context(), "broker: rotate failed", "label", label, "err", err)
+		http.Error(w, "rotate failed", http.StatusInternalServerError)
 	}
 }
 

--- a/tools/demarkus-broker/internal/broker/server_test.go
+++ b/tools/demarkus-broker/internal/broker/server_test.go
@@ -400,6 +400,137 @@ func TestDeleteTokenNotFound(t *testing.T) {
 	}
 }
 
+func TestRotateTokenSuccess(t *testing.T) {
+	// Bearer-authed POST /tokens/{label}/rotate returns 200 with the
+	// new MintResult JSON. Alice mints, then rotates; verifier is
+	// configured to return alice's identity on bearer verify so the
+	// owner check passes.
+	k8s := fake.NewSimpleClientset()
+	cfg := testConfig()
+	i := newIssuer(t, cfg, k8s)
+	minted, err := i.Mint(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true})
+	if err != nil {
+		t.Fatalf("seed mint: %v", err)
+	}
+	verifier := &fakeVerifier{claims: Claims{Email: "alice@example.com", EmailVerified: true}}
+	srv, _ := newTestServer(t, cfg, verifier, k8s)
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/tokens/"+minted[0].Label+"/rotate", http.NoBody)
+	req.Header.Set("Authorization", "Bearer alice-id-token")
+	resp, err := testClient(srv).Do(req)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+	var got MintResult
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Label == "" || got.Label == minted[0].Label {
+		t.Errorf("new label = %q, want non-empty and != old %q", got.Label, minted[0].Label)
+	}
+	if got.RawToken == "" {
+		t.Error("RawToken empty in rotate response")
+	}
+	if got.World != "team-a" {
+		t.Errorf("world = %q, want team-a", got.World)
+	}
+}
+
+func TestRotateTokenNotOwner(t *testing.T) {
+	// Alice mints, mallory tries to rotate. Verifier returns mallory's
+	// claims for the bearer; owner check inside RotateLabel fails →
+	// 403 (matches the DELETE owner-check shape from Slice B).
+	k8s := fake.NewSimpleClientset()
+	cfg := testConfig()
+	i := newIssuer(t, cfg, k8s)
+	minted, err := i.Mint(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true})
+	if err != nil {
+		t.Fatalf("seed mint: %v", err)
+	}
+	verifier := &fakeVerifier{claims: Claims{Email: "mallory@example.com", EmailVerified: true}}
+	srv, _ := newTestServer(t, cfg, verifier, k8s)
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/tokens/"+minted[0].Label+"/rotate", http.NoBody)
+	req.Header.Set("Authorization", "Bearer mallory-id-token")
+	resp, err := testClient(srv).Do(req)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestRotateTokenNoLongerAuthorized(t *testing.T) {
+	// Operator tightened the Allow predicate between mint and rotate
+	// to a domain alice no longer matches. Bearer is still valid
+	// (IdP didn't disable her account) but the world's allowlist
+	// rejects → 403 with the "no longer authorized" message. This
+	// is the rotate-as-relogin half of the re-auth story; without
+	// this gate a user removed from a group could rotate forever.
+	k8s := fake.NewSimpleClientset()
+	cfg := testConfig()
+	cfg.Worlds[0].Allow = AllowConfig{Domains: []string{"example.com"}}
+	i := newIssuer(t, cfg, k8s)
+	minted, err := i.Mint(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true})
+	if err != nil {
+		t.Fatalf("seed mint: %v", err)
+	}
+	cfg.Worlds[0].Allow = AllowConfig{Domains: []string{"other.example"}}
+
+	verifier := &fakeVerifier{claims: Claims{Email: "alice@example.com", EmailVerified: true}}
+	srv, _ := newTestServer(t, cfg, verifier, k8s)
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/tokens/"+minted[0].Label+"/rotate", http.NoBody)
+	req.Header.Set("Authorization", "Bearer alice-id-token")
+	resp, err := testClient(srv).Do(req)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestRotateTokenNotFound(t *testing.T) {
+	verifier := &fakeVerifier{claims: Claims{Email: "alice@example.com", EmailVerified: true}}
+	srv, _ := newTestServer(t, testConfig(), verifier, fake.NewSimpleClientset())
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/tokens/usr_nope/rotate", http.NoBody)
+	req.Header.Set("Authorization", "Bearer some-id-token")
+	resp, err := testClient(srv).Do(req)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestRotateTokenUnauthenticated(t *testing.T) {
+	// No bearer at all → 401 from the shared authenticate helper,
+	// before RotateLabel even runs. Same shape as the equivalent
+	// DELETE and GET /tokens unauthenticated guards.
+	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/tokens/whatever/rotate", http.NoBody)
+	resp, err := testClient(srv).Do(req)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
 // Sanity guard so the clock override on Server is exercised at least once.
 func TestServerClockExposed(t *testing.T) {
 	cfg := testConfig()

--- a/tools/demarkus-broker/internal/broker/server_test.go
+++ b/tools/demarkus-broker/internal/broker/server_test.go
@@ -10,10 +10,15 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 // testHTTPTimeout caps every test request against the in-process broker so
@@ -512,6 +517,96 @@ func TestRotateTokenNotFound(t *testing.T) {
 	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestRotateTokenSoftPartial(t *testing.T) {
+	// The handler's "mint succeeded, old revoke failed" branch is
+	// the most consequential code path on the rotate response —
+	// callers see 200 with a fresh token but the old label is still
+	// live in both Secrets until the sweeper retires it on expiry.
+	// Reactor strategy: count Updates against team-a's tokens
+	// Secret. The mint phase writes the new label as Update #1 and
+	// must pass. The revoke phase writes the old-label removal as
+	// Update #2 and we fail it with ServiceUnavailable (mutateSecret
+	// only retries on Conflict, so the unavailable propagates).
+	// Result: the new label is committed, the old label is NOT
+	// removed, and the handler returns 200 because the user's
+	// rotation succeeded from their perspective.
+	k8s := fake.NewSimpleClientset()
+	cfg := testConfig()
+	i := newIssuer(t, cfg, k8s)
+	minted, err := i.Mint(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true})
+	if err != nil {
+		t.Fatalf("seed mint: %v", err)
+	}
+	oldLabel := minted[0].Label
+
+	var teamAUpdates atomic.Int32
+	k8s.PrependReactor("update", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ua, ok := action.(k8stesting.UpdateAction)
+		if !ok || ua.GetNamespace() != "team-a" {
+			return false, nil, nil
+		}
+		n := teamAUpdates.Add(1)
+		if n >= 2 {
+			// Second team-a update is the revoke phase's removal
+			// of the old label. Simulate a transient k8s API blip
+			// — mutateSecret only retries on Conflict so this
+			// error propagates straight up to revokeIssuance.
+			return true, nil, apierrors.NewServiceUnavailable("simulated transient blip during old-label revoke")
+		}
+		return false, nil, nil
+	})
+
+	verifier := &fakeVerifier{claims: Claims{Email: "alice@example.com", EmailVerified: true}}
+	srv, _ := newTestServer(t, cfg, verifier, k8s)
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/tokens/"+oldLabel+"/rotate", http.NoBody)
+	req.Header.Set("Authorization", "Bearer alice-id-token")
+	resp, err := testClient(srv).Do(req)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s — soft-partial path must still return 200", resp.StatusCode, body)
+	}
+	var got MintResult
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Label == "" || got.Label == oldLabel {
+		t.Errorf("new label = %q, want non-empty and != old %q", got.Label, oldLabel)
+	}
+	if got.RawToken == "" {
+		t.Error("RawToken empty in soft-partial response")
+	}
+
+	// World Secret: BOTH labels still present — the old one
+	// because revoke failed, the new one because mint succeeded.
+	// The sweeper will retire the old on expiry.
+	worldSecret, err := k8s.CoreV1().Secrets("team-a").Get(context.Background(), "team-a-tokens", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get world Secret: %v", err)
+	}
+	gotTOML := string(worldSecret.Data[TokensSecretKey])
+	if !strings.Contains(gotTOML, oldLabel) {
+		t.Errorf("old label gone from world Secret despite failed revoke:\n%s", gotTOML)
+	}
+	if !strings.Contains(gotTOML, got.Label) {
+		t.Errorf("new label missing from world Secret on soft-partial:\n%s", gotTOML)
+	}
+
+	// Issuances Secret: both entries too. Owner alice now has TWO
+	// live issuances; this is the transient state the sweeper
+	// resolves on expiry.
+	live, err := i.List(context.Background(), "alice@example.com")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(live) != 2 {
+		t.Errorf("issuances after soft-partial rotate = %d, want 2 (old + new live until sweep)", len(live))
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token rotation endpoint: rotate tokens via POST /tokens/{label}. Rotation acts as a relogin—requires verified email, rechecks current access policy, preserves the original token scope, and updates expiration to current settings.
  * Soft-partial handling: if revoking the old label fails, rotation still returns the new token (200) while surface-warning/error is reported.

* **Bug Fixes / Behavior**
  * Clear HTTP mappings: 200 on success, 401 unauthenticated, 403 ownership or no-longer-authorized, 404 unknown label.

* **Tests**
  * Comprehensive rotation test suite added covering success, authorization, ownership, scope preservation, lifetime updates, missing worlds, and soft-partial revoke.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/112)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->