### PR TITLE
feat(tools): add insecureCookies dev mode to broker

### DIFF
--- a/deploy/helm/demarkus-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-config.yaml
@@ -50,6 +50,7 @@ stringData:
       stateTTL: {{ .Values.server.stateTTL | quote }}
       brokerNamespace: {{ include "demarkus-broker.brokerNamespace" . | quote }}
       issuancesSecret: {{ include "demarkus-broker.issuancesSecretName" . | quote }}
+      insecureCookies: {{ .Values.server.insecureCookies }}
     oidc:
       issuer: {{ required "oidc.issuer is required" .Values.oidc.issuer | quote }}
       clientID: {{ required "oidc.clientID is required" .Values.oidc.clientID | quote }}

--- a/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
@@ -43,6 +43,23 @@ tests:
           path: stringData["config.yaml"]
           pattern: 'sweeper:\s*\n\s*disabled: false\s*\n\s*interval: "5m"\s*\n\s*leaseName: "demarkus-broker-sweeper"'
 
+  - it: insecureCookies defaults to false (production-correct)
+    set:
+      oidc.clientSecret: shh
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'insecureCookies: false'
+
+  - it: insecureCookies override flows through to rendered config
+    set:
+      oidc.clientSecret: shh
+      server.insecureCookies: true
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'insecureCookies: true'
+
   - it: existingSecretRef path leaves clientSecret blank in rendered config
     set:
       oidc.existingSecretRef.name: my-oidc-secret

--- a/deploy/helm/demarkus-broker/values.yaml
+++ b/deploy/helm/demarkus-broker/values.yaml
@@ -48,6 +48,17 @@ server:
   # `helm uninstall` never wipe broker-minted issuance records.
   issuancesSecret: ""
 
+  # DEV-ONLY: drop the Secure attribute on the OIDC state cookie.
+  # Default false. Flip to true only for local / kind harnesses where the
+  # broker is reachable over plain HTTP and the Secure attribute would
+  # prevent the cookie jar from replaying the state on /auth/callback.
+  # Enabling this in a production deployment turns the state cookie into
+  # a downgrade-attack surface — any plaintext-hijacked redirect can
+  # complete the OIDC dance. Production deployments terminate TLS at the
+  # Ingress, in which case this stays false and the cookie's Secure
+  # attribute is honored end-to-end.
+  insecureCookies: false
+
 oidc:
   # OIDC discovery URL (e.g. https://accounts.google.com).
   issuer: ""

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -45,6 +45,14 @@ type ServerConfig struct {
 	// label → {email, world, paths, ...} map (JSON-encoded). World servers
 	// never read this Secret.
 	IssuancesSecret string `yaml:"issuancesSecret"`
+	// InsecureCookies drops the Secure attribute on the OIDC state cookie.
+	// Default false (production-correct: state cookies travel over HTTPS
+	// only). Flip to true ONLY for kind / local dev where the broker is
+	// reachable over plain HTTP and the Secure attribute would prevent the
+	// cookie jar from replaying it on /auth/callback. Enabling this in a
+	// real deployment turns the state cookie into a downgrade attack vector
+	// — any plaintext-hijacked redirect can complete the OIDC dance.
+	InsecureCookies bool `yaml:"insecureCookies"`
 }
 
 // OIDCConfig describes the OIDC client registration at the IdP. Discovery

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -131,7 +131,7 @@ func (s *Server) authLogin(w http.ResponseWriter, r *http.Request) {
 		Value:    signed,
 		Path:     "/auth/callback",
 		HttpOnly: true,
-		Secure:   true,
+		Secure:   !s.cfg.Server.InsecureCookies,
 		SameSite: http.SameSiteLaxMode,
 		Expires:  state.ExpiresAt,
 		MaxAge:   int(s.cfg.Server.StateTTL.Seconds()),
@@ -168,7 +168,7 @@ func (s *Server) authCallback(w http.ResponseWriter, r *http.Request) {
 		Value:    "",
 		Path:     "/auth/callback",
 		HttpOnly: true,
-		Secure:   true,
+		Secure:   !s.cfg.Server.InsecureCookies,
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   -1,
 	})

--- a/tools/demarkus-broker/internal/broker/server_test.go
+++ b/tools/demarkus-broker/internal/broker/server_test.go
@@ -108,37 +108,6 @@ func TestAuthLoginRedirectsAndSetsStateCookie(t *testing.T) {
 	}
 }
 
