### PR TITLE
fix(release): skip QEMU compile by pre-staging binaries for Docker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,10 +293,36 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GORELEASER_CURRENT_TAG: "server/v${{ needs.semver-server.outputs.new_version }}"
 
-      # Multi-stage Dockerfile compiles binaries from source; build context
-      # is the repo root because the server image bundles demarkus + demarkus-
-      # server which live in different go modules. Versions are stamped via
-      # build-args. Multi-arch matches the goreleaser binary matrix.
+      # Stage pre-built binaries into dist/docker/<arch>/ so the Dockerfile
+      # is COPY-only and buildx skips QEMU compilation entirely. demarkus-
+      # server comes from server/.goreleaser.yml above; demarkus CLI lives
+      # in client/ and isn't part of that goreleaser run, so we native
+      # cross-compile it inline (fast — no QEMU because the runner is
+      # amd64 and Go natively cross-compiles to any GOARCH).
+      - name: Stage binaries for Docker build
+        run: |
+          set -euxo pipefail
+          ls dist/
+          mkdir -p dist/docker/amd64 dist/docker/arm64 dist/docker/armv7
+
+          cp dist/demarkus-server_linux_amd64*/demarkus-server dist/docker/amd64/
+          cp dist/demarkus-server_linux_arm64*/demarkus-server dist/docker/arm64/
+          cp dist/demarkus-server_linux_arm_7*/demarkus-server dist/docker/armv7/
+
+          VER="${{ needs.semver-server.outputs.new_version }}"
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+            go build -C client -ldflags="-s -w -X main.version=$VER" \
+              -o ../dist/docker/amd64/demarkus ./cmd/demarkus
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
+            go build -C client -ldflags="-s -w -X main.version=$VER" \
+              -o ../dist/docker/arm64/demarkus ./cmd/demarkus
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 \
+            go build -C client -ldflags="-s -w -X main.version=$VER" \
+              -o ../dist/docker/armv7/demarkus ./cmd/demarkus
+
+      # Dockerfile is COPY-only over the staged binaries above. Multi-arch
+      # build under QEMU completes in seconds because no Go compile runs
+      # under emulation.
       - name: Build + push demarkus-server image
         uses: docker/build-push-action@v6
         with:
@@ -307,8 +333,6 @@ jobs:
           tags: |
             ghcr.io/latebit-io/demarkus-server:${{ needs.semver-server.outputs.new_version }}
             ghcr.io/latebit-io/demarkus-server:latest
-          build-args: |
-            VERSION=${{ needs.semver-server.outputs.new_version }}
 
       # Chart version + appVersion are pinned 1:1 to the server module
       # version so `helm install ghcr.io/.../charts/demarkus-server --version
@@ -372,10 +396,21 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GORELEASER_CURRENT_TAG: "client/v${{ needs.semver-client.outputs.new_version }}"
 
+      # Stage pre-built agent binaries (built by client/.goreleaser.yml's
+      # demarkus-agent build entry, image-only — no archive) into
+      # dist/docker/<arch>/ so the Dockerfile is COPY-only and buildx
+      # skips QEMU compilation.
+      - name: Stage binaries for Docker build
+        run: |
+          set -euxo pipefail
+          ls dist/
+          mkdir -p dist/docker/amd64 dist/docker/arm64 dist/docker/armv7
+          cp dist/demarkus-agent_linux_amd64*/demarkus-agent dist/docker/amd64/
+          cp dist/demarkus-agent_linux_arm64*/demarkus-agent dist/docker/arm64/
+          cp dist/demarkus-agent_linux_arm_7*/demarkus-agent dist/docker/armv7/
+
       # demarkus-agent lives in client/cmd/ so it rides the client release
-      # cadence. Multi-stage Dockerfile compiles from source; context is the
-      # repo root because the agent module's tools/ replace directive needs
-      # protocol/ alongside.
+      # cadence. Dockerfile is COPY-only over the staged binaries above.
       - name: Build + push demarkus-agent image
         uses: docker/build-push-action@v6
         with:
@@ -386,8 +421,6 @@ jobs:
           tags: |
             ghcr.io/latebit-io/demarkus-agent:${{ needs.semver-client.outputs.new_version }}
             ghcr.io/latebit-io/demarkus-agent:latest
-          build-args: |
-            VERSION=${{ needs.semver-client.outputs.new_version }}
 
       # Chart version + appVersion pinned 1:1 to the client module version
       # so the agent chart and the agent image released in the same module
@@ -450,10 +483,22 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GORELEASER_CURRENT_TAG: "tools/v${{ needs.semver-tools.outputs.new_version }}"
 
+      # Stage pre-built broker binary (built by tools/.goreleaser.yml
+      # above) into dist/docker/<arch>/ so the Dockerfile is COPY-only
+      # and buildx skips QEMU compilation.
+      - name: Stage binaries for Docker build
+        run: |
+          set -euxo pipefail
+          ls dist/
+          mkdir -p dist/docker/amd64 dist/docker/arm64 dist/docker/armv7
+          cp dist/demarkus-broker_linux_amd64*/demarkus-broker dist/docker/amd64/
+          cp dist/demarkus-broker_linux_arm64*/demarkus-broker dist/docker/arm64/
+          cp dist/demarkus-broker_linux_arm_7*/demarkus-broker dist/docker/armv7/
+
       # demarkus-broker is the only runtime image in tools/. Admin CLIs
       # (demarkus-token, demarkus-publish) ship as standalone binary archives
       # via goreleaser above and are not bundled into any image — see §6.7.A
-      # decisions on minimal pod blast radius.
+      # decisions on minimal pod blast radius. Dockerfile is COPY-only.
       - name: Build + push demarkus-broker image
         uses: docker/build-push-action@v6
         with:
@@ -464,8 +509,6 @@ jobs:
           tags: |
             ghcr.io/latebit-io/demarkus-broker:${{ needs.semver-tools.outputs.new_version }}
             ghcr.io/latebit-io/demarkus-broker:latest
-          build-args: |
-            VERSION=${{ needs.semver-tools.outputs.new_version }}
 
       # Chart version + appVersion pinned 1:1 to the tools module version so
       # the broker chart and the broker image released in the same bump

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ server/bin/
 client/bin/
 tools/bin/
 
+# goreleaser output + Docker build staging dir (image targets cross-
+# compile binaries here before invoking `docker build`).
+dist/
+
 # Stray binaries (built without -o flag)
 client/demarkus
 client/demarkus-tui

--- a/Makefile
+++ b/Makefile
@@ -58,27 +58,36 @@ tools: protocol
 # carries only the binaries it needs at runtime. Admin CLIs are NOT
 # bundled — they ship as standalone binaries via goreleaser archives.
 #
-# Each Dockerfile uses repo root as build context so it can reach across
-# go module boundaries (server image needs both server/ and client/ for
-# the CLI used by exec probes).
+# Each Dockerfile expects pre-built binaries in dist/docker/<arch>/ —
+# the targets below cross-compile natively (fast — no QEMU) for HOST_ARCH
+# before invoking `docker build`. Multi-arch matrix builds happen in the
+# release workflow via the same staging pattern.
 IMAGE_REGISTRY ?= ghcr.io/latebit-io
 TAG            ?= dev
+HOST_ARCH      ?= $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 
 image: image-server image-broker image-agent
 
 image-server:
-	@echo "Building $(IMAGE_REGISTRY)/demarkus-server:$(TAG)..."
-	docker build --build-arg VERSION=$(VERSION) -f server/Dockerfile -t $(IMAGE_REGISTRY)/demarkus-server:$(TAG) .
+	@echo "Building $(IMAGE_REGISTRY)/demarkus-server:$(TAG) for linux/$(HOST_ARCH)..."
+	@mkdir -p dist/docker/$(HOST_ARCH)
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(HOST_ARCH) go build -C server -ldflags "-s -w -X main.version=$(VERSION)" -o ../dist/docker/$(HOST_ARCH)/demarkus-server ./cmd/demarkus-server
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(HOST_ARCH) go build -C client -ldflags "-s -w -X main.version=$(VERSION)" -o ../dist/docker/$(HOST_ARCH)/demarkus ./cmd/demarkus
+	docker build --build-arg TARGETARCH=$(HOST_ARCH) -f server/Dockerfile -t $(IMAGE_REGISTRY)/demarkus-server:$(TAG) .
 	@echo "✓ Image built: $(IMAGE_REGISTRY)/demarkus-server:$(TAG)"
 
 image-broker:
