### PR TITLE
fix(tools): Add Helm chart for demarkus-broker application

### DIFF
--- a/deploy/helm/demarkus-broker/Chart.yaml
+++ b/deploy/helm/demarkus-broker/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: demarkus-broker
+description: |
+  OIDC token broker for demarkus. Exchanges a verified IdP identity for one
+  or more demarkus tokens, writing token hashes into per-world Kubernetes
+  Secrets and tracking ownership in a broker-namespace issuances Secret.
+  Multi-replica HA, leader-elected expiry/drift sweeper, per-subject and
+  per-IP rate limiting.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - demarkus
+  - mark-protocol
+  - oidc
+  - token-broker
+home: https://demarkus.io
+sources:
+  - https://github.com/latebit-io/demarkus
+maintainers:
+  - name: latebit-io
+    url: https://github.com/latebit-io

--- a/deploy/helm/demarkus-broker/README.md
+++ b/deploy/helm/demarkus-broker/README.md
@@ -1,0 +1,67 @@
+# demarkus-broker Helm chart
+
+OIDC token broker for demarkus. Exchanges a verified IdP identity for one
+or more demarkus tokens, writing token hashes into per-world Kubernetes
+Secrets and tracking ownership in a broker-namespace issuances Secret.
+
+## What this chart ships (chart-skeleton slice)
+
+- Multi-replica `Deployment` (default 2) with `RollingUpdate` strategy.
+- Chart-managed broker config Secret with auto-generated cookie HMAC key
+  preserved across `helm upgrade` via `lookup`.
+- Issuances Secret seeded empty on first install with
+  `helm.sh/resource-policy: keep` so chart updates and uninstalls never
+  wipe broker-minted issuance records.
+- ServiceAccount with optional GKE Workload Identity annotation.
+- Cluster-IP Service exposing the broker's HTTP listener.
+- Pod-level + container-level security context locked down: nonroot UID,
+  read-only root filesystem, all capabilities dropped, seccomp
+  RuntimeDefault, no privilege escalation.
+- TopologySpreadConstraints to keep replicas off the same node.
+- Resource requests/limits sized for the realistic ~10k-subjects
+  worst-case in the rate-limit registry doc-comment.
+
+Following slices add: per-world RBAC + NetworkPolicy + PDB, Ingress +
+TLS + production secret-ref plumbing, helm-unittest + kind integration
+in CI.
+
+## Quick install (development)
+
+```bash
+helm install broker deploy/helm/demarkus-broker \
+  --namespace demarkus-broker --create-namespace \
+  --set oidc.issuer=https://accounts.google.com \
+  --set oidc.clientID=YOUR_CLIENT_ID \
+  --set oidc.clientSecret=YOUR_CLIENT_SECRET \
+  --set oidc.redirectURL=https://broker.example.com/auth/callback \
+  --set-json 'worlds=[{"name":"team-a","namespace":"team-a","tokensSecret":"team-a-tokens","allow":{"domains":["example.com"]},"defaultToken":{"paths":["/team-a/*"],"operations":["read","publish"],"expiresAfter":"24h"}}]'
+```
+
+The world namespaces (`team-a` in the example) must already exist; the
+chart does not create them. RBAC across world namespaces ships in the
+RBAC slice.
+
+## Cookie key preservation
+
+The signed-state-cookie HMAC key is generated on first install and
+preserved across `helm upgrade` via a `lookup` of the live config
+Secret. To rotate the key, set `server.cookieKey` to a new
+base64-encoded value and restart the broker. Any in-flight OIDC login
+is invalidated by rotation, which is the intended behavior.
+
+## Issuances Secret resource policy
+
+The issuances Secret is created with `helm.sh/resource-policy: keep`.
+Consequences:
+
+- `helm upgrade` does not overwrite the broker's runtime writes.
+- `helm uninstall` does not delete the Secret. To fully clean up after
+  removing the chart, delete the Secret manually:
+  `kubectl delete secret <release>-issuances -n <broker-namespace>`.
+- Reinstalling the chart in the same namespace picks up the existing
+  issuance state, so users keep their tokens across chart lifecycle
+  events.
+
+## Values
+
+See `values.yaml` for the full schema with inline documentation.

