### PR TITLE
fix(tools):  Add Docker image publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,23 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GORELEASER_CURRENT_TAG: "server/v${{ needs.semver-server.outputs.new_version }}"
 
+      # Multi-stage Dockerfile compiles binaries from source; build context
+      # is the repo root because the server image bundles demarkus + demarkus-
+      # server which live in different go modules. Versions are stamped via
+      # build-args. Multi-arch matches the goreleaser binary matrix.
+      - name: Build + push demarkus-server image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: server/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            ghcr.io/latebit-io/demarkus-server:${{ needs.semver-server.outputs.new_version }}
+            ghcr.io/latebit-io/demarkus-server:latest
+          build-args: |
+            VERSION=${{ needs.semver-server.outputs.new_version }}
+
   release-client:
     needs: semver-client
     if: needs.semver-client.outputs.should_release == 'true'
@@ -272,6 +289,15 @@ jobs:
       - name: Fetch tags
         run: git fetch --tags --force
 
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
@@ -281,3 +307,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GORELEASER_CURRENT_TAG: "client/v${{ needs.semver-client.outputs.new_version }}"
+
+      # demarkus-agent lives in client/cmd/ so it rides the client release
+      # cadence. Multi-stage Dockerfile compiles from source; context is the
+      # repo root because the agent module's tools/ replace directive needs
+      # protocol/ alongside.
+      - name: Build + push demarkus-agent image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: client/cmd/demarkus-agent/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            ghcr.io/latebit-io/demarkus-agent:${{ needs.semver-client.outputs.new_version }}
+            ghcr.io/latebit-io/demarkus-agent:latest
+          build-args: |
+            VERSION=${{ needs.semver-client.outputs.new_version }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated Docker image builds and publishing now integrated into release workflows for server and agent components, with support for multiple architectures and versioned tagging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/122)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->