-	@echo "Building $(IMAGE_REGISTRY)/demarkus-broker:$(TAG)..."
-	docker build --build-arg VERSION=$(VERSION) -f tools/demarkus-broker/Dockerfile -t $(IMAGE_REGISTRY)/demarkus-broker:$(TAG) .
+	@echo "Building $(IMAGE_REGISTRY)/demarkus-broker:$(TAG) for linux/$(HOST_ARCH)..."
+	@mkdir -p dist/docker/$(HOST_ARCH)
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(HOST_ARCH) go build -C tools -ldflags "-s -w -X main.version=$(VERSION)" -o ../dist/docker/$(HOST_ARCH)/demarkus-broker ./demarkus-broker
+	docker build --build-arg TARGETARCH=$(HOST_ARCH) -f tools/demarkus-broker/Dockerfile -t $(IMAGE_REGISTRY)/demarkus-broker:$(TAG) .
 	@echo "✓ Image built: $(IMAGE_REGISTRY)/demarkus-broker:$(TAG)"
 
 image-agent:
-	@echo "Building $(IMAGE_REGISTRY)/demarkus-agent:$(TAG)..."
-	docker build --build-arg VERSION=$(VERSION) -f client/cmd/demarkus-agent/Dockerfile -t $(IMAGE_REGISTRY)/demarkus-agent:$(TAG) .
+	@echo "Building $(IMAGE_REGISTRY)/demarkus-agent:$(TAG) for linux/$(HOST_ARCH)..."
+	@mkdir -p dist/docker/$(HOST_ARCH)
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(HOST_ARCH) go build -C client -ldflags "-s -w -X main.version=$(VERSION)" -o ../dist/docker/$(HOST_ARCH)/demarkus-agent ./cmd/demarkus-agent
+	docker build --build-arg TARGETARCH=$(HOST_ARCH) -f client/cmd/demarkus-agent/Dockerfile -t $(IMAGE_REGISTRY)/demarkus-agent:$(TAG) .
 	@echo "✓ Image built: $(IMAGE_REGISTRY)/demarkus-agent:$(TAG)"
 
 # Run tests
@@ -92,7 +101,7 @@ test:
 # Clean build artifacts
 clean:
 	@echo "Cleaning build artifacts..."
-	@rm -rf server/bin client/bin tools/bin
+	@rm -rf server/bin client/bin tools/bin dist
 	@cd protocol && go clean
 	@cd server && go clean
 	@cd client && go clean

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ tools: protocol
 # release workflow via the same staging pattern.
 IMAGE_REGISTRY ?= ghcr.io/latebit-io
 TAG            ?= dev
-HOST_ARCH      ?= $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+HOST_ARCH      ?= $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/;s/armv7l/arm/')
 
 image: image-server image-broker image-agent
 

--- a/client/.goreleaser.yml
+++ b/client/.goreleaser.yml
@@ -58,6 +58,26 @@ builds:
     ldflags:
       - -s -w
 
+  # demarkus-agent ships only as a container image (release-client job
+  # bundles it into ghcr.io/.../demarkus-agent). Listed under builds:
+  # so goreleaser cross-compiles per-arch binaries that the Dockerfile
+  # then COPYs in — no archive entry, no end-user binary tarball.
+  - id: demarkus-agent
+    main: ./cmd/demarkus-agent
+    binary: demarkus-agent
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - "7"
+    ldflags:
+      - -s -w
+
 archives:
   - id: demarkus
     builds:

--- a/client/cmd/demarkus-agent/Dockerfile
+++ b/client/cmd/demarkus-agent/Dockerfile
@@ -1,35 +1,25 @@
 # demarkus-agent image. The agent is a daemon crawler with no probes
-# today (per chart values default), so the CLI is not bundled. If
-# probes are added later, this Dockerfile can grow to bundle /demarkus
-# alongside the agent.
+# today (per chart values default), so the CLI is not bundled.
 #
-# Build context = repo root so the protocol/ module is reachable via
-# the client/ replace directive:
-#   docker build -f client/cmd/demarkus-agent/Dockerfile -t demarkus-agent:dev .
+# Pre-built binary is staged into dist/docker/<arch>/ by the release
+# workflow (and by `make image-agent` for local dev). The Dockerfile is
+# COPY-only — no `RUN` step — so a buildx multi-arch build under QEMU
+# completes in seconds instead of minutes.
+#
+# Base is distroless/static:nonroot — it ships /etc/ssl/certs/ca-certificates.crt
+# so the agent's outbound mark:// crawls validate peer TLS when the
+# chart's `insecure: false` production default is on. Runs as UID 65532
+# by default; defense-in-depth USER matches the chart's
+# podSecurityContext.runAsUser.
+#
+# Build context = repo root. Staged paths the Dockerfile expects:
+#   dist/docker/amd64/demarkus-agent
+#   dist/docker/arm64/demarkus-agent
+#   dist/docker/armv7/demarkus-agent
 
