### PR TITLE
fix(deploy): Add Stage 4 mode with broker deployment and OIDC validation

### DIFF
--- a/deploy/k8s/examples/applicationset.yaml
+++ b/deploy/k8s/examples/applicationset.yaml
@@ -56,11 +56,23 @@ spec:
       # StatefulSet, so ignoring drift on the whole block costs nothing
       # operationally and prevents Argo from looping on a sync it can never
       # converge.
+      #
+      # The world's tokens Secret holds runtime state — the demarkus-broker
+      # appends per-mint hash entries to data.tokens.toml. Without ignoring
+      # /data, Argo's selfHeal would revert every mint immediately back to
+      # the chart-rendered admin-only contents (resourceVersion churns, but
+      # the broker's writes never stick). Ignoring /data leaves the chart
+      # in charge of the Secret's existence + initial admin token while
+      # letting the broker own its lifecycle from then on.
       ignoreDifferences:
         - group: apps
           kind: StatefulSet
           jsonPointers:
             - /spec/volumeClaimTemplates
+        - kind: Secret
+          name: "{{name}}-demarkus-server-tokens"
+          jsonPointers:
+            - /data
       syncPolicy:
         automated:
           prune: true

--- a/deploy/kind/mock-oidc.yaml
+++ b/deploy/kind/mock-oidc.yaml
@@ -9,6 +9,43 @@
 #
 # Reachable from broker pods at:
 #   http://mock-oauth2-server.demarkus.svc.cluster.local:8080/default
+#
+# JSON_CONFIG (mounted from the ConfigMap below) sets:
+#   - interactiveLogin=false so /authorize bypasses the HTML login form
+#     and 302s directly back with a code (lets curl-only smoke tests
+#     drive the full mint without scraping a form).
+#   - default tokenCallback claims include email=alice@example.com +
+#     email_verified=true so the broker's authorizedWorlds predicate
+#     (allow.emails: ["alice@example.com"]) matches.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mock-oauth2-server-config
+  labels:
+    app.kubernetes.io/name: mock-oauth2-server
+data:
+  config.json: |
+    {
+      "interactiveLogin": false,
+      "tokenCallbacks": [
+        {
+          "issuerId": "default",
+          "tokenExpiry": 3600,
+          "requestMappings": [
+            {
+              "requestParam": "grant_type",
+              "match": "authorization_code",
+              "claims": {
+                "sub": "alice-kind-test",
+                "email": "alice@example.com",
+                "email_verified": true
+              }
+            }
+          ]
+        }
+      ]
+    }
 ---
 apiVersion: v1
 kind: Service
@@ -40,6 +77,10 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: mock-oauth2-server
+      # Bounce the pod when the config changes so we don't ship a
+      # stale interactiveLogin / claims set on subsequent up.sh runs.
+      annotations:
+        checksum/config: "v1-alice-noninteractive"
     spec:
       containers:
         - name: mock-oauth2-server
@@ -51,6 +92,12 @@ spec:
           env:
             - name: SERVER_PORT
               value: "8080"
+            - name: JSON_CONFIG_PATH
+              value: /etc/mock-oauth2-server/config.json
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mock-oauth2-server
+              readOnly: true
           readinessProbe:
             httpGet:
               path: /default/.well-known/openid-configuration
@@ -70,3 +117,7 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+      volumes:
+        - name: config
+          configMap:
+            name: mock-oauth2-server-config

--- a/deploy/kind/up.sh
+++ b/deploy/kind/up.sh
@@ -1,18 +1,24 @@
 #!/usr/bin/env bash
 # kind harness for demarkus development.
 #
-# Stage 1 (default):    single-node kind cluster + demarkus-server chart.
-# Stage 2 (--with-broker):  + mock-oauth2-server + demarkus-broker chart.
-# Stage 3 (--with-argo):    + Argo CD + ApplicationSet templating two worlds.
+# Stage 1 (default):                          kind cluster + demarkus-server chart.
+# Stage 2 (--with-broker):                    + mock-oauth2-server + demarkus-broker.
+# Stage 3 (--with-argo):                      + Argo CD + ApplicationSet templating two worlds.
+# Stage 4 (--with-argo --with-broker):         + broker against the Argo worlds, then
+#                                              drive a full OIDC mint flow via curl and
+#                                              assert tokens land in BOTH world Secrets.
 #