--- a/deploy/helm/demarkus-broker/README.md
+++ b/deploy/helm/demarkus-broker/README.md
@@ -27,15 +27,32 @@ in CI.
 
 ## Quick install (development)
 
+Put the OIDC client secret in a values file rather than on the command
+line — `--set` values leak into shell history and `ps` output:
+
+```yaml
+# broker-secrets.values.yaml — do not commit
+oidc:
+  clientSecret: "YOUR_CLIENT_SECRET"
+```
+
+Then install:
+
 ```bash
 helm install broker deploy/helm/demarkus-broker \
   --namespace demarkus-broker --create-namespace \
+  --values broker-secrets.values.yaml \
   --set oidc.issuer=https://accounts.google.com \
   --set oidc.clientID=YOUR_CLIENT_ID \
-  --set oidc.clientSecret=YOUR_CLIENT_SECRET \
   --set oidc.redirectURL=https://broker.example.com/auth/callback \
   --set-json 'worlds=[{"name":"team-a","namespace":"team-a","tokensSecret":"team-a-tokens","allow":{"domains":["example.com"]},"defaultToken":{"paths":["/team-a/*"],"operations":["read","publish"],"expiresAfter":"24h"}}]'
 ```
+
+Production deployments should go further: store the OIDC client secret
+in a SealedSecret / External Secrets Operator / Vault-managed resource
+and reference it via `oidc.existingSecretRef` once the Ingress slice
+plumbs that field. Until then, treat `broker-secrets.values.yaml` as
+sensitive — gitignore it.
 
 The world namespaces (`team-a` in the example) must already exist; the
 chart does not create them. RBAC across world namespaces ships in the

