### PR TITLE
fix(tool): Add OIDC discovery endpoint with caching and field overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,4 +188,5 @@ jobs:
             --set oidc.issuer=https://accounts.google.com \
             --set oidc.clientID=test-client \
             --set oidc.clientSecret=test-secret \
-            --set oidc.redirectURL=https://broker.example/auth/callback
+            --set oidc.redirectURL=https://broker.example/auth/callback \
+            --set server.publicURL=https://broker.example

--- a/deploy/helm/demarkus-broker/README.md
+++ b/deploy/helm/demarkus-broker/README.md
@@ -39,6 +39,7 @@ oidc:
 helm install broker deploy/helm/demarkus-broker \
   --namespace demarkus-broker --create-namespace \
   --values broker-secrets.values.yaml \
+  --set server.publicURL=https://broker.example.com \
   --set oidc.issuer=https://accounts.google.com \
   --set oidc.clientID=YOUR_CLIENT_ID \
   --set oidc.redirectURL=https://broker.example.com/auth/callback \

--- a/deploy/helm/demarkus-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-config.yaml
@@ -50,6 +50,7 @@ stringData:
       stateTTL: {{ .Values.server.stateTTL | quote }}
       brokerNamespace: {{ include "demarkus-broker.brokerNamespace" . | quote }}
       issuancesSecret: {{ include "demarkus-broker.issuancesSecretName" . | quote }}
+      publicURL: {{ required "server.publicURL is required" .Values.server.publicURL | quote }}
       insecureCookies: {{ .Values.server.insecureCookies }}
     oidc:
       issuer: {{ required "oidc.issuer is required" .Values.oidc.issuer | quote }}

--- a/deploy/helm/demarkus-broker/tests/deployment_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/deployment_test.yaml
@@ -9,6 +9,7 @@ set:
   oidc.clientID: broker-app
   oidc.clientSecret: shh
   oidc.redirectURL: https://broker.example.com/auth/callback
+  server.publicURL: https://broker.example.com
 tests:
   - it: renders a Deployment with two replicas and rolling update strategy
     template: deployment.yaml

--- a/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
@@ -7,6 +7,7 @@ set:
   oidc.issuer: https://accounts.example.com
   oidc.clientID: broker-app
   oidc.redirectURL: https://broker.example.com/auth/callback
+  server.publicURL: https://broker.example.com
 tests:
   - it: rendered Secret has metadata.namespace explicitly set to release namespace
     set:
@@ -42,6 +43,22 @@ tests:
       - matchRegex:
           path: stringData["config.yaml"]
           pattern: 'sweeper:\s*\n\s*disabled: false\s*\n\s*interval: "5m"\s*\n\s*leaseName: "demarkus-broker-sweeper"'
+
+  - it: server.publicURL renders from values
+    set:
+      oidc.clientSecret: shh
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'publicURL: "https://broker.example.com"'
+
+  - it: fail-render when server.publicURL is blank (required at chart-render)
+    set:
+      oidc.clientSecret: shh
+      server.publicURL: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "server.publicURL is required"
 
   - it: insecureCookies defaults to false (production-correct)
     set:

--- a/deploy/helm/demarkus-broker/values.yaml
+++ b/deploy/helm/demarkus-broker/values.yaml
@@ -37,6 +37,16 @@ server:
   # redirect, short enough that a stale cookie cannot be replayed.
   stateTTL: 5m
 
+  # Externally-reachable base URL of the broker, no trailing slash
+  # (e.g. https://broker.acmecorp.com). Required: advertised as `issuer`
+  # in /.well-known/openid-configuration and used as the base for the
+  # broker-hosted device_authorization_endpoint + token_endpoint
+  # overrides the same doc emits (universe onboarding, plan PR2). May
+  # differ from oidc.redirectURL when the broker is fronted at a
+  # different path or behind an Ingress with rewrites — operators set
+  # this explicitly so the discovery doc never depends on guessing.
+  publicURL: ""
+
   # Namespace the broker itself runs in. Defaults to the release namespace
   # via the helper; override only if the issuances Secret lives elsewhere
   # (rare).

--- a/deploy/kind/values-broker-argo.yaml
+++ b/deploy/kind/values-broker-argo.yaml
@@ -14,6 +14,12 @@
 replicaCount: 1
 
 server:
+  # Advertised in /.well-known/openid-configuration as the broker's
+  # base URL. Stage 4 doesn't exercise the discovery doc, but the
+  # broker's LoadConfig requires the field so it must be set; localhost
+  # mirrors the redirectURL shape below.
+  publicURL: "http://localhost:8080"
+
   # DEV-ONLY. Drops the Secure attribute on the OIDC state cookie so
   # curl can drive /auth/login -> /auth/callback over plain HTTP. The
   # broker chart's values.yaml has the prominent comment warning

--- a/deploy/kind/values-broker.yaml
+++ b/deploy/kind/values-broker.yaml
@@ -8,6 +8,13 @@
 # cluster, and the PodDisruptionBudget would block scale-to-zero on teardown.
 replicaCount: 1
 
