### PR TITLE
fix(deploy): argocd

### DIFF
--- a/deploy/k8s/examples/applicationset.yaml
+++ b/deploy/k8s/examples/applicationset.yaml
@@ -1,0 +1,69 @@
+# Argo CD ApplicationSet — scale demarkus to many worlds from a single list.
+#
+# Each entry in `generators[0].list.elements` templates one Argo Application,
+# which installs the demarkus-server Helm chart from GHCR into its own
+# namespace. To add or remove a world, edit the list and let Argo reconcile.
+#
+# Used by the kind harness at deploy/kind/up.sh --with-argo. Intended as a
+# starting point for a customer GitOps repo — copy, adjust the world list,
+# pin the chart version, and commit.
+#
+# Prerequisites:
+#   - Argo CD installed in the `argocd` namespace.
+#   - Argo CD's repo-server configured with helm.enableOCI=true (see
+#     deploy/kind/values-argo.yaml for the kind reference; production
+#     deployments set the same flag in argocd-cm).
+#
+# Per-world isolation: each Application targets its own namespace, and the
+# demarkus-server chart's bootstrap Job creates the per-world tokens Secret
+# inside that namespace. Worlds are isolated by namespace boundary. Tighter
+# RBAC (an AppProject scoping per-world sync rights to specific teams) is a
+# customer-side extension — wire it against your identity provider's groups.
+
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: demarkus-worlds
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - name: world-a
+          - name: world-b
+  template:
+    metadata:
+      name: "{{name}}"
+    spec:
+      project: default
+      source:
+        repoURL: ghcr.io/latebit-io/charts
+        chart: demarkus-server
+        targetRevision: 0.17.9
+        helm:
+          releaseName: "{{name}}"
+          values: |
+            service:
+              type: ClusterIP
+            storage:
+              size: 1Gi
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "{{name}}"
+      # The StatefulSet's volumeClaimTemplates entry picks up server-side
+      # defaults (volumeMode, apiVersion/kind, status) that don't exist in
+      # the Helm-rendered manifest. volumeClaimTemplates is immutable on a
+      # StatefulSet, so ignoring drift on the whole block costs nothing
+      # operationally and prevents Argo from looping on a sync it can never
+      # converge.
+      ignoreDifferences:
+        - group: apps
+          kind: StatefulSet
+          jsonPointers:
+            - /spec/volumeClaimTemplates
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true

--- a/deploy/kind/up.sh
+++ b/deploy/kind/up.sh
@@ -24,7 +24,12 @@ SERVER_CHART="oci://ghcr.io/latebit-io/charts/demarkus-server"
 BROKER_RELEASE="${BROKER_RELEASE:-broker}"
 BROKER_CHART_VERSION="${BROKER_CHART_VERSION:-0.1.1}"
 BROKER_CHART="oci://ghcr.io/latebit-io/charts/demarkus-broker"
-ARGO_NAMESPACE="${ARGO_NAMESPACE:-argocd}"
+# Hard-coded to match deploy/k8s/examples/applicationset.yaml which pins
+# metadata.namespace: argocd. Making this env-overridable would silently
+# break: the script would install Argo into the override namespace while
+# the ApplicationSet still landed in argocd, and the kubectl waits below
+# would target the wrong namespace.
+ARGO_NAMESPACE=argocd
 ARGO_RELEASE="${ARGO_RELEASE:-argocd}"
 ARGO_CHART_VERSION="${ARGO_CHART_VERSION:-7.7.0}"
 ARGO_REPO_URL="${ARGO_REPO_URL:-https://argoproj.github.io/argo-helm}"
@@ -57,7 +62,7 @@ usage: up.sh [--with-broker | --with-argo]
 env overrides:
   CLUSTER, NAMESPACE, RELEASE, SERVER_CHART_VERSION,
   BROKER_RELEASE, BROKER_CHART_VERSION,
-  ARGO_NAMESPACE, ARGO_RELEASE, ARGO_CHART_VERSION, ARGO_REPO_URL
+  ARGO_RELEASE, ARGO_CHART_VERSION, ARGO_REPO_URL
 EOF
       exit 0
       ;;

--- a/deploy/kind/up.sh
+++ b/deploy/kind/up.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
-# Stage 1 of the kind harness: bring up a single-node kind cluster and install
-# the demarkus-server chart from GHCR. Verification runs `demarkus fetch`
-# against the server's own QUIC listener via `kubectl exec`, which exercises
-# the full read path without exposing anything to the host.
+# kind harness for demarkus development.
 #
