### PR TITLE
feat(tools): Add Secret preservation regression tests for demarkus-server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,17 @@ jobs:
             demarkus-server-tokens \
             broker-minted-test \
             ZmFrZS10b2tlbi1oYXNo
+      - name: Legacy-migration regression — demarkus-server
+        env:
+          SIMULATE_LEGACY_NO_KEEP: "true"
+        run: |
+          bash deploy/helm/test-upgrade-wipe.sh \
+            deploy/helm/demarkus-server \
+            demarkus-server-legacy \
+            test-server-legacy \
+            demarkus-server-legacy-tokens \
+            broker-minted-test \
+            ZmFrZS10b2tlbi1oYXNo
       - name: Upgrade-wipe regression — demarkus-broker
         run: |
           bash deploy/helm/test-upgrade-wipe.sh \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,3 +142,39 @@ jobs:
         run: helm unittest deploy/helm/demarkus-server
       - name: Unit test demarkus-broker chart
         run: helm unittest deploy/helm/demarkus-broker
+
+  test-charts-kind:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.charts == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.13.2
+      - uses: helm/kind-action@v1
+        with:
+          cluster_name: chart-upgrade-wipe
+      - name: Upgrade-wipe regression — demarkus-server
+        run: |
+          bash deploy/helm/test-upgrade-wipe.sh \
+            deploy/helm/demarkus-server \
+            demarkus-server \
+            test-server \
+            demarkus-server-tokens \
+            broker-minted-test \
+            ZmFrZS10b2tlbi1oYXNo
+      - name: Upgrade-wipe regression — demarkus-broker
+        run: |
+          bash deploy/helm/test-upgrade-wipe.sh \
+            deploy/helm/demarkus-broker \
+            demarkus-broker \
+            test-broker \
+            demarkus-broker-issuances \
+            broker-minted-test \
+            ZmFrZS1pc3N1YW5jZQ== \
+            --set oidc.issuer=https://accounts.google.com \
+            --set oidc.clientID=test-client \
+            --set oidc.clientSecret=test-secret \
+            --set oidc.redirectURL=https://broker.example/auth/callback

--- a/deploy/helm/demarkus-server/templates/tokens.yaml
+++ b/deploy/helm/demarkus-server/templates/tokens.yaml
@@ -1,25 +1,34 @@
 {{/*
-Both token Secrets are rendered with a `lookup`-skip + `helm.sh/resource-policy: keep`
-pattern so they survive `helm upgrade` and `helm uninstall` without wiping
-broker-minted entries.
+Token Secrets — three render branches keyed on the live Secret's state:
 
-Why both: the broker (Phase 6.2 / 6.3) mints per-user tokens by appending
-entries to the world's tokens Secret. On `helm upgrade` of this chart, a
-naive re-render would emit a Secret containing only the bootstrap admin
-entry — wiping every broker-minted user token. The lookup-skip branch keeps
-the existing Secret intact: on upgrade, `lookup` returns the live Secret,
-the template emits nothing, helm sees the resource was removed from the
-manifest, and the keep annotation on the live Secret prevents helm GC.
-Net effect: helm upgrades never touch broker-minted state.
+  1. First install (lookup returns nil) → render fresh content with the
+     `helm.sh/resource-policy: keep` annotation. `$rawToken` resolves to a
+     freshly-generated token; both Secrets ship with consistent raw+hash.
 
-The token-values Secret carries the same treatment so the bootstrap admin
-raw token survives upgrades — the broker reads it via `secretKeyRef` to
-authenticate against the world's server during bootstrap.
+  2. Legacy upgrade (Secret exists but LACKS the keep annotation) →
+     render the EXISTING data verbatim plus the keep annotation. This is
+     the migration path from §6.1's original template (PR #107) which
+     shipped without the keep annotation; without this branch, the
+     subsequent `lookup`-skip path would emit nothing, helm would diff
+     the old (annotation-less) manifest against the new (absent)
+     manifest, and DELETE the Secret on apply — wiping every broker-
+     minted user-token entry along the way. Re-rendering existing data
+     ensures helm's apply is a content no-op while the annotation lands
+     so future upgrades flip to branch 3.
 
-`lookup` returns nil during offline `helm template`, so tests and dry-runs
-always see the first-install render path. The single-render-pass invariant
-(one `$rawToken` flowing into both Secrets) only matters during first
-install; subsequent renders are skipped.
+  3. Race-free no-op (Secret exists AND has the keep annotation) → emit
+     nothing. helm sees the Secret was removed from the rendered
+     manifest, would normally GC it, but the keep annotation on the
+     live Secret blocks deletion. Net effect: helm upgrades after the
+     first migration NEVER touch the Secret content, leaving the broker
+     as the sole writer and eliminating any race window between
+     `helm template` and `helm apply`.
+
+`lookup` returns nil during offline `helm template` and helm-unittest, so
+both branches 1 (first install) and tests see the same fresh render. The
+legacy and race-free branches are only exercised against a real cluster
+— covered end-to-end by the kind `test-upgrade-wipe.sh` regression
+(normal mode + SIMULATE_LEGACY_NO_KEEP mode).
 */}}
 {{- $rawToken := include "demarkus-server.resolveAdminToken" . -}}
 {{- $hash := printf "sha256-%s" (sha256sum $rawToken) -}}
