### PR TITLE
feat(tools):  Add Helm chart unittest suites and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
               - 'client/**'
               - 'protocol/**'
             broker:
-              - 'tools/**'
+              - 'tools/demarkus-broker/**'
+              - 'tools/go.mod'
+              - 'tools/go.sum'
               - 'protocol/**'
             charts:
               - 'deploy/helm/**'
@@ -101,6 +103,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.broker == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -109,7 +112,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v7
         with:
           version: v2.9.0
-          working-directory: tools
+          working-directory: tools/demarkus-broker
       - name: Test
         run: cd tools && go test ./demarkus-broker/...
       - name: Vet
@@ -121,6 +124,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.charts == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: azure/setup-helm@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
       protocol: ${{ steps.filter.outputs.protocol }}
       server: ${{ steps.filter.outputs.server }}
       client: ${{ steps.filter.outputs.client }}
+      broker: ${{ steps.filter.outputs.broker }}
+      charts: ${{ steps.filter.outputs.charts }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -27,6 +29,11 @@ jobs:
             client:
               - 'client/**'
               - 'protocol/**'
+            broker:
+              - 'tools/**'
+              - 'protocol/**'
+            charts:
+              - 'deploy/helm/**'
 
   test-protocol:
     needs: detect-changes
@@ -89,3 +96,45 @@ jobs:
         run: cd client && go build -o /dev/null ./cmd/demarkus-tui
       - name: Build MCP
         run: cd client && go build -o /dev/null ./cmd/demarkus-mcp
+
+  test-broker:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.broker == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+      - uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.9.0
+          working-directory: tools
+      - name: Test
+        run: cd tools && go test ./demarkus-broker/...
+      - name: Vet
+        run: cd tools && go vet ./demarkus-broker/...
+      - name: Build
+        run: cd tools && go build -o /dev/null ./demarkus-broker
+
+  test-charts:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.charts == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.13.2
+      - name: Install helm-unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.6.2
+      - name: Lint demarkus-server chart
+        run: helm lint deploy/helm/demarkus-server
+      - name: Lint demarkus-broker chart
+        run: helm lint deploy/helm/demarkus-broker
+      - name: Lint demarkus-agent chart
+        run: helm lint deploy/helm/demarkus-agent
+      - name: Unit test demarkus-server chart
+        run: helm unittest deploy/helm/demarkus-server
+      - name: Unit test demarkus-broker chart
+        run: helm unittest deploy/helm/demarkus-broker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,8 @@ After each implementation run tests and pre-commit.sh.
 /guidelines.md     — Hard rules for code quality, must read before writing code
 /debugging.md      — Lessons from bugs and investigations
 /roadmap.md        — What's done, what's next
-/journal.md        — Session notes and evolution log
+Records (one per decision, zero-padded 4-digit sequence)
+- `/<project>/journal/<YYYY-MM-DD>.md` — dated session notes, one file per day
 /thoughts.md       — Agent reflections and ideas
 /guide.md          — Setup instructions for demarkus-soul
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ After each implementation run tests and pre-commit.sh.
 
 ### End of Session
 
-- Add a journal entry to `/journal.md` if something significant happened
+- Add a journal entry to `/<project>/journal/<YYYY-MM-DD>.md` if something significant happened
 
 ### Content Structure
 
@@ -35,8 +35,7 @@ After each implementation run tests and pre-commit.sh.
 /guidelines.md     — Hard rules for code quality, must read before writing code
 /debugging.md      — Lessons from bugs and investigations
 /roadmap.md        — What's done, what's next
-Records (one per decision, zero-padded 4-digit sequence)
-- `/<project>/journal/<YYYY-MM-DD>.md` — dated session notes, one file per day
+/<project>/journal/<YYYY-MM-DD>.md — Dated session notes, one file per day
 /thoughts.md       — Agent reflections and ideas
 /guide.md          — Setup instructions for demarkus-soul
 ```

--- a/deploy/helm/demarkus-broker/tests/deployment_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/deployment_test.yaml
@@ -1,0 +1,163 @@
+suite: deployment
+templates:
+  - deployment.yaml
+  - secret-config.yaml
+release:
+  namespace: broker-ns
+set:
+  oidc.issuer: https://accounts.example.com
+  oidc.clientID: broker-app
+  oidc.clientSecret: shh
+  oidc.redirectURL: https://broker.example.com/auth/callback
+tests:
+  - it: renders a Deployment with two replicas and rolling update strategy
+    template: deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-demarkus-broker
+      - equal:
+          path: spec.replicas
+          value: 2
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+
+  - it: container image uses AppVersion when image.tag empty
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/latebit-io/demarkus-broker:0.1.0
+
+  - it: checksum/config annotation present so config changes roll the pod
+    template: deployment.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: '^[0-9a-f]{64}$'
+
+  - it: pod-level securityContext locks down the pod
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 65532
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 65532
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 65532
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: container-level securityContext locks down the container
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: HTTP probes hit /healthz and /readyz on the http port
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: http
+
+  - it: probes omitted when probes.enabled=false
+    template: deployment.yaml
+    set:
+      probes.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: POD_NAME env always set from fieldRef metadata.name
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+
+  - it: OIDC_CLIENT_SECRET env absent when only clientSecret cleartext set
+    template: deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: OIDC_CLIENT_SECRET
+
+  - it: OIDC_CLIENT_SECRET env mounted via secretKeyRef when existingSecretRef.name set
+    template: deployment.yaml
+    set:
+      oidc.clientSecret: ""
+      oidc.existingSecretRef.name: my-oidc-secret
+      oidc.existingSecretRef.key: clientSecret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OIDC_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: my-oidc-secret
+                key: clientSecret
+
+  - it: topologySpread matchLabels populated from selector labels, not values empty default
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].maxSkew
+          value: 1
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: kubernetes.io/hostname
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].whenUnsatisfiable
+          value: ScheduleAnyway
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels["app.kubernetes.io/name"]
+          value: demarkus-broker
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: container args reference /etc/demarkus-broker/config.yaml
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "-config"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: /etc/demarkus-broker/config.yaml

--- a/deploy/helm/demarkus-broker/tests/ingress_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/ingress_test.yaml
@@ -1,0 +1,108 @@
+suite: ingress
+templates:
+  - ingress.yaml
+  - certificate.yaml
+set:
+  oidc.issuer: https://accounts.example.com
+  oidc.clientID: broker-app
+  oidc.clientSecret: shh
+  oidc.redirectURL: https://broker.example.com/auth/callback
+tests:
+  - it: Ingress and Certificate both absent by default (ingress.enabled=false)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fail-render when ingress.enabled=true but host blank
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.host is required when ingress.enabled is true"
+
+  - it: fail-render when both ingress.tls.existingSecret and certManager.enabled set (mutex)
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.host: broker.example.com
+      ingress.tls.existingSecret: my-tls
+      ingress.tls.certManager.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.tls.existingSecret and ingress.tls.certManager.enabled are mutually exclusive; set exactly one"
+
+  - it: Ingress with existingSecret references that Secret in TLS block
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.host: broker.example.com
+      ingress.tls.existingSecret: my-corp-tls
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: spec.tls[0].secretName
+          value: my-corp-tls
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: broker.example.com
+      - equal:
+          path: spec.rules[0].host
+          value: broker.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+
+  - it: cert-manager Certificate emitted only when ingress.enabled + certManager.enabled both true
+    template: certificate.yaml
+    set:
+      ingress.enabled: true
+      ingress.host: broker.example.com
+      ingress.tls.certManager.enabled: true
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-demarkus-broker-tls
+      - equal:
+          path: spec.secretName
+          value: RELEASE-NAME-demarkus-broker-tls
+      - equal:
+          path: spec.dnsNames[0]
+          value: broker.example.com
+      - equal:
+          path: spec.issuerRef.kind
+          value: ClusterIssuer
+      - equal:
+          path: spec.issuerRef.name
+          value: letsencrypt-prod
+
+  - it: Ingress with certManager mode references the chart-generated TLS Secret
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.host: broker.example.com
+      ingress.tls.certManager.enabled: true
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: RELEASE-NAME-demarkus-broker-tls
+
+  - it: ingress.className override propagates to ingressClassName
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.host: broker.example.com
+      ingress.className: traefik
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: traefik

--- a/deploy/helm/demarkus-broker/tests/networkpolicy_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/networkpolicy_test.yaml
@@ -1,0 +1,78 @@
+suite: networkpolicy
+templates:
+  - networkpolicy.yaml
+set:
+  oidc.issuer: https://accounts.example.com
+  oidc.clientID: broker-app
+  oidc.clientSecret: shh
+  oidc.redirectURL: https://broker.example.com/auth/callback
+tests:
+  - it: NetworkPolicy renders by default (chart-side opt-out, not opt-in)
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-demarkus-broker
+
+  - it: policyTypes includes Ingress AND Egress (no implicit allow-all in either direction)
+    asserts:
+      - equal:
+          path: spec.policyTypes
+          value: ["Ingress", "Egress"]
+
+  - it: ingress scoped to ingress-nginx namespace by default
+    asserts:
+      - equal:
+          path: spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: ingress-nginx
+      - equal:
+          path: spec.ingress[0].ports[0].protocol
+          value: TCP
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: 8080
+
+  - it: ingressFromNamespace override propagates
+    set:
+      networkPolicy.ingressFromNamespace: traefik-system
+    asserts:
+      - equal:
+          path: spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: traefik-system
+
+  - it: egress allows DNS to kube-system on UDP+TCP 53
+    asserts:
+      - equal:
+          path: spec.egress[0].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: kube-system
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            protocol: UDP
+            port: 53
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            protocol: TCP
+            port: 53
+
+  - it: egress allows TCP 443 unrestricted (apiserver + OIDC issuer)
+    asserts:
+      - notExists:
+          path: spec.egress[1].to
+      - equal:
+          path: spec.egress[1].ports[0].protocol
+          value: TCP
+      - equal:
+          path: spec.egress[1].ports[0].port
+          value: 443
+
+  - it: NetworkPolicy disabled when networkPolicy.enabled=false
+    set:
+      networkPolicy.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/demarkus-broker/tests/pdb_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/pdb_test.yaml
@@ -1,0 +1,42 @@
+suite: poddisruptionbudget
+templates:
+  - poddisruptionbudget.yaml
+set:
+  oidc.issuer: https://accounts.example.com
+  oidc.clientID: broker-app
+  oidc.clientSecret: shh
+  oidc.redirectURL: https://broker.example.com/auth/callback
+tests:
+  - it: PDB renders by default with minAvailable=1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-demarkus-broker
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: demarkus-broker
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: minAvailable override propagates
+    set:
+      podDisruptionBudget.minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+
+  - it: PDB skipped when podDisruptionBudget.enabled=false
+    set:
+      podDisruptionBudget.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/demarkus-broker/tests/rbac_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/rbac_test.yaml
@@ -1,0 +1,181 @@
+suite: rbac
+templates:
+  - rbac-broker-ns.yaml
+  - rbac-worlds.yaml
+release:
+  namespace: broker-ns
+set:
+  oidc.issuer: https://accounts.example.com
+  oidc.clientID: broker-app
+  oidc.clientSecret: shh
+  oidc.redirectURL: https://broker.example.com/auth/callback
+tests:
+  - it: broker-namespace Role + RoleBinding render in brokerNamespace
+    template: rbac-broker-ns.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        isKind:
+          of: Role
+      - documentIndex: 0
+        equal:
+          path: metadata.namespace
+          value: broker-ns
+      - documentIndex: 1
+        isKind:
+          of: RoleBinding
+      - documentIndex: 1
+        equal:
+          path: metadata.namespace
+          value: broker-ns
+
+  - it: broker-ns Role leases rule pinned to get/create/update on the configured leaseName
+    template: rbac-broker-ns.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: rules[0].apiGroups
+          value: ["coordination.k8s.io"]
+      - equal:
+          path: rules[0].resources
+          value: ["leases"]
+      - equal:
+          path: rules[0].resourceNames
+          value: ["demarkus-broker-sweeper"]
+      - equal:
+          path: rules[0].verbs
+          value: ["get", "create", "update"]
+
+  - it: broker-ns Role secrets rule pinned to get/update on issuancesSecret only
+    template: rbac-broker-ns.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: rules[1].apiGroups
+          value: [""]
+      - equal:
+          path: rules[1].resources
+          value: ["secrets"]
+      - equal:
+          path: rules[1].resourceNames
+          value: ["RELEASE-NAME-demarkus-broker-issuances"]
+      - equal:
+          path: rules[1].verbs
+          value: ["get", "update"]
+      - notContains:
+          path: rules[1].verbs
+          content: create
+      - notContains:
+          path: rules[1].verbs
+          content: delete
+      - notContains:
+          path: rules[1].verbs
+          content: list
+
+  - it: per-world template emits 2 Roles + 2 RoleBindings for two worlds
+    template: rbac-worlds.yaml
+    set:
+      worlds:
+        - name: team-a
+          namespace: team-a
+          tokensSecret: team-a-tokens
+          allow: {}
+          defaultToken:
+            paths: ["/team-a/*"]
+            operations: ["read"]
+            expiresAfter: 24h
+        - name: team-b
+          namespace: team-b
+          tokensSecret: team-b-tokens
+          allow: {}
+          defaultToken:
+            paths: ["/team-b/*"]
+            operations: ["read"]
+            expiresAfter: 24h
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: per-world Role scopes get/update to the named tokens Secret, NOT create
+    template: rbac-worlds.yaml
+    set:
+      worlds:
+        - name: team-a
+          namespace: team-a
+          tokensSecret: team-a-tokens
+          allow: {}
+          defaultToken:
+            paths: ["/team-a/*"]
+            operations: ["read"]
+            expiresAfter: 24h
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: team-a
+      - equal:
+          path: rules[0].apiGroups
+          value: [""]
+      - equal:
+          path: rules[0].resources
+          value: ["secrets"]
+      - equal:
+          path: rules[0].resourceNames
+          value: ["team-a-tokens"]
+      - equal:
+          path: rules[0].verbs
+          value: ["get", "update"]
+      - notContains:
+          path: rules[0].verbs
+          content: create
+      - notContains:
+          path: rules[0].verbs
+          content: delete
+
+  - it: per-world RoleBinding subject references broker SA in release namespace
+    template: rbac-worlds.yaml
+    set:
+      worlds:
+        - name: team-a
+          namespace: team-a
+          tokensSecret: team-a-tokens
+          allow: {}
+          defaultToken:
+            paths: ["/team-a/*"]
+            operations: ["read"]
+            expiresAfter: 24h
+    documentSelector:
+      path: kind
+      value: RoleBinding
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: team-a
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - equal:
+          path: subjects[0].name
+          value: RELEASE-NAME-demarkus-broker
+      - equal:
+          path: subjects[0].namespace
+          value: broker-ns
+
+  - it: rbac.create=false skips both broker-ns and per-world RBAC
+    set:
+      rbac.create: false
+      worlds:
+        - name: team-a
+          namespace: team-a
+          tokensSecret: team-a-tokens
+          allow: {}
+          defaultToken:
+            paths: ["/team-a/*"]
+            operations: ["read"]
+            expiresAfter: 24h
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
@@ -1,0 +1,99 @@
+suite: secret-config
+templates:
+  - secret-config.yaml
+release:
+  namespace: broker-ns
+set:
+  oidc.issuer: https://accounts.example.com
+  oidc.clientID: broker-app
+  oidc.redirectURL: https://broker.example.com/auth/callback
+tests:
+  - it: rendered Secret has metadata.namespace explicitly set to release namespace
+    set:
+      oidc.clientSecret: shh
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.namespace
+          value: broker-ns
+
+  - it: rate-limit defaults rendered explicitly (trustForwardedFor=true, 10/5 + 20/5)
+    set:
+      oidc.clientSecret: shh
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'rateLimit:\s*\n\s*disabled: false'
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'trustForwardedFor: true'
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'tokens:\s*\n\s*perMinute: 10\s*\n\s*burst: 5'
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'login:\s*\n\s*perMinute: 20\s*\n\s*burst: 5'
+
+  - it: sweeper defaults rendered explicitly
+    set:
+      oidc.clientSecret: shh
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'sweeper:\s*\n\s*disabled: false\s*\n\s*interval: "5m"\s*\n\s*leaseName: "demarkus-broker-sweeper"'
+
+  - it: existingSecretRef path leaves clientSecret blank in rendered config
+    set:
+      oidc.existingSecretRef.name: my-oidc-secret
+      oidc.existingSecretRef.key: clientSecret
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'clientSecret: ""'
+
+  - it: clientSecret cleartext mode renders the literal value
+    set:
+      oidc.clientSecret: literal-secret-value
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'clientSecret: "literal-secret-value"'
+
+  - it: fail-render when both clientSecret and existingSecretRef.name set (mutex)
+    set:
+      oidc.clientSecret: shh
+      oidc.existingSecretRef.name: my-oidc-secret
+      oidc.existingSecretRef.key: clientSecret
+    asserts:
+      - failedTemplate:
+          errorMessage: "oidc.clientSecret and oidc.existingSecretRef.name are mutually exclusive; set exactly one"
+
+  - it: fail-render when neither clientSecret nor existingSecretRef.name set
+    asserts:
+      - failedTemplate:
+          errorMessage: "oidc.clientSecret or oidc.existingSecretRef.name is required"
+
+  - it: fail-render when existingSecretRef.name set but key is blank
+    set:
+      oidc.existingSecretRef.name: my-oidc-secret
+      oidc.existingSecretRef.key: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "oidc.existingSecretRef.key is required when oidc.existingSecretRef.name is set"
+
+  - it: world with no allow block renders empty arrays for all three dimensions (does not panic)
+    set:
+      oidc.clientSecret: shh
+      worlds:
+        - name: team-a
+          namespace: team-a
+          tokensSecret: team-a-tokens
+          defaultToken:
+            paths: ["/team-a/*"]
+            operations: ["read"]
+            expiresAfter: 24h
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'allow:\s*\n\s*domains: \[\]\s*\n\s*groups: \[\]\s*\n\s*emails: \[\]'

--- a/deploy/helm/demarkus-broker/tests/secret-issuances_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/secret-issuances_test.yaml
@@ -1,0 +1,46 @@
+suite: secret-issuances
+templates:
+  - secret-issuances.yaml
+release:
+  namespace: broker-ns
+set:
+  oidc.issuer: https://accounts.example.com
+  oidc.clientID: broker-app
+  oidc.clientSecret: shh
+  oidc.redirectURL: https://broker.example.com/auth/callback
+tests:
+  - it: issuances Secret renders an empty Opaque Secret on offline template
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-demarkus-broker-issuances
+      - equal:
+          path: type
+          value: Opaque
+      - equal:
+          path: data
+          value: {}
+
+  - it: helm.sh/resource-policy keep annotation pinned so helm upgrade/uninstall do not wipe broker state
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: metadata.namespace tracks demarkus-broker.brokerNamespace helper
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: broker-ns
+
+  - it: server.brokerNamespace override moves the issuances Secret to that namespace
+    set:
+      server.brokerNamespace: alt-broker-ns
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: alt-broker-ns

--- a/deploy/helm/demarkus-server/tests/statefulset_test.yaml
+++ b/deploy/helm/demarkus-server/tests/statefulset_test.yaml
@@ -1,8 +1,10 @@
 suite: statefulset
 templates:
   - statefulset.yaml
+  - tokens.yaml
 tests:
   - it: renders a StatefulSet with correct name + replicas
+    template: statefulset.yaml
     asserts:
       - hasDocuments:
           count: 1
@@ -19,6 +21,7 @@ tests:
           value: RELEASE-NAME-demarkus-server
 
   - it: container args include -port and -root by default
+    template: statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -34,6 +37,7 @@ tests:
           content: /var/lib/demarkus/content
 
   - it: -read-only added when server.readOnly=true
+    template: statefulset.yaml
     set:
       server.readOnly: true
     asserts:
@@ -42,12 +46,14 @@ tests:
           content: "-read-only"
 
   - it: -read-only absent when server.readOnly=false (default)
+    template: statefulset.yaml
     asserts:
       - notContains:
           path: spec.template.spec.containers[0].args
           content: "-read-only"
 
   - it: TLS args + volume absent when no TLS configured
+    template: statefulset.yaml
     asserts:
       - notContains:
           path: spec.template.spec.containers[0].args
@@ -60,6 +66,7 @@ tests:
               secretName: RELEASE-NAME-demarkus-server-tls
 
   - it: TLS args + volume present when cert-manager enabled
+    template: statefulset.yaml
     set:
       tls.certManager.enabled: true
     asserts:
@@ -77,6 +84,7 @@ tests:
               secretName: RELEASE-NAME-demarkus-server-tls
 
   - it: TLS uses existingSecret when set
+    template: statefulset.yaml
     set:
       tls.existingSecret: my-corp-tls
     asserts:
@@ -88,6 +96,7 @@ tests:
               secretName: my-corp-tls
 
   - it: udpPort knob propagates to args and port
+    template: statefulset.yaml
     set:
       server.udpPort: 443
     asserts:
@@ -102,6 +111,7 @@ tests:
           value: UDP
 
   - it: pod-level securityContext has runAsNonRoot + seccompProfile
+    template: statefulset.yaml
     asserts:
       - equal:
           path: spec.template.spec.securityContext.runAsNonRoot
@@ -111,6 +121,7 @@ tests:
           value: RuntimeDefault
 
   - it: container-level securityContext locks down container
+    template: statefulset.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
@@ -123,6 +134,7 @@ tests:
           content: ALL
 
   - it: probes disabled when probes.enabled=false
+    template: statefulset.yaml
     set:
       probes.enabled: false
     asserts:
@@ -132,6 +144,7 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe
 
   - it: probes use demarkus CLI fetching agent-manifest
+    template: statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].livenessProbe.exec.command
@@ -144,6 +157,7 @@ tests:
           content: "mark://localhost:6309/.well-known/agent-manifest.md"
 
   - it: volumeClaimTemplates provisions content PVC
+    template: statefulset.yaml
     set:
       storage.className: premium-rwo
       storage.size: 10Gi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive Helm chart tests covering broker deployment (security, networking, RBAC, secrets, PDBs, ingress/certificate) and chart rendering behavior.
  * Added/expanded server StatefulSet test coverage.

* **Chores**
  * CI now runs targeted tests when broker or chart changes are detected.

* **Documentation**
  * Updated project journaling guidance to use dated, per-project records.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/118)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->