-# Subsequent stages will layer in the broker (Stage 2) and Argo CD with an
-# ApplicationSet over multiple worlds (Stage 3).
+# Stage 1 (default):    single-node kind cluster + demarkus-server chart.
+# Stage 2 (--with-broker):  + mock-oauth2-server + demarkus-broker chart.
+# Stage 3 (--with-argo):    + Argo CD + ApplicationSet templating two worlds.
+#
+# --with-argo replaces the Stage 1 server install with an Argo-managed
+# ApplicationSet so the worlds are GitOps-shaped from the start. It is not
+# combinable with --with-broker yet (the broker chart values are hard-wired
+# to the Stage 1 release name; multi-world broker wiring is a follow-up).
+#
+# Verification runs `demarkus` against each server's own QUIC listener via
+# `kubectl exec`, which exercises the full read path without exposing
+# anything to the host.
 
 set -euo pipefail
 
@@ -17,32 +24,56 @@ SERVER_CHART="oci://ghcr.io/latebit-io/charts/demarkus-server"
 BROKER_RELEASE="${BROKER_RELEASE:-broker}"
 BROKER_CHART_VERSION="${BROKER_CHART_VERSION:-0.1.1}"
 BROKER_CHART="oci://ghcr.io/latebit-io/charts/demarkus-broker"
+ARGO_NAMESPACE="${ARGO_NAMESPACE:-argocd}"
+ARGO_RELEASE="${ARGO_RELEASE:-argocd}"
+ARGO_CHART_VERSION="${ARGO_CHART_VERSION:-7.7.0}"
+ARGO_REPO_URL="${ARGO_REPO_URL:-https://argoproj.github.io/argo-helm}"
+# Must match the elements list in deploy/k8s/examples/applicationset.yaml.
+ARGO_WORLDS=(world-a world-b)
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." &>/dev/null && pwd)"
 VALUES_FILE="$SCRIPT_DIR/values-kind.yaml"
 BROKER_VALUES_FILE="$SCRIPT_DIR/values-broker.yaml"
+ARGO_VALUES_FILE="$SCRIPT_DIR/values-argo.yaml"
 MOCK_OIDC_MANIFEST="$SCRIPT_DIR/mock-oidc.yaml"
 KIND_CONFIG="$SCRIPT_DIR/kind-config.yaml"
+APPLICATIONSET_MANIFEST="$REPO_ROOT/deploy/k8s/examples/applicationset.yaml"
 
 WITH_BROKER=false
+WITH_ARGO=false
 for arg in "$@"; do
   case "$arg" in
     --with-broker) WITH_BROKER=true ;;
+    --with-argo)   WITH_ARGO=true ;;
     -h|--help)
       cat <<EOF
-usage: up.sh [--with-broker]
+usage: up.sh [--with-broker | --with-argo]
 
   --with-broker    also install mock-oauth2-server + demarkus-broker chart
+  --with-argo      install Argo CD + ApplicationSet templating two worlds
+                   (replaces the Stage 1 server install)
 
 env overrides:
   CLUSTER, NAMESPACE, RELEASE, SERVER_CHART_VERSION,
-  BROKER_RELEASE, BROKER_CHART_VERSION
+  BROKER_RELEASE, BROKER_CHART_VERSION,
+  ARGO_NAMESPACE, ARGO_RELEASE, ARGO_CHART_VERSION, ARGO_REPO_URL
 EOF
       exit 0
       ;;
     *) echo "unknown arg: $arg" >&2; exit 2 ;;
   esac
 done
+
+if [[ "$WITH_BROKER" == "true" && "$WITH_ARGO" == "true" ]]; then
+  cat >&2 <<EOF
+--with-broker and --with-argo cannot be combined: the broker chart values
+at $BROKER_VALUES_FILE are hard-wired to the Stage 1 release name
+'world-default', while --with-argo provisions world-a/world-b instead.
+Multi-world broker wiring is a follow-up.
+EOF
+  exit 2
+fi
 
 require() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -64,6 +95,93 @@ fi
 
 kubectl config use-context "kind-$CLUSTER" >/dev/null
 
