### PR TITLE
feat(tools):  Support external OIDC secrets and Ingress in demarkus-broker chart

### DIFF
--- a/deploy/helm/demarkus-broker/README.md
+++ b/deploy/helm/demarkus-broker/README.md
@@ -4,39 +4,36 @@ OIDC token broker for demarkus. Exchanges a verified IdP identity for one
 or more demarkus tokens, writing token hashes into per-world Kubernetes
 Secrets and tracking ownership in a broker-namespace issuances Secret.
 
-## What this chart ships (chart-skeleton slice)
+## What this chart ships
 
-- Multi-replica `Deployment` (default 2) with `RollingUpdate` strategy.
+- Multi-replica `Deployment` (default 2) with `RollingUpdate` strategy
+  and `PodDisruptionBudget` (`minAvailable: 1`).
 - Chart-managed broker config Secret with auto-generated cookie HMAC key
   preserved across `helm upgrade` via `lookup`.
 - Issuances Secret seeded empty on first install with
   `helm.sh/resource-policy: keep` so chart updates and uninstalls never
   wipe broker-minted issuance records.
-- ServiceAccount with optional GKE Workload Identity annotation.
-- Cluster-IP Service exposing the broker's HTTP listener.
-- Pod-level + container-level security context locked down: nonroot UID,
-  read-only root filesystem, all capabilities dropped, seccomp
-  RuntimeDefault, no privilege escalation.
+- Per-world `Role` + `RoleBinding` in each world's namespace
+  (`get/update` on the world's tokens Secret) plus broker-namespace
+  `Role` covering the sweeper Lease and the issuances Secret.
+- Default-on `NetworkPolicy` restricting ingress to the configured
+  Ingress controller namespace and egress to DNS + TCP 443.
+- Locked-down pod security context: nonroot UID, read-only root
+  filesystem, all capabilities dropped, seccomp RuntimeDefault.
+- Optional `Ingress` (default `ingressClassName: nginx`) with optional
+  cert-manager-managed TLS Certificate.
 - TopologySpreadConstraints to keep replicas off the same node.
-- Resource requests/limits sized for the realistic ~10k-subjects
-  worst-case in the rate-limit registry doc-comment.
-
-Following slices add: per-world RBAC + NetworkPolicy + PDB, Ingress +
-TLS + production secret-ref plumbing, helm-unittest + kind integration
-in CI.
 
 ## Quick install (development)
 
-Put the OIDC client secret in a values file rather than on the command
-line — `--set` values leak into shell history and `ps` output:
+Put sensitive values in a values file rather than on the command line —
+`--set` values leak into shell history and `ps` output:
 
 ```yaml
 # broker-secrets.values.yaml — do not commit
 oidc:
   clientSecret: "YOUR_CLIENT_SECRET"
 ```
-
-Then install:
 
 ```bash
 helm install broker deploy/helm/demarkus-broker \
@@ -45,18 +42,112 @@ helm install broker deploy/helm/demarkus-broker \
   --set oidc.issuer=https://accounts.google.com \
   --set oidc.clientID=YOUR_CLIENT_ID \
   --set oidc.redirectURL=https://broker.example.com/auth/callback \
+  --set ingress.enabled=true \
+  --set ingress.host=broker.example.com \
+  --set ingress.tls.certManager.enabled=true \
   --set-json 'worlds=[{"name":"team-a","namespace":"team-a","tokensSecret":"team-a-tokens","allow":{"domains":["example.com"]},"defaultToken":{"paths":["/team-a/*"],"operations":["read","publish"],"expiresAfter":"24h"}}]'
 ```
 
-Production deployments should go further: store the OIDC client secret
-in a SealedSecret / External Secrets Operator / Vault-managed resource
-and reference it via `oidc.existingSecretRef` once the Ingress slice
-plumbs that field. Until then, treat `broker-secrets.values.yaml` as
-sensitive — gitignore it.
+World namespaces must already exist — chart does not create them.
 
-The world namespaces (`team-a` in the example) must already exist; the
-chart does not create them. RBAC across world namespaces ships in the
-RBAC slice.
+## Production checklist
+
+Walk this list before exposing the broker to real traffic.
+
+### 1. Use `oidc.existingSecretRef` for the OAuth client secret
+
+The cleartext `oidc.clientSecret` values mode is fine for trials and
+dev, but the value lives in helm release history (`helm get values`
+shows it; `helm history` retains every revision). Production should
+externalize the secret.
+
+Create the Secret out of band — via External Secrets Operator, Sealed
+Secrets, Vault, or `kubectl`:
+
+```bash
+kubectl create secret generic broker-oidc \
+  --namespace demarkus-broker \
+  --from-literal=clientSecret=YOUR_CLIENT_SECRET
+```
+
+Then point the chart at it:
+
+```yaml
+oidc:
+  clientSecret: ""              # leave blank — the env var supplies it
+  existingSecretRef:
+    name: broker-oidc
+    key: clientSecret
+```
+
+The chart leaves `clientSecret` blank in the rendered config Secret and
+mounts `OIDC_CLIENT_SECRET` into the broker pod via `secretKeyRef`.
+The broker's `LoadConfig` applies the env-var override before
+validating the config. Setting both `clientSecret` and
+`existingSecretRef.name` fails template render with a clear error so
+the precedence is never ambiguous.
+
+### 2. Verify the X-Forwarded-For invariant for your Ingress controller
+
+The chart defaults `rateLimit.trustForwardedFor: true` (inverting the
+broker binary's safe-by-default `false`). The per-IP rate limiter on
+`/auth/login` is only effective when the Ingress controller in front
+of the broker **strips spoofed `X-Forwarded-For` from inbound requests
+and appends the real client IP.**
+
+| Controller     | Default behavior | Notes |
+|----------------|------------------|-------|
+| nginx-ingress  | Strips + appends | Default safe. `use-forwarded-headers` defaults to `false`, which makes the controller treat the inbound XFF as untrusted and overwrite it with the real client. |
+| Traefik        | Strips + appends | Default safe when used as the entrypoint. `forwardedHeaders.trustedIPs` controls when Traefik will trust an upstream's XFF — leave empty for direct-from-internet. |
+| HAProxy        | Configurable     | Set `option forwardfor` to append; older versions require `option http-pretend-keepalive` interactions to be checked. |
+| Cloud LB (ALB/GCLB) | Provider-dependent | Most cloud LBs append the source IP to XFF but do NOT strip what the client sent. Pair with a Pod-level controller (nginx-ingress in front of the broker pods) that does strip. |
+
+**If you're exposing the broker on a `NodePort`/`LoadBalancer` Service
+without an Ingress in front, set `rateLimit.trustForwardedFor: false`.**
+With trust enabled and no XFF-stripping proxy, an attacker can rotate
+the header on every request to bypass the per-IP limit on
+`/auth/login`. The chart's `NOTES.txt` flags this combination after
+install.
+
+### 3. Use real TLS, not the in-binary self-signed fallback
+
+The broker binary speaks plain HTTP inside the cluster — TLS
+termination is the Ingress controller's job. Two paths:
+
+- `ingress.tls.existingSecret: <name>` — point at a pre-existing
+  `kubernetes.io/tls` Secret (cert-manager-managed, externally
+  provisioned, manually created from your CA, etc.). The chart only
+  references the Secret; it does not create it.
+- `ingress.tls.certManager.enabled: true` — chart provisions a
+  cert-manager `Certificate` resource. Requires cert-manager installed
+  in the cluster and a working `Issuer` / `ClusterIssuer`. Default
+  issuer is `ClusterIssuer letsencrypt-prod`; override
+  `ingress.tls.certManager.issuerRef` for staging-issuers or
+  internal CAs.
+
+### 4. Confirm the install-time RBAC works for your cluster
+
+With `rbac.create: true` (default) the chart creates per-world
+`Role` + `RoleBinding` in every world's namespace. The
+ServiceAccount running `helm install` needs `Role`/`RoleBinding`
+create rights in each of those namespaces.
+
+On managed Kubernetes that typically means cluster-admin, or a custom
+install-time `ClusterRoleBinding` granting RBAC create in the world
+namespaces. If your cluster restricts cross-namespace RBAC
+management, set `rbac.create: false` and provision the per-world
+`Role`s out of band — every world entry needs `secrets`
+`get/update` on its `tokensSecret`, plus the broker-namespace `Role`
+covering `coordination.k8s.io/leases` + the issuances Secret.
+
+### 5. Set sensible resource limits and confirm the PDB
+
+The chart's defaults (`100m`/`128Mi` request, `500m`/`256Mi` limit)
+are sized for the realistic ~10k-subjects worst-case in the
+rate-limit registry doc-comment. Audit them against your actual
+expected concurrency. The default
+`podDisruptionBudget.minAvailable: 1` prevents a node drain from
+taking both replicas down.
 
 ## Cookie key preservation
 
@@ -73,7 +164,7 @@ Consequences:
 
 - `helm upgrade` does not overwrite the broker's runtime writes.
 - `helm uninstall` does not delete the Secret. To fully clean up after
-  removing the chart, delete the Secret manually:
+  removing the chart, delete it manually:
   `kubectl delete secret <release>-issuances -n <broker-namespace>`.
 - Reinstalling the chart in the same namespace picks up the existing
   issuance state, so users keep their tokens across chart lifecycle

--- a/deploy/helm/demarkus-broker/templates/NOTES.txt
+++ b/deploy/helm/demarkus-broker/templates/NOTES.txt
@@ -1,0 +1,56 @@
+demarkus-broker installed as release {{ .Release.Name | quote }} in namespace {{ .Release.Namespace | quote }}.
+
+== Broker URL ==
+{{- if .Values.ingress.enabled }}
+  Public:   https://{{ .Values.ingress.host }}/
+  Login:    https://{{ .Values.ingress.host }}/auth/login
+  Callback: https://{{ .Values.ingress.host }}/auth/callback
+  Routed through IngressClass {{ .Values.ingress.className | quote }}.
+  {{- if .Values.ingress.tls.certManager.enabled }}
+  TLS via cert-manager Certificate {{ include "demarkus-broker.fullname" . }}-tls (issuer: {{ .Values.ingress.tls.certManager.issuerRef.kind }}/{{ .Values.ingress.tls.certManager.issuerRef.name }}).
+  {{- else if .Values.ingress.tls.existingSecret }}
+  TLS via pre-existing Secret {{ .Values.ingress.tls.existingSecret | quote }}.
+  {{- else }}
+  TLS: not configured on the Ingress — controller-side TLS termination assumed.
+  {{- end }}
+{{- else }}
+  In-cluster: http://{{ include "demarkus-broker.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.server.port }}/
+  Ingress is disabled. Expose via port-forward for dev:
+    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "demarkus-broker.fullname" . }} {{ .Values.server.port }}:{{ .Values.server.port }}
+{{- end }}
+
+== Configured worlds ({{ len .Values.worlds }}) ==
+{{- range .Values.worlds }}
+  - {{ .name }} → secret {{ .namespace }}/{{ .tokensSecret }}
+{{- end }}
+
+== Prerequisites the chart does NOT enforce ==
+- Each world's namespace listed above must already exist; chart does not create them.
+- Each world's tokens Secret must already exist; demarkus-server chart's bootstrap Job creates it.
+{{- if .Values.rbac.create }}
+- The install-time ServiceAccount needs Role/RoleBinding create rights in every world's namespace (the chart created them per-world).
+{{- else }}
+- rbac.create=false: per-world Role + RoleBinding must be provisioned out of band.
+{{- end }}
+
+== Security invariants to verify ==
+{{- if and .Values.ingress.enabled .Values.rateLimit.trustForwardedFor }}
+- rateLimit.trustForwardedFor=true is in effect. This is only safe when the
+  Ingress controller {{ .Values.ingress.className | quote }} strips spoofed
+  X-Forwarded-For from inbound requests and appends the real client IP.
+  nginx-ingress and Traefik do this by default; verify the behavior for any
+  other controller before exposing /auth/login publicly.
+{{- else if .Values.rateLimit.trustForwardedFor }}
+- rateLimit.trustForwardedFor=true but no Ingress is configured. If the broker
+  is reachable from untrusted clients (e.g. NodePort/LoadBalancer Service), an
+  attacker can spoof X-Forwarded-For to bypass the per-IP rate limit on
+  /auth/login. Either deploy behind an XFF-stripping Ingress or set
+  rateLimit.trustForwardedFor=false.
+{{- end }}
+{{- if .Values.oidc.clientSecret }}
+- OIDC clientSecret is set in values (cleartext). The value lives in helm
+  release history. For production, switch to oidc.existingSecretRef pointing at
+  an externally-managed Secret (External Secrets / Sealed Secrets / Vault).
+{{- end }}
+
+Configure your OIDC IdP to allow the redirect URI {{ .Values.oidc.redirectURL | quote }}.