-func TestAuthLoginInsecureCookiesDropsSecureFlag(t *testing.T) {
-	cfg := testConfig()
-	cfg.Server.InsecureCookies = true
-	verifier := &fakeVerifier{authURL: "https://idp.example.com/authorize"}
-	srv, _ := newTestServer(t, cfg, verifier, fake.NewSimpleClientset())
-
-	client := testClient(srv)
-	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
-	resp, err := client.Get(srv.URL + "/auth/login")
-	if err != nil {
-		t.Fatalf("GET /auth/login: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	var stateCookie *http.Cookie
-	for _, c := range resp.Cookies() {
-		if c.Name == stateCookieName {
-			stateCookie = c
-			break
-		}
-	}
-	if stateCookie == nil {
-		t.Fatal("state cookie not set")
-	}
-	if !stateCookie.HttpOnly {
-		t.Errorf("HttpOnly = false, want true (insecureCookies only drops Secure)")
-	}
-	if stateCookie.Secure {
-		t.Errorf("Secure = true, want false when InsecureCookies is set")
-	}
-}
-
 // loginAndExtract simulates the /auth/login leg of the OIDC flow and
 // returns a client whose cookie jar holds the state cookie, plus the
 // nonce from the IdP redirect URL. Callers issue the /auth/callback
@@ -185,6 +154,99 @@ func loginAndExtract(t *testing.T, srv *httptest.Server) (client *http.Client, n
 		t.Fatalf("state cookie not retained by jar — check Secure/Path attributes")
 	}
 	return client, nonce
+}
+
+// TestStateCookieSecureMatchesInsecureCookiesFlag locks BOTH cookie-writing
+// sites (the set on /auth/login and the clear on /auth/callback) against
+// the same flag, so a future change that flips only one is caught here.
+func TestStateCookieSecureMatchesInsecureCookiesFlag(t *testing.T) {
+	tests := []struct {
+		name            string
+		insecureCookies bool
+		wantSecure      bool
+	}{
+		{"default keeps Secure=true on set and clear", false, true},
+		{"InsecureCookies drops Secure on set and clear", true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfig()
+			cfg.Server.InsecureCookies = tt.insecureCookies
+			verifier := &fakeVerifier{
+				authURL: "https://idp.example.com/authorize",
+				claims:  Claims{Email: "alice@example.com", EmailVerified: true, Subject: "google|123"},
+			}
+			srv, _ := newTestServer(t, cfg, verifier, fake.NewSimpleClientset())
+
+			// Single /auth/login so the jar captures one state cookie
+			// whose nonce we can replay on /auth/callback. A second
+			// /auth/login would rotate the nonce and the callback would
+			// fail at the state-mismatch guard before reaching the
+			// clear-cookie write.
+			jar, err := cookiejar.New(nil)
+			if err != nil {
+				t.Fatalf("cookiejar.New: %v", err)
+			}
+			client := testClient(srv)
+			client.Jar = jar
+			client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+			loginResp, err := client.Get(srv.URL + "/auth/login")
+			if err != nil {
+				t.Fatalf("GET /auth/login: %v", err)
+			}
+			_ = loginResp.Body.Close()
+			setCookie := findStateCookie(loginResp.Cookies())
+			if setCookie == nil {
+				t.Fatal("state cookie not set on /auth/login")
+			}
+			if setCookie.Secure != tt.wantSecure {
+				t.Errorf("login Secure = %v, want %v", setCookie.Secure, tt.wantSecure)
+			}
+			loc, err := url.Parse(loginResp.Header.Get("Location"))
+			if err != nil {
+				t.Fatalf("parse redirect Location: %v", err)
+			}
+			nonce := loc.Query().Get("state")
+			if nonce == "" {
+				t.Fatalf("missing state nonce after /auth/login")
+			}
+
+			// /auth/callback emits a clearing Set-Cookie with MaxAge<0
+			// using the same Secure flag. Verifying it here is the
+			// load-bearing assertion: without this, a regression on the
+			// clear path would slip past the login-path test.
+			req, _ := http.NewRequest(http.MethodGet,
+				srv.URL+"/auth/callback?code=abc&state="+url.QueryEscape(nonce), http.NoBody)
+			cbResp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("callback: %v", err)
+			}
+			_ = cbResp.Body.Close()
+			if cbResp.StatusCode != http.StatusOK {
+				t.Fatalf("callback status = %d, want 200 (so clear-cookie write is reached)", cbResp.StatusCode)
+			}
+			clearCookie := findStateCookie(cbResp.Cookies())
+			if clearCookie == nil {
+				t.Fatal("state cookie not cleared on /auth/callback")
+			}
+			if clearCookie.MaxAge >= 0 {
+				t.Errorf("clear MaxAge = %d, want < 0 (cookie should be cleared)", clearCookie.MaxAge)
+			}
+			if clearCookie.Secure != tt.wantSecure {
+				t.Errorf("callback clear Secure = %v, want %v", clearCookie.Secure, tt.wantSecure)
+			}
+		})
+	}
+}
+
+func findStateCookie(cookies []*http.Cookie) *http.Cookie {
+	for _, c := range cookies {
+		if c.Name == stateCookieName {
+			return c
+		}
+	}
+	return nil
 }
 
 func TestAuthCallbackSuccess(t *testing.T) {

--- a/tools/demarkus-broker/internal/broker/server_test.go
+++ b/tools/demarkus-broker/internal/broker/server_test.go
@@ -108,6 +108,37 @@ func TestAuthLoginRedirectsAndSetsStateCookie(t *testing.T) {
 	}
 }
 