@@ -27,7 +36,23 @@ install; subsequent renders are skipped.
 {{- $ns := .Release.Namespace -}}
 {{- $tokensName := include "demarkus-server.tokensSecretName" . -}}
 {{- $valuesName := include "demarkus-server.tokenValuesSecretName" . -}}
-{{- if not (lookup "v1" "Secret" $ns $tokensName) }}
+{{- $existingTokens := lookup "v1" "Secret" $ns $tokensName -}}
+{{- $tokensHasKeep := false -}}
+{{- if $existingTokens -}}
+  {{- $tokensAnnotations := default dict $existingTokens.metadata.annotations -}}
+  {{- if eq (index $tokensAnnotations "helm.sh/resource-policy") "keep" -}}
+    {{- $tokensHasKeep = true -}}
+  {{- end -}}
+{{- end -}}
+{{- $existingValues := lookup "v1" "Secret" $ns $valuesName -}}
+{{- $valuesHasKeep := false -}}
+{{- if $existingValues -}}
+  {{- $valuesAnnotations := default dict $existingValues.metadata.annotations -}}
+  {{- if eq (index $valuesAnnotations "helm.sh/resource-policy") "keep" -}}
+    {{- $valuesHasKeep = true -}}
+  {{- end -}}
+{{- end -}}
+{{- if not $existingTokens }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -48,8 +73,22 @@ stringData:
     operations = [
       {{- range $i, $o := $admin.operations }}{{ if $i }}, {{ end }}{{ $o | quote }}{{ end -}}
     ]
+{{- else if not $tokensHasKeep }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $tokensName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "demarkus-server.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+type: {{ default "Opaque" $existingTokens.type }}
+data:
+  {{- toYaml $existingTokens.data | nindent 2 }}
 {{- end }}
-{{- if and .Values.tokens.emitRawValues (not (lookup "v1" "Secret" $ns $valuesName)) }}
+{{- if .Values.tokens.emitRawValues }}
+{{- if not $existingValues }}
 ---
 apiVersion: v1
 kind: Secret
@@ -66,4 +105,20 @@ metadata:
 type: Opaque
 data:
   {{ $admin.label }}: {{ $rawToken | b64enc }}
+{{- else if not $valuesHasKeep }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $valuesName }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "demarkus-server.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+    demarkus.io/raw-tokens: "true"
+type: {{ default "Opaque" $existingValues.type }}
+data:
+  {{- toYaml $existingValues.data | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/demarkus-server/templates/tokens.yaml
+++ b/deploy/helm/demarkus-server/templates/tokens.yaml
@@ -1,17 +1,42 @@
 {{/*
-Both token Secrets are emitted from one file so a single $rawToken value flows
-into both (within the same template render pass). This avoids the trap where
-randAlphaNum runs separately per file and produces mismatched raw/hash.
+Both token Secrets are rendered with a `lookup`-skip + `helm.sh/resource-policy: keep`
+pattern so they survive `helm upgrade` and `helm uninstall` without wiping
+broker-minted entries.
+
+Why both: the broker (Phase 6.2 / 6.3) mints per-user tokens by appending
+entries to the world's tokens Secret. On `helm upgrade` of this chart, a
+naive re-render would emit a Secret containing only the bootstrap admin
+entry — wiping every broker-minted user token. The lookup-skip branch keeps
+the existing Secret intact: on upgrade, `lookup` returns the live Secret,
+the template emits nothing, helm sees the resource was removed from the
+manifest, and the keep annotation on the live Secret prevents helm GC.
+Net effect: helm upgrades never touch broker-minted state.
+
+The token-values Secret carries the same treatment so the bootstrap admin
+raw token survives upgrades — the broker reads it via `secretKeyRef` to
+authenticate against the world's server during bootstrap.
+
+`lookup` returns nil during offline `helm template`, so tests and dry-runs
+always see the first-install render path. The single-render-pass invariant
+(one `$rawToken` flowing into both Secrets) only matters during first
+install; subsequent renders are skipped.
 */}}
 {{- $rawToken := include "demarkus-server.resolveAdminToken" . -}}
 {{- $hash := printf "sha256-%s" (sha256sum $rawToken) -}}
 {{- $admin := .Values.tokens.admin -}}
+{{- $ns := .Release.Namespace -}}
+{{- $tokensName := include "demarkus-server.tokensSecretName" . -}}
+{{- $valuesName := include "demarkus-server.tokenValuesSecretName" . -}}
+{{- if not (lookup "v1" "Secret" $ns $tokensName) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "demarkus-server.tokensSecretName" . }}
+  name: {{ $tokensName }}
+  namespace: {{ $ns }}
   labels:
     {{- include "demarkus-server.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 type: Opaque
 stringData:
   tokens.toml: |
@@ -23,15 +48,18 @@ stringData:
     operations = [
       {{- range $i, $o := $admin.operations }}{{ if $i }}, {{ end }}{{ $o | quote }}{{ end -}}
     ]
-{{- if .Values.tokens.emitRawValues }}
+{{- end }}
+{{- if and .Values.tokens.emitRawValues (not (lookup "v1" "Secret" $ns $valuesName)) }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "demarkus-server.tokenValuesSecretName" . }}
+  name: {{ $valuesName }}
+  namespace: {{ $ns }}
   labels:
     {{- include "demarkus-server.labels" . | nindent 4 }}
   annotations:
+    helm.sh/resource-policy: keep
     # This Secret contains raw tokens. Intended for broker consumption (read +
     # revoke). The server never mounts this Secret.
     demarkus.io/raw-tokens: "true"

--- a/deploy/helm/demarkus-server/tests/tokens_test.yaml
+++ b/deploy/helm/demarkus-server/tests/tokens_test.yaml
@@ -92,3 +92,30 @@ tests:
       - equal:
           path: data.admin
           value: bXktbGl0ZXJhbC1yYXctdG9rZW4=  # base64 of "my-literal-raw-token"
+
+  - it: tokens Secret carries helm.sh/resource-policy keep so helm upgrade/uninstall do not wipe broker-minted entries
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-demarkus-server-tokens
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: token-values Secret carries helm.sh/resource-policy keep so the broker bootstrap raw token survives upgrades
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-demarkus-server-token-values
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: tokens Secret renders explicit metadata.namespace so the lookup-skip branch checks the right namespace on upgrade
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-demarkus-server-tokens
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE

--- a/deploy/helm/test-upgrade-wipe.sh
+++ b/deploy/helm/test-upgrade-wipe.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# test-upgrade-wipe.sh — verify a chart's resource-policy: keep + lookup-skip
+# pattern preserves out-of-band Secret mutations across helm upgrade and
+# helm uninstall.
+#
+# This is the kind-side end-to-end regression test for the property the
+# §6.1 and §6.3 charts both claim: that broker-minted token entries
+# appended to a chart-managed Secret survive `helm upgrade <release>`
+# (re-render must not overwrite live Secret content) and `helm uninstall
+# <release>` (Secret must persist so a subsequent reinstall picks up the
+# existing state).
+#
+# Usage:
+#   test-upgrade-wipe.sh <chart_path> <release_name> <namespace> \
+#                       <secret_name> <seed_key> <seed_value_b64> \
+#                       [helm-args...]
+#
+# The seeded data simulates a broker mint: kubectl-patch adds a fake key
+# into the Secret's data map after install, then upgrade + uninstall must
+# leave that key intact.
+
+set -euo pipefail
+
+if [[ $# -lt 6 ]]; then
+  echo "usage: $0 <chart> <release> <namespace> <secret> <seed_key> <seed_val_b64> [helm-args...]" >&2
+  exit 2
+fi
+
+CHART="$1"
+RELEASE="$2"
+NAMESPACE="$3"
+SECRET="$4"
+SEED_KEY="$5"
+SEED_VALUE_B64="$6"
+shift 6
+HELM_ARGS=("$@")
+
+echo "::group::test-upgrade-wipe: chart=$CHART release=$RELEASE namespace=$NAMESPACE secret=$SECRET"
+
+cleanup() {
+  set +e
+  helm uninstall "$RELEASE" --namespace "$NAMESPACE" --wait 2>/dev/null
+  kubectl -n "$NAMESPACE" delete secret "$SECRET" --ignore-not-found 2>/dev/null
+  kubectl delete namespace "$NAMESPACE" --ignore-not-found 2>/dev/null
+}
+trap cleanup EXIT
+
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+echo "--- helm install"
+helm install "$RELEASE" "$CHART" --namespace "$NAMESPACE" --wait=false "${HELM_ARGS[@]}"
+
+echo "--- wait for Secret $SECRET"
+for _ in $(seq 1 60); do
+  if kubectl -n "$NAMESPACE" get secret "$SECRET" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+if ! kubectl -n "$NAMESPACE" get secret "$SECRET" >/dev/null 2>&1; then
+  echo "FAIL: Secret $SECRET not created within 60s of install"
+  kubectl -n "$NAMESPACE" get secret
+  exit 1
+fi
+
+echo "--- assert resource-policy=keep annotation present (post-install)"
+policy=$(kubectl -n "$NAMESPACE" get secret "$SECRET" -o jsonpath='{.metadata.annotations.helm\.sh/resource-policy}')
+if [[ "$policy" != "keep" ]]; then
+  echo "FAIL: $SECRET annotation helm.sh/resource-policy=$policy, want 'keep'"
+  exit 1
+fi
+echo "OK: keep annotation present"
+
+echo "--- seed broker-minted data ($SEED_KEY=<redacted>)"
+# Strategic-merge patch: adds the key without touching other entries, and
+# handles the case where data is absent (empty {} in YAML is stored as nil,
+# which breaks JSON-patch `add /data/X` but merge-patch creates the map).
+kubectl -n "$NAMESPACE" patch secret "$SECRET" --type=merge \
+  -p "{\"data\":{\"${SEED_KEY}\":\"${SEED_VALUE_B64}\"}}"
+
+echo "--- helm upgrade (re-renders templates; lookup-skip + keep should preserve Secret)"
+helm upgrade "$RELEASE" "$CHART" --namespace "$NAMESPACE" --wait=false "${HELM_ARGS[@]}"
+
+echo "--- assert seeded data persists after upgrade"
+got=$(kubectl -n "$NAMESPACE" get secret "$SECRET" -o jsonpath="{.data.${SEED_KEY}}")
+if [[ "$got" != "$SEED_VALUE_B64" ]]; then
+  echo "FAIL: seeded ${SEED_KEY} missing or modified after upgrade"
+  echo "  got:  ${got}"
+  echo "  want: ${SEED_VALUE_B64}"
+  exit 1
+fi
+echo "OK: seeded data survived upgrade"
+
+echo "--- helm uninstall"
+helm uninstall "$RELEASE" --namespace "$NAMESPACE" --wait
+
+echo "--- assert Secret survives uninstall (resource-policy: keep)"
+if ! kubectl -n "$NAMESPACE" get secret "$SECRET" >/dev/null 2>&1; then
+  echo "FAIL: $SECRET deleted on uninstall — resource-policy=keep did not hold"
+  exit 1
+fi
+got=$(kubectl -n "$NAMESPACE" get secret "$SECRET" -o jsonpath="{.data.${SEED_KEY}}")
+if [[ "$got" != "$SEED_VALUE_B64" ]]; then
+  echo "FAIL: seeded ${SEED_KEY} lost after uninstall"
+  exit 1
+fi
+echo "OK: Secret + seeded data survived uninstall"
+
+echo "::endgroup::"
+echo "PASS: $CHART upgrade-wipe regression"

--- a/deploy/helm/test-upgrade-wipe.sh
+++ b/deploy/helm/test-upgrade-wipe.sh
@@ -101,7 +101,7 @@ echo "--- helm upgrade (re-renders templates; lookup-skip + keep should preserve
 helm upgrade "$RELEASE" "$CHART" --namespace "$NAMESPACE" --wait=false "${HELM_ARGS[@]}"
 
 echo "--- assert seeded data persists after upgrade"
-got=$(kubectl -n "$NAMESPACE" get secret "$SECRET" -o jsonpath="{.data.${SEED_KEY}}")
+got=$(kubectl -n "$NAMESPACE" get secret "$SECRET" -o jsonpath="{.data['${SEED_KEY}']}")
 if [[ "$got" != "$SEED_VALUE_B64" ]]; then
   echo "FAIL: seeded ${SEED_KEY} missing or modified after upgrade"
   echo "  got:  ${got}"
@@ -131,7 +131,7 @@ if ! kubectl -n "$NAMESPACE" get secret "$SECRET" >/dev/null 2>&1; then
   echo "FAIL: $SECRET deleted on uninstall — resource-policy=keep did not hold"
   exit 1
 fi
-got=$(kubectl -n "$NAMESPACE" get secret "$SECRET" -o jsonpath="{.data.${SEED_KEY}}")
+got=$(kubectl -n "$NAMESPACE" get secret "$SECRET" -o jsonpath="{.data['${SEED_KEY}']}")
 if [[ "$got" != "$SEED_VALUE_B64" ]]; then
   echo "FAIL: seeded ${SEED_KEY} lost after uninstall"
   exit 1

--- a/deploy/helm/test-upgrade-wipe.sh
+++ b/deploy/helm/test-upgrade-wipe.sh
@@ -71,6 +71,25 @@ if [[ "$policy" != "keep" ]]; then
 fi
 echo "OK: keep annotation present"
 
+# Optional legacy-state simulation: strips the keep annotation from the
+# Secret so the helm upgrade exercises the migration path from a release
+# that originally shipped without it. The chart's tokens.yaml has a
+# branch (lookup-found + missing keep) that re-renders the existing
+# data verbatim plus the keep annotation — without that branch, helm
+# would delete the Secret on apply because lookup-skip emits nothing
+# and the live Secret has no keep to block GC. Set
+# SIMULATE_LEGACY_NO_KEEP=true in CI to exercise it.
+if [[ "${SIMULATE_LEGACY_NO_KEEP:-false}" == "true" ]]; then
+  echo "--- simulate legacy state: remove keep annotation before upgrade"
+  kubectl -n "$NAMESPACE" annotate secret "$SECRET" helm.sh/resource-policy- --overwrite
+  policy=$(kubectl -n "$NAMESPACE" get secret "$SECRET" -o jsonpath='{.metadata.annotations.helm\.sh/resource-policy}')
+  if [[ -n "$policy" ]]; then
+    echo "FAIL: legacy-state simulation did not strip annotation; got '$policy'"
+    exit 1
+  fi
+  echo "OK: keep annotation removed (legacy state)"
+fi
+
 echo "--- seed broker-minted data ($SEED_KEY=<redacted>)"
 # Strategic-merge patch: adds the key without touching other entries, and
 # handles the case where data is absent (empty {} in YAML is stored as nil,
@@ -90,6 +109,19 @@ if [[ "$got" != "$SEED_VALUE_B64" ]]; then
   exit 1
 fi
 echo "OK: seeded data survived upgrade"
+
+# In legacy mode, the upgrade should ALSO have re-applied the keep
+# annotation via the migration branch. Verify it's back so the next
+# upgrade follows the race-free no-op path.
+if [[ "${SIMULATE_LEGACY_NO_KEEP:-false}" == "true" ]]; then
+  echo "--- assert keep annotation re-applied by migration branch"
+  policy=$(kubectl -n "$NAMESPACE" get secret "$SECRET" -o jsonpath='{.metadata.annotations.helm\.sh/resource-policy}')
+  if [[ "$policy" != "keep" ]]; then
+    echo "FAIL: migration upgrade did not restore keep annotation; got '$policy'"
+    exit 1
+  fi
+  echo "OK: keep annotation restored by legacy migration branch"
+fi
 
 echo "--- helm uninstall"
 helm uninstall "$RELEASE" --namespace "$NAMESPACE" --wait


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tokens and raw token values are now preserved across chart upgrades and uninstalls; legacy-release migrations will restore protection annotations when needed.
  * Added a CI regression job that exercises Helm/kind upgrade-wipe and legacy-migration scenarios, including broker token handling and deployment overrides.

* **Tests**
  * Added unit tests validating resource-protection and namespace behavior for token secrets.
  * Added an end-to-end regression test that seeds secret data, performs upgrades/uninstalls, and asserts data persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/119)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->