--- a/deploy/helm/demarkus-broker/templates/certificate.yaml
+++ b/deploy/helm/demarkus-broker/templates/certificate.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.ingress.enabled .Values.ingress.tls.certManager.enabled }}
+{{- if not .Values.ingress.host }}
+{{- fail "ingress.host is required when ingress.tls.certManager.enabled is true" }}
+{{- end }}
+{{- /* cert-manager Certificate that targets the TLS Secret the Ingress
+       references. cert-manager watches Certificate resources, talks to
+       the configured issuer (default: ClusterIssuer letsencrypt-prod),
+       and writes the resulting kubernetes.io/tls Secret. The Ingress
+       picks the Secret up by name.
+
+       Out-of-scope: DNS01 vs HTTP01 challenge selection lives on the
+       issuer, not here. ACME failure modes (rate limits, DNS
+       propagation) are documented in cert-manager's own docs. */ -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "demarkus-broker.fullname" . }}-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "demarkus-broker.labels" . | nindent 4 }}
+  {{- with .Values.ingress.tls.certManager.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  secretName: {{ include "demarkus-broker.fullname" . }}-tls
+  dnsNames:
+    - {{ .Values.ingress.host | quote }}
+  issuerRef:
+    kind: {{ .Values.ingress.tls.certManager.issuerRef.kind }}
+    name: {{ .Values.ingress.tls.certManager.issuerRef.name }}
+{{- end }}

--- a/deploy/helm/demarkus-broker/templates/deployment.yaml
+++ b/deploy/helm/demarkus-broker/templates/deployment.yaml
@@ -52,6 +52,20 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            {{- /* Production OIDC client secret path. When the operator
+                   points oidc.existingSecretRef at an externally-managed
+                   Secret, the chart leaves clientSecret blank in the
+                   config Secret and mounts OIDC_CLIENT_SECRET here.
+                   broker.LoadConfig applies the env var as an override
+                   before validate(). Cleartext-via-values mode skips
+                   this block entirely. */}}
+            {{- with .Values.oidc.existingSecretRef.name }}
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ . | quote }}
+                  key: {{ $.Values.oidc.existingSecretRef.key | quote }}
+            {{- end }}
           ports:
             - name: http
               protocol: TCP

