### PR TITLE
fix(tools):  Add per-subject and per-IP rate limiting middleware

### DIFF
--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -15,10 +15,11 @@ import (
 // is authorized to mint tokens for. The world Tokens Secrets live in each
 // world's namespace; the issuances Secret lives in the broker's namespace.
 type Config struct {
-	Server  ServerConfig  `yaml:"server"`
-	OIDC    OIDCConfig    `yaml:"oidc"`
-	Worlds  []WorldConfig `yaml:"worlds"`
-	Sweeper SweeperConfig `yaml:"sweeper"`
+	Server    ServerConfig    `yaml:"server"`
+	OIDC      OIDCConfig      `yaml:"oidc"`
+	Worlds    []WorldConfig   `yaml:"worlds"`
+	Sweeper   SweeperConfig   `yaml:"sweeper"`
+	RateLimit RateLimitConfig `yaml:"rateLimit"`
 }
 
 // ServerConfig holds the broker's own runtime settings — listen address,
@@ -153,6 +154,61 @@ type SweeperConfig struct {
 	LeaseName string `yaml:"leaseName"`
 }
 
+// RateLimitConfig caps per-subject and per-IP request rates against the
+// broker's HTTP surface (Slice C.4). Per-replica only: each broker pod
+// keeps its own in-memory limiter, so the effective rate seen by an
+// abusive client is up to N× the configured value in a multi-replica
+// deployment. Documented as a §Risks bullet; cluster-shared rate
+// limiting is a Phase 7+ follow-up when a customer's scale needs it.
+//
+// Defaults come from plan §6.2 Slice C.4: 10/min subject on /tokens,
+// /tokens/:label DELETE, /tokens/:label/rotate (single shared bucket,
+// burst 5); 20/min IP on /auth/login (burst 5). Operators tighten or
+// loosen via YAML.
+type RateLimitConfig struct {
+	// Disabled is the opt-out switch, same naming convention as
+	// SweeperConfig.Disabled. Zero-value (false) means the limiter
+	// runs with the configured rates, so an operator who omits the
+	// rateLimit block in their values file still gets the protection.
+	Disabled bool `yaml:"disabled"`
+	// Tokens governs the per-subject bucket shared across GET
+	// /tokens, DELETE /tokens/:label, and POST /tokens/:label/rotate.
+	// One shared bucket means a misbehaving client cannot multiply
+	// its effective rate by fanning out across the three routes.
+	Tokens RateLimitRouteConfig `yaml:"tokens"`
+	// Login governs the per-IP bucket on GET /auth/login. The
+	// callback is intentionally not rate-limited at this layer: the
+	// signed state cookie (HMAC-SHA256, 5-minute TTL) is the natural
+	// rate gate on /auth/callback, and adding an IP bucket there
+	// would penalize legitimate redirects from heavily-NATted
+	// corporate networks where many users share an egress IP.
+	Login RateLimitRouteConfig `yaml:"login"`
+	// TrustForwardedFor opts the IP limiter into honoring the
+	// leftmost X-Forwarded-For entry as the client IP. Default false
+	// because trusting XFF when the broker is not actually behind a
+	// proxy lets an attacker spoof the header to bypass per-IP
+	// limits. Operators flip this to true once the broker is
+	// deployed behind an Ingress/LB that strips spoofed XFF and
+	// appends the real client IP.
+	TrustForwardedFor bool `yaml:"trustForwardedFor"`
+}
+
+// RateLimitRouteConfig is the per-bucket knobs for a route group. Both
+// fields are required when the parent block is present and Disabled is
+// false; validation surfaces missing values at load rather than letting
+// a zero-rate limiter reject every request at runtime.
+type RateLimitRouteConfig struct {
+	// PerMinute is the steady-state replenishment rate in events per
+	// minute. We expose minutes (not events/sec) so the operator-
+	// facing knob matches the human-scale numbers in the plan.
+	PerMinute int `yaml:"perMinute"`
+	// Burst is the size of the token bucket, i.e. the largest sudden
+	// spike accepted before throttling kicks in. Must be >= 1; a
+	// zero burst with positive PerMinute would never accept any
+	// request because the limiter starts with an empty bucket.
+	Burst int `yaml:"burst"`
+}
+
 // TokenScope is the capability bundle every token minted for a given
 // world carries. Paths + Operations are written verbatim into the server-
 // readable tokens.toml; ExpiresAfter is the lifetime applied to each
@@ -257,6 +313,40 @@ func (c *Config) validate() error {
 	}
 	if c.Sweeper.LeaseName == "" {
 		c.Sweeper.LeaseName = "demarkus-broker-sweeper"
+	}
+	return c.RateLimit.applyDefaultsAndValidate()
+}
+
+// applyDefaultsAndValidate fills in plan §6.2 Slice C.4 defaults for the
+// rate-limit knobs and rejects negative values. Per-field defaults are
+// applied only when Disabled is false, so a fully-opted-out config can
+// leave the per-route blocks empty without tripping validation. Extracted
+// from validate() to keep both functions inside the gocyclo budget.
+func (r *RateLimitConfig) applyDefaultsAndValidate() error {
+	if r.Disabled {
+		return nil
+	}
+	if r.Tokens.PerMinute == 0 {
+		r.Tokens.PerMinute = 10
+	}
+	if r.Tokens.Burst == 0 {
+		r.Tokens.Burst = 5
+	}
+	if r.Login.PerMinute == 0 {
+		r.Login.PerMinute = 20
+	}
+	if r.Login.Burst == 0 {
+		r.Login.Burst = 5
+	}
+	switch {
+	case r.Tokens.PerMinute < 0:
+		return fmt.Errorf("rateLimit.tokens.perMinute must be >= 1 (got %d)", r.Tokens.PerMinute)
+	case r.Tokens.Burst < 0:
+		return fmt.Errorf("rateLimit.tokens.burst must be >= 1 (got %d)", r.Tokens.Burst)
+	case r.Login.PerMinute < 0:
+		return fmt.Errorf("rateLimit.login.perMinute must be >= 1 (got %d)", r.Login.PerMinute)
+	case r.Login.Burst < 0:
+		return fmt.Errorf("rateLimit.login.burst must be >= 1 (got %d)", r.Login.Burst)
 	}
 	return nil
 }

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -247,6 +247,85 @@ func TestLoadConfig(t *testing.T) {
       groups: ["engineering", "   "]`, 1),
 			wantErr: "allow.groups[1] is empty",
 		},
+		{
+			// Plan §6.2 Slice C.4 defaults: tokens 10/min burst 5,
+			// login 20/min burst 5. Operator omitting the block
+			// gets the production-safe values applied at validate
+			// — same shape as sweeper.interval defaulting.
+			name: "rateLimit defaults applied when block omitted",
+			body: validConfig,
+			validate: func(t *testing.T, c *Config) {
+				if c.RateLimit.Disabled {
+					t.Error("rateLimit.disabled = true, want false default")
+				}
+				if c.RateLimit.Tokens.PerMinute != 10 {
+					t.Errorf("rateLimit.tokens.perMinute = %d, want 10", c.RateLimit.Tokens.PerMinute)
+				}
+				if c.RateLimit.Tokens.Burst != 5 {
+					t.Errorf("rateLimit.tokens.burst = %d, want 5", c.RateLimit.Tokens.Burst)
+				}
+				if c.RateLimit.Login.PerMinute != 20 {
+					t.Errorf("rateLimit.login.perMinute = %d, want 20", c.RateLimit.Login.PerMinute)
+				}
+				if c.RateLimit.Login.Burst != 5 {
+					t.Errorf("rateLimit.login.burst = %d, want 5", c.RateLimit.Login.Burst)
+				}
+				if c.RateLimit.TrustForwardedFor {
+					t.Error("rateLimit.trustForwardedFor = true, want false default")
+				}
+			},
+		},
+		{
+			name: "rateLimit operator overrides honored",
+			body: validConfig + "rateLimit:\n  tokens:\n    perMinute: 60\n    burst: 10\n  login:\n    perMinute: 120\n    burst: 20\n  trustForwardedFor: true\n",
+			validate: func(t *testing.T, c *Config) {
+				if c.RateLimit.Tokens.PerMinute != 60 || c.RateLimit.Tokens.Burst != 10 {
+					t.Errorf("tokens = %+v, want 60/10", c.RateLimit.Tokens)
+				}
+				if c.RateLimit.Login.PerMinute != 120 || c.RateLimit.Login.Burst != 20 {
+					t.Errorf("login = %+v, want 120/20", c.RateLimit.Login)
+				}
+				if !c.RateLimit.TrustForwardedFor {
+					t.Error("trustForwardedFor not honored")
+				}
+			},
+		},
+		{
+			// disabled=true skips default-filling and value
+			// validation, so an operator who explicitly opts out
+			// can omit the per-route knobs entirely.
+			name: "rateLimit disabled bypasses field defaults",
+			body: validConfig + "rateLimit:\n  disabled: true\n",
+			validate: func(t *testing.T, c *Config) {
+				if !c.RateLimit.Disabled {
+					t.Error("disabled not honored")
+				}
+				if c.RateLimit.Tokens.PerMinute != 0 || c.RateLimit.Login.PerMinute != 0 {
+					t.Errorf("perMinute filled in despite disabled=true: tokens=%d login=%d",
+						c.RateLimit.Tokens.PerMinute, c.RateLimit.Login.PerMinute)
+				}
+			},
+		},
+		{
+			name:    "rateLimit.tokens.perMinute negative rejected",
+			body:    validConfig + "rateLimit:\n  tokens:\n    perMinute: -1\n    burst: 5\n",
+			wantErr: "rateLimit.tokens.perMinute must be >= 1",
+		},
+		{
+			name:    "rateLimit.tokens.burst negative rejected",
+			body:    validConfig + "rateLimit:\n  tokens:\n    perMinute: 10\n    burst: -1\n",
+			wantErr: "rateLimit.tokens.burst must be >= 1",
+		},
+		{
+			name:    "rateLimit.login.perMinute negative rejected",
+			body:    validConfig + "rateLimit:\n  login:\n    perMinute: -1\n    burst: 5\n",
+			wantErr: "rateLimit.login.perMinute must be >= 1",
+		},
+		{
+			name:    "rateLimit.login.burst negative rejected",
+			body:    validConfig + "rateLimit:\n  login:\n    perMinute: 20\n    burst: -1\n",
+			wantErr: "rateLimit.login.burst must be >= 1",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tools/demarkus-broker/internal/broker/ratelimit.go
+++ b/tools/demarkus-broker/internal/broker/ratelimit.go
@@ -1,0 +1,248 @@
+package broker
+
+import (
+	"context"
+	"math"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// ctxKey scopes context-stash keys to this package so callers outside the
+// broker can't accidentally collide with our keys.
+type ctxKey int
+
+const (
+	// ctxClaimsKey holds the verified OIDC Claims for an authed request,
+	// populated by requireAuth and read by handlers + subjectRateLimit.
+	// Using a typed key (rather than the bare string) is the standard
+	// idiom for in-package context propagation; nothing outside this
+	// package can read or write the value.
+	ctxClaimsKey ctxKey = iota
+)
+
+// ctxWithClaims returns ctx with the verified claims attached. Called from
+// requireAuth before dispatching to the next handler in the chain so all
+// downstream code (subjectRateLimit, the actual handler) shares one
+// authentication result rather than re-verifying the bearer token.
+func ctxWithClaims(ctx context.Context, c Claims) context.Context {
+	return context.WithValue(ctx, ctxClaimsKey, c)
+}
+
+// claimsFromCtx pulls the verified claims out of ctx. Returns the zero
+// Claims and false if the context did not pass through requireAuth — the
+// caller must treat that as a programming error since the middleware
+// chain should make it impossible for an authed handler to be reached
+// without claims set.
+func claimsFromCtx(ctx context.Context) (Claims, bool) {
+	c, ok := ctx.Value(ctxClaimsKey).(Claims)
+	return c, ok
+}
+
+// rateLimitRegistry keeps one *rate.Limiter per key (subject hash for the
+// authed /tokens routes, source IP for /auth/login). A sync.Map fits the
+// shape: lookups dominate writes, and key creation is one-time-per-key.
+//
+// Per-replica only by design: in a multi-replica broker each pod has its
+// own registry, so the effective rate seen by an abusive client is up to
+// N× the configured value (N = replica count). The plan §6.2 Slice C.4
+// accepts this as a Phase-7+ follow-up; a cluster-shared rate limiter
+// (memcached / Redis / k8s Lease-coordinated tokens) is the eventual fix
+// when an operator's deployment actually needs it.
+//
+// No idle-key GC for Slice C.4: the upper bound is (authed subjects) +
+// (recent client IPs). For single-org deployments that's small enough
+// that map growth isn't a concern. When the broker grows past that
+// scale, idle-key GC is a phase-7+ follow-up — a background goroutine
+// scanning for limiters whose token bucket is full (no recent activity)
+// and evicting them.
+type rateLimitRegistry struct {
+	mu        sync.Map // key string → *rate.Limiter
+	perMinute int
+	burst     int
+}
+
+// newRateLimitRegistry returns nil when the configured rate is non-
+// positive or the burst is zero/negative; the middleware reads "nil
+// registry → no enforcement" so a test or operator can disable a
+// specific dimension without threading a bool through every handler.
+func newRateLimitRegistry(perMinute, burst int) *rateLimitRegistry {
+	if perMinute <= 0 || burst <= 0 {
+		return nil
+	}
+	return &rateLimitRegistry{perMinute: perMinute, burst: burst}
+}
+
+// limiter returns the *rate.Limiter for a given key, creating it on
+// first access. The double-check via LoadOrStore is the standard
+// sync.Map "compute once" pattern: most reads find the existing entry,
+// only the very first request for a key allocates.
+func (r *rateLimitRegistry) limiter(key string) *rate.Limiter {
+	if v, ok := r.mu.Load(key); ok {
+		return v.(*rate.Limiter)
+	}
+	// rate.Limit accepts events/sec; we configure events/min so the
+	// operator-facing knob matches the human-scale rates in the plan.
+	lim := rate.NewLimiter(rate.Limit(float64(r.perMinute)/60.0), r.burst)
+	actual, _ := r.mu.LoadOrStore(key, lim)
+	return actual.(*rate.Limiter)
+}
+
+// reserve charges the bucket for one event keyed by key. Returns
+// allowed=true when the request may proceed immediately; false when it
+// should be rejected. retryAfter is set on denial as the duration until
+// the next token would be available (clamped to at least 1s so the
+// Retry-After header is never 0 — a 0 means "try again immediately"
+// which an aggressive client will interpret as "spam harder").
+//
+// We use Reserve()+Cancel() rather than Allow() so a denied request
+// does NOT consume budget: an attacker hammering the endpoint stays
+// stuck at the same retry window rather than pushing the recovery
+// indefinitely into the future. With Allow(), each denied attempt
+// would internally take a token and lengthen recovery.
+func (r *rateLimitRegistry) reserve(key string) (allowed bool, retryAfter time.Duration) {
+	lim := r.limiter(key)
+	res := lim.Reserve()
+	if !res.OK() {
+		// Practically unreachable since we don't set a max-future-
+		// reservation, but if it ever does happen treat it as denial
+		// with a 1s retry (the minimum nonzero hint).
+		return false, time.Second
+	}
+	if d := res.Delay(); d > 0 {
+		res.Cancel()
+		if d < time.Second {
+			d = time.Second
+		}
+		return false, d
+	}
+	return true, 0
+}
+
+// requireAuth verifies the bearer ID token on the request, stashes the
+// verified Claims on r.Context() under ctxClaimsKey, and calls the next
+// handler. On any failure it writes the 401 itself and short-circuits —
+// the next handler is not called.
+//
+// Extracted from the per-handler s.authenticate calls in Slice C.4 so
+// the subjectRateLimit middleware can key on hashSubject(claims.Subject)
+// without re-verifying the bearer.
+func (s *Server) requireAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw := bearerToken(r)
+		if raw == "" {
+			http.Error(w, "Authorization: Bearer <id_token> required", http.StatusUnauthorized)
+			return
+		}
+		claims, err := s.verifier.VerifyIDToken(r.Context(), raw)
+		if err != nil {
+			s.log.WarnContext(r.Context(), "broker: id_token verification failed", "err", err)
+			http.Error(w, "invalid bearer token", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(ctxWithClaims(r.Context(), claims)))
+	})
+}
+
+// subjectRateLimit enforces per-subject rate limiting on authed routes.
+// Must be composed AFTER requireAuth: it reads the verified claims off
+// the request context and keys on hashSubject(claims.Subject) so a
+// rotating client IP or multiple sessions for the same identity share
+// one bucket. When s.subjectReg is nil (rate limit disabled in config),
+// returns next unchanged so the route is free of measurement overhead.
+//
+// Bucket-sharing across the three /tokens routes is intentional: the
+// same actor doing /tokens GET + DELETE + rotate hits the same bucket,
+// so a misbehaving client can't burn 10× the configured budget by
+// fan-out across routes. Plan §6.2 C.4 decision.
+func (s *Server) subjectRateLimit(next http.Handler) http.Handler {
+	if s.subjectReg == nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		claims, ok := claimsFromCtx(r.Context())
+		if !ok {
+			// Programming error: subjectRateLimit composed without
+			// requireAuth upstream. Fail closed with 500 so the
+			// regression surfaces immediately rather than silently
+			// disabling rate-limiting on the route.
+			s.log.ErrorContext(r.Context(), "broker: subjectRateLimit missing claims in context — middleware miswired")
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		key := hashSubject(claims.Subject)
+		allowed, retryAfter := s.subjectReg.reserve(key)
+		if !allowed {
+			s.log.WarnContext(r.Context(), "broker: rate limit exceeded",
+				"route", r.URL.Path, "subject", key, "retryAfter", retryAfter)
+			w.Header().Set("Retry-After", strconv.Itoa(int(math.Ceil(retryAfter.Seconds()))))
+			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// ipRateLimit enforces source-IP rate limiting on unauthenticated routes
+// — primarily /auth/login so an unauthenticated client cannot exhaust
+// the OIDC dance machinery by spamming logins. Keys on s.clientIP(r)
+// which respects the trustForwardedFor flag.
+//
+// Returns next unchanged when s.loginReg is nil so the disabled state
+// has no per-request overhead.
+func (s *Server) ipRateLimit(next http.Handler) http.Handler {
+	if s.loginReg == nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := s.clientIP(r)
+		allowed, retryAfter := s.loginReg.reserve(key)
+		if !allowed {
+			s.log.WarnContext(r.Context(), "broker: rate limit exceeded",
+				"route", r.URL.Path, "ip", key, "retryAfter", retryAfter)
+			w.Header().Set("Retry-After", strconv.Itoa(int(math.Ceil(retryAfter.Seconds()))))
+			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// clientIP extracts the rate-limit key for IP-keyed routes. When
+// trustForwardedFor is enabled, uses the leftmost entry in X-Forwarded-
+// For (the standard "originating client" semantic for reverse proxies).
+// Otherwise uses the immediate peer from r.RemoteAddr.
+//
+// trustForwardedFor must stay OFF unless the broker is actually behind
+// a proxy that strips or appends to XFF correctly — otherwise an
+// attacker can spoof the header and bypass the per-IP limiter by
+// rotating through synthetic IPs. The chart-side §6.3 work will wire
+// this flag on when the broker sits behind the Ingress.
+func (s *Server) clientIP(r *http.Request) string {
+	if s.trustForwardedFor {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			// Leftmost non-empty entry. Trim whitespace because
+			// proxies commonly emit "ip1, ip2, ip3" with spaces.
+			for part := range strings.SplitSeq(xff, ",") {
+				part = strings.TrimSpace(part)
+				if part != "" {
+					return part
+				}
+			}
+		}
+	}
+	// SplitHostPort handles both "host:port" (real HTTP requests) and
+	// "[v6]:port" forms. On the rare error case (e.g. tests that
+	// inject an invalid RemoteAddr) fall back to the raw string so
+	// the limiter still groups consistently.
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/tools/demarkus-broker/internal/broker/ratelimit.go
+++ b/tools/demarkus-broker/internal/broker/ratelimit.go
@@ -55,12 +55,39 @@ func claimsFromCtx(ctx context.Context) (Claims, bool) {
 // (memcached / Redis / k8s Lease-coordinated tokens) is the eventual fix
 // when an operator's deployment actually needs it.
 //
-// No idle-key GC for Slice C.4: the upper bound is (authed subjects) +
-// (recent client IPs). For single-org deployments that's small enough
-// that map growth isn't a concern. When the broker grows past that
-// scale, idle-key GC is a phase-7+ follow-up — a background goroutine
-// scanning for limiters whose token bucket is full (no recent activity)
-// and evicting them.
+// No idle-key GC for Slice C.4. The two registries are bounded by:
+//
+//   - subjectReg keys are hashSubject(claims.Subject). A request only
+//     reaches subjectRateLimit after requireAuth has validated a real
+//     OIDC bearer, so growth is bounded by the IdP's user count (the
+//     attacker cannot inflate the keyspace without first holding valid
+//     IdP-issued tokens, which is itself rate-limited by the IdP).
+//   - loginReg keys come from s.clientIP(r). With trustForwardedFor=false
+//     (default we ship) the key is r.RemoteAddr — bounded by clients
+//     that can actually reach the broker's listener. With
+//     trustForwardedFor=true (chart-side §6.3 flips this on once the
+//     broker sits behind an Ingress that strips spoofed XFF), the key
+//     is the leftmost XFF entry, which a correctly-configured ingress
+//     caps to real client IPs.
+//
+// The unbounded-growth concern is real only when trustForwardedFor=true
+// AND the broker is internet-exposed without a trusted proxy in front —
+// i.e., a deployment misconfiguration the §6.3 chart docs call out. TTL
+// eviction does NOT fix that posture: under active attack an attacker
+// who rotates keys faster than the TTL gets fresh buckets indefinitely
+// (effective rate-limit disappears), and an LRU cap evicts legitimate
+// users' older buckets first while the attacker's freshly-created
+// buckets stay in the map. The defense at the right layer is upstream
+// (cluster-shared rate limiter at the broker pod set, or per-IP
+// rate-limit annotations at the ingress controller); Phase-7+ work.
+//
+// Realistic worst-case sizing for sized-up healthy deployments: a
+// long-running broker pod with ~10k distinct authenticated subjects
+// holds ~10k limiters at ~50 bytes each, ~500KB total. That's not a
+// memory-DoS-shaped quantity. If a customer's broker outgrows that,
+// idle-key GC (scan the sync.Map periodically, evict entries whose
+// token bucket is full + has not seen activity for a TTL) is a clean
+// additive change.
 type rateLimitRegistry struct {
 	mu        sync.Map // key string → *rate.Limiter
 	perMinute int

--- a/tools/demarkus-broker/internal/broker/ratelimit_test.go
+++ b/tools/demarkus-broker/internal/broker/ratelimit_test.go
@@ -276,7 +276,10 @@ func TestRateLimitTokensCrossSubjectIsolation(t *testing.T) {
 	for i := range 3 {
 		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/tokens", http.NoBody)
 		req.Header.Set("Authorization", "Bearer alice-token")
-		resp, _ := client.Do(req)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("alice attempt %d: %v", i+1, err)
+		}
 		_ = resp.Body.Close()
 		if i < 2 && resp.StatusCode != http.StatusOK {
 			t.Fatalf("alice attempt %d status = %d, want 200", i+1, resp.StatusCode)
@@ -312,7 +315,10 @@ func TestRateLimitTokensSharedBucketAcrossRoutes(t *testing.T) {
 	// 1st: GET /tokens (200, empty list).
 	req1, _ := http.NewRequest(http.MethodGet, srv.URL+"/tokens", http.NoBody)
 	req1.Header.Set("Authorization", "Bearer alice-token")
-	r1, _ := client.Do(req1)
+	r1, err := client.Do(req1)
+	if err != nil {
+		t.Fatalf("1st (GET): %v", err)
+	}
 	_ = r1.Body.Close()
 	if r1.StatusCode != http.StatusOK {
 		t.Fatalf("1st (GET) status = %d, want 200", r1.StatusCode)
@@ -320,7 +326,10 @@ func TestRateLimitTokensSharedBucketAcrossRoutes(t *testing.T) {
 	// 2nd: DELETE /tokens/nope (404 from handler, but counts).
 	req2, _ := http.NewRequest(http.MethodDelete, srv.URL+"/tokens/usr_nope", http.NoBody)
 	req2.Header.Set("Authorization", "Bearer alice-token")
-	r2, _ := client.Do(req2)
+	r2, err := client.Do(req2)
+	if err != nil {
+		t.Fatalf("2nd (DELETE): %v", err)
+	}
 	_ = r2.Body.Close()
 	if r2.StatusCode != http.StatusNotFound {
 		t.Fatalf("2nd (DELETE) status = %d, want 404 (handler-side; rate limit must not fire here)", r2.StatusCode)
@@ -329,7 +338,10 @@ func TestRateLimitTokensSharedBucketAcrossRoutes(t *testing.T) {
 	// because the shared bucket is now empty.
 	req3, _ := http.NewRequest(http.MethodPost, srv.URL+"/tokens/usr_nope/rotate", http.NoBody)
 	req3.Header.Set("Authorization", "Bearer alice-token")
-	r3, _ := client.Do(req3)
+	r3, err := client.Do(req3)
+	if err != nil {
+		t.Fatalf("3rd (ROTATE): %v", err)
+	}
 	_ = r3.Body.Close()
 	if r3.StatusCode != http.StatusTooManyRequests {
 		t.Errorf("3rd (ROTATE on a different route) status = %d, want 429 — shared-bucket invariant broken", r3.StatusCode)
@@ -386,10 +398,13 @@ func TestRateLimitLoginIPCrossIPIsolation(t *testing.T) {
 	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 
 	// IP A: 3 attempts (last 429s).
-	for range 3 {
+	for i := range 3 {
 		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/auth/login", http.NoBody)
 		req.Header.Set("X-Forwarded-For", "198.51.100.10")
-		resp, _ := client.Do(req)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("IP A attempt %d: %v", i+1, err)
+		}
 		_ = resp.Body.Close()
 	}
 	// IP B: must pass — independent bucket.
@@ -422,7 +437,10 @@ func TestRateLimitLoginIPIgnoresForwardedForByDefault(t *testing.T) {
 	for i, ip := range []string{"198.51.100.10", "198.51.100.20", "198.51.100.30"} {
 		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/auth/login", http.NoBody)
 		req.Header.Set("X-Forwarded-For", ip)
-		resp, _ := client.Do(req)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("attempt %d (XFF=%s): %v", i+1, ip, err)
+		}
 		_ = resp.Body.Close()
 		if i < 2 && resp.StatusCode != http.StatusFound {
 			t.Fatalf("attempt %d status = %d, want 302 within burst", i+1, resp.StatusCode)

--- a/tools/demarkus-broker/internal/broker/ratelimit_test.go
+++ b/tools/demarkus-broker/internal/broker/ratelimit_test.go
@@ -1,0 +1,462 @@
+package broker
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// testRateLimitConfig returns a deliberately tight rate-limit profile so
+// integration tests can exhaust the bucket with a handful of requests.
+// burst=2 keeps the request count per test small without making the
+// limiter so coarse that timing-dependent assertions become flaky.
+func testRateLimitConfig() RateLimitConfig {
+	return RateLimitConfig{
+		Tokens: RateLimitRouteConfig{PerMinute: 60, Burst: 2},
+		Login:  RateLimitRouteConfig{PerMinute: 60, Burst: 2},
+	}
+}
+
+func TestRateLimitRegistryNilWhenDisabledOrZero(t *testing.T) {
+	// newRateLimitRegistry must return nil for invalid inputs so the
+	// "disabled = no enforcement" guarantee in the middleware (nil
+	// registry → passthrough) cannot be silently broken by a config
+	// that left fields at zero. Pins the contract Routes() depends on.
+	tests := []struct {
+		name       string
+		perMinute  int
+		burst      int
+		wantNonNil bool
+	}{
+		{"zero perMinute", 0, 5, false},
+		{"zero burst", 10, 0, false},
+		{"negative perMinute", -1, 5, false},
+		{"negative burst", 10, -1, false},
+		{"valid", 10, 5, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newRateLimitRegistry(tt.perMinute, tt.burst)
+			if (got != nil) != tt.wantNonNil {
+				t.Errorf("got=%v, want non-nil=%v", got, tt.wantNonNil)
+			}
+		})
+	}
+}
+
+func TestRateLimitRegistryAllowsBurstThenDenies(t *testing.T) {
+	reg := newRateLimitRegistry(60, 2)
+	for i := range 2 {
+		allowed, _ := reg.reserve("k")
+		if !allowed {
+			t.Errorf("attempt %d denied; burst=2 should allow first two", i+1)
+		}
+	}
+	allowed, retryAfter := reg.reserve("k")
+	if allowed {
+		t.Error("3rd attempt allowed; burst+1 should deny")
+	}
+	if retryAfter < time.Second {
+		// Minimum 1s floor on retryAfter so the HTTP Retry-After
+		// header is never 0 (a 0 hints "try again immediately"
+		// which an aggressive client interprets as "spam harder").
+		t.Errorf("retryAfter = %s, want >= 1s (floor enforced)", retryAfter)
+	}
+}
+
+func TestRateLimitRegistryCrossKeyIsolation(t *testing.T) {
+	reg := newRateLimitRegistry(60, 2)
+	// Exhaust k1.
+	reg.reserve("k1")
+	reg.reserve("k1")
+	if allowed, _ := reg.reserve("k1"); allowed {
+		t.Fatal("k1 not exhausted after burst+1 attempts")
+	}
+	// k2's bucket is independent and must still allow.
+	if allowed, _ := reg.reserve("k2"); !allowed {
+		t.Error("k2 denied even though k1 was the one exhausted — cross-key isolation broken")
+	}
+}
+
+func TestRateLimitRegistryDenialDoesNotConsumeBudget(t *testing.T) {
+	// PerMinute=600 = 10 tokens/sec = 1 token per 100ms. Burst=2.
+	// Spam many denials in a tight loop; if denials consumed budget
+	// (Reserve without Cancel), each one would push the next-allowed
+	// time further out, and 150ms wouldn't be enough to recover.
+	// With the Reserve+Cancel pattern, one token regenerates per
+	// 100ms regardless of denial volume.
+	reg := newRateLimitRegistry(600, 2)
+	reg.reserve("k")
+	reg.reserve("k")
+	for i := range 50 {
+		if allowed, _ := reg.reserve("k"); allowed {
+			t.Fatalf("attempt %d unexpectedly allowed before regen window", i)
+		}
+	}
+	time.Sleep(150 * time.Millisecond)
+	if allowed, _ := reg.reserve("k"); !allowed {
+		t.Error("recovery after 150ms denied — denials consumed budget (Cancel missing)")
+	}
+}
+
+func TestServerClientIP(t *testing.T) {
+	// clientIP gates the IP-keyed limiter; getting this wrong either
+	// makes the limiter useless behind an Ingress (every request
+	// appears as one IP) or trivially bypassable via XFF header
+	// spoofing. Table covers both regression vectors.
+	tests := []struct {
+		name              string
+		trustForwardedFor bool
+		remoteAddr        string
+		xff               string
+		want              string
+	}{
+		{
+			name:       "untrusted XFF ignored",
+			remoteAddr: "10.0.0.5:55555",
+			xff:        "1.2.3.4",
+			want:       "10.0.0.5",
+		},
+		{
+			name:              "trusted XFF single hop",
+			trustForwardedFor: true,
+			remoteAddr:        "10.0.0.5:55555",
+			xff:               "1.2.3.4",
+			want:              "1.2.3.4",
+		},
+		{
+			name:              "trusted XFF multi hop takes leftmost",
+			trustForwardedFor: true,
+			remoteAddr:        "10.0.0.5:55555",
+			xff:               "1.2.3.4, 10.0.0.1, 10.0.0.2",
+			want:              "1.2.3.4",
+		},
+		{
+			name:              "trusted XFF empty falls back to RemoteAddr",
+			trustForwardedFor: true,
+			remoteAddr:        "10.0.0.5:55555",
+			xff:               "",
+			want:              "10.0.0.5",
+		},
+		{
+			name:              "trusted XFF with only whitespace falls back",
+			trustForwardedFor: true,
+			remoteAddr:        "10.0.0.5:55555",
+			xff:               " , ",
+			want:              "10.0.0.5",
+		},
+		{
+			name:       "ipv6 RemoteAddr",
+			remoteAddr: "[::1]:55555",
+			want:       "::1",
+		},
+		{
+			name:       "invalid RemoteAddr falls back to raw",
+			remoteAddr: "garbage",
+			want:       "garbage",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{trustForwardedFor: tt.trustForwardedFor}
+			r, _ := http.NewRequest(http.MethodGet, "/", http.NoBody)
+			r.RemoteAddr = tt.remoteAddr
+			if tt.xff != "" {
+				r.Header.Set("X-Forwarded-For", tt.xff)
+			}
+			if got := s.clientIP(r); got != tt.want {
+				t.Errorf("clientIP = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubjectRateLimitMissingClaimsIs500(t *testing.T) {
+	// Regression guard: if a future route registration composes
+	// subjectRateLimit without requireAuth upstream, the request
+	// reaches the middleware with no claims in ctx. We surface that
+	// as 500 + an error log rather than silently disabling the limit
+	// (which would be the worst-of-both: production looks fine, but
+	// a misbehaving caller gets unbounded throughput).
+	srv := NewServer(testConfigWithRateLimit(), newTestSigner(t), &fakeVerifier{}, NewIssuer(testConfig(), fake.NewSimpleClientset()), nil)
+	h := srv.subjectRateLimit(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("handler reached despite missing claims")
+		w.WriteHeader(http.StatusOK)
+	}))
+	rr := httptest.NewRecorder()
+	r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/tokens", http.NoBody)
+	h.ServeHTTP(rr, r)
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rr.Code)
+	}
+}
+
+// testConfigWithRateLimit returns a testConfig with a tight rate limit
+// applied, plus enough multi-claim verifier wiring usable across the
+// subject-keyed tests below. Splitting it out keeps each test focused
+// on the property it pins.
+func testConfigWithRateLimit() *Config {
+	cfg := testConfig()
+	cfg.RateLimit = testRateLimitConfig()
+	return cfg
+}
+
+// twoSubjectVerifier returns a fakeVerifier whose VerifyIDToken maps
+// bearer string → distinct Claims (different Subject = different
+// hashSubject = different rate-limit key). Used to pin cross-subject
+// isolation: alice exhausts her bucket, bob is unaffected.
+func twoSubjectVerifier() *fakeVerifier {
+	return &fakeVerifier{
+		verifyFn: func(raw string) (Claims, error) {
+			switch raw {
+			case "alice-token":
+				return Claims{Email: "alice@example.com", EmailVerified: true, Subject: "google|alice"}, nil
+			case "bob-token":
+				return Claims{Email: "bob@example.com", EmailVerified: true, Subject: "google|bob"}, nil
+			default:
+				return Claims{}, errors.New("unknown bearer token")
+			}
+		},
+	}
+}
+
+func TestRateLimitTokensExhaustsAndReturns429WithRetryAfter(t *testing.T) {
+	cfg := testConfigWithRateLimit()
+	srv, _ := newTestServer(t, cfg, twoSubjectVerifier(), fake.NewSimpleClientset())
+	client := testClient(srv)
+
+	// burst=2, so the first two requests pass and the third 429s.
+	for i := range 2 {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/tokens", http.NoBody)
+		req.Header.Set("Authorization", "Bearer alice-token")
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("attempt %d: %v", i+1, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("attempt %d status = %d, want 200 (within burst)", i+1, resp.StatusCode)
+		}
+	}
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/tokens", http.NoBody)
+	req.Header.Set("Authorization", "Bearer alice-token")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("3rd: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusTooManyRequests {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("3rd status = %d body=%s, want 429", resp.StatusCode, body)
+	}
+	// Retry-After header must be set with a positive integer-second
+	// hint so CLI clients can honor it. A missing or 0 value would
+	// be read as "retry now" and defeat the limiter.
+	if h := resp.Header.Get("Retry-After"); h == "" || h == "0" {
+		t.Errorf("Retry-After = %q, want a positive integer-second hint", h)
+	}
+}
+
+func TestRateLimitTokensCrossSubjectIsolation(t *testing.T) {
+	// Alice exhausts her bucket; bob's identity has a different
+	// Subject → different hashSubject → different bucket → his
+	// requests still pass. Without this property, a single noisy
+	// user could DoS the entire authed surface for everyone else.
+	cfg := testConfigWithRateLimit()
+	srv, _ := newTestServer(t, cfg, twoSubjectVerifier(), fake.NewSimpleClientset())
+	client := testClient(srv)
+
+	for i := range 3 {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/tokens", http.NoBody)
+		req.Header.Set("Authorization", "Bearer alice-token")
+		resp, _ := client.Do(req)
+		_ = resp.Body.Close()
+		if i < 2 && resp.StatusCode != http.StatusOK {
+			t.Fatalf("alice attempt %d status = %d, want 200", i+1, resp.StatusCode)
+		}
+		if i == 2 && resp.StatusCode != http.StatusTooManyRequests {
+			t.Fatalf("alice attempt 3 status = %d, want 429 (precondition)", resp.StatusCode)
+		}
+	}
+	// Bob should still pass through cleanly.
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/tokens", http.NoBody)
+	req.Header.Set("Authorization", "Bearer bob-token")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("bob: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("bob status = %d, want 200 (his bucket should be independent)", resp.StatusCode)
+	}
+}
+
+func TestRateLimitTokensSharedBucketAcrossRoutes(t *testing.T) {
+	// Plan §6.2 C.4 decision: the three /tokens routes share one
+	// per-subject bucket so a misbehaving client cannot multiply
+	// effective throughput by fanning out (list + revoke + rotate
+	// each at 10/min would give 30/min effective). With burst=2,
+	// 1 list + 1 delete should be allowed; the 3rd request — on a
+	// distinct route — must 429.
+	cfg := testConfigWithRateLimit()
+	srv, _ := newTestServer(t, cfg, twoSubjectVerifier(), fake.NewSimpleClientset())
+	client := testClient(srv)
+
+	// 1st: GET /tokens (200, empty list).
+	req1, _ := http.NewRequest(http.MethodGet, srv.URL+"/tokens", http.NoBody)
+	req1.Header.Set("Authorization", "Bearer alice-token")
+	r1, _ := client.Do(req1)
+	_ = r1.Body.Close()
+	if r1.StatusCode != http.StatusOK {
+		t.Fatalf("1st (GET) status = %d, want 200", r1.StatusCode)
+	}
+	// 2nd: DELETE /tokens/nope (404 from handler, but counts).
+	req2, _ := http.NewRequest(http.MethodDelete, srv.URL+"/tokens/usr_nope", http.NoBody)
+	req2.Header.Set("Authorization", "Bearer alice-token")
+	r2, _ := client.Do(req2)
+	_ = r2.Body.Close()
+	if r2.StatusCode != http.StatusNotFound {
+		t.Fatalf("2nd (DELETE) status = %d, want 404 (handler-side; rate limit must not fire here)", r2.StatusCode)
+	}
+	// 3rd: POST /tokens/.../rotate on a different route — must 429
+	// because the shared bucket is now empty.
+	req3, _ := http.NewRequest(http.MethodPost, srv.URL+"/tokens/usr_nope/rotate", http.NoBody)
+	req3.Header.Set("Authorization", "Bearer alice-token")
+	r3, _ := client.Do(req3)
+	_ = r3.Body.Close()
+	if r3.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("3rd (ROTATE on a different route) status = %d, want 429 — shared-bucket invariant broken", r3.StatusCode)
+	}
+}
+
+func TestRateLimitLoginIPExhaustsAndReturns429WithRetryAfter(t *testing.T) {
+	// /auth/login is keyed by source IP. Behind an Ingress every
+	// request has the same r.RemoteAddr (the controller IP), so we
+	// enable trustForwardedFor and craft per-request XFF values to
+	// simulate different originating clients. This test pins the
+	// "one IP exhausting its bucket returns 429" property.
+	cfg := testConfigWithRateLimit()
+	cfg.RateLimit.TrustForwardedFor = true
+	srv, _ := newTestServer(t, cfg, &fakeVerifier{authURL: "https://idp.example.com/authorize"}, fake.NewSimpleClientset())
+	client := testClient(srv)
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	for i := range 2 {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/auth/login", http.NoBody)
+		req.Header.Set("X-Forwarded-For", "203.0.113.7")
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("attempt %d: %v", i+1, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusFound {
+			t.Fatalf("attempt %d status = %d, want 302 (within burst)", i+1, resp.StatusCode)
+		}
+	}
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/auth/login", http.NoBody)
+	req.Header.Set("X-Forwarded-For", "203.0.113.7")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("3rd: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("3rd status = %d, want 429", resp.StatusCode)
+	}
+	if h := resp.Header.Get("Retry-After"); h == "" || h == "0" {
+		t.Errorf("Retry-After = %q, want positive", h)
+	}
+}
+
+func TestRateLimitLoginIPCrossIPIsolation(t *testing.T) {
+	// Spoofed-IP A exhausts its bucket; spoofed-IP B still passes.
+	// Only meaningful with trustForwardedFor=true; the next test
+	// pins the opposite default-trust posture.
+	cfg := testConfigWithRateLimit()
+	cfg.RateLimit.TrustForwardedFor = true
+	srv, _ := newTestServer(t, cfg, &fakeVerifier{authURL: "https://idp.example.com/authorize"}, fake.NewSimpleClientset())
+	client := testClient(srv)
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	// IP A: 3 attempts (last 429s).
+	for range 3 {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/auth/login", http.NoBody)
+		req.Header.Set("X-Forwarded-For", "198.51.100.10")
+		resp, _ := client.Do(req)
+		_ = resp.Body.Close()
+	}
+	// IP B: must pass — independent bucket.
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/auth/login", http.NoBody)
+	req.Header.Set("X-Forwarded-For", "198.51.100.20")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("IP B: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("IP B status = %d, want 302 — cross-IP isolation broken", resp.StatusCode)
+	}
+}
+
+func TestRateLimitLoginIPIgnoresForwardedForByDefault(t *testing.T) {
+	// trustForwardedFor=false (default). XFF must be ignored so an
+	// attacker cannot bypass the per-IP limit by spoofing the
+	// header. Both "IPs" share the same actual r.RemoteAddr
+	// (127.0.0.1 from httptest), so the bucket exhausts across
+	// requests with different XFF values.
+	cfg := testConfigWithRateLimit()
+	// Explicitly false; the default is already false but the
+	// assertion below depends on this — restating is documentation.
+	cfg.RateLimit.TrustForwardedFor = false
+	srv, _ := newTestServer(t, cfg, &fakeVerifier{authURL: "https://idp.example.com/authorize"}, fake.NewSimpleClientset())
+	client := testClient(srv)
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	for i, ip := range []string{"198.51.100.10", "198.51.100.20", "198.51.100.30"} {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/auth/login", http.NoBody)
+		req.Header.Set("X-Forwarded-For", ip)
+		resp, _ := client.Do(req)
+		_ = resp.Body.Close()
+		if i < 2 && resp.StatusCode != http.StatusFound {
+			t.Fatalf("attempt %d status = %d, want 302 within burst", i+1, resp.StatusCode)
+		}
+		// 3rd must be 429 because all three requests came from the
+		// same r.RemoteAddr (XFF is ignored when trust is off).
+		if i == 2 && resp.StatusCode != http.StatusTooManyRequests {
+			t.Errorf("attempt 3 status = %d, want 429 — spoofed XFF must NOT split buckets when trust is off", resp.StatusCode)
+		}
+	}
+}
+
+func TestRateLimitDisabledBypasses(t *testing.T) {
+	// rateLimit.disabled=true skips all enforcement: subjectReg and
+	// loginReg are nil, both middlewares pass through. Pins the
+	// operator-side opt-out so a single-replica dev deployment can
+	// disable the limiter without losing any other behavior.
+	cfg := testConfig()
+	cfg.RateLimit = RateLimitConfig{Disabled: true}
+	srv, _ := newTestServer(t, cfg, twoSubjectVerifier(), fake.NewSimpleClientset())
+	client := testClient(srv)
+
+	for i := range 20 {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/tokens", http.NoBody)
+		req.Header.Set("Authorization", "Bearer alice-token")
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("attempt %d: %v", i+1, err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("attempt %d status = %d body=%s; disabled limiter must let all requests through",
+				i+1, resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+	}
+}

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -27,6 +27,18 @@ type Server struct {
 	issuer   *Issuer
 	log      *slog.Logger
 	clock    func() time.Time
+
+	// subjectReg is the per-subject limiter shared across the three
+	// /tokens routes; loginReg is the per-IP limiter for /auth/login.
+	// Either may be nil (Slice C.4 RateLimitConfig.Disabled, or a test
+	// that constructs Config{} without rate-limit fields set), in
+	// which case the corresponding middleware is a no-op passthrough.
+	subjectReg *rateLimitRegistry
+	loginReg   *rateLimitRegistry
+	// trustForwardedFor mirrors RateLimitConfig.TrustForwardedFor; the
+	// flag is hoisted onto Server so the ipRateLimit middleware can
+	// read it without re-reaching into Config on every request.
+	trustForwardedFor bool
 }
 
 // NewServer wires a Server. The caller is responsible for constructing the
@@ -36,28 +48,54 @@ func NewServer(cfg *Config, signer *Signer, verifier Verifier, issuer *Issuer, l
 	if log == nil {
 		log = slog.Default()
 	}
-	return &Server{
-		cfg:      cfg,
-		signer:   signer,
-		verifier: verifier,
-		issuer:   issuer,
-		log:      log,
-		clock:    time.Now,
+	s := &Server{
+		cfg:               cfg,
+		signer:            signer,
+		verifier:          verifier,
+		issuer:            issuer,
+		log:               log,
+		clock:             time.Now,
+		trustForwardedFor: cfg.RateLimit.TrustForwardedFor,
 	}
+	// Build the registries unless the operator disabled the limiter
+	// entirely. newRateLimitRegistry returns nil for zero/negative
+	// inputs, so tests that construct Config{} without RateLimit set
+	// get registry=nil and the middleware passes through cleanly —
+	// matching the pre-Slice-C.4 behavior of those tests.
+	if !cfg.RateLimit.Disabled {
+		s.subjectReg = newRateLimitRegistry(cfg.RateLimit.Tokens.PerMinute, cfg.RateLimit.Tokens.Burst)
+		s.loginReg = newRateLimitRegistry(cfg.RateLimit.Login.PerMinute, cfg.RateLimit.Login.Burst)
+	}
+	return s
 }
 
 // Routes returns an http.Handler with the broker's routes registered.
 // Routes are mounted on the default ServeMux pattern syntax (Go 1.22+),
 // which gives us method + path matching without a router library.
+//
+// Middleware composition (Slice C.4):
+//   - /healthz, /readyz, /auth/callback: no middleware. Health probes
+//     must succeed without auth or rate-limiting, and /auth/callback's
+//     own state-cookie HMAC gate is the natural rate limit.
+//   - /auth/login: ipRateLimit only. Unauthenticated by design — the
+//     IP limiter is the only backstop against an attacker hammering
+//     the OIDC redirect machinery.
+//   - /tokens, /tokens/:label DELETE, /tokens/:label/rotate:
+//     requireAuth (verifies bearer, stashes claims on ctx) → then
+//     subjectRateLimit (reads claims from ctx, keys on subject hash) →
+//     handler (reads claims from ctx via claimsFromCtx).
 func (s *Server) Routes() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", s.healthz)
 	mux.HandleFunc("GET /readyz", s.readyz)
-	mux.HandleFunc("GET /auth/login", s.authLogin)
+	mux.Handle("GET /auth/login", s.ipRateLimit(http.HandlerFunc(s.authLogin)))
 	mux.HandleFunc("GET /auth/callback", s.authCallback)
-	mux.HandleFunc("GET /tokens", s.listTokens)
-	mux.HandleFunc("DELETE /tokens/{label}", s.deleteToken)
-	mux.HandleFunc("POST /tokens/{label}/rotate", s.rotateToken)
+	authedSubject := func(h http.HandlerFunc) http.Handler {
+		return s.requireAuth(s.subjectRateLimit(h))
+	}
+	mux.Handle("GET /tokens", authedSubject(s.listTokens))
+	mux.Handle("DELETE /tokens/{label}", authedSubject(s.deleteToken))
+	mux.Handle("POST /tokens/{label}/rotate", authedSubject(s.rotateToken))
 	return mux
 }
 
@@ -186,8 +224,12 @@ type listTokensResponse struct {
 }
 
 func (s *Server) listTokens(w http.ResponseWriter, r *http.Request) {
-	claims, ok := s.authenticate(w, r)
+	claims, ok := claimsFromCtx(r.Context())
 	if !ok {
+		// Unreachable via Routes() composition (requireAuth always
+		// runs first). The 500 makes the regression loud if a future
+		// route registration forgets to chain requireAuth.
+		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 	issuances, err := s.issuer.List(r.Context(), claims.Email)
@@ -200,8 +242,9 @@ func (s *Server) listTokens(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) deleteToken(w http.ResponseWriter, r *http.Request) {
-	claims, ok := s.authenticate(w, r)
+	claims, ok := claimsFromCtx(r.Context())
 	if !ok {
+		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 	label := r.PathValue("label")
@@ -226,8 +269,9 @@ func (s *Server) deleteToken(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) rotateToken(w http.ResponseWriter, r *http.Request) {
-	claims, ok := s.authenticate(w, r)
+	claims, ok := claimsFromCtx(r.Context())
 	if !ok {
+		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 	label := r.PathValue("label")
@@ -273,24 +317,6 @@ func (s *Server) rotateToken(w http.ResponseWriter, r *http.Request) {
 		s.log.ErrorContext(r.Context(), "broker: rotate failed", "label", label, "err", err)
 		http.Error(w, "rotate failed", http.StatusInternalServerError)
 	}
-}
-
-// authenticate validates the bearer ID token on the request and returns
-// the verified claims. On any failure it writes the appropriate HTTP
-// response and returns ok=false; the caller must return immediately.
-func (s *Server) authenticate(w http.ResponseWriter, r *http.Request) (Claims, bool) {
-	raw := bearerToken(r)
-	if raw == "" {
-		http.Error(w, "Authorization: Bearer <id_token> required", http.StatusUnauthorized)
-		return Claims{}, false
-	}
-	claims, err := s.verifier.VerifyIDToken(r.Context(), raw)
-	if err != nil {
-		s.log.WarnContext(r.Context(), "broker: id_token verification failed", "err", err)
-		http.Error(w, "invalid bearer token", http.StatusUnauthorized)
-		return Claims{}, false
-	}
-	return claims, true
 }
 
 func bearerToken(r *http.Request) string {

--- a/tools/demarkus-broker/main.go
+++ b/tools/demarkus-broker/main.go
@@ -6,9 +6,11 @@
 // Current scope: single broker, multi-world support with
 // domain/groups/emails allowlists (Slice C.1), browser code-flow for
 // /auth/login + /auth/callback, bearer-token (ID token) authentication
-// for /tokens and DELETE /tokens/:label, leader-elected expiry/drift
-// sweeper (Slice C.2). No rotate endpoint, no rate limit — Slice C.3
-// and C.4 respectively.
+// for /tokens, DELETE /tokens/:label, and POST /tokens/:label/rotate
+// (Slice C.3), leader-elected expiry/drift sweeper (Slice C.2), and
+// per-subject + per-IP rate limiting (Slice C.4) via in-memory token
+// buckets keyed by hashSubject(claims.Subject) on authed routes and
+// source IP on /auth/login.
 package main
 
 import (
@@ -85,6 +87,16 @@ func run(configPath, kubeconfigPath string, log *slog.Logger) error {
 
 	issuer := broker.NewIssuer(cfg, k8s)
 	srv := broker.NewServer(cfg, signer, verifier, issuer, log)
+	if cfg.RateLimit.Disabled {
+		log.Info("broker: rate limit disabled (rateLimit.disabled=true)")
+	} else {
+		log.Info("broker: rate limit enabled",
+			"tokensPerMin", cfg.RateLimit.Tokens.PerMinute,
+			"tokensBurst", cfg.RateLimit.Tokens.Burst,
+			"loginPerMin", cfg.RateLimit.Login.PerMinute,
+			"loginBurst", cfg.RateLimit.Login.Burst,
+			"trustForwardedFor", cfg.RateLimit.TrustForwardedFor)
+	}
 
 	httpSrv := &http.Server{
 		Addr:              cfg.Server.Addr,

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/latebit/demarkus/protocol v0.0.0-00010101000000-000000000000
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/time v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.0
 	k8s.io/apimachinery v0.36.0
@@ -41,7 +42,6 @@ require (
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/term v0.39.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-subject rate limiting on authenticated token endpoints and per-IP rate limiting on the login endpoint, configurable with rate and burst settings
  * Optional trust-forwarded-headers support for IP-based limits; rate limiting can be disabled

* **Tests**
  * Added comprehensive tests covering registry behavior, middleware enforcement, and client IP derivation

* **Documentation**
  * Updated docs/logging to reflect rate limiting and token rotation

* **Chores**
  * Added time-related dependency for rate limiting implementation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/114)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->