### PR TITLE
fix(install):  Migrate demarkus-token and demarkus-publish to tools release

### DIFF
--- a/install-readonly.sh
+++ b/install-readonly.sh
@@ -76,7 +76,10 @@ download_binary() {
   local dest="$4"
 
   local tag="${component}/v${version}"
-  local archive="demarkus-${component}_${version}_linux_${ARCH}.tar.gz"
+  # Archive name is per-binary (e.g. demarkus-server_..., demarkus-publish_...).
+  # Both server (single-binary archive) and tools (one archive per binary,
+  # post-§6.7.A) follow this shape; the checksums file is per-release.
+  local archive="${binary}_${version}_linux_${ARCH}.tar.gz"
   local checksums="demarkus-${component}_checksums.txt"
   local base_url="https://github.com/${GITHUB_REPO}/releases/download/${tag}"
 
@@ -189,15 +192,20 @@ do_install() {
   cp "${tmpdir}/demarkus-server" "${root}/bin/demarkus-server"
   chmod 755 "${root}/bin/demarkus-server"
 
-  # Also install demarkus-publish to /usr/local/bin (runs outside the chroot)
-  download_binary "server" "$version" "demarkus-publish" "$tmpdir" 2>/dev/null || true
-  if [ -f "${tmpdir}/demarkus-publish" ]; then
-    cp "${tmpdir}/demarkus-publish" /usr/local/bin/demarkus-publish
-    chmod 755 /usr/local/bin/demarkus-publish
-    log_info "Installed demarkus-publish to /usr/local/bin/"
-  else
-    log_warn "demarkus-publish not found in release — build from source or publish via protocol"
+  # Also install demarkus-publish to /usr/local/bin (runs outside the chroot).
+  # demarkus-publish lives in the tools/ release as of §6.7.A; pinned to the
+  # latest tools tag here because read-only installs don't have a CONFIG_DIR
+  # version marker to anchor a coordinated upgrade.
+  local tools_version
+  tools_version=$(fetch_latest_version "tools")
+  if [ -z "$tools_version" ]; then
+    log_error "Could not find tools release — demarkus-publish is required for read-only installs."
+    exit 1
   fi
+  download_binary "tools" "$tools_version" "demarkus-publish" "$tmpdir"
+  cp "${tmpdir}/demarkus-publish" /usr/local/bin/demarkus-publish
+  chmod 755 /usr/local/bin/demarkus-publish
+  log_info "Installed demarkus-publish v${tools_version} to /usr/local/bin/"
 
   rm -rf "$tmpdir"
 

--- a/install.sh
+++ b/install.sh
@@ -959,7 +959,7 @@ do_install() {
 
   # Download and install server binaries
   download_and_verify "server" "$version" "$_TMPDIR"
-  install_binaries "$_TMPDIR" "demarkus-server" "demarkus-token"
+  install_binaries "$_TMPDIR" "demarkus-server"
 
   # Download and install client binaries (separate archives)
   local client_version
@@ -974,6 +974,24 @@ do_install() {
   else
     log_warn "Could not find client release, skipping client install"
   fi
+
+  # Download and install admin CLIs from the tools/ release.
+  # demarkus-token + demarkus-publish moved out of the server archive in §6.7.A.
+  local tools_version
+  tools_version=$(fetch_latest_version "tools")
+  if [ -z "$tools_version" ]; then
+    log_error "Could not find tools release — demarkus-token is required for token generation."
+    exit 1
+  fi
+  # Pre-fetch the tools-release checksums file so download_and_verify_asset
+  # can verify each per-binary archive against it.
+  download_asset_file "tools/v${tools_version}" "demarkus-tools_checksums.txt" \
+    "${_TMPDIR}/demarkus-tools_checksums.txt" 2>/dev/null \
+    || log_warn "Could not download tools checksums; per-binary verification will be skipped"
+  download_and_verify_asset "demarkus-token" "$tools_version" "tools" "$_TMPDIR"
+  install_binaries "$_TMPDIR" "demarkus-token"
+  download_and_verify_asset "demarkus-publish" "$tools_version" "tools" "$_TMPDIR"
+  install_binaries "$_TMPDIR" "demarkus-publish"
 
   # Create user before directories (chown needs the user to exist)
   create_system_user
@@ -1092,6 +1110,7 @@ do_install() {
   log_info "Server:    ${INSTALL_DIR}/demarkus-server"
   log_info "Client:    ${INSTALL_DIR}/demarkus"
   log_info "Token tool: ${INSTALL_DIR}/demarkus-token"
+  log_info "Publish tool: ${INSTALL_DIR}/demarkus-publish"
   log_info "Content:   ${content_root}"
   log_info "Config:    ${CONFIG_DIR}/"
   log_info "Tokens:    ${tokens_file}"
@@ -1280,6 +1299,19 @@ _do_update_inner() {
     download_and_verify_asset "demarkus-mcp" "$client_version" "client" "$_TMPDIR"
   fi
 
+  # Download new admin CLIs from the tools/ release.
+  local tools_version
+  tools_version=$(fetch_latest_version "tools")
+  if [ -n "$tools_version" ]; then
+    download_asset_file "tools/v${tools_version}" "demarkus-tools_checksums.txt" \
+      "${_TMPDIR}/demarkus-tools_checksums.txt" 2>/dev/null \
+      || log_warn "Could not download tools checksums; per-binary verification will be skipped"
+    download_and_verify_asset "demarkus-token" "$tools_version" "tools" "$_TMPDIR"
+    download_and_verify_asset "demarkus-publish" "$tools_version" "tools" "$_TMPDIR"
+  else
+    log_warn "Could not find tools release; skipping demarkus-token/demarkus-publish update"
+  fi
+
   # Run migrations before replacing binaries
   migrate "$from" "$to"
 
@@ -1305,11 +1337,15 @@ _do_update_inner() {
   fi
 
   # Replace binaries
-  install_binaries "$_TMPDIR" "demarkus-server" "demarkus-token"
+  install_binaries "$_TMPDIR" "demarkus-server"
   if [ -n "$client_version" ]; then
     install_binaries "$_TMPDIR" "demarkus"
     install_binaries "$_TMPDIR" "demarkus-tui"
     install_binaries "$_TMPDIR" "demarkus-mcp"
+  fi
+  if [ -n "$tools_version" ]; then
+    install_binaries "$_TMPDIR" "demarkus-token"
+    install_binaries "$_TMPDIR" "demarkus-publish"
   fi
 
   # Restart service
@@ -1454,7 +1490,7 @@ do_uninstall() {
   fi
 
   # Remove binaries
-  for bin in demarkus-server demarkus-token demarkus demarkus-tui demarkus-mcp demarkus-install; do
+  for bin in demarkus-server demarkus-token demarkus-publish demarkus demarkus-tui demarkus-mcp demarkus-install; do
     $SUDO rm -f "${INSTALL_DIR}/${bin}"
   done
   log_info "Removed binaries from ${INSTALL_DIR}/"

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -184,8 +184,11 @@ ensure_binaries() {
   fi
 
   # Record installed versions so subsequent ensure_binaries calls can detect
-  # drift after a plugin update bumps SERVER_VERSION / CLIENT_VERSION.
-  printf 'server=%s,client=%s\n' "${SERVER_VERSION}" "${CLIENT_VERSION}" > "${PLUGIN_VERSION_FILE}"
+  # drift after a plugin update bumps any of the pins. Must match the format
+  # emitted by _desired_versions() exactly, otherwise the comparison there
+  # treats every startup as drift and triggers a redundant re-download.
+  printf 'server=%s,client=%s,tools=%s\n' \
+    "${SERVER_VERSION}" "${CLIENT_VERSION}" "${TOOLS_VERSION}" > "${PLUGIN_VERSION_FILE}"
 
   log "binaries installed to ${PLUGIN_BIN_DIR}"
 }

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -25,8 +25,11 @@ readonly DEFAULT_PORT=6310             # plugin's first-choice port for its own 
 readonly ISOLATED_PORT_START=16310
 readonly ISOLATED_PORT_END=16509
 
-readonly SERVER_VERSION="0.17.4"
-readonly CLIENT_VERSION="0.12.26"
+readonly SERVER_VERSION="0.17.8"
+readonly CLIENT_VERSION="0.12.30"
+# demarkus-token moved from the server archive to its own tools/ release
+# in §6.7.A. Pin separately so a tools-only release can be picked up.
+readonly TOOLS_VERSION="0.1.0"
 
 # Sentinel file recording the SERVER/CLIENT versions of the binaries currently
 # installed at PLUGIN_BIN_DIR. ensure_binaries compares this against the
@@ -105,7 +108,7 @@ _installed_versions() {
 
 # _desired_versions — the version pin the plugin currently expects.
 _desired_versions() {
-  echo "server=${SERVER_VERSION},client=${CLIENT_VERSION}"
+  echo "server=${SERVER_VERSION},client=${CLIENT_VERSION},tools=${TOOLS_VERSION}"
 }
 
 # ensure_binaries — download + install to PLUGIN_BIN_DIR if any are missing
@@ -142,7 +145,7 @@ ensure_binaries() {
     tmp=$(mktemp -d)
     trap 'rm -rf "${tmp}"' EXIT
 
-    log "downloading demarkus binaries (server v${SERVER_VERSION}, client v${CLIENT_VERSION}, ${plat})"
+    log "downloading demarkus binaries (server v${SERVER_VERSION}, client v${CLIENT_VERSION}, tools v${TOOLS_VERSION}, ${plat})"
 
     local server_archive="demarkus-server_${SERVER_VERSION}_${plat}.tar.gz"
     local server_base="https://github.com/latebit-io/demarkus/releases/download/server%2Fv${SERVER_VERSION}"
@@ -157,6 +160,15 @@ ensure_binaries() {
     curl -fsSL -o "${tmp}/client_checksums.txt" "${client_base}/demarkus-client_checksums.txt"  || die "download client checksums"
     (cd "${tmp}" && sha256_verify client_checksums.txt "${mcp_archive}")
     tar -xzf "${tmp}/${mcp_archive}" -C "${tmp}"
+
+    # demarkus-token ships in the tools/ release as of §6.7.A; pre-§6.7.A
+    # plugin installs pulled it from the server archive.
+    local token_archive="demarkus-token_${TOOLS_VERSION}_${plat}.tar.gz"
+    local tools_base="https://github.com/latebit-io/demarkus/releases/download/tools%2Fv${TOOLS_VERSION}"
+    curl -fsSL -o "${tmp}/${token_archive}"    "${tools_base}/${token_archive}"               || die "download ${token_archive}"
+    curl -fsSL -o "${tmp}/tools_checksums.txt" "${tools_base}/demarkus-tools_checksums.txt"   || die "download tools checksums"
+    (cd "${tmp}" && sha256_verify tools_checksums.txt "${token_archive}")
+    tar -xzf "${tmp}/${token_archive}" -C "${tmp}"
 
     install -m 0755 "${tmp}/demarkus-server" "${PLUGIN_BIN_DIR}/demarkus-server"
     install -m 0755 "${tmp}/demarkus-token"  "${PLUGIN_BIN_DIR}/demarkus-token"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer and updater now install and uninstall the publish tool.
  * Token and publish binaries are sourced from a dedicated tools release alongside server and client releases.

* **Chores**
  * Bumped server to 0.17.8 and client to 0.12.30.
  * Added a pinned tools release (0.1.0) for token/publish distribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/127)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->