### PR TITLE
feat(deploy):  Add Kind cluster provisioning harness for development

### DIFF
--- a/deploy/kind/down.sh
+++ b/deploy/kind/down.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER="${CLUSTER:-knowledge-system}"
+
+if kind get clusters | grep -qx "$CLUSTER"; then
+  kind delete cluster --name "$CLUSTER"
+else
+  echo "kind cluster '$CLUSTER' not found, nothing to do"
+fi

--- a/deploy/kind/kind-config.yaml
+++ b/deploy/kind/kind-config.yaml
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: knowledge-system
+nodes:
+  - role: control-plane

--- a/deploy/kind/up.sh
+++ b/deploy/kind/up.sh
@@ -34,7 +34,7 @@ if kind get clusters | grep -qx "$CLUSTER"; then
   echo "--- kind cluster '$CLUSTER' already exists, reusing"
 else
   echo "--- creating kind cluster '$CLUSTER'"
-  kind create cluster --config "$KIND_CONFIG"
+  kind create cluster --name "$CLUSTER" --config "$KIND_CONFIG"
 fi
 
 kubectl config use-context "kind-$CLUSTER" >/dev/null
@@ -47,7 +47,7 @@ helm upgrade --install "$RELEASE" "$SERVER_CHART" \
   --wait --timeout 5m
 
 POD_SELECTOR="app.kubernetes.io/instance=$RELEASE,app.kubernetes.io/name=demarkus-server"
-POD=$(kubectl -n "$NAMESPACE" get pods -l "$POD_SELECTOR" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+POD=$(kubectl -n "$NAMESPACE" get pods -l "$POD_SELECTOR" -o jsonpath='{.items[0].metadata.name}')
 if [[ -z "$POD" ]]; then
   echo "no demarkus-server pod found for selector: $POD_SELECTOR" >&2
   exit 1

--- a/deploy/kind/up.sh
+++ b/deploy/kind/up.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Stage 1 of the kind harness: bring up a single-node kind cluster and install
+# the demarkus-server chart from GHCR. Verification runs `demarkus fetch`
+# against the server's own QUIC listener via `kubectl exec`, which exercises
+# the full read path without exposing anything to the host.
+#
+# Subsequent stages will layer in the broker (Stage 2) and Argo CD with an
+# ApplicationSet over multiple worlds (Stage 3).
+
+set -euo pipefail
+
+CLUSTER="${CLUSTER:-knowledge-system}"
+NAMESPACE="${NAMESPACE:-demarkus}"
+RELEASE="${RELEASE:-world-default}"
+SERVER_CHART_VERSION="${SERVER_CHART_VERSION:-0.17.8}"
+SERVER_CHART="oci://ghcr.io/latebit-io/charts/demarkus-server"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+VALUES_FILE="$SCRIPT_DIR/values-kind.yaml"
+KIND_CONFIG="$SCRIPT_DIR/kind-config.yaml"
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "missing required tool: $1" >&2
+    exit 1
+  }
+}
+
+require kind
+require helm
+require kubectl
+
+if kind get clusters | grep -qx "$CLUSTER"; then
+  echo "--- kind cluster '$CLUSTER' already exists, reusing"
+else
+  echo "--- creating kind cluster '$CLUSTER'"
+  kind create cluster --config "$KIND_CONFIG"
+fi
+
+kubectl config use-context "kind-$CLUSTER" >/dev/null
+
+echo "--- installing demarkus-server chart $SERVER_CHART_VERSION"
+helm upgrade --install "$RELEASE" "$SERVER_CHART" \
+  --version "$SERVER_CHART_VERSION" \
+  --namespace "$NAMESPACE" --create-namespace \
+  --values "$VALUES_FILE" \
+  --wait --timeout 5m
+
+POD="${RELEASE}-demarkus-server-0"
+echo "--- waiting for pod $POD"
+kubectl -n "$NAMESPACE" wait --for=condition=ready "pod/$POD" --timeout=120s
+
+echo "--- smoke test: fetch /.well-known/agent-manifest.md from inside the pod"
+kubectl -n "$NAMESPACE" exec "$POD" -- \
+  demarkus -insecure fetch "mark://localhost:6309/.well-known/agent-manifest.md"
+
+# The chart emits two Secrets when emitRawValues=true (default):
+#   <release>-demarkus-server-tokens         server-mounted, hash-only TOML
+#   <release>-demarkus-server-token-values   raw admin token
+TOKEN_SECRET="${RELEASE}-demarkus-server-token-values"
+if kubectl -n "$NAMESPACE" get secret "$TOKEN_SECRET" >/dev/null 2>&1; then
+  echo "--- admin token (from $TOKEN_SECRET):"
+  kubectl -n "$NAMESPACE" get secret "$TOKEN_SECRET" \
+    -o jsonpath='{.data.admin}' | base64 -d
+  echo
+fi
+
+cat <<EOF
+
+ready.
+
+cluster:   kind-$CLUSTER
+namespace: $NAMESPACE
+release:   $RELEASE
+service:   $RELEASE-demarkus-server.$NAMESPACE.svc.cluster.local:6309 (UDP)
+
+interact from inside the cluster:
+  kubectl -n $NAMESPACE exec -it $POD -- \\
+    demarkus -insecure fetch mark://localhost:6309/.well-known/agent-manifest.md
+
+tear down:
+  $SCRIPT_DIR/down.sh
+EOF