-FROM golang:1.26-alpine AS build
-WORKDIR /src
-
-COPY protocol/go.mod protocol/go.sum protocol/
-COPY client/go.mod   client/go.sum   client/
-
-COPY protocol/ protocol/
-COPY client/   client/
-
-ARG VERSION=dev
-ENV CGO_ENABLED=0
-
-RUN go build -C client -ldflags="-s -w -X main.version=${VERSION}" -o /out/demarkus-agent ./cmd/demarkus-agent
-
-FROM scratch
-# Trust store for outbound TLS. The agent crawls remote mark:// servers
-# whose QUIC TLS certificates require validation when `insecure: false`
-# (the chart's production default). Without this bundle, the agent's
-# fetch handshakes fail against any non-self-signed peer.
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=build /out/demarkus-agent /demarkus-agent
-# Match the chart's podSecurityContext.runAsUser so the image runs
-# non-root even when deployed outside k8s. Defense-in-depth on top of
-# the chart's runAsNonRoot: true.
+FROM gcr.io/distroless/static-debian12:nonroot
+ARG TARGETARCH
+ARG TARGETVARIANT
+COPY dist/docker/${TARGETARCH}${TARGETVARIANT}/demarkus-agent /demarkus-agent
 USER 65532:65532
 ENTRYPOINT ["/demarkus-agent"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,41 +3,28 @@
 #   /demarkus         — CLI; the helm chart's exec probes invoke it
 #                       against the local server's agent-manifest path
 #
-# Admin CLIs (demarkus-token, demarkus-publish) are NOT bundled —
-# they ship as standalone binaries via tools/.goreleaser.yml so the
-# running server pod's blast radius stays minimal. Operators run them
-# locally or in dedicated Job pods, not via kubectl exec.
+# Pre-built binaries are staged into dist/docker/<arch>/ by the release
+# workflow (and by `make image-server` for local dev). The Dockerfile is
+# COPY-only — no `RUN` step — so a buildx multi-arch build under QEMU
+# completes in seconds instead of minutes (no Go compile under emulation).
 #
-# Build context = repo root so the multi-module source tree
-# (protocol/ + server/ + client/) is reachable from one Dockerfile:
-#   docker build -f server/Dockerfile -t demarkus-server:dev .
+# Build context = repo root. Staged paths the Dockerfile expects:
+#   dist/docker/amd64/{demarkus-server,demarkus}
+#   dist/docker/arm64/{demarkus-server,demarkus}
+#   dist/docker/armv7/{demarkus-server,demarkus}
 #
-# Smoke-tested end-to-end via deploy/kind/up.sh.
-
-FROM golang:1.26-alpine AS build
-WORKDIR /src
-
-COPY protocol/go.mod protocol/go.sum protocol/
-COPY server/go.mod   server/go.sum   server/
-COPY client/go.mod   client/go.sum   client/
-
-COPY protocol/ protocol/
-COPY server/   server/
-COPY client/   client/
-
-ARG VERSION=dev
-ENV CGO_ENABLED=0
-
-RUN go build -C server -ldflags="-s -w -X main.version=${VERSION}" -o /out/demarkus-server ./cmd/demarkus-server
-RUN go build -C client -ldflags="-s -w -X main.version=${VERSION}" -o /out/demarkus        ./cmd/demarkus
+# Admin CLIs (demarkus-token, demarkus-publish) are NOT bundled — they
+# ship as standalone binaries via tools/.goreleaser.yml so the running
+# server pod's blast radius stays minimal.
 
 FROM scratch
-COPY --from=build /out/demarkus-server /demarkus-server
-COPY --from=build /out/demarkus        /demarkus
+ARG TARGETARCH
+ARG TARGETVARIANT
+COPY dist/docker/${TARGETARCH}${TARGETVARIANT}/demarkus-server /demarkus-server
+COPY dist/docker/${TARGETARCH}${TARGETVARIANT}/demarkus        /demarkus
 # Match the chart's podSecurityContext.runAsUser so the image runs
 # non-root even when deployed outside k8s (plain `docker run`, CI
-# runners, etc.). The chart enforces this via runAsNonRoot: true; the
-# Dockerfile-level USER is defense-in-depth.
+# runners, etc.). Defense-in-depth on top of the chart's runAsNonRoot.
 USER 65532:65532
 EXPOSE 6309/udp
 ENTRYPOINT ["/demarkus-server"]

--- a/tools/demarkus-broker/Dockerfile
+++ b/tools/demarkus-broker/Dockerfile
@@ -1,36 +1,24 @@
 # demarkus-broker image. Single binary; the broker is HTTP-only and uses
 # HTTP /healthz + /readyz probes, so the CLI is not bundled.
 #
-# Build context = repo root so the protocol/ module is reachable via the
-# tools/ replace directive:
-#   docker build -f tools/demarkus-broker/Dockerfile -t demarkus-broker:dev .
+# Pre-built binary is staged into dist/docker/<arch>/ by the release
+# workflow (and by `make image-broker` for local dev). The Dockerfile is
+# COPY-only — no `RUN` step — so a buildx multi-arch build under QEMU
+# completes in seconds instead of minutes.
 #
-# Smoke-tested end-to-end on kind via deploy/kind/up.sh --with-broker,
-# which discovers against an in-cluster mock OIDC issuer.
+# Base is distroless/static:nonroot — it ships /etc/ssl/certs/ca-certificates.crt
+# for the broker's outbound HTTPS to the OIDC issuer (discovery + token
+# exchange), and runs as UID 65532 by default. Defense-in-depth USER
+# directive matches the chart's podSecurityContext.runAsUser.
+#
+# Build context = repo root. Staged paths the Dockerfile expects:
+#   dist/docker/amd64/demarkus-broker
+#   dist/docker/arm64/demarkus-broker
+#   dist/docker/armv7/demarkus-broker
 
-FROM golang:1.26-alpine AS build
-WORKDIR /src
-
-COPY protocol/go.mod protocol/go.sum protocol/
-COPY tools/go.mod    tools/go.sum    tools/
-
-COPY protocol/ protocol/
-COPY tools/    tools/
-
-ARG VERSION=dev
-ENV CGO_ENABLED=0
-
-RUN go build -C tools -ldflags="-s -w -X main.version=${VERSION}" -o /out/demarkus-broker ./demarkus-broker
-
-FROM scratch
-# Trust store for outbound TLS. The broker calls the OIDC issuer's
-# discovery (.well-known/openid-configuration) and token endpoints over
-# HTTPS; without /etc/ssl/certs/ca-certificates.crt, Go's TLS handshake
-# fails certificate validation against the IdP.
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=build /out/demarkus-broker /demarkus-broker
-# Match the chart's podSecurityContext.runAsUser so the image runs
-# non-root even when deployed outside k8s. Defense-in-depth on top of
-# the chart's runAsNonRoot: true.
+FROM gcr.io/distroless/static-debian12:nonroot
+ARG TARGETARCH
+ARG TARGETVARIANT
+COPY dist/docker/${TARGETARCH}${TARGETVARIANT}/demarkus-broker /demarkus-broker
 USER 65532:65532
 ENTRYPOINT ["/demarkus-broker"]


### PR DESCRIPTION
## Summary

The release pipeline took ~30 minutes per module because the Dockerfiles ran a multi-stage `RUN go build ...` *inside* the container. Under `docker/build-push-action` with `platforms: linux/amd64,linux/arm64,linux/arm/v7`, the arm64 and arm/v7 builds were compiling Go from source under QEMU emulation — wall-clock disaster.

Rework: pre-build binaries outside Docker (goreleaser already cross-compiles natively), stage them per-arch, and let the Dockerfile be COPY-only. buildx multi-arch is still in play, but each per-arch image is just file copies + metadata — no execution, no QEMU overhead.

### Changes

- **Dockerfiles** are now COPY-only:
  - `server/Dockerfile` — `FROM scratch` + COPY pre-built `demarkus-server` and `demarkus` CLI.
  - `tools/demarkus-broker/Dockerfile` — `FROM gcr.io/distroless/static-debian12:nonroot` (ships CA bundle for outbound HTTPS to OIDC issuer) + COPY pre-built broker.
  - `client/cmd/demarkus-agent/Dockerfile` — same distroless base + COPY pre-built agent.
- **`.github/workflows/release.yml`** — each release job adds a "Stage binaries for Docker build" step before `docker/build-push-action`. Server's step also natively cross-compiles `demarkus` from `client/` inline (the demarkus CLI lives in client/ but ships in the server image; goreleaser's server config doesn't build it).
- **`client/.goreleaser.yml`** gains a `demarkus-agent` `builds:` entry (image-only; no `archives:` entry, no end-user tarball). The binary lands in `dist/` for the staging step.
- **`Makefile`** `image-*` targets cross-compile + stage for `HOST_ARCH` (host arch auto-detected) before invoking `docker build`. Local dev story is symmetric to the release flow.
- **`.gitignore`** — `dist/` added so staged binaries don't pollute the working tree.

### Image semantics unchanged

Same binaries, same `USER 65532:65532`, same `ENTRYPOINT`. Sizes:

| Image | Size | Why |
| --- | --- | --- |
| demarkus-server | 14.6 MB | scratch + 7.2MB server + 7.4MB CLI |
| demarkus-broker | 28.2 MB | distroless 2MB + 26MB broker binary (k8s-client-go + OIDC) |
| demarkus-agent | 9.4 MB | distroless 2MB + 7.3MB agent |

Broker's bulk is the binary itself, not base bloat.

## Test plan

- [x] `make image` builds all three images locally — completes in ~10s total (was ~30s under the previous Go compile inside Docker, even single-arch).
- [x] `docker run --rm <image> -help` exits cleanly for all three images.
- [x] `docker run --rm --entrypoint /demarkus <server-image> ...` exercises the bundled CLI in the server image (still present, still callable from the chart's exec probes).
- [x] `bash pre-commit.sh` clean.
- [ ] Multi-arch wall-clock win is verifiable only after merge — expect each release job's Docker step to drop from ~30 min to seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined container build pipeline by staging prebuilt binaries and using lightweight distroless bases, reducing image sizes and build time.
  * Improved multi‑architecture support to produce consistent images for common CPU platforms.
  * Updated build and packaging flow for more reliable, maintainable container releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/133)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->