-# --with-argo replaces the Stage 1 server install with an Argo-managed
-# ApplicationSet so the worlds are GitOps-shaped from the start. It is not
-# combinable with --with-broker yet (the broker chart values are hard-wired
-# to the Stage 1 release name; multi-world broker wiring is a follow-up).
+# Stage 3 replaces the Stage 1 server install with an Argo-managed
+# ApplicationSet; the worlds are GitOps-shaped from the start. Stage 4 layers
+# the broker on top of Stage 3 and uses deploy/kind/values-broker-argo.yaml
+# (multi-world wiring + server.insecureCookies=true so curl can drive the OIDC
+# state cookie over plain HTTP).
 #
 # Verification runs `demarkus` against each server's own QUIC listener via
 # `kubectl exec`, which exercises the full read path without exposing
-# anything to the host.
+# anything to the host. Stage 4 also runs an ephemeral curl pod that drives
+# /auth/login -> /authorize -> /auth/callback and asserts the broker's
+# mint response references both worlds.
 
 set -euo pipefail
 
@@ -22,8 +28,11 @@ RELEASE="${RELEASE:-world-default}"
 SERVER_CHART_VERSION="${SERVER_CHART_VERSION:-0.17.9}"
 SERVER_CHART="oci://ghcr.io/latebit-io/charts/demarkus-server"
 BROKER_RELEASE="${BROKER_RELEASE:-broker}"
-BROKER_CHART_VERSION="${BROKER_CHART_VERSION:-0.1.1}"
+BROKER_CHART_VERSION="${BROKER_CHART_VERSION:-0.1.3}"
 BROKER_CHART="oci://ghcr.io/latebit-io/charts/demarkus-broker"
+# Ephemeral curl pod image used by the Stage 4 mint smoke test. Pinned so
+# behavior is reproducible across hosts; busybox sh + curl is all we need.
+MINT_CURL_IMAGE="${MINT_CURL_IMAGE:-curlimages/curl:8.11.1}"
 # Hard-coded to match deploy/k8s/examples/applicationset.yaml which pins
 # metadata.namespace: argocd. Making this env-overridable would silently
 # break: the script would install Argo into the override namespace while
@@ -40,6 +49,7 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." &>/dev/null && pwd)"
 VALUES_FILE="$SCRIPT_DIR/values-kind.yaml"
 BROKER_VALUES_FILE="$SCRIPT_DIR/values-broker.yaml"
+BROKER_ARGO_VALUES_FILE="$SCRIPT_DIR/values-broker-argo.yaml"
 ARGO_VALUES_FILE="$SCRIPT_DIR/values-argo.yaml"
 MOCK_OIDC_MANIFEST="$SCRIPT_DIR/mock-oidc.yaml"
 KIND_CONFIG="$SCRIPT_DIR/kind-config.yaml"
@@ -53,32 +63,27 @@ for arg in "$@"; do
     --with-argo)   WITH_ARGO=true ;;
     -h|--help)
       cat <<EOF
-usage: up.sh [--with-broker | --with-argo]
+usage: up.sh [--with-broker] [--with-argo]
 
-  --with-broker    also install mock-oauth2-server + demarkus-broker chart
+  --with-broker    install mock-oauth2-server + demarkus-broker chart
   --with-argo      install Argo CD + ApplicationSet templating two worlds
                    (replaces the Stage 1 server install)
+
+  Combine both for Stage 4: Argo-managed worlds + broker wired across
+  them. up.sh then drives a full OIDC mint flow via curl and asserts
+  tokens land in BOTH world Secrets.
 
 env overrides:
   CLUSTER, NAMESPACE, RELEASE, SERVER_CHART_VERSION,
   BROKER_RELEASE, BROKER_CHART_VERSION,
