### PR TITLE
feat(tools): Add Helm templates for NetworkPolicy, PodDisruptionBudget, and RBAC

### DIFF
--- a/deploy/helm/demarkus-broker/templates/networkpolicy.yaml
+++ b/deploy/helm/demarkus-broker/templates/networkpolicy.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- /* Default-on NetworkPolicy. The broker accepts inbound traffic only
+   from the ingress controller's namespace and emits outbound traffic
+   only to DNS + TCP 443 (kube-apiserver via the cluster Service + the
+   OIDC issuer's discovery / JWKS endpoints).
+
+   Relies on the automatic `kubernetes.io/metadata.name` namespace
+   label (Kubernetes 1.21+). Older clusters must label the
+   ingress-controller and kube-system namespaces explicitly, or set
+   `networkPolicy.enabled: false` and ship their own policy.
+
+   If your OIDC issuer is not on TCP 443 (e.g. a self-hosted Keycloak
+   on a non-standard port) or your kube-apiserver listens on 6443
+   instead of 443, disable this policy and supply your own. */ -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "demarkus-broker.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "demarkus-broker.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "demarkus-broker.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressFromNamespace | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.server.port }}
+  egress:
+    # DNS — UDP + TCP to kube-system (CoreDNS / kube-dns).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # TCP 443 to anywhere — kube-apiserver via the cluster Service and
+    # the OIDC issuer's discovery + JWKS endpoints. Intentionally not
+    # restricted to specific destinations: pinning the apiserver IP/CIDR
+    # breaks across managed-k8s providers, and pinning the OIDC issuer
+    # CIDR breaks every time the IdP rotates its frontends.
+    - ports:
+        - protocol: TCP
+          port: 443
+{{- end }}

--- a/deploy/helm/demarkus-broker/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/demarkus-broker/templates/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "demarkus-broker.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "demarkus-broker.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "demarkus-broker.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/demarkus-broker/templates/rbac-broker-ns.yaml
+++ b/deploy/helm/demarkus-broker/templates/rbac-broker-ns.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.rbac.create }}
+{{- /* Broker-namespace RBAC: the broker SA's access to its own state.
+
+   - coordination.k8s.io/leases: the sweeper's leader-election Lease. Both
+     get/update are scoped to the configured lease name; create is in the
+     same rule because Helm install needs to seed the Lease on first
+     leadership acquisition. The k8s RBAC "create cannot be restricted by
+     resourceName" caveat means create effectively allows any Lease in
+     this namespace — acceptable scope since the namespace is broker-owned.
+
+   - secrets: the chart-created issuances Secret. Only get/update needed
+     since the chart's secret-issuances.yaml seeds it at install time; the
+     broker never needs to bootstrap it at runtime. */ -}}
+{{- $brokerNs := include "demarkus-broker.brokerNamespace" . -}}
+{{- $name := include "demarkus-broker.fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  namespace: {{ $brokerNs }}
+  labels:
+    {{- include "demarkus-broker.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames: [{{ .Values.sweeper.leaseName | quote }}]
+    verbs: ["get", "create", "update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ include "demarkus-broker.issuancesSecretName" . | quote }}]
+    verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  namespace: {{ $brokerNs }}
+  labels:
+    {{- include "demarkus-broker.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "demarkus-broker.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}
+{{- end }}

--- a/deploy/helm/demarkus-broker/templates/rbac-worlds.yaml
+++ b/deploy/helm/demarkus-broker/templates/rbac-worlds.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.rbac.create }}
+{{- /* Per-world RBAC: one Role + RoleBinding per worlds[] entry, each
+   scoped to a single Secret in that world's namespace. The world's
+   tokens Secret must already exist (created by the demarkus-server
+   chart's bootstrap Job in §6.1) — the broker only needs get/update,
+   never create. If the Secret is missing at first mint the broker
+   returns a clear "Secret not found" error rather than silently
+   bootstrapping into a namespace it shouldn't own.
+
+   The chart's install-time ServiceAccount must already have permission
+   to create Roles + RoleBindings in each world's namespace. Operators
+   that manage RBAC out of band (Argo CD AppProject, OPA, etc.) should
+   set `rbac.create: false` and provision these Roles separately. */ -}}
+{{- $fullname := include "demarkus-broker.fullname" . -}}
+{{- $saName := include "demarkus-broker.serviceAccountName" . -}}
+{{- $saNamespace := .Release.Namespace -}}
+{{- $labels := include "demarkus-broker.labels" . -}}
+{{- range .Values.worlds }}
+{{- $name := printf "%s-world-%s" $fullname .name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  namespace: {{ .namespace }}
+  labels:
+    {{- $labels | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ .tokensSecret | quote }}]
+    verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  namespace: {{ .namespace }}
+  labels:
+    {{- $labels | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $saName }}
+    namespace: {{ $saNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional network policy controls to manage pod-to-pod and external traffic access
  * Added pod disruption budget configuration to maintain availability during cluster maintenance
  * Added role-based access control configuration for broker and world operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/116)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->