--- a/deploy/helm/demarkus-broker/templates/_helpers.tpl
+++ b/deploy/helm/demarkus-broker/templates/_helpers.tpl
@@ -1,0 +1,94 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "demarkus-broker.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name.
+*/}}
+{{- define "demarkus-broker.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "demarkus-broker.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "demarkus-broker.labels" -}}
+helm.sh/chart: {{ include "demarkus-broker.chart" . }}
+{{ include "demarkus-broker.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "demarkus-broker.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "demarkus-broker.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "demarkus-broker.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "demarkus-broker.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Broker namespace. Defaults to the release namespace; override only when
+the issuances Secret deliberately lives elsewhere (rare).
+*/}}
+{{- define "demarkus-broker.brokerNamespace" -}}
+{{- default .Release.Namespace .Values.server.brokerNamespace -}}
+{{- end -}}
+
+{{/*
+Names for the chart-managed Secrets.
+*/}}
+{{- define "demarkus-broker.configSecretName" -}}
+{{- printf "%s-config" (include "demarkus-broker.fullname" .) -}}
+{{- end -}}
+
+{{- define "demarkus-broker.issuancesSecretName" -}}
+{{- default (printf "%s-issuances" (include "demarkus-broker.fullname" .)) .Values.server.issuancesSecret -}}
+{{- end -}}
+
+{{/*
+Cookie key resolution. Order of precedence:
+  1. .Values.server.cookieKey (operator-supplied literal)
+  2. Existing config Secret (preserves the key across helm upgrades)
+  3. Freshly generated 32-byte key, base64-encoded
+
+Generated only ONCE on first install; subsequent helm-upgrades read the
+existing Secret via `lookup` so the cookie key — and therefore in-flight
+state cookies — survive chart updates.
+
+NOTE: `lookup` returns nil during `helm template` (no cluster context),
+so a fresh `randAlphaNum` runs on every offline render. Tests should not
+assert on exact key values, only on structure.
+*/}}
+{{- define "demarkus-broker.resolveCookieKey" -}}
+{{- if .Values.server.cookieKey -}}
+{{- .Values.server.cookieKey -}}
+{{- else -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "demarkus-broker.configSecretName" .) -}}
+{{- if and $existing (index $existing.data "cookie-key") -}}
+{{- index $existing.data "cookie-key" | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 32 | b64enc -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/demarkus-broker/templates/deployment.yaml
+++ b/deploy/helm/demarkus-broker/templates/deployment.yaml
@@ -1,0 +1,120 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "demarkus-broker.fullname" . }}
+  labels:
+    {{- include "demarkus-broker.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  selector:
+    matchLabels:
+      {{- include "demarkus-broker.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "demarkus-broker.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret-config.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "demarkus-broker.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: broker
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          args:
+            - -config
+            - /etc/demarkus-broker/config.yaml
+          env:
+            # POD_NAME is the holder identity stamped onto the
+            # leader-election Lease (see brokerIdentity in main.go). Without
+            # this, multiple replicas would race with the same hostname-
+            # derived identity and the lease handoff log would be unreadable.
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: http
+              protocol: TCP
+              containerPort: {{ .Values.server.port }}
+          {{- if .Values.probes.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/demarkus-broker
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ include "demarkus-broker.configSecretName" . }}
+            items:
+              - key: config.yaml
+                path: config.yaml
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range $constraint := . }}
+        - maxSkew: {{ $constraint.maxSkew }}
+          topologyKey: {{ $constraint.topologyKey }}
+          whenUnsatisfiable: {{ $constraint.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "demarkus-broker.selectorLabels" $ | nindent 14 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/demarkus-broker/templates/deployment.yaml
+++ b/deploy/helm/demarkus-broker/templates/deployment.yaml
@@ -52,10 +52,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
           ports:
             - name: http
               protocol: TCP

--- a/deploy/helm/demarkus-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-config.yaml
@@ -20,6 +20,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "demarkus-broker.configSecretName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "demarkus-broker.labels" . | nindent 4 }}
 type: Opaque
@@ -39,13 +40,19 @@ stringData:
       redirectURL: {{ required "oidc.redirectURL is required" .Values.oidc.redirectURL | quote }}
     worlds:
 {{- range .Values.worlds }}
+      {{- /* Wrap .allow with `default (dict)` because Go templates panic on
+             nil pointer access — operators commonly omit the allow block
+             entirely to get the "all empty = open world" predicate from
+             worldAllows. Without this guard, .allow.domains evaluates a
+             nil .allow and template rendering aborts. */ -}}
+      {{- $allow := default (dict) .allow }}
       - name: {{ .name | quote }}
         namespace: {{ .namespace | quote }}
         tokensSecret: {{ .tokensSecret | quote }}
         allow:
-          domains: {{ default (list) .allow.domains | toJson }}
-          groups: {{ default (list) .allow.groups | toJson }}
-          emails: {{ default (list) .allow.emails | toJson }}
+          domains: {{ default (list) (get $allow "domains") | toJson }}
+          groups: {{ default (list) (get $allow "groups") | toJson }}
+          emails: {{ default (list) (get $allow "emails") | toJson }}
         defaultToken:
           paths: {{ .defaultToken.paths | toJson }}
           operations: {{ .defaultToken.operations | toJson }}

--- a/deploy/helm/demarkus-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-config.yaml
@@ -1,0 +1,66 @@
+{{/*
+Broker configuration Secret. Holds the full config.yaml that the broker
+reads at startup (CLI arg -config defaults to /etc/demarkus-broker/config.yaml)
+plus a separate `cookie-key` data field that the resolveCookieKey helper
+reads from the live Secret on subsequent helm-upgrades to preserve the
+HMAC key across chart updates.
+
+Both the cookie-key field and the cookieKey embedded in the config.yaml
+field are populated from a single $cookieKey variable so they can never
+drift within a single render pass. On `helm upgrade` the lookup branch
+of resolveCookieKey returns the live cluster value; on first `helm
+install` (and on offline `helm template`) randAlphaNum produces a fresh
+key.
+
+The config.yaml is rendered as a Secret rather than a ConfigMap because
+it contains both the OIDC client secret and the cookie HMAC key.
+*/}}
+{{- $cookieKey := include "demarkus-broker.resolveCookieKey" . -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "demarkus-broker.configSecretName" . }}
+  labels:
+    {{- include "demarkus-broker.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  cookie-key: {{ $cookieKey | quote }}
+  config.yaml: |
+    server:
+      addr: {{ printf ":%d" (int .Values.server.port) | quote }}
+      cookieKey: {{ $cookieKey | quote }}
+      stateTTL: {{ .Values.server.stateTTL | quote }}
+      brokerNamespace: {{ include "demarkus-broker.brokerNamespace" . | quote }}
+      issuancesSecret: {{ include "demarkus-broker.issuancesSecretName" . | quote }}
+    oidc:
+      issuer: {{ required "oidc.issuer is required" .Values.oidc.issuer | quote }}
+      clientID: {{ required "oidc.clientID is required" .Values.oidc.clientID | quote }}
+      clientSecret: {{ required "oidc.clientSecret is required" .Values.oidc.clientSecret | quote }}
+      redirectURL: {{ required "oidc.redirectURL is required" .Values.oidc.redirectURL | quote }}
+    worlds:
+{{- range .Values.worlds }}
+      - name: {{ .name | quote }}
+        namespace: {{ .namespace | quote }}
+        tokensSecret: {{ .tokensSecret | quote }}
+        allow:
+          domains: {{ default (list) .allow.domains | toJson }}
+          groups: {{ default (list) .allow.groups | toJson }}
+          emails: {{ default (list) .allow.emails | toJson }}
+        defaultToken:
+          paths: {{ .defaultToken.paths | toJson }}
+          operations: {{ .defaultToken.operations | toJson }}
+          expiresAfter: {{ .defaultToken.expiresAfter | quote }}
+{{- end }}
+    sweeper:
+      disabled: {{ .Values.sweeper.disabled }}
+      interval: {{ .Values.sweeper.interval | quote }}
+      leaseName: {{ .Values.sweeper.leaseName | quote }}
+    rateLimit:
+      disabled: {{ .Values.rateLimit.disabled }}
+      tokens:
+        perMinute: {{ .Values.rateLimit.tokens.perMinute }}
+        burst: {{ .Values.rateLimit.tokens.burst }}
+      login:
+        perMinute: {{ .Values.rateLimit.login.perMinute }}
+        burst: {{ .Values.rateLimit.login.burst }}
+      trustForwardedFor: {{ .Values.rateLimit.trustForwardedFor }}

--- a/deploy/helm/demarkus-broker/templates/secret-issuances.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-issuances.yaml
@@ -1,0 +1,36 @@
+{{/*
+Issuances Secret. The broker writes the label -> {email, world, paths,
+operations, issued_at, expires} map here at runtime; this template only
+seeds an empty Secret on first install so the broker has a target to
+write to.
+
+Two helm-correctness invariants:
+
+  1. `helm.sh/resource-policy: keep` — once created, helm uninstall does
+     NOT delete this Secret. Reinstalling the chart picks up the same
+     issuance state, so users keep their tokens across chart lifecycle
+     events.
+
+  2. `lookup`-skip — on `helm upgrade`, the lookup branch returns the
+     existing live Secret, so the template renders nothing. helm sees
+     the resource was removed from the rendered manifest and would
+     normally garbage-collect it; the resource-policy: keep annotation
+     on the LIVE Secret prevents that. Net effect: chart updates never
+     touch the broker's runtime state.
+
+  `lookup` returns nil during `helm template` (no cluster context), so
+  offline renders always emit the empty Secret. helm-unittest assertions
+  see the empty Secret and can verify the resource-policy annotation.
+*/}}
+{{- if not (lookup "v1" "Secret" .Release.Namespace (include "demarkus-broker.issuancesSecretName" .)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "demarkus-broker.issuancesSecretName" . }}
+  labels:
+    {{- include "demarkus-broker.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+type: Opaque
+data: {}
+{{- end }}

--- a/deploy/helm/demarkus-broker/templates/secret-issuances.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-issuances.yaml
@@ -22,11 +22,19 @@ Two helm-correctness invariants:
   offline renders always emit the empty Secret. helm-unittest assertions
   see the empty Secret and can verify the resource-policy annotation.
 */}}
-{{- if not (lookup "v1" "Secret" .Release.Namespace (include "demarkus-broker.issuancesSecretName" .)) }}
+{{- /* The issuances Secret lives in server.brokerNamespace, which the
+       broker reads at runtime to locate its own issuance state. Default
+       resolves to .Release.Namespace via the helper; an explicit override
+       puts the Secret in a different namespace and requires matching RBAC
+       (shipped in the RBAC slice). Both the lookup and the rendered
+       metadata.namespace use the helper so they always agree. */ -}}
+{{- $brokerNs := include "demarkus-broker.brokerNamespace" . -}}
+{{- if not (lookup "v1" "Secret" $brokerNs (include "demarkus-broker.issuancesSecretName" .)) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "demarkus-broker.issuancesSecretName" . }}
+  namespace: {{ $brokerNs }}
   labels:
     {{- include "demarkus-broker.labels" . | nindent 4 }}
   annotations:

--- a/deploy/helm/demarkus-broker/templates/service.yaml
+++ b/deploy/helm/demarkus-broker/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "demarkus-broker.fullname" . }}
+  labels:
+    {{- include "demarkus-broker.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.server.port }}
+      targetPort: http
+  selector:
+    {{- include "demarkus-broker.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/demarkus-broker/templates/serviceaccount.yaml
+++ b/deploy/helm/demarkus-broker/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "demarkus-broker.serviceAccountName" . }}
+  labels:
+    {{- include "demarkus-broker.labels" . | nindent 4 }}
+  {{- $ann := deepCopy (default dict .Values.serviceAccount.annotations) }}
+  {{- if .Values.serviceAccount.workloadIdentity.gsa }}
+  {{- $_ := set $ann "iam.gke.io/gcp-service-account" .Values.serviceAccount.workloadIdentity.gsa }}
+  {{- end }}
+  {{- if $ann }}
+  annotations:
+    {{- toYaml $ann | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/demarkus-broker/values.yaml
+++ b/deploy/helm/demarkus-broker/values.yaml
@@ -1,0 +1,218 @@
+# Default values for demarkus-broker.
+# Override with --values or --set on `helm install`.
+
+image:
+  # Must include the demarkus-broker binary on PATH at /demarkus-broker.
+  repository: ghcr.io/latebit-io/demarkus-broker
+  # tag defaults to .Chart.appVersion when empty
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# Multi-replica HA. Slice C of the broker is stateless modulo k8s Secret
+# writes (resourceVersion optimistic concurrency on world tokens Secret +
+# issuances Secret); the sweeper coordinates via a coordination.k8s.io/Lease
+# so N>=2 replicas is the production posture. Drop to 1 only for dev/trial
+# clusters where you also want to flip sweeper.disabled=true to skip the
+# leader-election overhead.
+replicaCount: 2
+
+server:
+  # HTTP listen port inside the pod. The broker speaks plain HTTP — the
+  # Ingress (shipped in the Ingress slice) terminates TLS. The pod listens
+  # on this port; the Service forwards to it; the deployment renders
+  # containerPort from this value.
+  port: 8080
+
+  # Signed-state-cookie HMAC key, base64-encoded. When empty the chart
+  # generates a fresh 32-byte key on first install and preserves it across
+  # `helm upgrade` via `lookup` on the existing config Secret. Override only
+  # if you want to manage the key out-of-band (rotate by setting a new value
+  # and bouncing the broker; any in-flight login is invalidated).
+  cookieKey: ""
+
+  # State cookie TTL. Long enough for a real user to complete the OIDC
+  # redirect, short enough that a stale cookie cannot be replayed.
+  stateTTL: 5m
+
+  # Namespace the broker itself runs in. Defaults to the release namespace
+  # via the helper; override only if the issuances Secret lives elsewhere
+  # (rare).
+  brokerNamespace: ""
+
+  # Secret name for the broker's issuance state (label -> {email, world,
+  # ...}). Default derived from the release name. The Secret is created
+  # with `helm.sh/resource-policy: keep` so `helm upgrade` and
+  # `helm uninstall` never wipe broker-minted issuance records.
+  issuancesSecret: ""
+
+oidc:
+  # OIDC discovery URL (e.g. https://accounts.google.com).
+  issuer: ""
+  # OAuth client ID registered at the IdP.
+  clientID: ""
+  # OAuth client secret. Two modes:
+  #   1. Cleartext via this field — chart bakes it into the config Secret.
+  #      Easiest install path; the value lives in helm release history.
+  #   2. existingSecretRef — point at an externally-managed Secret created
+  #      by External Secrets Operator / Sealed Secrets / kubectl. The
+  #      Ingress slice wires this mode end-to-end; not yet plumbed here.
+  clientSecret: ""
+  # Public URL of /auth/callback. Must exactly match the redirect URI
+  # registered with the IdP.
+  redirectURL: ""
+
+# Per-world authorization. Each entry produces one Role + RoleBinding in
+# the world's namespace (RBAC slice) granting the broker SA get/patch on
+# the named tokens Secret.
+worlds: []
+  # - name: team-a
+  #   namespace: team-a
+  #   tokensSecret: team-a-tokens
+  #   allow:
+  #     domains: ["nesto.ca"]
+  #     groups: ["engineering"]
+  #     emails: ["alice@example.com"]
+  #   defaultToken:
+  #     paths: ["/team-a/*"]
+  #     operations: ["read", "publish"]
+  #     expiresAfter: 24h
+
+# Periodic expiry + drift sweeper. Leader-elected via
+# coordination.k8s.io/Lease so multi-replica deployments enforce
+# singleton sweep without coordination on the broker side. Named
+# `disabled` (not `enabled`) so the YAML zero-value is the
+# production-safe behavior — omit the block and the sweeper runs.
+sweeper:
+  disabled: false
+  interval: 5m
+  leaseName: demarkus-broker-sweeper
+
+# Per-subject + per-IP token-bucket rate limiting. Same `disabled`-not-
+# `enabled` naming so omission keeps the protection on. Defaults match
+# plan §6.2 Slice C.4: 10/min subject burst 5 (shared across the three
+# /tokens routes), 20/min IP burst 5 on /auth/login.
+#
+# trustForwardedFor: the chart default is true because the broker's
+# deployment posture is "behind an Ingress that strips spoofed
+# X-Forwarded-For and appends the real client IP." This INVERTS the
+# binary's default (false). The Ingress slice wires the controller-side
+# XFF stripping so the per-IP limiter on /auth/login is effective.
+# Flip to false only when running the broker without an Ingress in
+# front (dev / port-forward).
+rateLimit:
+  disabled: false
+  tokens:
+    perMinute: 10
+    burst: 5
+  login:
+    perMinute: 20
+    burst: 5
+  trustForwardedFor: true
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+# Liveness + readiness use the broker's own /healthz and /readyz HTTP
+# endpoints (unauthed and rate-limit-bypassed by design — Slice C.4 §Routes).
+probes:
+  enabled: true
+  liveness:
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 5
+  readiness:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  # Workload Identity (GKE) annotation — sets iam.gke.io/gcp-service-account
+  # so the broker SA impersonates the named GSA without static keys.
+  workloadIdentity:
+    gsa: ""
+
+# RBAC ships in the RBAC slice. Schema declared here so values structure
+# is stable.
+rbac:
+  # When true (default), the chart creates per-world Role + RoleBinding
+  # in each world's namespace plus a broker-namespace Role for the
+  # sweeper Lease and the issuances Secret. Flip to false if your
+  # cluster manages RBAC out-of-band (operator policies, GitOps Roles).
+  create: true
+
+# NetworkPolicy ships in the RBAC slice. Schema declared here so values
+# structure is stable.
+networkPolicy:
+  enabled: true
+  # Ingress controller namespace selector — broker accepts inbound HTTP
+  # only from pods in this namespace. Override to match your controller
+  # (defaults assume nginx-ingress in namespace `ingress-nginx`).
+  ingressFromNamespace: ingress-nginx
+
+# PodDisruptionBudget ships in the RBAC slice. Schema declared here so
+# values structure is stable.
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+# Ingress + cert-manager ship in the Ingress slice. Schema declared here
+# so values structure is stable.
+ingress:
+  enabled: false
+  className: nginx
+  host: ""
+  annotations: {}
+  tls:
+    existingSecret: ""
+    certManager:
+      enabled: false
+      issuerRef:
+        kind: ClusterIssuer
+        name: letsencrypt-prod
+      annotations: {}
+
+service:
+  type: ClusterIP
+  annotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+
+# TopologySpreadConstraints keep the two replicas off the same node when
+# possible. ScheduleAnyway so the broker still schedules on
+# single-node clusters or when capacity is tight.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels: {} # filled by deployment template using selector labels
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}
+podLabels: {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Helm chart for demarkus-broker providing Deployment, Service, Secrets, and optional ServiceAccount manifests for Kubernetes.
  * Chart preserves session cookie keys and seeds/retains an issuances Secret across upgrades.
  * Exposes full configuration via values (server, OIDC, worlds, rate limiting, probes, resources, scheduling, Ingress/TLS, workload identity).
* **Documentation**
  * Included chart README with install notes, configuration guidance, and upgrade/secret behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/115)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->