--- a/deploy/kind/up.sh
+++ b/deploy/kind/up.sh
@@ -46,7 +46,12 @@ helm upgrade --install "$RELEASE" "$SERVER_CHART" \
   --values "$VALUES_FILE" \
   --wait --timeout 5m
 
-POD="${RELEASE}-demarkus-server-0"
+POD_SELECTOR="app.kubernetes.io/instance=$RELEASE,app.kubernetes.io/name=demarkus-server"
+POD=$(kubectl -n "$NAMESPACE" get pods -l "$POD_SELECTOR" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+if [[ -z "$POD" ]]; then
+  echo "no demarkus-server pod found for selector: $POD_SELECTOR" >&2
+  exit 1
+fi
 echo "--- waiting for pod $POD"
 kubectl -n "$NAMESPACE" wait --for=condition=ready "pod/$POD" --timeout=120s
 
@@ -57,13 +62,9 @@ kubectl -n "$NAMESPACE" exec "$POD" -- \
 # The chart emits two Secrets when emitRawValues=true (default):
 #   <release>-demarkus-server-tokens         server-mounted, hash-only TOML
 #   <release>-demarkus-server-token-values   raw admin token
+# We deliberately do not print the token here — a kind dev cluster is
+# ephemeral and the user can pull it on demand with the command shown below.
 TOKEN_SECRET="${RELEASE}-demarkus-server-token-values"
-if kubectl -n "$NAMESPACE" get secret "$TOKEN_SECRET" >/dev/null 2>&1; then
-  echo "--- admin token (from $TOKEN_SECRET):"
-  kubectl -n "$NAMESPACE" get secret "$TOKEN_SECRET" \
-    -o jsonpath='{.data.admin}' | base64 -d
-  echo
-fi
 
 cat <<EOF
 
@@ -77,6 +78,9 @@ service:   $RELEASE-demarkus-server.$NAMESPACE.svc.cluster.local:6309 (UDP)
 interact from inside the cluster:
   kubectl -n $NAMESPACE exec -it $POD -- \\
     demarkus -insecure fetch mark://localhost:6309/.well-known/agent-manifest.md
+
+retrieve the admin token (when you need it):
+  kubectl -n $NAMESPACE get secret $TOKEN_SECRET -o jsonpath='{.data.admin}' | base64 -d
 
 tear down:
   $SCRIPT_DIR/down.sh

--- a/deploy/kind/values-kind.yaml
+++ b/deploy/kind/values-kind.yaml
@@ -1,0 +1,12 @@
+# Chart overrides for the kind harness in deploy/kind/up.sh.
+# Stage 1: server only, no external exposure, server self-signs its TLS cert.
+
+service:
+  type: ClusterIP
+
+storage:
+  size: 1Gi
+
+# tls block intentionally left at chart defaults — neither existingSecret nor
+# certManager.enabled is set, so the server auto-generates a self-signed dev
+# cert at startup. Clients verify with `demarkus -insecure`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a local Kubernetes harness to create and tear down a single-node kind cluster for testing.
  * Automates deployment of the app via Helm with local chart overrides (ClusterIP service, 1Gi storage).
  * Performs readiness checks, waits for server pod readiness, and verifies service functionality.
  * Prints connection and verification instructions without exposing secrets, streamlining local development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/126)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->