+if [[ "$WITH_ARGO" == "true" ]]; then
+  echo "--- installing argo-cd chart $ARGO_CHART_VERSION"
+  # `helm repo add` is idempotent across reruns when the URL matches; with a
+  # different URL it errors. Force-update so reruns don't fail if the user
+  # has the repo registered under a different URL.
+  helm repo add argo "$ARGO_REPO_URL" --force-update >/dev/null
+  helm repo update argo >/dev/null
+  helm upgrade --install "$ARGO_RELEASE" argo/argo-cd \
+    --version "$ARGO_CHART_VERSION" \
+    --namespace "$ARGO_NAMESPACE" --create-namespace \
+    --values "$ARGO_VALUES_FILE" \
+    --wait --timeout 10m
+
+  echo "--- applying ApplicationSet from $APPLICATIONSET_MANIFEST"
+  kubectl apply -f "$APPLICATIONSET_MANIFEST"
+
+  # The ApplicationSet controller has to reconcile before the per-world
+  # Applications exist; `kubectl wait` errors out immediately if the named
+  # resource is absent, so poll for creation first, then wait on health.
+  for world in "${ARGO_WORLDS[@]}"; do
+    echo "--- waiting for Application/$world to be created"
+    for _ in $(seq 1 60); do
+      if kubectl -n "$ARGO_NAMESPACE" get application "$world" >/dev/null 2>&1; then
+        break
+      fi
+      sleep 2
+    done
+    if ! kubectl -n "$ARGO_NAMESPACE" get application "$world" >/dev/null 2>&1; then
+      echo "Application/$world never materialized — check the ApplicationSet controller logs" >&2
+      exit 1
+    fi
+  done
+
+  echo "--- waiting for Applications to become Healthy"
+  # Two-step wait: Synced first (chart pulled + manifests applied), then
+  # Healthy (workloads ready). Splitting these surfaces a clearer failure
+  # mode when OCI pull or RBAC blocks the sync vs. when a pod is crashing.
+  for world in "${ARGO_WORLDS[@]}"; do
+    kubectl -n "$ARGO_NAMESPACE" wait --for=jsonpath='{.status.sync.status}'=Synced \
+      "application/$world" --timeout=5m
+    kubectl -n "$ARGO_NAMESPACE" wait --for=jsonpath='{.status.health.status}'=Healthy \
+      "application/$world" --timeout=5m
+  done
+
+  for world in "${ARGO_WORLDS[@]}"; do
+    echo "--- smoke test for world $world"
+    WORLD_POD_SELECTOR="app.kubernetes.io/instance=$world,app.kubernetes.io/name=demarkus-server"
+    WORLD_POD=$(kubectl -n "$world" get pods -l "$WORLD_POD_SELECTOR" -o jsonpath='{.items[0].metadata.name}')
+    if [[ -z "$WORLD_POD" ]]; then
+      echo "no demarkus-server pod found in namespace $world for selector $WORLD_POD_SELECTOR" >&2
+      exit 1
+    fi
+    kubectl -n "$world" exec "$WORLD_POD" -- \
+      /demarkus -insecure -no-cache "mark://localhost:6309/.well-known/agent-manifest.md"
+  done
+
+  cat <<EOF
+
+ready (with argo).
+
+cluster:         kind-$CLUSTER
+argo namespace:  $ARGO_NAMESPACE
+argo release:    $ARGO_RELEASE
+worlds:          ${ARGO_WORLDS[*]}
+
+inspect Applications:
+  kubectl -n $ARGO_NAMESPACE get application
+
+open the Argo UI:
+  kubectl -n $ARGO_NAMESPACE port-forward svc/$ARGO_RELEASE-server 8080:80
+  open http://localhost:8080
+
+retrieve the Argo CD initial admin password:
+  kubectl -n $ARGO_NAMESPACE get secret argocd-initial-admin-secret \\
+    -o jsonpath='{.data.password}' | base64 -d ; echo
+
+server fetch from inside a world (replace world-a with any of: ${ARGO_WORLDS[*]}):
+  kubectl -n world-a exec -it \\
+    \$(kubectl -n world-a get pods -l app.kubernetes.io/name=demarkus-server -o jsonpath='{.items[0].metadata.name}') -- \\
+    /demarkus -insecure -no-cache mark://localhost:6309/.well-known/agent-manifest.md
+
+tear down:
+  $SCRIPT_DIR/down.sh
+EOF
+  exit 0
+fi
+
 echo "--- installing demarkus-server chart $SERVER_CHART_VERSION"
 helm upgrade --install "$RELEASE" "$SERVER_CHART" \
   --version "$SERVER_CHART_VERSION" \
@@ -82,7 +200,7 @@ kubectl -n "$NAMESPACE" wait --for=condition=ready "pod/$POD" --timeout=120s
 
 echo "--- smoke test: fetch /.well-known/agent-manifest.md from inside the pod"
 kubectl -n "$NAMESPACE" exec "$POD" -- \
-  demarkus -insecure fetch "mark://localhost:6309/.well-known/agent-manifest.md"
+  /demarkus -insecure -no-cache "mark://localhost:6309/.well-known/agent-manifest.md"
 
 # The chart emits two Secrets when emitRawValues=true (default):
 #   <release>-demarkus-server-tokens         server-mounted, hash-only TOML
@@ -134,7 +252,7 @@ probe the broker (from another shell):
 
 server fetch from inside the cluster:
   kubectl -n $NAMESPACE exec -it $POD -- \\
-    demarkus -insecure fetch mark://localhost:6309/.well-known/agent-manifest.md
+    /demarkus -insecure -no-cache mark://localhost:6309/.well-known/agent-manifest.md
 
 retrieve the admin token (when you need it):
   kubectl -n $NAMESPACE get secret $TOKEN_SECRET -o jsonpath='{.data.admin}' | base64 -d