--- a/deploy/helm/demarkus-broker/templates/ingress.yaml
+++ b/deploy/helm/demarkus-broker/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+{{- if not .Values.ingress.host }}
+{{- fail "ingress.host is required when ingress.enabled is true" }}
+{{- end }}
+{{- $tlsSecret := "" -}}
+{{- if .Values.ingress.tls.existingSecret -}}
+{{- $tlsSecret = .Values.ingress.tls.existingSecret -}}
+{{- else if .Values.ingress.tls.certManager.enabled -}}
+{{- $tlsSecret = printf "%s-tls" (include "demarkus-broker.fullname" .) -}}
+{{- end -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "demarkus-broker.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "demarkus-broker.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- if $tlsSecret }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ $tlsSecret }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path | quote }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "demarkus-broker.fullname" . }}
+                port:
+                  number: {{ .Values.server.port }}
+{{- end }}

--- a/deploy/helm/demarkus-broker/templates/ingress.yaml
+++ b/deploy/helm/demarkus-broker/templates/ingress.yaml
@@ -2,6 +2,14 @@
 {{- if not .Values.ingress.host }}
 {{- fail "ingress.host is required when ingress.enabled is true" }}
 {{- end }}
+{{- /* existingSecret and certManager.enabled are mutually exclusive
+       operator-facing modes. Allowing both would silently render an
+       Ingress pointing at existingSecret while certificate.yaml emitted
+       a cert-manager Certificate trying to manage a different Secret;
+       fail-fast keeps the TLS-source contract unambiguous. */ -}}
+{{- if and .Values.ingress.tls.existingSecret .Values.ingress.tls.certManager.enabled }}
+{{- fail "ingress.tls.existingSecret and ingress.tls.certManager.enabled are mutually exclusive; set exactly one" }}
+{{- end }}
 {{- $tlsSecret := "" -}}
 {{- if .Values.ingress.tls.existingSecret -}}
 {{- $tlsSecret = .Values.ingress.tls.existingSecret -}}