-  ARGO_RELEASE, ARGO_CHART_VERSION, ARGO_REPO_URL
+  ARGO_RELEASE, ARGO_CHART_VERSION, ARGO_REPO_URL,
+  MINT_CURL_IMAGE
 EOF
       exit 0
       ;;
     *) echo "unknown arg: $arg" >&2; exit 2 ;;
   esac
 done
-
-if [[ "$WITH_BROKER" == "true" && "$WITH_ARGO" == "true" ]]; then
-  cat >&2 <<EOF
---with-broker and --with-argo cannot be combined: the broker chart values
-at $BROKER_VALUES_FILE are hard-wired to the Stage 1 release name
-'world-default', while --with-argo provisions world-a/world-b instead.
-Multi-world broker wiring is a follow-up.
-EOF
-  exit 2
-fi
 
 require() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -155,6 +160,120 @@ if [[ "$WITH_ARGO" == "true" ]]; then
     kubectl -n "$world" exec "$WORLD_POD" -- \
       /demarkus -insecure -no-cache "mark://localhost:6309/.well-known/agent-manifest.md"
   done
+
+  # Stage 4: layer the broker on top of the Argo-managed worlds and drive
+  # a real OIDC mint. The broker is universe-singleton (one per ApplicationSet
+  # multi-world deployment), not per-world, so it installs via helm direct
+  # rather than through Argo — see /journal/2026-05-14.md for why we didn't
+  # template it inside the ApplicationSet.
+  if [[ "$WITH_BROKER" == "true" ]]; then
+    echo "--- applying mock-oauth2-server (OIDC issuer; JSON_CONFIG sets interactiveLogin=false so curl can drive /authorize without an HTML form)"
+    kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+    kubectl -n "$NAMESPACE" apply -f "$MOCK_OIDC_MANIFEST"
+    kubectl -n "$NAMESPACE" rollout status deployment/mock-oauth2-server --timeout=120s
+
+    echo "--- installing demarkus-broker chart $BROKER_CHART_VERSION (multi-world wiring)"
+    # helm --wait blocks on /readyz, which only flips green after OIDC
+    # discovery succeeds. RBAC fan-out across world-a + world-b namespaces
+    # also runs at install time — a failure here means the cross-namespace
+    # Role/RoleBinding pattern broke under multi-world.
+    helm upgrade --install "$BROKER_RELEASE" "$BROKER_CHART" \
+      --version "$BROKER_CHART_VERSION" \
+      --namespace "$NAMESPACE" --create-namespace \
+      --values "$BROKER_ARGO_VALUES_FILE" \
+      --wait --timeout 5m
+
+    BROKER_POD_SELECTOR="app.kubernetes.io/instance=$BROKER_RELEASE,app.kubernetes.io/name=demarkus-broker"
+    BROKER_POD=$(kubectl -n "$NAMESPACE" get pods -l "$BROKER_POD_SELECTOR" -o jsonpath='{.items[0].metadata.name}')
+    if [[ -z "$BROKER_POD" ]]; then
+      echo "no demarkus-broker pod found for selector: $BROKER_POD_SELECTOR" >&2
+      exit 1
+    fi
+
+    echo "--- driving OIDC mint flow from an ephemeral curl pod"
+    # We synthesize the redirect chain by hand rather than letting curl
+    # follow -L. The reason: the broker's redirectURL points at localhost
+    # (the cookie's Path=/auth/callback scope only matches if the host
+    # part is the same as the broker we hit), so we have to re-target the
+    # callback URL at the broker's in-cluster Service while preserving the
+    # signed state cookie. -L would chase the redirect to literal
+    # localhost:8080 inside the curl pod, which is itself.
+    kubectl run -n "$NAMESPACE" mint-smoke --rm -i --restart=Never \
+      --image="$MINT_CURL_IMAGE" --command -- sh -c '
+set -eu
+
+BROKER=http://'"$BROKER_RELEASE"'-demarkus-broker.'"$NAMESPACE"'.svc.cluster.local:8080
+
+# 0. Wait for the broker Service to be reachable. helm --wait returned
+#    on /readyz green, but the Service endpoints object can lag the pod-
+#    Ready transition by a second or two, and curl on a fresh pod that
+#    races that window sees "Failed to connect after 1 ms".
+for attempt in $(seq 1 15); do
+  if curl -sS -o /dev/null --max-time 2 "$BROKER/healthz"; then
+    break
+  fi
+  sleep 2
+done
+curl -sSf -o /dev/null "$BROKER/healthz" || { echo "FAIL: broker unreachable after retries"; exit 1; }
+
+# 1. /auth/login — broker signs a state cookie (Secure dropped because
+#    server.insecureCookies=true in values-broker-argo.yaml) and 302s
+#    to mock-oauth2-server.
+curl -sS -c /tmp/cookies -D /tmp/login.h -o /dev/null "$BROKER/auth/login"
+IDP=$(awk "/^[Ll]ocation:/{print \$2}" /tmp/login.h | tr -d "\r")
+[ -n "$IDP" ] || { echo "FAIL: no Location from /auth/login"; cat /tmp/login.h; exit 1; }
+
+# 2. /authorize — mock-oauth2-server is configured with
+#    interactiveLogin=false so it 302s back with code+state.
+curl -sS -D /tmp/idp.h -o /dev/null "$IDP"
+CB=$(awk "/^[Ll]ocation:/{print \$2}" /tmp/idp.h | tr -d "\r")
+[ -n "$CB" ] || { echo "FAIL: no Location from /authorize"; cat /tmp/idp.h; exit 1; }
+
+# 3. Extract code+state from the callback URL the IdP redirected to.
+CODE=$(printf "%s" "$CB" | sed -n "s/.*[?&]code=\([^&]*\).*/\1/p")
+STATE=$(printf "%s" "$CB" | sed -n "s/.*[?&]state=\([^&]*\).*/\1/p")
+[ -n "$CODE" ] && [ -n "$STATE" ] || { echo "FAIL: bad callback URL: $CB"; exit 1; }
+
+# 4. /auth/callback against the broker (not the literal localhost the
+#    IdP redirected to). The state cookie from step 1 replays.
+MINT=$(curl -sS -b /tmp/cookies "$BROKER/auth/callback?code=$CODE&state=$STATE")
+echo "mint response: $MINT"
+
+# 5. Both worlds must appear in the mint response. The broker writes a
+#    token into each world Secret as part of Mint() before returning
+#    200, so this implicitly asserts the cross-namespace RBAC worked.
+echo "$MINT" | grep -q "\"world\":\"world-a\"" || { echo "FAIL: world-a missing from mint response"; exit 1; }
+echo "$MINT" | grep -q "\"world\":\"world-b\"" || { echo "FAIL: world-b missing from mint response"; exit 1; }
+echo "OK: mint succeeded for both worlds"
+'
+
+    cat <<EOF
+
+ready (with argo + broker).
+
+cluster:         kind-$CLUSTER
+argo namespace:  $ARGO_NAMESPACE
+broker ns:       $NAMESPACE
+broker release:  $BROKER_RELEASE
+broker pod:      $BROKER_POD
+worlds:          ${ARGO_WORLDS[*]}
+mock OIDC:       mock-oauth2-server.$NAMESPACE.svc.cluster.local:8080/default
+
+inspect minted tokens in each world (decoded TOML):
+  for w in ${ARGO_WORLDS[*]}; do
+    echo "=== \$w ==="
+    kubectl -n \$w get secret \$w-demarkus-server-tokens -o jsonpath='{.data.tokens\\.toml}' | base64 -d
+  done
+
+re-run the mint flow (handy for poking at logs):
+  kubectl run -n $NAMESPACE mint-replay --rm -i --restart=Never \\
+    --image=$MINT_CURL_IMAGE -- curl -sS http://$BROKER_RELEASE-demarkus-broker:8080/healthz
+
+tear down:
+  $SCRIPT_DIR/down.sh
+EOF
+    exit 0
+  fi
 
   cat <<EOF
 