+func TestAuthLoginInsecureCookiesDropsSecureFlag(t *testing.T) {
+	cfg := testConfig()
+	cfg.Server.InsecureCookies = true
+	verifier := &fakeVerifier{authURL: "https://idp.example.com/authorize"}
+	srv, _ := newTestServer(t, cfg, verifier, fake.NewSimpleClientset())
+
+	client := testClient(srv)
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	resp, err := client.Get(srv.URL + "/auth/login")
+	if err != nil {
+		t.Fatalf("GET /auth/login: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var stateCookie *http.Cookie
+	for _, c := range resp.Cookies() {
+		if c.Name == stateCookieName {
+			stateCookie = c
+			break
+		}
+	}
+	if stateCookie == nil {
+		t.Fatal("state cookie not set")
+	}
+	if !stateCookie.HttpOnly {
+		t.Errorf("HttpOnly = false, want true (insecureCookies only drops Secure)")
+	}
+	if stateCookie.Secure {
+		t.Errorf("Secure = true, want false when InsecureCookies is set")
+	}
+}
+
 // loginAndExtract simulates the /auth/login leg of the OIDC flow and
 // returns a client whose cookie jar holds the state cookie, plus the
 // nonce from the IdP redirect URL. Callers issue the /auth/callback


### PR DESCRIPTION
## Summary

Drops the \`Secure\` attribute on the OIDC state cookie when \`server.insecureCookies: true\` is set in the broker's config (default: false). Intended for the kind harness (Stage 4 mint-flow smoke test) where the broker is reachable only over plain HTTP and the \`Secure\` attribute prevents a cookie jar from replaying state on \`/auth/callback\`. Production deployments terminate TLS at the Ingress, keep the default false, and the \`Secure\` attribute is honored end-to-end.

- \`ServerConfig.InsecureCookies\` (\`yaml:"insecureCookies"\`) added; load path is the existing YAML config Secret — no new env-var surface.
- Two cookie write sites in \`server.go\` (auth/login set + auth/callback clear) now compute \`Secure: !s.cfg.Server.InsecureCookies\`.
- Chart \`server.insecureCookies\` value (default \`false\`) renders into the config Secret. Doc comment explicit about the downgrade-attack surface in production.

### Why this rather than TLS in kind

Discussed in design before coding. Production-fidelity TLS in kind (ingress-nginx + cert-manager + per-pod \`hostAliases\` + CA-bundle injection) requires sizeable chart-template extensions (\`extraVolumes\`, \`hostAliases\`, \`extraEnv\`) that exist *only* to paper over kind's self-signed-and-no-DNS environment — exactly the kind of leaky abstraction the chart shouldn't grow. A small documented DEV-ONLY flag is a cleaner fit: kind harness opts in, production never does. Matches the pattern of \`argo-cd\`'s \`server.insecure: true\` already used by Stage 3.

## Test plan

- [x] \`go test ./tools/demarkus-broker/...\` — full broker suite green (existing tests cover the default \`Secure=true\` path; new test \`TestAuthLoginInsecureCookiesDropsSecureFlag\` covers the flipped flag)
- [x] \`helm unittest deploy/helm/demarkus-broker\` — 51 tests pass including two new \`secret-config\` assertions (default false renders explicitly, override flows through)
- [x] \`bash pre-commit.sh\` — fmt/vet/lint clean across all modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to control the OIDC state cookie's Secure attribute (defaults to secure; can be enabled for local/non‑HTTPS scenarios).

* **Tests**
  * Added tests validating default and enabled behaviors, including rendered config and end‑to‑end cookie write/clear behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/132)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->