--- a/deploy/helm/demarkus-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-config.yaml
@@ -15,6 +15,16 @@ key.
 The config.yaml is rendered as a Secret rather than a ConfigMap because
 it contains both the OIDC client secret and the cookie HMAC key.
 */}}
+{{- /* Reject ambiguous values: clientSecret cleartext and existingSecretRef
+       are mutually exclusive operator-facing modes. With both set the
+       runtime precedence (env var wins over file) would be a surprising
+       footgun for whoever reads the values file later. */ -}}
+{{- if and .Values.oidc.clientSecret .Values.oidc.existingSecretRef.name -}}
+{{- fail "oidc.clientSecret and oidc.existingSecretRef.name are mutually exclusive; set exactly one" -}}
+{{- end -}}
+{{- if and (not .Values.oidc.clientSecret) (not .Values.oidc.existingSecretRef.name) -}}
+{{- fail "oidc.clientSecret or oidc.existingSecretRef.name is required" -}}
+{{- end -}}
 {{- $cookieKey := include "demarkus-broker.resolveCookieKey" . -}}
 apiVersion: v1
 kind: Secret
@@ -36,7 +46,13 @@ stringData:
     oidc:
       issuer: {{ required "oidc.issuer is required" .Values.oidc.issuer | quote }}
       clientID: {{ required "oidc.clientID is required" .Values.oidc.clientID | quote }}