--- a/deploy/kind/up.sh
+++ b/deploy/kind/up.sh
@@ -204,28 +204,32 @@ set -eu
 
 BROKER=http://'"$BROKER_RELEASE"'-demarkus-broker.'"$NAMESPACE"'.svc.cluster.local:8080
 
+# Hard timeouts so a DNS or TCP stall fails the smoke test in seconds
+# instead of pinning the kubectl-run pod open until cluster cleanup.
+CURL="curl -sS --connect-timeout 5 --max-time 15"
+
 # 0. Wait for the broker Service to be reachable. helm --wait returned
 #    on /readyz green, but the Service endpoints object can lag the pod-
 #    Ready transition by a second or two, and curl on a fresh pod that
 #    races that window sees "Failed to connect after 1 ms".
 for attempt in $(seq 1 15); do
-  if curl -sS -o /dev/null --max-time 2 "$BROKER/healthz"; then
+  if $CURL -o /dev/null "$BROKER/healthz"; then
     break
   fi
   sleep 2
 done
-curl -sSf -o /dev/null "$BROKER/healthz" || { echo "FAIL: broker unreachable after retries"; exit 1; }
+$CURL -f -o /dev/null "$BROKER/healthz" || { echo "FAIL: broker unreachable after retries"; exit 1; }
 
 # 1. /auth/login — broker signs a state cookie (Secure dropped because
 #    server.insecureCookies=true in values-broker-argo.yaml) and 302s
 #    to mock-oauth2-server.