+server:
+  # Advertised in /.well-known/openid-configuration as the broker's
+  # base URL. Stage 2 doesn't exercise the discovery doc, but the
+  # broker's LoadConfig requires the field so it must be set; localhost
+  # mirrors the redirectURL shape below.
+  publicURL: "http://localhost:8080"
+
 # OIDC points at the in-cluster mock issuer applied alongside this chart.
 # clientID/clientSecret can be any value — mock-oauth2-server accepts any
 # client registration by default. redirectURL is only exercised if a real

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -3,6 +3,7 @@ package broker
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -304,13 +305,20 @@ func (c *Config) validate() error {
 	if c.Server.IssuancesSecret == "" {
 		return fmt.Errorf("server.issuancesSecret is required")
 	}
+	// Normalize before the empty-check so values like "   " or "/" are
+	// caught here instead of silently producing a broken issuer URL
+	// downstream (e.g. "/device/authorize" with no scheme/host).
+	c.Server.PublicURL = strings.TrimRight(strings.TrimSpace(c.Server.PublicURL), "/")
 	if c.Server.PublicURL == "" {
 		return fmt.Errorf("server.publicURL is required")
 	}
-	// Trim once at load so every downstream consumer (discovery doc,
-	// future device-flow URLs, /me/install) sees a canonical no-trailing-
-	// slash form without each one re-trimming.
-	c.Server.PublicURL = strings.TrimRight(c.Server.PublicURL, "/")
+	// Enforce absolute-URL shape. Without scheme+host the override would
+	// emit values like "/device/authorize" into the discovery doc, which
+	// every OIDC client would reject — fail fast at config load instead
+	// of producing a broker that boots but serves a useless well-known.
+	if u, err := url.Parse(c.Server.PublicURL); err != nil || u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("server.publicURL must be an absolute URL (got %q)", c.Server.PublicURL)
+	}
 	if c.Server.StateTTL == 0 {
 		c.Server.StateTTL = 5 * time.Minute
 	}

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -45,6 +45,15 @@ type ServerConfig struct {
 	// label → {email, world, paths, ...} map (JSON-encoded). World servers
 	// never read this Secret.
 	IssuancesSecret string `yaml:"issuancesSecret"`
+	// PublicURL is the broker's externally-reachable base URL (e.g.
+	// https://broker.acmecorp.com), trailing slash stripped at load. Used as
+	// the issuer + base for device_authorization_endpoint and token_endpoint
+	// in /.well-known/openid-configuration (universe onboarding PR2). The
+	// broker has no other way to know its own externally-visible URL —
+	// OIDC.RedirectURL is purpose-specific (the IdP redirect target) and
+	// may differ from the broker's base when the broker is fronted at a
+	// path or behind an Ingress with rewrites.
+	PublicURL string `yaml:"publicURL"`
 	// InsecureCookies drops the Secure attribute on the OIDC state cookie.
 	// Default false (production-correct: state cookies travel over HTTPS
 	// only). Flip to true ONLY for kind / local dev where the broker is
@@ -295,6 +304,13 @@ func (c *Config) validate() error {
 	if c.Server.IssuancesSecret == "" {
 		return fmt.Errorf("server.issuancesSecret is required")
 	}
+	if c.Server.PublicURL == "" {
+		return fmt.Errorf("server.publicURL is required")
+	}
+	// Trim once at load so every downstream consumer (discovery doc,
+	// future device-flow URLs, /me/install) sees a canonical no-trailing-
+	// slash form without each one re-trimming.
+	c.Server.PublicURL = strings.TrimRight(c.Server.PublicURL, "/")
 	if c.Server.StateTTL == 0 {
 		c.Server.StateTTL = 5 * time.Minute
 	}

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -14,6 +14,7 @@ server:
   cookieKey: "dGVzdC1rZXk="
   brokerNamespace: demarkus-broker
   issuancesSecret: broker-issuances
+  publicURL: "https://broker.example.com"
 oidc:
   issuer: https://accounts.google.com
   clientID: client-abc
@@ -326,6 +327,25 @@ func TestLoadConfig(t *testing.T) {
 			name:    "rateLimit.login.burst negative rejected",
 			body:    validConfig + "rateLimit:\n  login:\n    perMinute: 20\n    burst: -1\n",
 			wantErr: "rateLimit.login.burst must be >= 1",
+		},
+		{
+			name:    "missing server.publicURL",
+			body:    strings.Replace(validConfig, `publicURL: "https://broker.example.com"`, `publicURL: ""`, 1),
+			wantErr: "server.publicURL is required",
+		},
+		{
+			// PublicURL trailing slash is stripped at load so every
+			// downstream consumer (discovery doc, /me/install) sees a
+			// canonical form without re-trimming on every call.
+			name: "server.publicURL trailing slash stripped",
+			body: strings.Replace(validConfig,
+				`publicURL: "https://broker.example.com"`,
+				`publicURL: "https://broker.example.com/"`, 1),
+			validate: func(t *testing.T, c *Config) {
+				if c.Server.PublicURL != "https://broker.example.com" {
+					t.Errorf("PublicURL = %q, want trailing slash stripped", c.Server.PublicURL)
+				}
+			},
 		},
 		{
 			// publicURL is optional — when omitted (validConfig), it

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -334,6 +334,31 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: "server.publicURL is required",
 		},
 		{
+			// Whitespace-only is functionally the same as empty —
+			// normalize before the empty-check so a yaml-quoted
+			// "   " value is rejected with the same error, not
+			// silently allowed through to break downstream URL
+			// construction.
+			name:    "server.publicURL whitespace-only rejected",
+			body:    strings.Replace(validConfig, `publicURL: "https://broker.example.com"`, `publicURL: "   "`, 1),
+			wantErr: "server.publicURL is required",
+		},
+		{
+			// Bare "/" trims down to "" after the canonicalization
+			// pass and falls into the same is-required branch.
+			name:    "server.publicURL bare slash rejected",
+			body:    strings.Replace(validConfig, `publicURL: "https://broker.example.com"`, `publicURL: "/"`, 1),
+			wantErr: "server.publicURL is required",
+		},
+		{
+			// Without scheme + host the override would render
+			// nonsense like "not-a-url/device/authorize" into the
+			// discovery doc. Catch at config load.
+			name:    "server.publicURL without scheme rejected",
+			body:    strings.Replace(validConfig, `publicURL: "https://broker.example.com"`, `publicURL: "broker.example.com"`, 1),
+			wantErr: "server.publicURL must be an absolute URL",
+		},
+		{
 			// PublicURL trailing slash is stripped at load so every
 			// downstream consumer (discovery doc, /me/install) sees a
 			// canonical form without re-trimming on every call.

--- a/tools/demarkus-broker/internal/broker/discovery.go
+++ b/tools/demarkus-broker/internal/broker/discovery.go
@@ -202,6 +202,15 @@ func (d *Discovery) get(ctx context.Context) []byte {
 // failure it leaves the prior cache untouched and returns the error
 // (caller decides whether to surface or fall back to stale).
 func (d *Discovery) refresh(ctx context.Context) error {
+	// Belt-and-suspenders timeout on the fetch context: the default
+	// http.Client has discoveryHTTPTimeout, but a caller may inject a
+	// custom HTTPClient via DiscoveryConfig with no Timeout field set
+	// (the constructor honors caller-supplied clients verbatim). Wrap
+	// here so refresh() is bounded regardless of how the client was
+	// configured and regardless of whether the caller's ctx has a
+	// deadline.
+	ctx, cancel := context.WithTimeout(ctx, discoveryHTTPTimeout)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, d.idpDiscovery, http.NoBody)
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)

--- a/tools/demarkus-broker/internal/broker/discovery.go
+++ b/tools/demarkus-broker/internal/broker/discovery.go
@@ -1,0 +1,236 @@
+package broker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// defaultDiscoveryTTL is the cache lifetime of the rendered
+// .well-known/openid-configuration body. Plan §Risks "discovery doc cache
+// invalidation" calls for ~5 minutes: short enough that an IdP key
+// rotation propagates inside a single TTL, long enough that polling
+// device-flow clients (PR3) don't redrive the upstream fetch on every
+// /device/token tick.
+const defaultDiscoveryTTL = 5 * time.Minute
+
+// discoveryHTTPTimeout caps each upstream IdP fetch. The broker blocks
+// startup on the initial fetch via NewDiscovery, so an unresponsive IdP
+// must surface as a configured-failure within seconds rather than hanging
+// the pod past its readiness probe.
+const discoveryHTTPTimeout = 10 * time.Second
+
+// maxDiscoveryBodySize bounds how much we read from the upstream IdP. A
+// real OIDC discovery doc is ~2-4 KiB; the limit just stops a hostile or
+// misbehaving upstream from forcing the broker to buffer arbitrary bytes.
+const maxDiscoveryBodySize = 1 << 20 // 1 MiB
+
+// Discovery handles GET /.well-known/openid-configuration. It fetches the
+// configured IdP's own discovery doc once at startup, overrides the
+// broker-hosted endpoints (issuer + device_authorization_endpoint +
+// token_endpoint), caches the rendered body, and serves it from the
+// cache. After the TTL elapses the next request triggers a refresh
+// inline; failed refreshes fall back to the prior cached body
+// (stale-while-error) because a polling device-flow client benefits
+// more from a slightly-stale doc than a 5xx.
+//
+// Why a broker-hosted discovery doc instead of plugin-side IdP-direct:
+// the plugin sees one OIDC surface regardless of which IdP a customer
+// wired up (Google, Okta, Entra, Auth0). Every per-IdP quirk — device
+// endpoint paths, scope strings, error-code spellings — stays inside the
+// broker, and every coding-agent plugin we eventually ship reuses the
+// same client without per-IdP discovery logic. See plan §"Why broker is
+// the device-flow shim, not plugin going IdP-direct".
+//
+// What is NOT yet end-to-end correct in PR2: jwks_uri stays pointed at
+// the IdP (proxied through unchanged), but issuer is overridden to the
+// broker. Until PR4 mints broker-signed id_tokens with a broker-hosted
+// jwks_uri, strict OIDC-client validation against this discovery doc
+// would reject id_tokens that came signed by the IdP and carry the IdP's
+// own `iss` claim. The plugin's device-flow client (PR6) consumes only
+// device_authorization_endpoint + token_endpoint from this doc, so the
+// mismatch does not affect it; the gap closes in PR4 when broker
+// re-signs.
+type Discovery struct {
+	brokerURL    string
+	idpDiscovery string
+	httpClient   *http.Client
+	ttl          time.Duration
+	clock        func() time.Time
+	log          *slog.Logger
+
+	mu    sync.RWMutex
+	body  []byte
+	until time.Time
+}
+
+// DiscoveryConfig is the input bundle to NewDiscovery. Single struct so
+// the constructor signature stays one-argument + error per
+// /guidelines.md.
+type DiscoveryConfig struct {
+	// BrokerURL is the broker's externally-reachable base URL with no
+	// trailing slash, e.g. https://broker.acmecorp.com. Loaded from
+	// Server.PublicURL (broker config trims the slash once at load).
+	BrokerURL string
+	// IdPIssuer is the OIDC issuer URL, same value as OIDCConfig.Issuer.
+	// NewDiscovery fetches IdPIssuer + "/.well-known/openid-configuration"
+	// at startup.
+	IdPIssuer string
+	// HTTPClient is the client used for the upstream fetch. NewDiscovery
+	// installs a 10-second timeout default when nil so a hung IdP cannot
+	// pin the broker's startup past its readiness probe.
+	HTTPClient *http.Client
+	// TTL is the cache lifetime of the rendered doc. Defaults to
+	// defaultDiscoveryTTL when zero. Negative values are accepted by the
+	// constructor but render the cache effectively-disabled (every
+	// request triggers a refresh) — intended only for tests.
+	TTL time.Duration
+	// Clock injects a controllable time source for tests. Defaults to
+	// time.Now.
+	Clock func() time.Time
+	// Log receives stale-fallback warnings. Defaults to slog.Default()
+	// when nil; production wiring passes the broker's structured logger
+	// so the warnings land in the same JSON stream as everything else.
+	Log *slog.Logger
+}
+
+// NewDiscovery constructs the handler and performs the initial fetch. A
+// failed initial fetch is fatal — the broker would otherwise come up
+// with /.well-known/openid-configuration serving 5xx, which a strict
+// discovery-doc client would treat as configuration error anyway.
+// Failing-fast at startup turns the misconfiguration into a pod
+// CrashLoopBackOff that the operator notices immediately.
+func NewDiscovery(ctx context.Context, cfg DiscoveryConfig) (*Discovery, error) {
+	if cfg.BrokerURL == "" {
+		return nil, fmt.Errorf("broker: discovery: brokerURL is required")
+	}
+	if cfg.IdPIssuer == "" {
+		return nil, fmt.Errorf("broker: discovery: idpIssuer is required")
+	}
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: discoveryHTTPTimeout}
+	}
+	ttl := cfg.TTL
+	if ttl == 0 {
+		ttl = defaultDiscoveryTTL
+	}
+	clock := cfg.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+	log := cfg.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	d := &Discovery{
+		brokerURL:    strings.TrimRight(cfg.BrokerURL, "/"),
+		idpDiscovery: strings.TrimRight(cfg.IdPIssuer, "/") + "/.well-known/openid-configuration",
+		httpClient:   client,
+		ttl:          ttl,
+		clock:        clock,
+		log:          log,
+	}
+	if err := d.refresh(ctx); err != nil {
+		return nil, fmt.Errorf("broker: discovery: initial fetch %s: %w", d.idpDiscovery, err)
+	}
+	return d, nil
+}
+
+// Handler is the http.Handler for GET /.well-known/openid-configuration.
+// Public, unauthenticated, cacheable: this is the OIDC well-known surface
+// every plugin client hits before the device-flow dance.
+func (d *Discovery) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := d.get(r.Context())
+		w.Header().Set("Content-Type", "application/json")
+		// Cache-Control matches the broker-side TTL window so a CDN or
+		// other intermediary sees the same caching horizon. 300s comes
+		// from defaultDiscoveryTTL — kept literal here because the
+		// HTTP header value is part of the wire contract and shouldn't
+		// silently drift if a future patch changes the in-process TTL.
+		w.Header().Set("Cache-Control", "public, max-age=300")
+		_, _ = w.Write(body)
+	})
+}
+
+// get returns the cached body, refreshing inline on TTL expiry. Stale
+// served on refresh failure so the well-known endpoint stays available
+// during transient upstream issues.
+func (d *Discovery) get(ctx context.Context) []byte {
+	d.mu.RLock()
+	expired := !d.clock().Before(d.until)
+	d.mu.RUnlock()
+	if expired {
+		if err := d.refresh(ctx); err != nil {
+			d.log.WarnContext(ctx, "broker: discovery refresh failed, serving stale",
+				"err", err, "upstream", d.idpDiscovery)
+		}
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.body
+}
+
+// refresh performs one upstream fetch + override pass. On success it
+// publishes the new body + new TTL window under the write lock; on
+// failure it leaves the prior cache untouched and returns the error
+// (caller decides whether to surface or fall back to stale).
+func (d *Discovery) refresh(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, d.idpDiscovery, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("upstream fetch: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("upstream status %d", resp.StatusCode)
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxDiscoveryBodySize))
+	if err != nil {
+		return fmt.Errorf("read upstream body: %w", err)
+	}
+	body, err := applyDiscoveryOverrides(raw, d.brokerURL)
+	if err != nil {
+		return err
+	}
+	d.mu.Lock()
+	d.body = body
+	d.until = d.clock().Add(d.ttl)
+	d.mu.Unlock()
+	return nil
+}
+
+// applyDiscoveryOverrides parses the upstream JSON, rewrites the three
+// broker-hosted endpoints, and re-marshals. Decoded into map[string]any
+// so unknown IdP-specific fields (Google's
+// `code_challenge_methods_supported`, Auth0's `mfa_challenge_endpoint`,
+// Okta's request_object_signing_alg lists, etc.) round-trip through
+// without us tracking each one in a typed struct — proxying everything
+// else verbatim is the point of this layer.
+func applyDiscoveryOverrides(raw []byte, brokerURL string) ([]byte, error) {
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("decode upstream discovery: %w", err)
+	}
+	doc["issuer"] = brokerURL
+	doc["device_authorization_endpoint"] = brokerURL + "/device/authorize"
+	doc["token_endpoint"] = brokerURL + "/device/token"
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(doc); err != nil {
+		return nil, fmt.Errorf("encode rendered discovery: %w", err)
+	}
+	return buf.Bytes(), nil
+}