-      clientSecret: {{ required "oidc.clientSecret is required" .Values.oidc.clientSecret | quote }}
+      {{- /* When existingSecretRef is set, leave clientSecret blank in the
+             rendered config — the broker's LoadConfig applies the
+             OIDC_CLIENT_SECRET env-var override (sourced via secretKeyRef
+             in deployment.yaml) before validate() runs. The mutual-
+             exclusion guard above ensures exactly one path produces the
+             runtime value. */}}
+      clientSecret: {{ default "" .Values.oidc.clientSecret | quote }}
       redirectURL: {{ required "oidc.redirectURL is required" .Values.oidc.redirectURL | quote }}
     worlds:
 {{- range .Values.worlds }}

--- a/deploy/helm/demarkus-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-config.yaml
@@ -25,6 +25,13 @@ it contains both the OIDC client secret and the cookie HMAC key.
 {{- if and (not .Values.oidc.clientSecret) (not .Values.oidc.existingSecretRef.name) -}}
 {{- fail "oidc.clientSecret or oidc.existingSecretRef.name is required" -}}
 {{- end -}}
+{{- /* Catch this at render time rather than at pod startup: a blank
+       existingSecretRef.key would render a secretKeyRef with no key,
+       which the kubelet rejects with a CreateContainerConfigError
+       only after the pod schedules. */ -}}
+{{- if and .Values.oidc.existingSecretRef.name (not .Values.oidc.existingSecretRef.key) -}}
+{{- fail "oidc.existingSecretRef.key is required when oidc.existingSecretRef.name is set" -}}
+{{- end -}}
 {{- $cookieKey := include "demarkus-broker.resolveCookieKey" . -}}
 apiVersion: v1
 kind: Secret

--- a/deploy/helm/demarkus-broker/values.yaml
+++ b/deploy/helm/demarkus-broker/values.yaml
@@ -53,12 +53,24 @@ oidc:
   # OAuth client ID registered at the IdP.
   clientID: ""
   # OAuth client secret. Two modes:
-  #   1. Cleartext via this field — chart bakes it into the config Secret.
-  #      Easiest install path; the value lives in helm release history.
-  #   2. existingSecretRef — point at an externally-managed Secret created
-  #      by External Secrets Operator / Sealed Secrets / kubectl. The
-  #      Ingress slice wires this mode end-to-end; not yet plumbed here.
+  #   1. Cleartext via this field — chart bakes it into the chart-managed
+  #      config Secret. Easiest install path; the value lives in helm
+  #      release history.
+  #   2. existingSecretRef below — production path. Chart leaves
+  #      clientSecret blank in the config Secret and mounts
+  #      OIDC_CLIENT_SECRET into the broker pod from an externally-
+  #      managed Kubernetes Secret (External Secrets Operator, Sealed
+  #      Secrets, kubectl-created). Broker reads the env var on startup
+  #      via the LoadConfig override path.
+  # Set exactly one of clientSecret or existingSecretRef.name; the chart
+  # fails template-render if both are set so the precedence isn't ambiguous
+  # to a reader of the values file.
   clientSecret: ""
+  existingSecretRef:
+    # Name of the operator-managed Secret. Empty disables this mode.
+    name: ""
+    # Data key inside the Secret holding the OAuth client secret.
+    key: clientSecret
   # Public URL of /auth/callback. Must exactly match the redirect URI
   # registered with the IdP.
   redirectURL: ""
@@ -167,13 +179,38 @@ podDisruptionBudget:
   enabled: true
   minAvailable: 1
 
-# Ingress + cert-manager ship in the Ingress slice. Schema declared here
-# so values structure is stable.
+# Ingress fronts the broker's plain-HTTP listener with TLS termination
+# at the controller. The chart's `rateLimit.trustForwardedFor: true`
+# default is only safe when the Ingress controller strips spoofed
+# X-Forwarded-For from inbound requests and appends the real client IP
+# — verify this for your controller before exposing the broker
+# (nginx-ingress and Traefik do it by default; some Cloud LBs need
+# explicit config). See README "X-Forwarded-For invariant".
 ingress:
   enabled: false
+  # IngressClass to route through. nginx is the most common managed-k8s
+  # default; override for traefik / haproxy / cloud-specific classes.
   className: nginx
+  # Public hostname the broker is reachable at, e.g. broker.example.com.
+  # Required when ingress.enabled is true.
   host: ""
+  # Controller-specific annotations. The broker's HTTP surface is
+  # bog-standard so most defaults work; common knobs would be
+  # nginx.ingress.kubernetes.io/proxy-body-size or
+  # cert-manager.io/cluster-issuer.
   annotations: {}
+  # Path to expose. Defaults to the whole broker surface at /.
+  path: /
+  pathType: Prefix
+  # TLS configuration. Three modes:
+  #   1. existingSecret: reference a pre-existing kubernetes.io/tls Secret
+  #      (cert-manager-managed, externally-provisioned, etc.).
+  #   2. certManager.enabled=true: chart provisions a cert-manager
+  #      Certificate resource that creates the TLS Secret in this
+  #      release's namespace.
+  #   3. neither set: Ingress has no TLS block (Ingress controller
+  #      handles TLS termination externally, or the deployment runs
+  #      without TLS — not recommended for production).
   tls:
     existingSecret: ""
     certManager:
@@ -181,6 +218,7 @@ ingress:
       issuerRef:
         kind: ClusterIssuer
         name: letsencrypt-prod