-curl -sS -c /tmp/cookies -D /tmp/login.h -o /dev/null "$BROKER/auth/login"
+$CURL -c /tmp/cookies -D /tmp/login.h -o /dev/null "$BROKER/auth/login"
 IDP=$(awk "/^[Ll]ocation:/{print \$2}" /tmp/login.h | tr -d "\r")
 [ -n "$IDP" ] || { echo "FAIL: no Location from /auth/login"; cat /tmp/login.h; exit 1; }
 
 # 2. /authorize — mock-oauth2-server is configured with
 #    interactiveLogin=false so it 302s back with code+state.
-curl -sS -D /tmp/idp.h -o /dev/null "$IDP"
+$CURL -D /tmp/idp.h -o /dev/null "$IDP"
 CB=$(awk "/^[Ll]ocation:/{print \$2}" /tmp/idp.h | tr -d "\r")
 [ -n "$CB" ] || { echo "FAIL: no Location from /authorize"; cat /tmp/idp.h; exit 1; }
 
@@ -236,10 +240,15 @@ STATE=$(printf "%s" "$CB" | sed -n "s/.*[?&]state=\([^&]*\).*/\1/p")
 
 # 4. /auth/callback against the broker (not the literal localhost the
 #    IdP redirected to). The state cookie from step 1 replays.
-MINT=$(curl -sS -b /tmp/cookies "$BROKER/auth/callback?code=$CODE&state=$STATE")
-echo "mint response: $MINT"
+MINT=$($CURL -b /tmp/cookies "$BROKER/auth/callback?code=$CODE&state=$STATE")
 
-# 5. Both worlds must appear in the mint response. The broker writes a
+# 5. Print the mint response with the raw bearer tokens redacted. Worlds,
+#    labels, and expiry stay visible for debugging; the secret material
+#    that the broker just minted does NOT land in terminal/CI logs.
+SAFE=$(echo "$MINT" | sed "s/\"token\":\"[^\"]*\"/\"token\":\"REDACTED\"/g")
+echo "mint response: $SAFE"
+
+# 6. Both worlds must appear in the mint response. The broker writes a
 #    token into each world Secret as part of Mint() before returning
 #    200, so this implicitly asserts the cross-namespace RBAC worked.
 echo "$MINT" | grep -q "\"world\":\"world-a\"" || { echo "FAIL: world-a missing from mint response"; exit 1; }

