### PR TITLE
fix(tool):  Add optional publicURL field to broker world configuration 

### DIFF
--- a/deploy/helm/demarkus-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-config.yaml
@@ -73,6 +73,12 @@ stringData:
       - name: {{ .name | quote }}
         namespace: {{ .namespace | quote }}
         tokensSecret: {{ .tokensSecret | quote }}
+        {{- /* publicURL is the world's reachable address for client install
+               (universe onboarding). Optional in values; render explicitly
+               so the resulting YAML shape is stable across "set" and "unset"
+               and the operator can grep for the field. Blank string means
+               "skip in /me/install" — enforced by the broker, not here. */}}
+        publicURL: {{ default "" .publicURL | quote }}
         allow:
           domains: {{ default (list) (get $allow "domains") | toJson }}
           groups: {{ default (list) (get $allow "groups") | toJson }}

--- a/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
@@ -114,3 +114,36 @@ tests:
       - matchRegex:
           path: stringData["config.yaml"]
           pattern: 'allow:\s*\n\s*domains: \[\]\s*\n\s*groups: \[\]\s*\n\s*emails: \[\]'
+
+  - it: world without publicURL renders an empty publicURL field (stable shape)
+    set:
+      oidc.clientSecret: shh
+      worlds:
+        - name: team-a
+          namespace: team-a
+          tokensSecret: team-a-tokens
+          defaultToken:
+            paths: ["/team-a/*"]
+            operations: ["read"]
+            expiresAfter: 24h
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'publicURL: ""'
+
+  - it: world with publicURL renders the operator-supplied value
+    set:
+      oidc.clientSecret: shh
+      worlds:
+        - name: team-a
+          namespace: team-a
+          tokensSecret: team-a-tokens
+          publicURL: "mark://team-a.cluster.local:6309"
+          defaultToken:
+            paths: ["/team-a/*"]
+            operations: ["read"]
+            expiresAfter: 24h
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'publicURL: "mark://team-a.cluster.local:6309"'

--- a/deploy/helm/demarkus-broker/values.yaml
+++ b/deploy/helm/demarkus-broker/values.yaml
@@ -94,6 +94,13 @@ worlds: []
   # - name: team-a
   #   namespace: team-a
   #   tokensSecret: team-a-tokens
+  #   # Reachable address handed to clients via /me/install during user
+  #   # onboarding (mark://host:port). Optional: worlds without a publicURL
+  #   # are minted-for as before but excluded from /me/install responses,
+  #   # because there is no address to wire the client to. Typically the
+  #   # VPN-reachable hostname or in-cluster Service when the user's
+  #   # network can route to it; see docs/deployment/security-topology.md.
+  #   publicURL: "mark://world-a.cluster.internal:6309"
   #   allow:
   #     domains: ["nesto.ca"]
   #     groups: ["engineering"]

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -81,6 +81,15 @@ type WorldConfig struct {
 	// TokensSecret is the name of the world's tokens.toml Secret. The
 	// broker requires get/patch on this Secret in that namespace.
 	TokensSecret string `yaml:"tokensSecret"`
+	// PublicURL is the world's reachable address for client installation
+	// (typically `mark://host:port`). Consumed by /me/install (universe
+	// onboarding) so the plugin can wire a client at this address. Optional:
+	// when blank, the world is omitted from /me/install responses because
+	// there is no address to hand the client. The field exists here on
+	// WorldConfig — not in the world's own Secret — because the broker is
+	// the single source of truth for what a user is told to connect to;
+	// the world server itself does not know its externally-visible URL.
+	PublicURL string `yaml:"publicURL"`
 	// Allow is the per-world authorization predicate. See AllowConfig for
 	// the rules. When every list is empty the world accepts any verified
 	// identity (back-compat with pre-Slice-C configs that had only

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -327,6 +327,33 @@ func TestLoadConfig(t *testing.T) {
 			body:    validConfig + "rateLimit:\n  login:\n    perMinute: 20\n    burst: -1\n",
 			wantErr: "rateLimit.login.burst must be >= 1",
 		},
+		{
+			// publicURL is optional — when omitted (validConfig), it
+			// must round-trip to the zero value. /me/install will
+			// skip worlds whose PublicURL is blank.
+			name: "publicURL defaults to empty string when omitted",
+			body: validConfig,
+			validate: func(t *testing.T, c *Config) {
+				if c.Worlds[0].PublicURL != "" {
+					t.Errorf("PublicURL = %q, want empty default", c.Worlds[0].PublicURL)
+				}
+			},
+		},
+		{
+			// publicURL is parsed as a plain string here; shape
+			// validation lives in the /me/install consumer (PR5) so
+			// PR1 only asserts the field round-trips through YAML.
+			name: "publicURL round-trips through YAML",
+			body: strings.Replace(validConfig,
+				"tokensSecret: team-a-tokens",
+				"tokensSecret: team-a-tokens\n    publicURL: \"mark://team-a.cluster.local:6309\"", 1),
+			validate: func(t *testing.T, c *Config) {
+				want := "mark://team-a.cluster.local:6309"
+				if c.Worlds[0].PublicURL != want {
+					t.Errorf("PublicURL = %q, want %q", c.Worlds[0].PublicURL, want)
+				}
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a `publicURL` field per world to specify the installation address used during onboarding.
  * Worlds without a configured `publicURL` are created but excluded from installation responses.

* **Documentation**
  * Updated configuration documentation with `publicURL` examples and clarified behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/135)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->