@@ -156,7 +274,7 @@ service:   $RELEASE-demarkus-server.$NAMESPACE.svc.cluster.local:6309 (UDP)
 
 interact from inside the cluster:
   kubectl -n $NAMESPACE exec -it $POD -- \\
-    demarkus -insecure fetch mark://localhost:6309/.well-known/agent-manifest.md
+    /demarkus -insecure -no-cache mark://localhost:6309/.well-known/agent-manifest.md
 
 retrieve the admin token (when you need it):
   kubectl -n $NAMESPACE get secret $TOKEN_SECRET -o jsonpath='{.data.admin}' | base64 -d

--- a/deploy/kind/values-argo.yaml
+++ b/deploy/kind/values-argo.yaml
@@ -1,0 +1,13 @@
+# Argo CD chart overrides for the kind harness.
+#
+# Two settings matter for Stage 3:
+#   - helm.enableOCI=true so argocd-repo-server can pull demarkus-server
+#     from oci://ghcr.io/latebit-io/charts (anonymous public registry).
+#   - server.insecure=true so argocd-server speaks plain HTTP behind no TLS;
+#     kind has no ingress controller and we drive everything via port-forward.
+
+configs:
+  cm:
+    helm.enableOCI: "true"
+  params:
+    server.insecure: true


### PR DESCRIPTION
## Summary

Stage 3 of the kind harness: Argo CD + ApplicationSet over a `worlds:` list, replacing the Stage 1 server install with a GitOps-shaped multi-world setup.

- `deploy/k8s/examples/applicationset.yaml` — single Argo CD `ApplicationSet` with a list generator over `[world-a, world-b]`. Each templated Application installs `oci://ghcr.io/latebit-io/charts/demarkus-server@0.17.9` into its own namespace via `CreateNamespace=true`. Per-world isolation by namespace boundary; tighter Argo RBAC (AppProject scoping) is a customer-side extension wired against their identity provider.
- `deploy/kind/values-argo.yaml` — Argo CD chart overrides: `configs.cm.helm.enableOCI: "true"` (anonymous OCI pulls from GHCR) and `configs.params."server.insecure": true` (port-forward speaks plain HTTP for dev UI access).
- `deploy/kind/up.sh --with-argo` — installs `argo-cd 7.7.0` from the argo-helm repo, applies the ApplicationSet, two-step polls each Application to Synced + Healthy, then exec-smoke-tests each world. `--with-broker` and `--with-argo` are mutually exclusive (broker chart values hard-wire `world-default`; multi-world broker wiring is a follow-up).

### Drift gotcha worth noting

First end-to-end run looped on "Partial sync" — Kubernetes injects `apiVersion`/`kind`/`volumeMode: Filesystem`/`status: phase: Pending` into the StatefulSet's `volumeClaimTemplates` after admission, and `ServerSideApply=true` does not normalize that. Fix is `ignoreDifferences` against `/spec/volumeClaimTemplates` on `apps/StatefulSet`. Costs nothing operationally because `volumeClaimTemplates` is immutable on a StatefulSet (storage size changes already require recreate). Dropped `ServerSideApply=true` at the same time — the chart works fine with client-side apply and SSA wasn't earning its keep.

### Architectural choice

Single ApplicationSet + default AppProject, **not** Application-per-world + per-world AppProject. AppProject RBAC only pays off when bound to an identity-provider user model that a kind dev cluster doesn't have; whatever AppProject the example ships would be replaced wholesale by a customer's IdP-tied story. A `appproject-example.yaml` follow-up showing the production-shaped extension stays open.

## Test plan

- [x] `bash -n deploy/kind/up.sh` syntax-checks clean
- [x] `deploy/kind/up.sh --help` shows both `--with-broker` and `--with-argo`
- [x] `deploy/kind/up.sh --with-broker --with-argo` rejects the combo with exit 2
- [x] Clean-slate `deploy/kind/up.sh --with-argo`: kind cluster → argocd installed → ApplicationSet applied → both Applications Synced + Healthy → smoke-test fetch round-trip against world-a and world-b each returns the documented Stage 1 `not-found` (CLI exit 0, protocol round-trip success)
- [x] `deploy/kind/down.sh` cleanly tears down the cluster
- [x] `bash pre-commit.sh` clean across protocol/server/client/tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Argo CD integration to deploy apps across multiple "world" namespaces with automated sync, pruning, self-heal and health monitoring.
  * Introduced a deploy-harness option to enable Argo CD setup with per-world smoke tests.
  * Enabled OCI registry chart access and configured the local Argo Server to use plain HTTP for the kind stage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/131)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->