--- a/deploy/kind/values-broker-argo.yaml
+++ b/deploy/kind/values-broker-argo.yaml
@@ -1,0 +1,84 @@
+# Broker chart overrides for the kind harness when the worlds are
+# Argo-managed (deploy/k8s/examples/applicationset.yaml templates
+# world-a + world-b). Used by deploy/kind/up.sh when --with-argo and
+# --with-broker are both set.
+#
+# Goal: exercise the FULL mint flow end-to-end against multiple worlds.
+# A successful mint via /auth/login → /auth/callback writes a hashed
+# token entry into BOTH world-a and world-b tokens Secrets, proving
+# cross-namespace RBAC + the per-world allow predicate fan-out.
+
+# Single replica — leader-elected sweeper is unnecessary on a 1-node
+# kind cluster, and the PodDisruptionBudget would block scale-to-zero
+# on teardown.
+replicaCount: 1
+
+server:
+  # DEV-ONLY. Drops the Secure attribute on the OIDC state cookie so
+  # curl can drive /auth/login -> /auth/callback over plain HTTP. The
+  # broker chart's values.yaml has the prominent comment warning
+  # against production use; we opt in here knowing the kind cluster
+  # is local-only and never exposed.
+  insecureCookies: true
+
+# OIDC points at the in-cluster mock issuer applied alongside this
+# chart. mock-oauth2-server is configured with interactiveLogin=false
+# and a tokenCallback that returns email=alice@example.com so the
+# broker's authorizedWorlds predicate (allow.emails below) matches.
+oidc:
+  issuer: http://mock-oauth2-server.demarkus.svc.cluster.local:8080/default
+  clientID: demarkus-broker-kind
+  clientSecret: dev-secret
+  # redirectURL is what the broker tells the IdP to redirect the user
+  # back to. For the kind smoke test the curl client hits the broker's
+  # Service directly via kubectl exec, so the localhost shape is the
+  # one whose cookie scope (Path=/auth/callback) matches the actual
+  # request URL.
+  redirectURL: http://localhost:8080/auth/callback
+
+# One entry per Argo-templated world. The TokensSecret name matches
+# the demarkus-server chart's `<release>-demarkus-server-tokens`
+# template; the ApplicationSet uses release name = world name, so the
+# Secrets land at world-a-demarkus-server-tokens and
+# world-b-demarkus-server-tokens in their respective namespaces.
+worlds:
+  - name: world-a
+    namespace: world-a
+    tokensSecret: world-a-demarkus-server-tokens
+    allow:
+      emails: ["alice@example.com"]
+    defaultToken:
+      paths: ["/*"]
+      operations: ["read", "publish"]
+      expiresAfter: 24h
+  - name: world-b
+    namespace: world-b
+    tokensSecret: world-b-demarkus-server-tokens
+    allow:
+      emails: ["alice@example.com"]
+    defaultToken:
+      paths: ["/*"]
+      operations: ["read", "publish"]
+      expiresAfter: 24h
+
+# Sweeper coordinates via a Lease across replicas; with 1 replica it's
+# overhead. Drift sweep is unnecessary on a clean dev cluster.
+sweeper:
+  disabled: true
+
+# Rate limiting depends on a trustworthy X-Forwarded-For from an Ingress
+# controller; kind has no ingress controller in this harness.
+rateLimit:
+  disabled: true
+
+# NetworkPolicy restricts inbound to ingress-nginx namespace by default;
+# without ingress-nginx the broker becomes unreachable for the smoke test.
+networkPolicy:
+  enabled: false
+
+# PDB needs >=2 replicas to be meaningful and would block teardown.
+podDisruptionBudget:
+  enabled: false
+
+ingress:
+  enabled: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stage 4 local cluster mode: combines Argo-managed worlds with broker + OIDC minting and automated verification.
  * In-cluster mock OIDC server for end-to-end auth/mint testing.
  * Per-world token secret handling tuned so runtime token writes aren’t reverted by Argo self-heal.

* **Chores**
  * Bumped broker chart and added configurable curl image and Argo-specific broker values for the Stage 4 flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/134)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->