--- a/tools/demarkus-broker/internal/broker/discovery.go
+++ b/tools/demarkus-broker/internal/broker/discovery.go
@@ -69,6 +69,14 @@ type Discovery struct {
 	mu    sync.RWMutex
 	body  []byte
 	until time.Time
+
+	// refreshMu serializes TTL-expiry refreshes so N concurrent in-flight
+	// requests fire at most one upstream fetch instead of N. Cheap insurance
+	// — without it, a popular broker behind a fronting cache that all
+	// expires the well-known doc simultaneously would multiply load on the
+	// IdP by the in-flight request count. Held across the upstream fetch +
+	// body publish; the regular mu still owns reads of body/until.
+	refreshMu sync.Mutex
 }
 
 // DiscoveryConfig is the input bundle to NewDiscovery. Single struct so
@@ -163,16 +171,26 @@ func (d *Discovery) Handler() http.Handler {
 
 // get returns the cached body, refreshing inline on TTL expiry. Stale
 // served on refresh failure so the well-known endpoint stays available
-// during transient upstream issues.
+// during transient upstream issues. refreshMu serializes refreshes so
+// concurrent expirers don't stampede the upstream IdP — late arrivals
+// re-check the TTL after taking the lock and skip the fetch when a
+// prior holder already refreshed.
 func (d *Discovery) get(ctx context.Context) []byte {
 	d.mu.RLock()
 	expired := !d.clock().Before(d.until)
 	d.mu.RUnlock()
 	if expired {
-		if err := d.refresh(ctx); err != nil {
-			d.log.WarnContext(ctx, "broker: discovery refresh failed, serving stale",
-				"err", err, "upstream", d.idpDiscovery)
+		d.refreshMu.Lock()
+		d.mu.RLock()
+		stillExpired := !d.clock().Before(d.until)
+		d.mu.RUnlock()
+		if stillExpired {
+			if err := d.refresh(ctx); err != nil {
+				d.log.WarnContext(ctx, "broker: discovery refresh failed, serving stale",
+					"err", err, "upstream", d.idpDiscovery)
+			}
 		}
+		d.refreshMu.Unlock()
 	}
 	d.mu.RLock()
 	defer d.mu.RUnlock()

--- a/tools/demarkus-broker/internal/broker/discovery_test.go
+++ b/tools/demarkus-broker/internal/broker/discovery_test.go
@@ -1,0 +1,313 @@
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// idpDiscoveryFixture is the upstream OIDC discovery JSON the broker
+// fetches. Modeled on a typical Google / Okta / Auth0 doc so the proxy
+// assertions cover real-world field names; includes both the fields the
+// broker overrides (issuer, device_authorization_endpoint, token_endpoint)
+// and the fields it must pass through unchanged (jwks_uri,
+// userinfo_endpoint, authorization_endpoint, plus IdP-specific extras
+// like code_challenge_methods_supported).
+const idpDiscoveryFixture = `{
+  "issuer": "https://idp.example.com",
+  "authorization_endpoint": "https://idp.example.com/authorize",
+  "device_authorization_endpoint": "https://idp.example.com/oauth/device/code",
+  "token_endpoint": "https://idp.example.com/oauth/token",
+  "userinfo_endpoint": "https://idp.example.com/userinfo",
+  "jwks_uri": "https://idp.example.com/.well-known/jwks.json",
+  "response_types_supported": ["code"],
+  "grant_types_supported": ["authorization_code", "urn:ietf:params:oauth:grant-type:device_code"],
+  "code_challenge_methods_supported": ["S256"]
+}`
+
+// fakeDiscoveryIdP serves the discovery fixture and counts hits so tests can
+// assert cache vs. refresh behavior without timing.
+type fakeDiscoveryIdP struct {
+	server *httptest.Server
+	hits   atomic.Int64
+	body   atomic.Value // string
+	status atomic.Int32 // HTTP status; 0 = use 200
+}
+
+func newFakeDiscoveryIdP(t *testing.T) *fakeDiscoveryIdP {
+	t.Helper()
+	idp := &fakeDiscoveryIdP{}
+	idp.body.Store(idpDiscoveryFixture)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		idp.hits.Add(1)
+		status := int(idp.status.Load())
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, idp.body.Load().(string))
+	})
+	idp.server = httptest.NewServer(mux)
+	t.Cleanup(idp.server.Close)
+	return idp
+}
+
+func (idp *fakeDiscoveryIdP) issuer() string  { return idp.server.URL }
+func (idp *fakeDiscoveryIdP) hitCount() int64 { return idp.hits.Load() }
+
+// newTestDiscovery builds a Discovery against a fakeDiscoveryIdP using a clock the
+// caller can advance. Returns both so callers can step time and assert
+// per-tick behavior.
+func newTestDiscovery(t *testing.T, idp *fakeDiscoveryIdP, ttl time.Duration) (*Discovery, *fakeClock) {
+	t.Helper()
+	clk := &fakeClock{now: time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)}
+	d, err := NewDiscovery(context.Background(), DiscoveryConfig{
+		BrokerURL: "https://broker.example.com",
+		IdPIssuer: idp.issuer(),
+		TTL:       ttl,
+		Clock:     clk.Now,
+	})
+	if err != nil {
+		t.Fatalf("NewDiscovery: %v", err)
+	}
+	return d, clk
+}
+
+type fakeClock struct{ now time.Time }
+
+func (c *fakeClock) Now() time.Time          { return c.now }
+func (c *fakeClock) Advance(d time.Duration) { c.now = c.now.Add(d) }
+
+func TestNewDiscoveryRequiresBrokerURL(t *testing.T) {
+	_, err := NewDiscovery(context.Background(), DiscoveryConfig{IdPIssuer: "https://idp"})
+	if err == nil || !strings.Contains(err.Error(), "brokerURL is required") {
+		t.Fatalf("err = %v, want brokerURL required", err)
+	}
+}
+
+func TestNewDiscoveryRequiresIdPIssuer(t *testing.T) {
+	_, err := NewDiscovery(context.Background(), DiscoveryConfig{BrokerURL: "https://broker"})
+	if err == nil || !strings.Contains(err.Error(), "idpIssuer is required") {
+		t.Fatalf("err = %v, want idpIssuer required", err)
+	}
+}
+
+func TestNewDiscoveryFailsOnUnreachableIdP(t *testing.T) {
+	// Closed-immediately httptest.Server gives us a URL that resolves
+	// but refuses connections — the same observable shape as a real
+	// network-down upstream.
+	srv := httptest.NewServer(http.NewServeMux())
+	srv.Close()
+	_, err := NewDiscovery(context.Background(), DiscoveryConfig{
+		BrokerURL: "https://broker.example.com",
+		IdPIssuer: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected initial fetch to fail on unreachable IdP")
+	}
+	if !strings.Contains(err.Error(), "initial fetch") {
+		t.Errorf("err = %v, want 'initial fetch' substring", err)
+	}
+}
+
+func TestNewDiscoveryFailsOnUpstream5xx(t *testing.T) {
+	idp := newFakeDiscoveryIdP(t)
+	idp.status.Store(http.StatusServiceUnavailable)
+	_, err := NewDiscovery(context.Background(), DiscoveryConfig{
+		BrokerURL: "https://broker.example.com",
+		IdPIssuer: idp.issuer(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "upstream status 503") {
+		t.Fatalf("err = %v, want upstream status 503", err)
+	}
+}
+
+func TestDiscoveryOverridesBrokerEndpoints(t *testing.T) {
+	idp := newFakeDiscoveryIdP(t)
+	d, _ := newTestDiscovery(t, idp, time.Minute)
+	doc := serveAndDecode(t, d)
+	tests := []struct {
+		field string
+		want  string
+	}{
+		// issuer rewritten so the well-known doc identifies the broker
+		// as the OIDC surface, not the IdP behind it.
+		{"issuer", "https://broker.example.com"},
+		// device_authorization_endpoint moved to the broker — clients
+		// post their device-flow start here, not at the IdP.
+		{"device_authorization_endpoint", "https://broker.example.com/device/authorize"},
+		// token_endpoint moved to the broker — clients poll their
+		// device-code exchange here, broker mediates with the IdP.
+		{"token_endpoint", "https://broker.example.com/device/token"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			got, _ := doc[tt.field].(string)
+			if got != tt.want {
+				t.Errorf("%s = %q, want %q", tt.field, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiscoveryProxiesUnOverriddenFields(t *testing.T) {
+	// Round-trips fields the broker does NOT take over: jwks_uri,
+	// userinfo_endpoint, authorization_endpoint, plus IdP-specific
+	// metadata arrays. Tests both presence and exact value so a
+	// regression that silently drops or rewrites these surfaces here.
+	idp := newFakeDiscoveryIdP(t)
+	d, _ := newTestDiscovery(t, idp, time.Minute)
+	doc := serveAndDecode(t, d)
+	tests := []struct {
+		field string
+		want  any
+	}{
+		{"jwks_uri", "https://idp.example.com/.well-known/jwks.json"},
+		{"userinfo_endpoint", "https://idp.example.com/userinfo"},
+		{"authorization_endpoint", "https://idp.example.com/authorize"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			got := doc[tt.field]
+			if fmt.Sprint(got) != fmt.Sprint(tt.want) {
+				t.Errorf("%s = %v, want %v", tt.field, got, tt.want)
+			}
+		})
+	}
+	// Arrays should come through structurally intact.
+	if got, ok := doc["response_types_supported"].([]any); !ok || len(got) != 1 || got[0] != "code" {
+		t.Errorf("response_types_supported = %v, want [code]", doc["response_types_supported"])
+	}
+	if got, ok := doc["code_challenge_methods_supported"].([]any); !ok || len(got) != 1 || got[0] != "S256" {
+		t.Errorf("code_challenge_methods_supported = %v, want [S256]", doc["code_challenge_methods_supported"])
+	}
+}
+
+func TestDiscoveryServesContentTypeAndCacheControl(t *testing.T) {
+	idp := newFakeDiscoveryIdP(t)
+	d, _ := newTestDiscovery(t, idp, time.Minute)
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", http.NoBody))
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "public, max-age=300" {
+		t.Errorf("Cache-Control = %q, want 'public, max-age=300'", got)
+	}
+}
+
+func TestDiscoveryCachesWithinTTL(t *testing.T) {
+	// Initial NewDiscovery counts as the first hit. Subsequent requests
+	// inside the TTL window must not redrive the upstream — otherwise
+	// the cache is doing nothing and a polling device-flow client would
+	// fan its load straight onto the IdP.
+	idp := newFakeDiscoveryIdP(t)
+	d, clk := newTestDiscovery(t, idp, time.Minute)
+	if got := idp.hitCount(); got != 1 {
+		t.Fatalf("after construction: hits = %d, want 1", got)
+	}
+	for range 5 {
+		clk.Advance(10 * time.Second)
+		_ = serveAndDecode(t, d)
+	}
+	if got := idp.hitCount(); got != 1 {
+		t.Errorf("after 5 calls within TTL: hits = %d, want 1", got)
+	}
+}
+
+func TestDiscoveryRefreshesAfterTTL(t *testing.T) {
+	idp := newFakeDiscoveryIdP(t)
+	d, clk := newTestDiscovery(t, idp, time.Minute)
+	clk.Advance(time.Minute + time.Second)
+	_ = serveAndDecode(t, d)
+	if got := idp.hitCount(); got != 2 {
+		t.Errorf("after TTL elapsed: hits = %d, want 2", got)
+	}
+}
+
+func TestDiscoveryServesStaleOnRefreshFailure(t *testing.T) {
+	// When refresh fails (IdP suddenly returns 5xx), the handler must
+	// still serve the previously-cached body — a polling client
+	// benefits from a slightly-stale doc more than from a 5xx during
+	// transient upstream outages.
+	idp := newFakeDiscoveryIdP(t)
+	d, clk := newTestDiscovery(t, idp, time.Minute)
+	original := serveAndDecode(t, d)
+	idp.status.Store(http.StatusServiceUnavailable)
+	clk.Advance(time.Minute + time.Second)
+	stale := serveAndDecode(t, d)
+	if stale["issuer"] != original["issuer"] {
+		t.Errorf("stale issuer = %v, want match original %v", stale["issuer"], original["issuer"])
+	}
+	// Confirm we actually tried to refresh (so we know we're testing
+	// the stale-fallback path, not just the in-TTL cache path).
+	if got := idp.hitCount(); got < 2 {
+		t.Errorf("hits = %d, want >= 2 (initial + attempted refresh)", got)
+	}
+}
+
+func TestDiscoveryRecoversAfterTransientFailure(t *testing.T) {
+	idp := newFakeDiscoveryIdP(t)
+	d, clk := newTestDiscovery(t, idp, time.Minute)
+	idp.status.Store(http.StatusServiceUnavailable)
+	clk.Advance(time.Minute + time.Second)
+	_ = serveAndDecode(t, d) // serves stale
+	idp.status.Store(0)      // back to 200
+	clk.Advance(time.Minute + time.Second)
+	doc := serveAndDecode(t, d)
+	if doc["issuer"] != "https://broker.example.com" {
+		t.Errorf("after recovery: issuer = %v, want broker URL", doc["issuer"])
+	}
+}
+
+func TestDiscoveryBrokerURLTrailingSlashTrimmed(t *testing.T) {
+	idp := newFakeDiscoveryIdP(t)
+	d, err := NewDiscovery(context.Background(), DiscoveryConfig{
+		BrokerURL: "https://broker.example.com/", // trailing slash
+		IdPIssuer: idp.issuer(),
+	})
+	if err != nil {
+		t.Fatalf("NewDiscovery: %v", err)
+	}
+	doc := serveAndDecode(t, d)
+	// Without the trim, the override would emit
+	// https://broker.example.com//device/authorize (double slash).
+	if got := doc["device_authorization_endpoint"]; got != "https://broker.example.com/device/authorize" {
+		t.Errorf("device_authorization_endpoint = %v, want no double slash", got)
+	}
+}
+
+func TestDiscoveryRejectsInvalidUpstreamJSON(t *testing.T) {
+	idp := newFakeDiscoveryIdP(t)
+	idp.body.Store("not-json")
+	_, err := NewDiscovery(context.Background(), DiscoveryConfig{
+		BrokerURL: "https://broker.example.com",
+		IdPIssuer: idp.issuer(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "decode upstream discovery") {
+		t.Fatalf("err = %v, want decode error", err)
+	}
+}
+
+func serveAndDecode(t *testing.T, d *Discovery) map[string]any {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", http.NoBody))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	return doc
+}

--- a/tools/demarkus-broker/internal/broker/discovery_test.go
+++ b/tools/demarkus-broker/internal/broker/discovery_test.go
@@ -286,6 +286,37 @@ func TestDiscoveryBrokerURLTrailingSlashTrimmed(t *testing.T) {
 	}
 }
 
+func TestDiscoveryRefreshSerializedAcrossConcurrentExpiry(t *testing.T) {
+	// Without the refresh mutex, N concurrent goroutines arriving after
+	// TTL expiry all see expired=true and each fires its own upstream
+	// fetch — at scale that's a stampede on the IdP every time the
+	// well-known cache rolls. The mutex serializes refreshes; late
+	// arrivals re-check TTL after lock acquisition and skip the fetch
+	// because a prior holder already refreshed. Assert at most ONE
+	// extra upstream hit (initial + one refresh) regardless of the
+	// concurrent caller count.
+	idp := newFakeDiscoveryIdP(t)
+	d, clk := newTestDiscovery(t, idp, time.Minute)
+	if got := idp.hitCount(); got != 1 {
+		t.Fatalf("after construction: hits = %d, want 1", got)
+	}
+	clk.Advance(time.Minute + time.Second)
+	const callers = 16
+	done := make(chan struct{}, callers)
+	for range callers {
+		go func() {
+			_ = serveAndDecode(t, d)
+			done <- struct{}{}
+		}()
+	}
+	for range callers {
+		<-done
+	}
+	if got := idp.hitCount(); got != 2 {
+		t.Errorf("after %d concurrent post-TTL requests: hits = %d, want 2 (initial + 1 refresh)", callers, got)
+	}
+}
+
 func TestDiscoveryRejectsInvalidUpstreamJSON(t *testing.T) {
 	idp := newFakeDiscoveryIdP(t)
 	idp.body.Store("not-json")

--- a/tools/demarkus-broker/internal/broker/discovery_test.go
+++ b/tools/demarkus-broker/internal/broker/discovery_test.go
@@ -302,15 +302,22 @@ func TestDiscoveryRefreshSerializedAcrossConcurrentExpiry(t *testing.T) {
 	}
 	clk.Advance(time.Minute + time.Second)
 	const callers = 16
-	done := make(chan struct{}, callers)
+	// Each worker reports its error (or nil) back through the channel.
+	// We deliberately do not call t.Fatalf from inside the goroutine —
+	// t.Fatalf panics the calling goroutine without releasing pending
+	// sends, which would deadlock this test on the receive loop below
+	// before we ever observed the failure.
+	errs := make(chan error, callers)
 	for range callers {
 		go func() {
-			_ = serveAndDecode(t, d)
-			done <- struct{}{}
+			_, err := serveAndDecodeErr(d)
+			errs <- err
 		}()
 	}
 	for range callers {
-		<-done
+		if err := <-errs; err != nil {
+			t.Fatal(err)
+		}
 	}
 	if got := idp.hitCount(); got != 2 {
 		t.Errorf("after %d concurrent post-TTL requests: hits = %d, want 2 (initial + 1 refresh)", callers, got)
@@ -331,14 +338,27 @@ func TestDiscoveryRejectsInvalidUpstreamJSON(t *testing.T) {
 
 func serveAndDecode(t *testing.T, d *Discovery) map[string]any {
 	t.Helper()
+	doc, err := serveAndDecodeErr(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return doc
+}
+
+// serveAndDecodeErr is the goroutine-safe variant of serveAndDecode:
+// returns errors instead of calling t.Fatalf, so tests that fan out
+// across goroutines (the concurrency-stampede assertion) can surface
+// failures through a channel without deadlocking the test on a panicked
+// worker that never signals completion.
+func serveAndDecodeErr(d *Discovery) (map[string]any, error) {
 	rec := httptest.NewRecorder()
 	d.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", http.NoBody))
 	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d", rec.Code)
+		return nil, fmt.Errorf("status = %d", rec.Code)
 	}
 	var doc map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
-		t.Fatalf("decode body: %v", err)
+		return nil, fmt.Errorf("decode body: %w", err)
 	}
-	return doc
+	return doc, nil
 }

--- a/tools/demarkus-broker/internal/broker/ratelimit_test.go
+++ b/tools/demarkus-broker/internal/broker/ratelimit_test.go
@@ -185,7 +185,7 @@ func TestSubjectRateLimitMissingClaimsIs500(t *testing.T) {
 	// as 500 + an error log rather than silently disabling the limit
 	// (which would be the worst-of-both: production looks fine, but
 	// a misbehaving caller gets unbounded throughput).
-	srv := NewServer(testConfigWithRateLimit(), newTestSigner(t), &fakeVerifier{}, NewIssuer(testConfig(), fake.NewSimpleClientset()), nil)
+	srv := NewServer(testConfigWithRateLimit(), newTestSigner(t), &fakeVerifier{}, NewIssuer(testConfig(), fake.NewSimpleClientset()), nil, nil)
 	h := srv.subjectRateLimit(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Error("handler reached despite missing claims")
 		w.WriteHeader(http.StatusOK)

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -21,12 +21,13 @@ const stateCookieName = "broker_oidc_state"
 // Issuer interfaces; tests pass a fakeVerifier and a fake-clientset-backed
 // Issuer and exercise every route end-to-end without network or kube.
 type Server struct {
-	cfg      *Config
-	signer   *Signer
-	verifier Verifier
-	issuer   *Issuer
-	log      *slog.Logger
-	clock    func() time.Time
+	cfg       *Config
+	signer    *Signer
+	verifier  Verifier
+	issuer    *Issuer
+	discovery *Discovery
+	log       *slog.Logger
+	clock     func() time.Time
 
 	// subjectReg is the per-subject limiter shared across the three
 	// /tokens routes; loginReg is the per-IP limiter for /auth/login.
@@ -42,9 +43,11 @@ type Server struct {
 }
 
 // NewServer wires a Server. The caller is responsible for constructing the
-// Signer, Verifier, and Issuer in advance — keeps this constructor cheap
-// enough for tests to call directly.
-func NewServer(cfg *Config, signer *Signer, verifier Verifier, issuer *Issuer, log *slog.Logger) *Server {
+// Signer, Verifier, Issuer, and Discovery in advance — keeps this
+// constructor cheap enough for tests to call directly. discovery is
+// optional: tests that don't exercise the well-known route pass nil and
+// Routes() skips registering it.
+func NewServer(cfg *Config, signer *Signer, verifier Verifier, issuer *Issuer, discovery *Discovery, log *slog.Logger) *Server {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -53,6 +56,7 @@ func NewServer(cfg *Config, signer *Signer, verifier Verifier, issuer *Issuer, l
 		signer:            signer,
 		verifier:          verifier,
 		issuer:            issuer,
+		discovery:         discovery,
 		log:               log,
 		clock:             time.Now,
 		trustForwardedFor: cfg.RateLimit.TrustForwardedFor,
@@ -88,6 +92,13 @@ func (s *Server) Routes() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", s.healthz)
 	mux.HandleFunc("GET /readyz", s.readyz)
+	// /.well-known/openid-configuration: public, unauthenticated, no
+	// rate limit. Polling-friendly: device-flow clients fetch it once
+	// per /soul-join and never again; intermediaries cache via the
+	// Cache-Control header the Discovery handler emits.
+	if s.discovery != nil {
+		mux.Handle("GET /.well-known/openid-configuration", s.discovery.Handler())
+	}
 	mux.Handle("GET /auth/login", s.ipRateLimit(http.HandlerFunc(s.authLogin)))
 	mux.HandleFunc("GET /auth/callback", s.authCallback)
 	authedSubject := func(h http.HandlerFunc) http.Handler {

--- a/tools/demarkus-broker/internal/broker/server_test.go
+++ b/tools/demarkus-broker/internal/broker/server_test.go
@@ -49,7 +49,7 @@ func newTestServer(t *testing.T, cfg *Config, verifier Verifier, k8s *fake.Clien
 	// any real wall-clock that is later than that date, breaking the
 	// callback tests. The issuer's clock stays pinned so token-expiry
 	// assertions in issuer tests remain deterministic.
-	brokerSrv = NewServer(cfg, signer, verifier, issuer, nil)
+	brokerSrv = NewServer(cfg, signer, verifier, issuer, nil, nil)
 	// NewTLSServer (not NewServer): the state cookie is set with
 	// Secure=true and Path=/auth/callback, attributes only enforceable
 	// over HTTPS. Without TLS we'd be relying on manual AddCookie calls
@@ -72,6 +72,67 @@ func TestHealthAndReady(t *testing.T) {
 		if resp.StatusCode != http.StatusOK {
 			t.Errorf("%s: status = %d", path, resp.StatusCode)
 		}
+	}
+}
+
+// TestWellKnownDiscoveryRouteRegistered guards the Routes() composition:
+// when a Discovery is wired into NewServer, the broker mux exposes it at
+// /.well-known/openid-configuration. The discovery_test.go suite covers
+// the proxy + cache mechanics; this test just confirms the mount point so
+// a future refactor can't quietly drop the route registration.
+func TestWellKnownDiscoveryRouteRegistered(t *testing.T) {
+	idpMux := http.NewServeMux()
+	idpMux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"issuer":"https://idp.example.com","jwks_uri":"https://idp.example.com/jwks"}`)
+	})
+	idp := httptest.NewServer(idpMux)
+	t.Cleanup(idp.Close)
+
+	d, err := NewDiscovery(context.Background(), DiscoveryConfig{
+		BrokerURL: "https://broker.example.com",
+		IdPIssuer: idp.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewDiscovery: %v", err)
+	}
+	cfg := testConfig()
+	srv := NewServer(cfg, newTestSigner(t), &fakeVerifier{}, NewIssuer(cfg, fake.NewSimpleClientset()), d, nil)
+	tsrv := httptest.NewServer(srv.Routes())
+	t.Cleanup(tsrv.Close)
+
+	resp, err := http.Get(tsrv.URL + "/.well-known/openid-configuration")
+	if err != nil {
+		t.Fatalf("GET well-known: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got, _ := doc["issuer"].(string); got != "https://broker.example.com" {
+		t.Errorf("issuer = %q, want broker URL (override applied via mounted route)", got)
+	}
+}
+
+// TestWellKnownDiscoveryRouteSkippedWhenNil guards the inverse: tests
+// that don't construct a Discovery (the common case for server_test.go)
+// get a 404 rather than a nil dereference. Without the nil-guard in
+// Routes(), the bare NewServer(..., nil, ...) call in newTestServer
+// would crash any handler test that happened to hit /.well-known.
+func TestWellKnownDiscoveryRouteSkippedWhenNil(t *testing.T) {
+	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+	resp, err := testClient(srv).Get(srv.URL + "/.well-known/openid-configuration")
+	if err != nil {
+		t.Fatalf("GET well-known: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 when discovery is nil", resp.StatusCode)
 	}
 }
 
@@ -722,7 +783,7 @@ func TestRotateTokenUnauthenticated(t *testing.T) {
 // Sanity guard so the clock override on Server is exercised at least once.
 func TestServerClockExposed(t *testing.T) {
 	cfg := testConfig()
-	s := NewServer(cfg, newTestSigner(t), &fakeVerifier{}, NewIssuer(cfg, fake.NewSimpleClientset()), nil)
+	s := NewServer(cfg, newTestSigner(t), &fakeVerifier{}, NewIssuer(cfg, fake.NewSimpleClientset()), nil, nil)
 	fixed := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	s.clock = func() time.Time { return fixed }
 	if !s.clock().Equal(fixed) {

--- a/tools/demarkus-broker/internal/broker/server_test.go
+++ b/tools/demarkus-broker/internal/broker/server_test.go
@@ -101,7 +101,7 @@ func TestWellKnownDiscoveryRouteRegistered(t *testing.T) {
 	tsrv := httptest.NewServer(srv.Routes())
 	t.Cleanup(tsrv.Close)
 
-	resp, err := http.Get(tsrv.URL + "/.well-known/openid-configuration")
+	resp, err := testClient(tsrv).Get(tsrv.URL + "/.well-known/openid-configuration")
 	if err != nil {
 		t.Fatalf("GET well-known: %v", err)
 	}

--- a/tools/demarkus-broker/main.go
+++ b/tools/demarkus-broker/main.go
@@ -86,7 +86,21 @@ func run(configPath, kubeconfigPath string, log *slog.Logger) error {
 	}
 
 	issuer := broker.NewIssuer(cfg, k8s)
-	srv := broker.NewServer(cfg, signer, verifier, issuer, log)
+
+	// Discovery does an eager IdP fetch at startup — same failure mode
+	// as NewVerifier above (fails fast on misconfigured / unreachable
+	// IdP). 5-minute TTL refresh keeps key-rotation propagation bounded
+	// per plan §Risks.
+	discovery, err := broker.NewDiscovery(context.Background(), broker.DiscoveryConfig{
+		BrokerURL: cfg.Server.PublicURL,
+		IdPIssuer: cfg.OIDC.Issuer,
+		Log:       log,
+	})
+	if err != nil {
+		return err
+	}
+
+	srv := broker.NewServer(cfg, signer, verifier, issuer, discovery, log)
 	if cfg.RateLimit.Disabled {
 		log.Info("broker: rate limit disabled (rateLimit.disabled=true)")
 	} else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broker now serves a /.well-known/openid-configuration endpoint that proxies upstream discovery and rewrites issuer/device_authorization/token endpoints.

* **Configuration**
  * Introduced a required server.publicURL setting (validated and canonicalized; trailing slash trimmed) with local/dev defaults.

* **Behavior**
  * Discovery responses cached with TTL, refresh on expiry, and serve stale on refresh failure; refreshes serialized to avoid stampedes.

* **Tests**
  * Added tests and CI chart checks covering discovery behavior and server.publicURL handling.

* **Documentation**
  * Chart README install example updated to include server.publicURL.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/136)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->