+      # Annotations on the Certificate resource.
       annotations: {}
 
 service:

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -243,10 +243,26 @@ func LoadConfig(path string) (*Config, error) {
 	if err := dec.Decode(&c); err != nil {
 		return nil, fmt.Errorf("broker: parse config %s: %w", path, err)
 	}
+	c.applyEnvOverrides()
 	if err := c.validate(); err != nil {
 		return nil, fmt.Errorf("broker: validate config %s: %w", path, err)
 	}
 	return &c, nil
+}
+
+// applyEnvOverrides lets a small set of high-sensitivity fields come from
+// environment variables instead of the on-disk config. Today only
+// OIDC_CLIENT_SECRET is supported, so production deployments can keep the
+// OAuth client secret in an externally-managed Kubernetes Secret (External
+// Secrets Operator, Sealed Secrets, Vault) mounted via secretKeyRef rather
+// than baked into the chart-rendered config Secret where it would leak
+// into helm release history. The env var wins over the file value when
+// both are set; an empty env var is treated as unset so an accidentally
+// cleared variable doesn't blank out a file-supplied value at runtime.
+func (c *Config) applyEnvOverrides() {
+	if v := os.Getenv("OIDC_CLIENT_SECRET"); v != "" {
+		c.OIDC.ClientSecret = v
+	}
 }
 
 func (c *Config) validate() error {

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -354,5 +355,78 @@ func TestLoadConfigMissingFile(t *testing.T) {
 	_, err := LoadConfig(filepath.Join(t.TempDir(), "nope.yaml"))
 	if err == nil {
 		t.Fatal("expected error for missing file")
+	}
+}
+
+// OIDC_CLIENT_SECRET env-var override lets the chart-rendered config
+// Secret keep clientSecret blank and source the real value from an
+// externally-managed Kubernetes Secret (External Secrets / Sealed
+// Secrets / Vault) mounted via secretKeyRef. The env var wins over the
+// file value when both are set, and an empty env var is treated as
+// unset so an accidentally cleared variable cannot silently blank the
+// runtime value.
+func TestLoadConfigOIDCClientSecretEnvOverride(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileVal  string
+		setEnv   bool
+		envVal   string
+		wantErr  string
+		wantCSec string
+	}{
+		{
+			name:     "env overrides file value",
+			fileVal:  "shh-from-file",
+			setEnv:   true,
+			envVal:   "shh-from-env",
+			wantCSec: "shh-from-env",
+		},
+		{
+			name:     "env supplies value when file is empty",
+			fileVal:  "",
+			setEnv:   true,
+			envVal:   "shh-from-env",
+			wantCSec: "shh-from-env",
+		},
+		{
+			name:     "empty env does not clobber file value",
+			fileVal:  "shh-from-file",
+			setEnv:   true,
+			envVal:   "",
+			wantCSec: "shh-from-file",
+		},
+		{
+			name:    "no env, no file value, validate rejects",
+			fileVal: "",
+			setEnv:  false,
+			wantErr: "oidc.clientSecret is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// t.Setenv unsets on test cleanup so each row is isolated;
+			// not calling Setenv when setEnv=false ensures the var is
+			// unset for that case (parent process is not expected to
+			// have it set during `go test`).
+			if tt.setEnv {
+				t.Setenv("OIDC_CLIENT_SECRET", tt.envVal)
+			}
+			body := strings.Replace(validConfig,
+				"clientSecret: shh",
+				"clientSecret: "+strconv.Quote(tt.fileVal), 1)
+			cfg, err := LoadConfig(writeConfig(t, body))
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			if cfg.OIDC.ClientSecret != tt.wantCSec {
+				t.Errorf("ClientSecret = %q, want %q", cfg.OIDC.ClientSecret, tt.wantCSec)
+			}
+		})
 	}
 }

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -404,13 +404,17 @@ func TestLoadConfigOIDCClientSecretEnvOverride(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// t.Setenv unsets on test cleanup so each row is isolated;
-			// not calling Setenv when setEnv=false ensures the var is
-			// unset for that case (parent process is not expected to
-			// have it set during `go test`).
-			if tt.setEnv {
-				t.Setenv("OIDC_CLIENT_SECRET", tt.envVal)
+			// Always Setenv to make the test deterministic regardless of
+			// whether the parent CI shell happens to have OIDC_CLIENT_SECRET
+			// exported. t.Setenv restores the previous value (including
+			// "unset") on test cleanup. Empty value is treated as unset by
+			// applyEnvOverrides, which is the property the setEnv=false
+			// case is asserting.
+			envVal := tt.envVal
+			if !tt.setEnv {
+				envVal = ""
 			}
+			t.Setenv("OIDC_CLIENT_SECRET", envVal)
 			body := strings.Replace(validConfig,
 				"clientSecret: shh",
 				"clientSecret: "+strconv.Quote(tt.fileVal), 1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Ingress support with path/pathType and cert-manager TLS; conditional TLS certificate provisioning and runtime OIDC secret injection via env var.
  * Option to reference OIDC client secrets from existing Kubernetes Secrets instead of cleartext values.

* **Documentation**
  * Expanded README with clearer install/production guidance and explicit post-install release notes covering endpoints, RBAC, TLS, and OIDC redirect setup.

* **Tests**
  * Added tests verifying OIDC client secret environment-variable override behavior.

* **Validation**
  * Chart now validates mutually exclusive/required TLS and OIDC secret configurations at render time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/117)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->