### PR TITLE
fix(tool):  Implement RFC 8628 Device Authorization Grant

### DIFF
--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -63,6 +63,18 @@ type ServerConfig struct {
 	// real deployment turns the state cookie into a downgrade attack vector
 	// — any plaintext-hijacked redirect can complete the OIDC dance.
 	InsecureCookies bool `yaml:"insecureCookies"`
+	// DeviceCodeTTL caps the lifetime of an RFC 8628 device-flow grant —
+	// the window between /device/authorize and the user completing the
+	// IdP redirect at /device. Default 10 minutes; matches the value
+	// Google + Auth0 use, long enough for a user to switch devices and
+	// complete the OIDC dance, short enough that an abandoned grant
+	// evicts before clogging the in-memory store.
+	DeviceCodeTTL time.Duration `yaml:"deviceCodeTTL"`
+	// DevicePollInterval is the minimum allowed gap between successive
+	// /device/token polls before the broker returns RFC 8628 slow_down.
+	// Default 5s; matches the `interval` value the authorize response
+	// emits to clients.
+	DevicePollInterval time.Duration `yaml:"devicePollInterval"`
 }
 
 // OIDCConfig describes the OIDC client registration at the IdP. Discovery
@@ -325,6 +337,9 @@ func (c *Config) validate() error {
 	if c.Server.StateTTL < 0 {
 		return fmt.Errorf("server.stateTTL must be > 0 (got %s)", c.Server.StateTTL)
 	}
+	if err := c.Server.applyDeviceFlowDefaults(); err != nil {
+		return err
+	}
 	if c.OIDC.Issuer == "" {
 		return fmt.Errorf("oidc.issuer is required")
 	}
@@ -372,6 +387,30 @@ func (c *Config) validate() error {
 		c.Sweeper.LeaseName = "demarkus-broker-sweeper"
 	}
 	return c.RateLimit.applyDefaultsAndValidate()
+}
+
+// applyDeviceFlowDefaults fills in PR3 device-flow defaults and rejects
+// degenerate combinations. Extracted from Config.validate to keep the
+// outer function inside the gocyclo budget. Pollinterval must be
+// strictly less than the TTL — a configuration where every legitimate
+// poll trips slow_down would deadlock a real client.
+func (s *ServerConfig) applyDeviceFlowDefaults() error {
+	if s.DeviceCodeTTL == 0 {
+		s.DeviceCodeTTL = 10 * time.Minute
+	}
+	if s.DeviceCodeTTL < 0 {
+		return fmt.Errorf("server.deviceCodeTTL must be > 0 (got %s)", s.DeviceCodeTTL)
+	}
+	if s.DevicePollInterval == 0 {
+		s.DevicePollInterval = 5 * time.Second
+	}
+	if s.DevicePollInterval < 0 {
+		return fmt.Errorf("server.devicePollInterval must be > 0 (got %s)", s.DevicePollInterval)
+	}
+	if s.DevicePollInterval >= s.DeviceCodeTTL {
+		return fmt.Errorf("server.devicePollInterval (%s) must be < server.deviceCodeTTL (%s)", s.DevicePollInterval, s.DeviceCodeTTL)
+	}
+	return nil
 }
 
 // applyDefaultsAndValidate fills in plan §6.2 Slice C.4 defaults for the

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -391,7 +391,7 @@ func (c *Config) validate() error {
 
 // applyDeviceFlowDefaults fills in PR3 device-flow defaults and rejects
 // degenerate combinations. Extracted from Config.validate to keep the
-// outer function inside the gocyclo budget. Pollinterval must be
+// outer function inside the gocyclo budget. PollInterval must be
 // strictly less than the TTL — a configuration where every legitimate
 // poll trips slow_down would deadlock a real client.
 func (s *ServerConfig) applyDeviceFlowDefaults() error {

--- a/tools/demarkus-broker/internal/broker/device.go
+++ b/tools/demarkus-broker/internal/broker/device.go
@@ -1,0 +1,364 @@
+package broker
+
+import (
+	"context"
+	"embed"
+	"html/template"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// deviceCookieName is the cookie carrying the in-flight device_code from
+// the /device form submit through to /auth/callback. Separate from
+// stateCookieName (broker_oidc_state) because the two have different
+// paths and lifetimes: the state cookie scopes to /auth/callback and
+// expires with StateTTL; the device cookie scopes to / so the form
+// handler can set it and the callback can read it, and lives as long as
+// the device-code TTL.
+const deviceCookieName = "broker_device_code"
+
+// deviceGrantType is the RFC 8628 §3.4 grant_type identifier the polling
+// client must send to /device/token. Reproduced as a constant so a typo
+// in the handler can't silently accept arbitrary grant types.
+const deviceGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+
+//go:embed templates/device_form.html templates/device_done.html
+var deviceTemplatesFS embed.FS
+
+// deviceTemplates is the parsed template set. Parsed eagerly at process
+// start (via init) so a malformed template fails the binary rather than
+// the first user request. Both pages are self-contained; the embed.FS
+// keeps them inside the binary so the broker image needs no external
+// assets to render the device-flow surface.
+var deviceTemplates = template.Must(template.ParseFS(deviceTemplatesFS,
+	"templates/device_form.html",
+	"templates/device_done.html"))
+
+// deviceFormData drives the user_code entry page. PrefilledUserCode is
+// non-empty when the user followed verification_uri_complete (the
+// authorize response's helper URL that embeds the code as a query
+// param); Error is set when a previous submit failed and we re-render
+// with feedback.
+type deviceFormData struct {
+	PrefilledUserCode string
+	Error             string
+}
+
+// deviceAuthorizeResponse mirrors RFC 8628 §3.2. Field names are JSON-
+// spec-defined; do not rename.
+type deviceAuthorizeResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+// deviceTokenSuccess mirrors RFC 8628 §3.5 success — the same shape as
+// an OAuth2 token endpoint response when the polling completes. We
+// forward the IdP's raw id_token + access_token verbatim; refresh_token
+// is intentionally omitted in PR3 and lands in PR4.
+type deviceTokenSuccess struct {
+	AccessToken string `json:"access_token"`
+	IDToken     string `json:"id_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+// deviceTokenError is the standard OAuth2 error response shape (RFC
+// 6749 §5.2 + RFC 8628 §3.5 augmentation). Codes used here:
+// authorization_pending, slow_down, expired_token, access_denied,
+// invalid_grant, invalid_request, unsupported_grant_type.
+type deviceTokenError struct {
+	Error string `json:"error"`
+}
+
+// deviceAuthorize implements POST /device/authorize (RFC 8628 §3.1).
+// Generates a fresh device_code + user_code, stashes a pending state
+// in the deviceStore, and returns the codes plus the verification
+// URLs the user follows in a browser. The client_id form parameter is
+// accepted (per RFC) but unused — the broker is the only relying
+// party in this flow, so a registration check would have no security
+// value. We log the supplied value at debug for observability without
+// gating on it.
+func (s *Server) deviceAuthorize(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "invalid_request"})
+		return
+	}
+	if id := r.PostFormValue("client_id"); id != "" {
+		s.log.DebugContext(r.Context(), "broker: device authorize", "client_id", id)
+	}
+	deviceCode, userCode, expiresAt, err := s.deviceStore.Authorize()
+	if err != nil {
+		s.log.ErrorContext(r.Context(), "broker: device authorize failed", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	now := s.clock()
+	verificationURI := s.cfg.Server.PublicURL + "/device"
+	verificationURIComplete := verificationURI + "?user_code=" + url.QueryEscape(userCode)
+	writeJSON(w, http.StatusOK, deviceAuthorizeResponse{
+		DeviceCode:              deviceCode,
+		UserCode:                userCode,
+		VerificationURI:         verificationURI,
+		VerificationURIComplete: verificationURIComplete,
+		// Round down: a slightly-shorter advertised window is safer
+		// than advertising more time than the store will honor.
+		ExpiresIn: int(expiresAt.Sub(now).Seconds()),
+		Interval:  int(s.cfg.Server.DevicePollInterval.Seconds()),
+	})
+}
+
+// deviceFormGet renders the user_code entry page. If verification_uri_
+// complete was followed the user_code query param is prefilled into
+// the form so the user only has to click submit, but they can still
+// edit it before submitting (matches the behavior most IdP device
+// flows ship with).
+func (s *Server) deviceFormGet(w http.ResponseWriter, r *http.Request) {
+	data := deviceFormData{PrefilledUserCode: r.URL.Query().Get("user_code")}
+	s.renderDeviceForm(w, r, data, http.StatusOK)
+}
+
+// deviceFormPost handles the user_code submit. Validates the code
+// resolves to a pending grant, sets the device cookie, and 302s to
+// /auth/login to start the OIDC dance. On invalid codes the form
+// re-renders with an error message — distinguished only as "invalid or
+// expired" since exposing whether a specific code was issued would
+// turn this endpoint into an enumeration oracle.
+func (s *Server) deviceFormPost(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		s.renderDeviceForm(w, r, deviceFormData{Error: "invalid request"}, http.StatusBadRequest)
+		return
+	}
+	userCode := r.PostFormValue("user_code")
+	deviceCode, ok := s.deviceStore.LookupByUserCode(userCode)
+	if !ok {
+		s.renderDeviceForm(w, r, deviceFormData{
+			PrefilledUserCode: userCode,
+			Error:             "Invalid or expired code. Restart the join command and try again.",
+		}, http.StatusBadRequest)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     deviceCookieName,
+		Value:    deviceCode,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   !s.cfg.Server.InsecureCookies,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   int(s.cfg.Server.DeviceCodeTTL.Seconds()),
+	})
+	http.Redirect(w, r, "/auth/login", http.StatusFound)
+}
+
+// deviceToken implements POST /device/token (RFC 8628 §3.4 + §3.5).
+// The polling client sends the same device_code on each call; the
+// broker responds with authorization_pending until /auth/callback
+// runs the OAuth exchange and Binds the result, then returns the
+// success payload (raw IdP id_token + access_token) on the next poll.
+func (s *Server) deviceToken(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "invalid_request"})
+		return
+	}
+	if got := r.PostFormValue("grant_type"); got != deviceGrantType {
+		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "unsupported_grant_type"})
+		return
+	}
+	deviceCode := r.PostFormValue("device_code")
+	if deviceCode == "" {
+		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "invalid_request"})
+		return
+	}
+	out := s.deviceStore.Poll(deviceCode)
+	switch {
+	case out.Status == statusComplete:
+		now := s.clock()
+		expiresIn := 0
+		if !out.Result.Expiry.IsZero() {
+			expiresIn = max(int(out.Result.Expiry.Sub(now).Seconds()), 0)
+		}
+		writeJSON(w, http.StatusOK, deviceTokenSuccess{
+			AccessToken: out.Result.AccessToken,
+			IDToken:     out.Result.RawIDToken,
+			TokenType:   "Bearer",
+			ExpiresIn:   expiresIn,
+		})
+	case out.Status == statusExpired:
+		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "expired_token"})
+	case out.Status == statusDenied:
+		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "access_denied"})
+	case out.SlowDown:
+		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "slow_down"})
+	default:
+		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "authorization_pending"})
+	}
+}
+
+// renderDeviceForm writes the user_code entry HTML. Templates are
+// pre-parsed (deviceTemplates) so a render failure is a programming
+// error rather than a runtime configuration concern.
+func (s *Server) renderDeviceForm(w http.ResponseWriter, r *http.Request, data deviceFormData, status int) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	if err := deviceTemplates.ExecuteTemplate(w, "device_form.html", data); err != nil {
+		// Logged-only: the response status + body is already in flight
+		// (WriteHeader fires before ExecuteTemplate writes any markup),
+		// so http.Error here would corrupt the response. The render
+		// failure means there's broken template state in the binary and
+		// the only sane recovery is a broker rebuild.
+		s.log.ErrorContext(r.Context(), "broker: device form render", "err", err)
+	}
+}
+
+// renderDeviceDone writes the "you can close this tab" confirmation
+// after a successful device-flow callback. Same render-failure posture
+// as renderDeviceForm.
+func (s *Server) renderDeviceDone(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if err := deviceTemplates.ExecuteTemplate(w, "device_done.html", nil); err != nil {
+		s.log.ErrorContext(r.Context(), "broker: device done render", "err", err)
+	}
+}
+
+// deviceCallback is /auth/callback's device-flow branch — dispatched
+// from authCallback when the device cookie is present. Validates the
+// OIDC state cookie (same gates as the browser path), runs Exchange,
+// and Binds the result into the deviceStore for the polling client to
+// pick up on its next /device/token call. Renders device_done.html
+// regardless of outcome (success / IdP-denied / Bind-failed) — the
+// user-facing tab carries no actionable detail, and the polling
+// client distinguishes by the next /device/token response. Logs carry
+// the operational detail for the operator.
+//
+// IdP-denied branch translates ?error=... into deviceStore.Deny so
+// the polling client sees RFC 8628 access_denied rather than timing
+// out with expired_token (plan §Open Question 1 lean: cleaner UX).
+func (s *Server) deviceCallback(w http.ResponseWriter, r *http.Request, deviceCode string) {
+	if _, ok := s.deviceStore.LookupByDeviceCode(deviceCode); !ok {
+		// Cookie pointed at a code the store doesn't know — could be
+		// post-restart memory loss, post-expiry-sweep, or a forged
+		// cookie. Either way nothing to recover; the polling client
+		// already lost the grant. Clear the cookie on the way out so
+		// the next request lands cleanly on the browser path.
+		s.clearDeviceCookie(w)
+		http.Error(w, "device session expired", http.StatusBadRequest)
+		return
+	}
+
+	queryState := r.URL.Query().Get("state")
+	if queryState == "" {
+		s.clearDeviceCookie(w)
+		http.Error(w, "missing state", http.StatusBadRequest)
+		return
+	}
+	stateCookie, err := r.Cookie(stateCookieName)
+	if err != nil {
+		s.clearDeviceCookie(w)
+		http.Error(w, "missing state cookie", http.StatusBadRequest)
+		return
+	}
+	state, err := s.signer.Verify(stateCookie.Value)
+	if err != nil {
+		s.log.WarnContext(r.Context(), "broker: device callback state cookie invalid", "err", err)
+		s.clearDeviceCookie(w)
+		http.Error(w, "invalid state", http.StatusUnauthorized)
+		return
+	}
+	if state.Nonce != queryState {
+		s.log.WarnContext(r.Context(), "broker: device callback state mismatch", "want", state.Nonce, "got", queryState)
+		s.clearDeviceCookie(w)
+		http.Error(w, "state mismatch", http.StatusUnauthorized)
+		return
+	}
+	// Both cookies have done their job. Clear now (before any
+	// WriteHeader call) so a replay can't reuse them and the
+	// browser does not retain them for the next request.
+	http.SetCookie(w, &http.Cookie{
+		Name:     stateCookieName,
+		Value:    "",
+		Path:     "/auth/callback",
+		HttpOnly: true,
+		Secure:   !s.cfg.Server.InsecureCookies,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+	s.clearDeviceCookie(w)
+
+	if errParam := r.URL.Query().Get("error"); errParam != "" {
+		s.log.InfoContext(r.Context(), "broker: device callback denied by idp", "err", errParam)
+		if denyErr := s.deviceStore.Deny(deviceCode); denyErr != nil {
+			s.log.WarnContext(r.Context(), "broker: device deny failed", "err", denyErr)
+		}
+		s.renderDeviceDone(w, r)
+		return
+	}
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		http.Error(w, "missing code", http.StatusBadRequest)
+		return
+	}
+
+	exchange, err := s.verifier.Exchange(r.Context(), code)
+	if err != nil {
+		s.log.WarnContext(r.Context(), "broker: device callback oauth exchange failed", "err", err)
+		if denyErr := s.deviceStore.Deny(deviceCode); denyErr != nil {
+			s.log.WarnContext(r.Context(), "broker: device deny failed", "err", denyErr)
+		}
+		s.renderDeviceDone(w, r)
+		return
+	}
+	if err := s.deviceStore.Bind(deviceCode, &exchange); err != nil {
+		s.log.WarnContext(r.Context(), "broker: device bind failed",
+			"err", err, "subject", hashSubject(exchange.Claims.Subject))
+		s.renderDeviceDone(w, r)
+		return
+	}
+	s.log.InfoContext(r.Context(), "broker: device bind succeeded",
+		"subject", hashSubject(exchange.Claims.Subject))
+	s.renderDeviceDone(w, r)
+}
+
+// RunDeviceJanitor sweeps the deviceStore on a fixed cadence until ctx
+// is canceled. Sweep cadence is half the configured device-code TTL so
+// terminal entries are evicted within one TTL window after resolution.
+// Unlike the Sweeper, this janitor needs no leader election: the store
+// is per-replica in-memory state (plan §"Single broker only for now"),
+// so each replica sweeps its own store. Multi-replica deployments are
+// out of scope until the device store grows a shared backing store.
+func (s *Server) RunDeviceJanitor(ctx context.Context) {
+	ttl := s.cfg.Server.DeviceCodeTTL
+	if ttl <= 0 {
+		ttl = 10 * time.Minute
+	}
+	tick := max(ttl/2, time.Second)
+	t := time.NewTicker(tick)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.deviceStore.Sweep()
+		}
+	}
+}
+
+// clearDeviceCookie zeroes the device cookie. Called from /auth/callback's
+// device branch after Bind (or Deny) so the cookie can't replay against a
+// later flow. Mirrors the state-cookie clearing pattern in authCallback.
+func (s *Server) clearDeviceCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     deviceCookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   !s.cfg.Server.InsecureCookies,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+}

--- a/tools/demarkus-broker/internal/broker/device.go
+++ b/tools/demarkus-broker/internal/broker/device.go
@@ -79,19 +79,27 @@ type deviceTokenError struct {
 // deviceAuthorize implements POST /device/authorize (RFC 8628 §3.1).
 // Generates a fresh device_code + user_code, stashes a pending state
 // in the deviceStore, and returns the codes plus the verification
-// URLs the user follows in a browser. The client_id form parameter is
-// accepted (per RFC) but unused — the broker is the only relying
-// party in this flow, so a registration check would have no security
-// value. We log the supplied value at debug for observability without
-// gating on it.
+// URLs the user follows in a browser.
+//
+// client_id is REQUIRED per RFC 8628 §3.1; missing or empty returns
+// invalid_request. The broker does not validate the value against a
+// registration table — the plugin clients (demarkus-join + Claude
+// Code plugin) are not multiplexed identities and a registration
+// check would have no security value here. The check exists to
+// filter malformed clients and to keep the protocol surface
+// spec-conformant for any standard OIDC device-flow library a user
+// might plug in. Value is logged at debug for observability only.
 func (s *Server) deviceAuthorize(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "invalid_request"})
 		return
 	}
-	if id := r.PostFormValue("client_id"); id != "" {
-		s.log.DebugContext(r.Context(), "broker: device authorize", "client_id", id)
+	clientID := r.PostFormValue("client_id")
+	if clientID == "" {
+		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "invalid_request"})
+		return
 	}
+	s.log.DebugContext(r.Context(), "broker: device authorize", "client_id", clientID)
 	deviceCode, userCode, expiresAt, err := s.deviceStore.Authorize()
 	if err != nil {
 		s.log.ErrorContext(r.Context(), "broker: device authorize failed", "err", err)
@@ -201,6 +209,12 @@ func (s *Server) deviceToken(w http.ResponseWriter, r *http.Request) {
 		if !out.Result.Expiry.IsZero() {
 			expiresIn = max(int(out.Result.Expiry.Sub(now).Seconds()), 0)
 		}
+		// Tokens are bearer credentials — any intermediary that
+		// caches this response is a credential-leak vector. Set the
+		// canonical OAuth2 §5.1 no-store headers BEFORE writeJSON
+		// fires WriteHeader so they actually land in the response.
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Pragma", "no-cache")
 		writeJSON(w, http.StatusOK, deviceTokenSuccess{
 			AccessToken: out.Result.AccessToken,
 			IDToken:     out.Result.RawIDToken,
@@ -287,10 +301,17 @@ func (s *Server) deviceCallback(w http.ResponseWriter, r *http.Request, deviceCo
 
 	exchange, err := s.verifier.Exchange(r.Context(), code)
 	if err != nil {
+		// Do NOT translate broker-side exchange failures into
+		// access_denied: that error is reserved for the user
+		// explicitly denying at the IdP (handled above on the
+		// `error` query param). Calling Deny here would permanently
+		// tell the polling client "user rejected" on a transient
+		// failure (JWKS unreachable, IdP rate-limited, etc.). Leave
+		// the grant pending so the user can retry by re-running
+		// /soul-join; if the broker stays broken until the device
+		// code's TTL, the polling client sees expired_token, which
+		// is the truthful state.
 		s.log.WarnContext(r.Context(), "broker: device callback oauth exchange failed", "err", err)
-		if denyErr := s.deviceStore.Deny(deviceCode); denyErr != nil {
-			s.log.WarnContext(r.Context(), "broker: device deny failed", "err", denyErr)
-		}
 		s.renderDeviceDone(w, r)
 		return
 	}

--- a/tools/demarkus-broker/internal/broker/device.go
+++ b/tools/demarkus-broker/internal/broker/device.go
@@ -114,9 +114,11 @@ func (s *Server) deviceAuthorize(w http.ResponseWriter, r *http.Request) {
 		UserCode:                userCode,
 		VerificationURI:         verificationURI,
 		VerificationURIComplete: verificationURIComplete,
-		// Round down: a slightly-shorter advertised window is safer
-		// than advertising more time than the store will honor.
-		ExpiresIn: int(expiresAt.Sub(now).Seconds()),
+		// Round down + clamp to 0 under any clock skew: advertising
+		// a negative window confuses clients, and a slightly-shorter
+		// window is safer than advertising more time than the store
+		// will honor.
+		ExpiresIn: max(int(expiresAt.Sub(now).Seconds()), 0),
 		Interval:  int(s.cfg.Server.DevicePollInterval.Seconds()),
 	})
 }

--- a/tools/demarkus-broker/internal/broker/device.go
+++ b/tools/demarkus-broker/internal/broker/device.go
@@ -128,7 +128,26 @@ func (s *Server) deviceFormGet(w http.ResponseWriter, r *http.Request) {
 // re-renders with an error message — distinguished only as "invalid or
 // expired" since exposing whether a specific code was issued would
 // turn this endpoint into an enumeration oracle.
+//
+// CSRF defense: a cross-origin POST that successfully reached this
+// handler could bind a victim's IdP identity to an attacker-supplied
+// device_code (the attacker would have called /device/authorize first
+// and embedded their own user_code in a form on a page the victim
+// visits). SameSite=Lax doesn't help here because we are SETTING the
+// device cookie cross-site, not reading an existing one. The Origin
+// header check below catches every browser-shape CSRF attempt: modern
+// browsers always send Origin on POST, so any cross-origin POST will
+// have an Origin pointing at the attacker's site, which we reject.
+// Non-browser clients (curl, Go's http.Client) omit Origin and are
+// allowed; they are not vulnerable to the CSRF tricked-browser
+// scenario by construction.
 func (s *Server) deviceFormPost(w http.ResponseWriter, r *http.Request) {
+	if !sameOriginPost(r) {
+		s.log.WarnContext(r.Context(), "broker: device form POST blocked — cross-origin",
+			"origin", r.Header.Get("Origin"), "host", r.Host)
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
 	if err := r.ParseForm(); err != nil {
 		s.renderDeviceForm(w, r, deviceFormData{Error: "invalid request"}, http.StatusBadRequest)
 		return
@@ -346,6 +365,30 @@ func (s *Server) RunDeviceJanitor(ctx context.Context) {
 			s.deviceStore.Sweep()
 		}
 	}
+}
+
+// sameOriginPost returns false when the request carries an Origin
+// header whose host differs from r.Host — the canonical signal of a
+// cross-origin browser POST. Absence of Origin is treated as
+// "not a browser" (curl, Go's http.Client, server-to-server tooling
+// — none of which are CSRF-vulnerable, since CSRF requires an
+// authenticated user-agent the attacker can puppet).
+//
+// We don't compare against cfg.Server.PublicURL because in dev /
+// kind / port-forward setups the user reaches the broker through a
+// host that differs from PublicURL; r.Host reflects the actual host
+// the browser sees and the Origin it sends, which is what we want
+// for a strict same-origin gate.
+func sameOriginPost(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return u.Host == r.Host
 }
 
 // clearDeviceCookie zeroes the device cookie. Called from /auth/callback's

--- a/tools/demarkus-broker/internal/broker/device.go
+++ b/tools/demarkus-broker/internal/broker/device.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -245,68 +246,30 @@ func (s *Server) renderDeviceDone(w http.ResponseWriter, r *http.Request) {
 }
 
 // deviceCallback is /auth/callback's device-flow branch — dispatched
-// from authCallback when the device cookie is present. Validates the
-// OIDC state cookie (same gates as the browser path), runs Exchange,
-// and Binds the result into the deviceStore for the polling client to
-// pick up on its next /device/token call. Renders device_done.html
-// regardless of outcome (success / IdP-denied / Bind-failed) — the
-// user-facing tab carries no actionable detail, and the polling
-// client distinguishes by the next /device/token response. Logs carry
-// the operational detail for the operator.
+// by authCallback when the verified State carries a non-empty
+// DeviceCode. State validation (signature, nonce match, expiry,
+// cookie clear) is owned by the caller; this function is invoked
+// only after those gates pass.
+//
+// Runs Exchange and Binds the result into the deviceStore for the
+// polling client to pick up. Renders device_done.html regardless of
+// outcome (success / IdP-denied / Bind-failed) — the user-facing tab
+// carries no actionable detail, and the polling client distinguishes
+// by the next /device/token response. Logs carry the operational
+// detail for the operator.
 //
 // IdP-denied branch translates ?error=... into deviceStore.Deny so
 // the polling client sees RFC 8628 access_denied rather than timing
 // out with expired_token (plan §Open Question 1 lean: cleaner UX).
 func (s *Server) deviceCallback(w http.ResponseWriter, r *http.Request, deviceCode string) {
 	if _, ok := s.deviceStore.LookupByDeviceCode(deviceCode); !ok {
-		// Cookie pointed at a code the store doesn't know — could be
-		// post-restart memory loss, post-expiry-sweep, or a forged
-		// cookie. Either way nothing to recover; the polling client
-		// already lost the grant. Clear the cookie on the way out so
-		// the next request lands cleanly on the browser path.
-		s.clearDeviceCookie(w)
+		// State carried a device_code the store doesn't recognize —
+		// could be post-restart memory loss, post-expiry sweep, or
+		// the grant was already resolved. The polling client (if any)
+		// already lost the grant.
 		http.Error(w, "device session expired", http.StatusBadRequest)
 		return
 	}
-
-	queryState := r.URL.Query().Get("state")
-	if queryState == "" {
-		s.clearDeviceCookie(w)
-		http.Error(w, "missing state", http.StatusBadRequest)
-		return
-	}
-	stateCookie, err := r.Cookie(stateCookieName)
-	if err != nil {
-		s.clearDeviceCookie(w)
-		http.Error(w, "missing state cookie", http.StatusBadRequest)
-		return
-	}
-	state, err := s.signer.Verify(stateCookie.Value)
-	if err != nil {
-		s.log.WarnContext(r.Context(), "broker: device callback state cookie invalid", "err", err)
-		s.clearDeviceCookie(w)
-		http.Error(w, "invalid state", http.StatusUnauthorized)
-		return
-	}
-	if state.Nonce != queryState {
-		s.log.WarnContext(r.Context(), "broker: device callback state mismatch", "want", state.Nonce, "got", queryState)
-		s.clearDeviceCookie(w)
-		http.Error(w, "state mismatch", http.StatusUnauthorized)
-		return
-	}
-	// Both cookies have done their job. Clear now (before any
-	// WriteHeader call) so a replay can't reuse them and the
-	// browser does not retain them for the next request.
-	http.SetCookie(w, &http.Cookie{
-		Name:     stateCookieName,
-		Value:    "",
-		Path:     "/auth/callback",
-		HttpOnly: true,
-		Secure:   !s.cfg.Server.InsecureCookies,
-		SameSite: http.SameSiteLaxMode,
-		MaxAge:   -1,
-	})
-	s.clearDeviceCookie(w)
 
 	if errParam := r.URL.Query().Get("error"); errParam != "" {
 		s.log.InfoContext(r.Context(), "broker: device callback denied by idp", "err", errParam)
@@ -368,27 +331,41 @@ func (s *Server) RunDeviceJanitor(ctx context.Context) {
 }
 
 // sameOriginPost returns false when the request carries an Origin
-// header whose host differs from r.Host — the canonical signal of a
-// cross-origin browser POST. Absence of Origin is treated as
-// "not a browser" (curl, Go's http.Client, server-to-server tooling
-// — none of which are CSRF-vulnerable, since CSRF requires an
-// authenticated user-agent the attacker can puppet).
+// header whose scheme+host differs from the request's own — the
+// canonical signal of a cross-origin browser POST. Both axes
+// matter: `http://broker.example.com` and `https://broker.example.com`
+// are distinct origins, so a host-only match would let an attacker on
+// a downgraded scheme through.
 //
-// We don't compare against cfg.Server.PublicURL because in dev /
-// kind / port-forward setups the user reaches the broker through a
-// host that differs from PublicURL; r.Host reflects the actual host
-// the browser sees and the Origin it sends, which is what we want
-// for a strict same-origin gate.
+// Absence of Origin is treated as "not a browser" (curl, Go's
+// http.Client, server-to-server tooling — none of which are CSRF-
+// vulnerable, since CSRF requires an authenticated user-agent the
+// attacker can puppet).
+//
+// Expected scheme: X-Forwarded-Proto wins when present (we are
+// behind a TLS-terminating ingress per the standard deployment
+// shape; a browser-driven CSRF cannot forge this header since it is
+// stripped/rewritten by the ingress), falling back to r.TLS to
+// distinguish direct HTTPS from plain HTTP. Expected host: r.Host
+// — what the browser actually saw — rather than cfg.Server.PublicURL,
+// so dev / kind / port-forward setups where users reach the broker
+// on a different host than PublicURL keep working.
 func sameOriginPost(r *http.Request) bool {
 	origin := r.Header.Get("Origin")
 	if origin == "" {
 		return true
 	}
 	u, err := url.Parse(origin)
-	if err != nil || u.Host == "" {
+	if err != nil || u.Host == "" || u.Scheme == "" {
 		return false
 	}
-	return u.Host == r.Host
+	expectedScheme := "http"
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		expectedScheme = strings.ToLower(proto)
+	} else if r.TLS != nil {
+		expectedScheme = "https"
+	}
+	return u.Host == r.Host && strings.EqualFold(u.Scheme, expectedScheme)
 }
 
 // clearDeviceCookie zeroes the device cookie. Called from /auth/callback's

--- a/tools/demarkus-broker/internal/broker/device_store.go
+++ b/tools/demarkus-broker/internal/broker/device_store.go
@@ -1,0 +1,422 @@
+package broker
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// userCodeAlphabet is the character set for user-readable device codes.
+// Excludes 0, 1, I, L, O, U to remove the visual confusables that trip
+// up users typing the code at a verification URL on a phone or laptop.
+// 30 chars; with two 4-character groups (8 total) the space is 30^8 ≈
+// 6.6×10^11. Birthday-paradox collision under a 10-minute TTL with even
+// pathological authorize rates stays in the negligible range, and the
+// generator still retries on collision as cheap insurance.
+const userCodeAlphabet = "23456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+// userCodeLen is the total character count (not counting the hyphen).
+const userCodeLen = 8
+
+// userCodeHyphenAt is the index the display hyphen is inserted at when
+// rendering for the user. Server-side comparison always strips hyphens
+// + uppercases first, so a user typing "WDJB-MJHT", "wdjbmjht", or
+// "wdjb mjht" with stray whitespace all resolve to the same canonical
+// form.
+const userCodeHyphenAt = 4
+
+// deviceCodeBytes is the raw entropy in the opaque device_code returned
+// to the polling client. 32 bytes = 64 hex chars; the device_code is
+// only ever handled machine-to-machine, so length is not a UX concern.
+const deviceCodeBytes = 32
+
+// deviceCodeGenAttempts caps user-code collision retries. With the
+// alphabet size above, three attempts is sufficient under any realistic
+// load; a fourth would only paper over a malfunctioning RNG.
+const deviceCodeGenAttempts = 3
+
+// deviceStatus is the device-flow state-machine value. The four states
+// map directly to RFC 8628 §3.5 outcomes the polling client sees on
+// /device/token: authorization_pending → statusPending; success → the
+// 200-with-tokens response built from statusComplete; expired_token →
+// statusExpired; access_denied → statusDenied.
+type deviceStatus int
+
+const (
+	statusPending deviceStatus = iota
+	statusComplete
+	statusExpired
+	statusDenied
+)
+
+// deviceCodeState is one in-flight device-flow grant. Created by
+// Authorize, mutated by Poll/Bind/Deny/Sweep, read by every handler.
+// All fields are owned by the deviceStore's mutex; callers must not
+// mutate after the value is returned outside the lock.
+type deviceCodeState struct {
+	DeviceCode   string
+	UserCode     string // canonical (no hyphen, uppercase)
+	Status       deviceStatus
+	CreatedAt    time.Time
+	ExpiresAt    time.Time
+	LastPolledAt time.Time // zero until first /device/token poll
+
+	// Populated by Bind on successful IdP exchange; consumed by Poll
+	// to build the statusComplete response. Zero values otherwise.
+	Result ExchangeResult
+}
+
+// pollResult is what the /device/token handler dispatches on. SlowDown
+// is set only for a pending poll that arrived before the configured
+// minimum interval elapsed — handler translates to the RFC 8628
+// "slow_down" error response (status stays statusPending in the
+// store; we just signal the rate violation to the handler).
+type pollResult struct {
+	Status   deviceStatus
+	SlowDown bool
+	Result   ExchangeResult // only set when Status == statusComplete
+}
+
+// errDeviceCodeNotFound is returned by Bind / Poll / Deny when the
+// device_code is unknown. Treated as expired/denied at the HTTP layer
+// — never echoed to the client beyond the standard RFC 8628 error
+// codes, since revealing whether a device_code ever existed would
+// turn the polling endpoint into an enumeration oracle.
+var errDeviceCodeNotFound = errors.New("device code not found")
+
+// errDeviceCodeTerminal is returned by Bind when the state has already
+// transitioned out of pending (already complete / expired / denied).
+// The /auth/callback path treats it as a no-op success: the device
+// flow already moved on, and overwriting would silently invalidate
+// whichever resolution landed first.
+var errDeviceCodeTerminal = errors.New("device code in terminal state")
+
+// deviceStore is the in-memory state for all active device-flow grants
+// on this broker replica. Single-broker invariant per plan §"Single
+// broker only for now": no Redis, no Secret-backed persistence — a
+// broker restart drops all in-flight flows and clients see
+// expired_token on next poll. Acceptable for the ten-minute device-code
+// TTL; revisit if HA broker ever lands.
+type deviceStore struct {
+	mu sync.Mutex
+
+	codes     map[string]*deviceCodeState // device_code → state
+	userIndex map[string]string           // canonical user_code → device_code
+
+	clock        func() time.Time
+	expiresIn    time.Duration
+	pollInterval time.Duration
+}
+
+// newDeviceStore builds a fresh in-memory store. expiresIn is the
+// device-code TTL (10m default — see plan open question §5);
+// pollInterval is the minimum allowed gap between /device/token polls
+// (5s default, matches the value emitted in the authorize response's
+// `interval` field). clock is injected so tests can drive expiry and
+// slow_down without sleeping.
+func newDeviceStore(clock func() time.Time, expiresIn, pollInterval time.Duration) *deviceStore {
+	if clock == nil {
+		clock = time.Now
+	}
+	return &deviceStore{
+		codes:        make(map[string]*deviceCodeState),
+		userIndex:    make(map[string]string),
+		clock:        clock,
+		expiresIn:    expiresIn,
+		pollInterval: pollInterval,
+	}
+}
+
+// Authorize creates a new pending grant and returns the codes the
+// /device/authorize handler echoes back to the polling client. The
+// caller composes the verification_uri + verification_uri_complete
+// from the broker's PublicURL; this method owns only the secret-
+// material side.
+//
+// User-code collisions are theoretically possible (30^8 ≈ 6.6×10^11
+// addresses, ~600 simultaneously-active codes under any realistic
+// load); we retry up to deviceCodeGenAttempts times and surface an
+// error on the unlikely third collision rather than allow a silent
+// overwrite of an in-flight code.
+func (s *deviceStore) Authorize() (deviceCode, userCode string, expiresAt time.Time, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.clock()
+	expiresAt = now.Add(s.expiresIn)
+
+	deviceCode, err = newDeviceCode()
+	if err != nil {
+		return "", "", time.Time{}, fmt.Errorf("device code: %w", err)
+	}
+
+	var canonical string
+	for range deviceCodeGenAttempts {
+		canonical, err = newUserCode()
+		if err != nil {
+			return "", "", time.Time{}, fmt.Errorf("user code: %w", err)
+		}
+		if _, taken := s.userIndex[canonical]; !taken {
+			break
+		}
+		canonical = ""
+	}
+	if canonical == "" {
+		return "", "", time.Time{}, fmt.Errorf("user code: exhausted %d collision retries", deviceCodeGenAttempts)
+	}
+
+	s.codes[deviceCode] = &deviceCodeState{
+		DeviceCode: deviceCode,
+		UserCode:   canonical,
+		Status:     statusPending,
+		CreatedAt:  now,
+		ExpiresAt:  expiresAt,
+	}
+	s.userIndex[canonical] = deviceCode
+	return deviceCode, formatUserCode(canonical), expiresAt, nil
+}
+
+// LookupByUserCode resolves a user-typed code to its device_code. The
+// /device POST handler normalizes (strip hyphens + uppercase) before
+// calling; this method does the same defensively so a misuse from a
+// future handler doesn't silently fail to match. Returns false on
+// unknown codes and on terminal-state matches (expired / complete /
+// denied) — the form handler should not let a user complete a flow
+// that has already resolved.
+func (s *deviceStore) LookupByUserCode(userCode string) (string, bool) {
+	canonical := canonicalizeUserCode(userCode)
+	if canonical == "" {
+		return "", false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	deviceCode, ok := s.userIndex[canonical]
+	if !ok {
+		return "", false
+	}
+	state, ok := s.codes[deviceCode]
+	if !ok {
+		return "", false
+	}
+	if state.Status != statusPending {
+		return "", false
+	}
+	if s.clock().After(state.ExpiresAt) {
+		return "", false
+	}
+	return deviceCode, true
+}
+
+// LookupByDeviceCode returns a copy of the state for the given
+// device_code, or false if absent. Used by /auth/callback's device
+// branch to validate the cookie before kicking the OAuth exchange.
+// Returns a copy (not a pointer) so callers can't accidentally mutate
+// the store's state outside the mutex.
+func (s *deviceStore) LookupByDeviceCode(deviceCode string) (deviceCodeState, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.codes[deviceCode]
+	if !ok {
+		return deviceCodeState{}, false
+	}
+	return *state, true
+}
+
+// Bind transitions a pending grant to statusComplete and stashes the
+// IdP exchange result for the polling client to pick up. Called from
+// /auth/callback's device-cookie branch after the OAuth exchange
+// succeeds. Takes a pointer to avoid copying ExchangeResult (~120
+// bytes) through the call site; the store still owns its copy via
+// the dereference into deviceCodeState.Result. Returns
+// errDeviceCodeNotFound for unknown codes and errDeviceCodeTerminal
+// if the grant has already resolved (already complete, expired, or
+// denied) — the callback handler treats the terminal case as a
+// no-op, since whatever already resolved is the authoritative outcome.
+func (s *deviceStore) Bind(deviceCode string, result *ExchangeResult) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.codes[deviceCode]
+	if !ok {
+		return errDeviceCodeNotFound
+	}
+	now := s.clock()
+	if state.Status == statusPending && now.After(state.ExpiresAt) {
+		state.Status = statusExpired
+	}
+	if state.Status != statusPending {
+		return errDeviceCodeTerminal
+	}
+	state.Status = statusComplete
+	state.Result = *result
+	return nil
+}
+
+// Deny transitions a pending grant to statusDenied. Called from
+// /auth/callback's device-cookie branch when the IdP redirects back
+// with an `error` query param (user denied consent at the IdP). The
+// polling client sees access_denied on the next /device/token poll.
+// Same terminal-state semantics as Bind.
+func (s *deviceStore) Deny(deviceCode string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.codes[deviceCode]
+	if !ok {
+		return errDeviceCodeNotFound
+	}
+	now := s.clock()
+	if state.Status == statusPending && now.After(state.ExpiresAt) {
+		state.Status = statusExpired
+	}
+	if state.Status != statusPending {
+		return errDeviceCodeTerminal
+	}
+	state.Status = statusDenied
+	return nil
+}
+
+// Poll advances the state machine on each /device/token call. The
+// returned pollResult tells the handler exactly what to write:
+//   - Status==statusPending, SlowDown==false → "authorization_pending"
+//   - Status==statusPending, SlowDown==true  → "slow_down"
+//   - Status==statusComplete                 → success body w/ tokens
+//   - Status==statusExpired                  → "expired_token"
+//   - Status==statusDenied                   → "access_denied"
+//
+// Expiry is checked lazily on poll: a state that crossed ExpiresAt
+// while still pending gets transitioned to statusExpired here, so the
+// next poll sees expired_token even if the janitor hasn't swept yet.
+func (s *deviceStore) Poll(deviceCode string) pollResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.codes[deviceCode]
+	if !ok {
+		return pollResult{Status: statusExpired}
+	}
+	now := s.clock()
+	if state.Status == statusPending && now.After(state.ExpiresAt) {
+		state.Status = statusExpired
+	}
+	if state.Status != statusPending {
+		out := pollResult{Status: state.Status}
+		if state.Status == statusComplete {
+			out.Result = state.Result
+		}
+		return out
+	}
+	// Plan §Open Question 4: RFC 8628 §3.5 says the server MAY require
+	// the client to increase its interval by 5s on each slow_down. PR3
+	// just enforces the configured minimum; if the client polls early,
+	// signal slow_down without bumping. Revisit if IdP abuse becomes a
+	// real signal in production.
+	if !state.LastPolledAt.IsZero() && now.Sub(state.LastPolledAt) < s.pollInterval {
+		return pollResult{Status: statusPending, SlowDown: true}
+	}
+	state.LastPolledAt = now
+	return pollResult{Status: statusPending}
+}
+
+// Sweep evicts terminal entries that have aged out. Called by the
+// janitor goroutine at half the device-code TTL. Pending entries past
+// ExpiresAt are not eagerly transitioned here — Poll does that
+// lazily on next poll — but their user_code reservation is released
+// so the alphabet doesn't slowly clog up with expired-but-never-
+// polled codes.
+//
+// retainGrace gives recently-resolved entries a short window so a
+// polling client racing the sweep can still read its statusComplete
+// result before the entry vanishes. One poll-interval is plenty;
+// any client that hasn't polled within that window after completion
+// is effectively gone.
+func (s *deviceStore) Sweep() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.clock()
+	retainGrace := s.pollInterval
+	for code, state := range s.codes {
+		expired := now.After(state.ExpiresAt)
+		if state.Status == statusPending && expired {
+			state.Status = statusExpired
+		}
+		terminal := state.Status != statusPending
+		past := now.After(state.ExpiresAt.Add(retainGrace))
+		if terminal && past {
+			delete(s.codes, code)
+			delete(s.userIndex, state.UserCode)
+		}
+	}
+}
+
+// newDeviceCode returns a fresh opaque device_code from crypto/rand.
+func newDeviceCode() (string, error) {
+	buf := make([]byte, deviceCodeBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// newUserCode returns a canonical (no-hyphen, uppercase) user_code
+// drawn uniformly from userCodeAlphabet. The handler formats with a
+// hyphen before rendering; Lookup normalizes user input back to
+// canonical form before comparing.
+//
+// Uses crypto/rand with rejection sampling so the alphabet's
+// non-power-of-two size doesn't bias toward early characters. The
+// rejection rate is well under 1% for our 30-char alphabet
+// (256 % 30 = 16; reject 16/256 ≈ 6.25% per byte), so the average
+// cost is one rand.Read of a tiny buffer.
+func newUserCode() (string, error) {
+	const maxByte = 256 - (256 % len(userCodeAlphabet))
+	out := make([]byte, 0, userCodeLen)
+	buf := make([]byte, 1)
+	for len(out) < userCodeLen {
+		if _, err := rand.Read(buf); err != nil {
+			return "", err
+		}
+		if int(buf[0]) >= maxByte {
+			continue
+		}
+		out = append(out, userCodeAlphabet[int(buf[0])%len(userCodeAlphabet)])
+	}
+	return string(out), nil
+}
+
+// canonicalizeUserCode strips whitespace + hyphens and uppercases the
+// input so the lookup compares against the canonical (alphabet-only)
+// form stored in userIndex. Returns "" on any character outside the
+// alphabet so the lookup naturally fails without exposing the
+// rejection reason to the caller.
+func canonicalizeUserCode(in string) string {
+	in = strings.ToUpper(strings.TrimSpace(in))
+	out := make([]byte, 0, userCodeLen)
+	for i := 0; i < len(in); i++ {
+		c := in[i]
+		if c == '-' || c == ' ' {
+			continue
+		}
+		if !strings.ContainsRune(userCodeAlphabet, rune(c)) {
+			return ""
+		}
+		out = append(out, c)
+		if len(out) > userCodeLen {
+			return ""
+		}
+	}
+	if len(out) != userCodeLen {
+		return ""
+	}
+	return string(out)
+}
+
+// formatUserCode inserts the display hyphen so the user sees
+// "WDJB-MJHT" rather than "WDJBMJHT". Canonical form is stored
+// server-side; the hyphen is purely a readability affordance.
+func formatUserCode(canonical string) string {
+	if len(canonical) != userCodeLen {
+		return canonical
+	}
+	return canonical[:userCodeHyphenAt] + "-" + canonical[userCodeHyphenAt:]
+}

--- a/tools/demarkus-broker/internal/broker/device_store_test.go
+++ b/tools/demarkus-broker/internal/broker/device_store_test.go
@@ -1,0 +1,389 @@
+package broker
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testExpiresIn    = 10 * time.Minute
+	testPollInterval = 5 * time.Second
+)
+
+func newTestDeviceStore(t *testing.T) (*deviceStore, *fakeClock) {
+	t.Helper()
+	c := &fakeClock{now: time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)}
+	return newDeviceStore(c.Now, testExpiresIn, testPollInterval), c
+}
+
+func TestDeviceStoreAuthorize(t *testing.T) {
+	t.Run("populates state and returns formatted user code", func(t *testing.T) {
+		store, clock := newTestDeviceStore(t)
+
+		deviceCode, userCode, expiresAt, err := store.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		if deviceCode == "" {
+			t.Fatal("empty device code")
+		}
+		if !strings.Contains(userCode, "-") {
+			t.Fatalf("user code missing hyphen: %q", userCode)
+		}
+		if len(userCode) != userCodeLen+1 {
+			t.Fatalf("user code wrong length: got %d want %d", len(userCode), userCodeLen+1)
+		}
+		if got, want := expiresAt, clock.Now().Add(testExpiresIn); !got.Equal(want) {
+			t.Fatalf("expiresAt: got %v want %v", got, want)
+		}
+
+		// Resolve back via lookup to confirm the user_code is indexed.
+		gotDevice, ok := store.LookupByUserCode(userCode)
+		if !ok {
+			t.Fatal("LookupByUserCode returned false")
+		}
+		if gotDevice != deviceCode {
+			t.Fatalf("user-code index mismatch: got %q want %q", gotDevice, deviceCode)
+		}
+	})
+
+	t.Run("device codes are unique across calls", func(t *testing.T) {
+		store, _ := newTestDeviceStore(t)
+		seenDevice := make(map[string]bool)
+		seenUser := make(map[string]bool)
+		for range 50 {
+			deviceCode, userCode, _, err := store.Authorize()
+			if err != nil {
+				t.Fatalf("Authorize: %v", err)
+			}
+			if seenDevice[deviceCode] {
+				t.Fatalf("duplicate device_code: %q", deviceCode)
+			}
+			if seenUser[userCode] {
+				t.Fatalf("duplicate user_code: %q", userCode)
+			}
+			seenDevice[deviceCode] = true
+			seenUser[userCode] = true
+		}
+	})
+}
+
+func TestDeviceStoreLookupByUserCode(t *testing.T) {
+	t.Run("accepts canonical, hyphenated, and whitespace forms", func(t *testing.T) {
+		store, _ := newTestDeviceStore(t)
+		deviceCode, userCode, _, err := store.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		canonical := strings.ReplaceAll(userCode, "-", "")
+
+		variants := []string{
+			userCode,
+			canonical,
+			strings.ToLower(userCode),
+			" " + userCode + " ",
+			canonical[:4] + " " + canonical[4:],
+		}
+		for _, v := range variants {
+			got, ok := store.LookupByUserCode(v)
+			if !ok {
+				t.Fatalf("variant %q: not found", v)
+			}
+			if got != deviceCode {
+				t.Fatalf("variant %q: mismatch", v)
+			}
+		}
+	})
+
+	t.Run("rejects unknown / malformed inputs", func(t *testing.T) {
+		store, _ := newTestDeviceStore(t)
+		cases := []struct {
+			name  string
+			input string
+		}{
+			{"empty", ""},
+			{"too short", "ABCD"},
+			{"too long", "ABCDEFGHIJK"},
+			{"alphabet violation", "11110000"},
+			{"never-issued", "AAAAAAAA"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				if _, ok := store.LookupByUserCode(tc.input); ok {
+					t.Fatalf("expected miss for %q", tc.input)
+				}
+			})
+		}
+	})
+
+	t.Run("misses after expiry without sweep", func(t *testing.T) {
+		store, clock := newTestDeviceStore(t)
+		_, userCode, _, err := store.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		clock.Advance(testExpiresIn + time.Second)
+		if _, ok := store.LookupByUserCode(userCode); ok {
+			t.Fatal("expected lookup to miss after TTL")
+		}
+	})
+
+	t.Run("misses after Bind", func(t *testing.T) {
+		store, _ := newTestDeviceStore(t)
+		deviceCode, userCode, _, err := store.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		if err := store.Bind(deviceCode, &ExchangeResult{}); err != nil {
+			t.Fatalf("Bind: %v", err)
+		}
+		if _, ok := store.LookupByUserCode(userCode); ok {
+			t.Fatal("expected lookup to miss after Bind")
+		}
+	})
+}
+
+func TestDeviceStoreBind(t *testing.T) {
+	t.Run("transitions pending to complete with result", func(t *testing.T) {
+		store, _ := newTestDeviceStore(t)
+		deviceCode, _, _, err := store.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		result := ExchangeResult{
+			Claims:      Claims{Subject: "sub", Email: "alice@example.com", EmailVerified: true},
+			RawIDToken:  "id-token",
+			AccessToken: "access-token",
+		}
+		if err := store.Bind(deviceCode, &result); err != nil {
+			t.Fatalf("Bind: %v", err)
+		}
+		out := store.Poll(deviceCode)
+		if out.Status != statusComplete {
+			t.Fatalf("status: got %v want statusComplete", out.Status)
+		}
+		if out.Result.RawIDToken != "id-token" {
+			t.Fatalf("forwarded id_token mismatch: %q", out.Result.RawIDToken)
+		}
+		if out.Result.AccessToken != "access-token" {
+			t.Fatalf("forwarded access_token mismatch: %q", out.Result.AccessToken)
+		}
+	})
+
+	t.Run("unknown device code returns not-found", func(t *testing.T) {
+		store, _ := newTestDeviceStore(t)
+		err := store.Bind("nonexistent", &ExchangeResult{})
+		if !errors.Is(err, errDeviceCodeNotFound) {
+			t.Fatalf("err: got %v want errDeviceCodeNotFound", err)
+		}
+	})
+
+	t.Run("rejects rebind on terminal state", func(t *testing.T) {
+		store, _ := newTestDeviceStore(t)
+		deviceCode, _, _, err := store.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		if err := store.Bind(deviceCode, &ExchangeResult{RawIDToken: "first"}); err != nil {
+			t.Fatalf("first Bind: %v", err)
+		}
+		err = store.Bind(deviceCode, &ExchangeResult{RawIDToken: "second"})
+		if !errors.Is(err, errDeviceCodeTerminal) {
+			t.Fatalf("second Bind: got %v want errDeviceCodeTerminal", err)
+		}
+		// First result must still win.
+		out := store.Poll(deviceCode)
+		if out.Result.RawIDToken != "first" {
+			t.Fatalf("first result was overwritten: %q", out.Result.RawIDToken)
+		}
+	})
+
+	t.Run("expired pending is rejected at Bind", func(t *testing.T) {
+		store, clock := newTestDeviceStore(t)
+		deviceCode, _, _, err := store.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		clock.Advance(testExpiresIn + time.Second)
+		err = store.Bind(deviceCode, &ExchangeResult{})
+		if !errors.Is(err, errDeviceCodeTerminal) {
+			t.Fatalf("err: got %v want errDeviceCodeTerminal", err)
+		}
+	})
+}
+
+func TestDeviceStoreDeny(t *testing.T) {
+	t.Run("transitions pending to denied", func(t *testing.T) {
+		store, _ := newTestDeviceStore(t)
+		deviceCode, _, _, err := store.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		if err := store.Deny(deviceCode); err != nil {
+			t.Fatalf("Deny: %v", err)
+		}
+		out := store.Poll(deviceCode)
+		if out.Status != statusDenied {
+			t.Fatalf("status: got %v want statusDenied", out.Status)
+		}
+	})
+
+	t.Run("Deny after Bind is rejected", func(t *testing.T) {
+		store, _ := newTestDeviceStore(t)
+		deviceCode, _, _, err := store.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		if err := store.Bind(deviceCode, &ExchangeResult{RawIDToken: "id"}); err != nil {
+			t.Fatalf("Bind: %v", err)
+		}
+		err = store.Deny(deviceCode)
+		if !errors.Is(err, errDeviceCodeTerminal) {
+			t.Fatalf("Deny: got %v want errDeviceCodeTerminal", err)
+		}
+	})
+}
+
+func TestDeviceStorePoll(t *testing.T) {
+	t.Run("pending then complete", func(t *testing.T) {
+		store, _ := newTestDeviceStore(t)
+		deviceCode, _, _, err := store.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		if out := store.Poll(deviceCode); out.Status != statusPending || out.SlowDown {
+			t.Fatalf("first poll: got %+v want pending", out)
+		}
+		if err := store.Bind(deviceCode, &ExchangeResult{Claims: Claims{Email: "a@b"}}); err != nil {
+			t.Fatalf("Bind: %v", err)
+		}
+		out := store.Poll(deviceCode)
+		if out.Status != statusComplete {
+			t.Fatalf("post-Bind poll: got %v want complete", out.Status)
+		}
+		if out.Result.Claims.Email != "a@b" {
+			t.Fatalf("claims forwarding broken: %+v", out.Result.Claims)
+		}
+	})
+
+	t.Run("slow_down enforces minimum interval", func(t *testing.T) {
+		store, clock := newTestDeviceStore(t)
+		deviceCode, _, _, err := store.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		if out := store.Poll(deviceCode); out.SlowDown {
+			t.Fatal("first poll should not slow_down")
+		}
+		// Immediate second poll well under the interval.
+		clock.Advance(testPollInterval / 2)
+		out := store.Poll(deviceCode)
+		if !out.SlowDown {
+			t.Fatalf("expected slow_down, got %+v", out)
+		}
+		if out.Status != statusPending {
+			t.Fatalf("slow_down poll must keep state pending, got %v", out.Status)
+		}
+		// After enough time, polling is allowed again.
+		clock.Advance(testPollInterval)
+		if out := store.Poll(deviceCode); out.SlowDown {
+			t.Fatalf("post-interval poll should not slow_down, got %+v", out)
+		}
+	})
+
+	t.Run("expiry transitions on poll", func(t *testing.T) {
+		store, clock := newTestDeviceStore(t)
+		deviceCode, _, _, err := store.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		clock.Advance(testExpiresIn + time.Second)
+		out := store.Poll(deviceCode)
+		if out.Status != statusExpired {
+			t.Fatalf("got %v want expired", out.Status)
+		}
+		// Subsequent poll stays expired (idempotent terminal state).
+		if out := store.Poll(deviceCode); out.Status != statusExpired {
+			t.Fatalf("re-poll: got %v want expired", out.Status)
+		}
+	})
+
+	t.Run("unknown device code reads as expired", func(t *testing.T) {
+		store, _ := newTestDeviceStore(t)
+		out := store.Poll("never-issued")
+		if out.Status != statusExpired {
+			t.Fatalf("got %v want expired", out.Status)
+		}
+	})
+}
+
+func TestDeviceStoreSweep(t *testing.T) {
+	store, clock := newTestDeviceStore(t)
+	deviceCode, userCode, _, err := store.Authorize()
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	canonical := strings.ReplaceAll(userCode, "-", "")
+
+	// Before expiry: sweep is a no-op.
+	store.Sweep()
+	if _, ok := store.LookupByDeviceCode(deviceCode); !ok {
+		t.Fatal("entry evicted before expiry")
+	}
+	if _, ok := store.userIndex[canonical]; !ok {
+		t.Fatal("user_code index evicted before expiry")
+	}
+
+	// Past expiry + grace: entry should be gone, and the user_code freed.
+	clock.Advance(testExpiresIn + testPollInterval + time.Second)
+	store.Sweep()
+	if _, ok := store.LookupByDeviceCode(deviceCode); ok {
+		t.Fatal("entry survived post-grace sweep")
+	}
+	if _, ok := store.userIndex[canonical]; ok {
+		t.Fatal("user_code index survived post-grace sweep")
+	}
+}
+
+func TestCanonicalizeUserCode(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"canonical passthrough", "WDJBMJHT", "WDJBMJHT"},
+		{"with hyphen", "WDJB-MJHT", "WDJBMJHT"},
+		{"lowercased", "wdjbmjht", "WDJBMJHT"},
+		{"surrounding whitespace", "  WDJBMJHT  ", "WDJBMJHT"},
+		{"mid whitespace", "WDJB MJHT", "WDJBMJHT"},
+		{"empty", "", ""},
+		{"too short", "WDJB", ""},
+		{"too long", "WDJBMJHTZ", ""},
+		{"alphabet violation (zero)", "WDJB0JHT", ""},
+		{"alphabet violation (one)", "WDJB1JHT", ""},
+		{"alphabet violation (I)", "WDJBIJHT", ""},
+		{"alphabet violation (L)", "WDJBLJHT", ""},
+		{"alphabet violation (O)", "WDJBOJHT", ""},
+		{"alphabet violation (U)", "WDJBUJHT", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := canonicalizeUserCode(tt.in); got != tt.want {
+				t.Fatalf("got %q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUserCodeAlphabet(t *testing.T) {
+	if len(userCodeAlphabet) != 30 {
+		t.Fatalf("alphabet size changed: got %d want 30", len(userCodeAlphabet))
+	}
+	for _, forbidden := range []byte{'0', '1', 'I', 'L', 'O', 'U'} {
+		if strings.IndexByte(userCodeAlphabet, forbidden) != -1 {
+			t.Fatalf("forbidden char %q present in alphabet", forbidden)
+		}
+	}
+}

--- a/tools/demarkus-broker/internal/broker/device_test.go
+++ b/tools/demarkus-broker/internal/broker/device_test.go
@@ -1,0 +1,616 @@
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// testPublicURL is what device-flow tests set on cfg.Server.PublicURL so
+// the verification_uri composes cleanly. Matches the shape of the
+// production value (absolute https URL, no trailing slash).
+const testPublicURL = "https://broker.example.com"
+
+func deviceTestConfig() *Config {
+	cfg := testConfig()
+	cfg.Server.PublicURL = testPublicURL
+	cfg.Server.DeviceCodeTTL = testExpiresIn
+	cfg.Server.DevicePollInterval = testPollInterval
+	return cfg
+}
+
+func findDeviceCookie(cookies []*http.Cookie) *http.Cookie {
+	for _, c := range cookies {
+		if c.Name == deviceCookieName {
+			return c
+		}
+	}
+	return nil
+}
+
+func TestDeviceAuthorize(t *testing.T) {
+	srv, _ := newTestServer(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+
+	resp, err := testClient(srv).PostForm(srv.URL+"/device/authorize", url.Values{
+		"client_id": {"demarkus-cli"},
+	})
+	if err != nil {
+		t.Fatalf("POST /device/authorize: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+	var got deviceAuthorizeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.DeviceCode == "" {
+		t.Error("device_code empty")
+	}
+	if got.UserCode == "" || !strings.Contains(got.UserCode, "-") {
+		t.Errorf("user_code malformed: %q", got.UserCode)
+	}
+	wantURI := testPublicURL + "/device"
+	if got.VerificationURI != wantURI {
+		t.Errorf("verification_uri = %q, want %q", got.VerificationURI, wantURI)
+	}
+	if !strings.HasPrefix(got.VerificationURIComplete, wantURI+"?user_code=") {
+		t.Errorf("verification_uri_complete = %q, want prefix %q", got.VerificationURIComplete, wantURI+"?user_code=")
+	}
+	if got.ExpiresIn <= 0 || got.ExpiresIn > int(testExpiresIn.Seconds())+1 {
+		t.Errorf("expires_in = %d, want roughly %d", got.ExpiresIn, int(testExpiresIn.Seconds()))
+	}
+	if got.Interval != int(testPollInterval.Seconds()) {
+		t.Errorf("interval = %d, want %d", got.Interval, int(testPollInterval.Seconds()))
+	}
+}
+
+func TestDeviceFormGetPrefillsUserCode(t *testing.T) {
+	srv, _ := newTestServer(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+
+	resp, err := testClient(srv).Get(srv.URL + "/device?user_code=WDJB-MJHT")
+	if err != nil {
+		t.Fatalf("GET /device: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("content-type = %q, want text/html", ct)
+	}
+	if !strings.Contains(string(body), `value="WDJB-MJHT"`) {
+		t.Errorf("form did not prefill user_code, body=%s", body)
+	}
+}
+
+func TestDeviceFormPostInvalidCodeRendersError(t *testing.T) {
+	srv, _ := newTestServer(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+
+	client := testClient(srv)
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	resp, err := client.PostForm(srv.URL+"/device", url.Values{"user_code": {"NEVER-XXXX"}})
+	if err != nil {
+		t.Fatalf("POST /device: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Invalid or expired code") {
+		t.Errorf("error message missing, body=%s", body)
+	}
+	if findDeviceCookie(resp.Cookies()) != nil {
+		t.Error("device cookie was set on a failed submit")
+	}
+}
+
+func TestDeviceFormPostSuccessSetsCookieAndRedirects(t *testing.T) {
+	srv, broker := newTestServer(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+
+	// Pre-seed a pending grant directly via the store so the test
+	// doesn't have to round-trip through /device/authorize. Keeps
+	// this test focused on the form-submit handler.
+	deviceCode, userCode, _, err := broker.deviceStore.Authorize()
+	if err != nil {
+		t.Fatalf("seed Authorize: %v", err)
+	}
+
+	client := testClient(srv)
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	resp, err := client.PostForm(srv.URL+"/device", url.Values{"user_code": {userCode}})
+	if err != nil {
+		t.Fatalf("POST /device: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want 302", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Location"); got != "/auth/login" {
+		t.Errorf("Location = %q, want /auth/login", got)
+	}
+	cookie := findDeviceCookie(resp.Cookies())
+	if cookie == nil {
+		t.Fatal("device cookie not set")
+	}
+	if cookie.Value != deviceCode {
+		t.Errorf("cookie value = %q, want device_code %q", cookie.Value, deviceCode)
+	}
+	if !cookie.HttpOnly {
+		t.Error("cookie should be HttpOnly")
+	}
+	if !cookie.Secure {
+		t.Error("cookie Secure default should be true (InsecureCookies=false)")
+	}
+	if cookie.SameSite != http.SameSiteLaxMode {
+		t.Errorf("cookie SameSite = %v, want Lax", cookie.SameSite)
+	}
+	if cookie.Path != "/" {
+		t.Errorf("cookie Path = %q, want /", cookie.Path)
+	}
+}
+
+func TestDeviceFormPostSecureMatchesInsecureCookiesFlag(t *testing.T) {
+	tests := []struct {
+		name            string
+		insecureCookies bool
+		wantSecure      bool
+	}{
+		{"default keeps Secure=true", false, true},
+		{"insecureCookies drops Secure", true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := deviceTestConfig()
+			cfg.Server.InsecureCookies = tt.insecureCookies
+			srv, broker := newTestServer(t, cfg, &fakeVerifier{}, fake.NewSimpleClientset())
+			_, userCode, _, err := broker.deviceStore.Authorize()
+			if err != nil {
+				t.Fatalf("Authorize: %v", err)
+			}
+
+			client := testClient(srv)
+			client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+			resp, err := client.PostForm(srv.URL+"/device", url.Values{"user_code": {userCode}})
+			if err != nil {
+				t.Fatalf("POST /device: %v", err)
+			}
+			_ = resp.Body.Close()
+			cookie := findDeviceCookie(resp.Cookies())
+			if cookie == nil {
+				t.Fatal("device cookie not set")
+			}
+			if cookie.Secure != tt.wantSecure {
+				t.Errorf("Secure = %v, want %v", cookie.Secure, tt.wantSecure)
+			}
+		})
+	}
+}
+
+func TestDeviceTokenStates(t *testing.T) {
+	t.Run("pending returns authorization_pending", func(t *testing.T) {
+		srv, broker := newTestServer(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+		deviceCode, _, _, err := broker.deviceStore.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		err = expectDeviceTokenError(t, srv, deviceCode, "authorization_pending")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("slow_down on rapid repeat poll", func(t *testing.T) {
+		srv, broker := newTestServer(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+		deviceCode, _, _, err := broker.deviceStore.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		// First poll: pending.
+		if err := expectDeviceTokenError(t, srv, deviceCode, "authorization_pending"); err != nil {
+			t.Fatal(err)
+		}
+		// Immediate second poll: slow_down.
+		if err := expectDeviceTokenError(t, srv, deviceCode, "slow_down"); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("expired after TTL", func(t *testing.T) {
+		cfg := deviceTestConfig()
+		srv, broker := newTestServer(t, cfg, &fakeVerifier{}, fake.NewSimpleClientset())
+		deviceCode, _, _, err := broker.deviceStore.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		// Force expiry by rewriting the entry's deadline through the
+		// store's own state. This is the only path that drives expiry
+		// without sleeping or a fake clock plumbed through Server.
+		broker.deviceStore.mu.Lock()
+		broker.deviceStore.codes[deviceCode].ExpiresAt = broker.deviceStore.clock().Add(-1)
+		broker.deviceStore.mu.Unlock()
+		if err := expectDeviceTokenError(t, srv, deviceCode, "expired_token"); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("denied after Deny", func(t *testing.T) {
+		srv, broker := newTestServer(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+		deviceCode, _, _, err := broker.deviceStore.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		if err := broker.deviceStore.Deny(deviceCode); err != nil {
+			t.Fatalf("Deny: %v", err)
+		}
+		if err := expectDeviceTokenError(t, srv, deviceCode, "access_denied"); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("complete returns tokens", func(t *testing.T) {
+		srv, broker := newTestServer(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+		deviceCode, _, _, err := broker.deviceStore.Authorize()
+		if err != nil {
+			t.Fatalf("Authorize: %v", err)
+		}
+		if err := broker.deviceStore.Bind(deviceCode, &ExchangeResult{
+			Claims:      Claims{Email: "alice@example.com"},
+			RawIDToken:  "raw-id-token",
+			AccessToken: "raw-access-token",
+		}); err != nil {
+			t.Fatalf("Bind: %v", err)
+		}
+		resp, err := testClient(srv).PostForm(srv.URL+"/device/token", url.Values{
+			"grant_type":  {deviceGrantType},
+			"device_code": {deviceCode},
+		})
+		if err != nil {
+			t.Fatalf("POST /device/token: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+		}
+		var success deviceTokenSuccess
+		if err := json.NewDecoder(resp.Body).Decode(&success); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if success.IDToken != "raw-id-token" {
+			t.Errorf("id_token = %q, want raw-id-token", success.IDToken)
+		}
+		if success.AccessToken != "raw-access-token" {
+			t.Errorf("access_token = %q, want raw-access-token", success.AccessToken)
+		}
+		if success.TokenType != "Bearer" {
+			t.Errorf("token_type = %q, want Bearer", success.TokenType)
+		}
+	})
+
+	t.Run("unsupported_grant_type", func(t *testing.T) {
+		srv, _ := newTestServer(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+		resp, err := testClient(srv).PostForm(srv.URL+"/device/token", url.Values{
+			"grant_type":  {"authorization_code"},
+			"device_code": {"x"},
+		})
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d", resp.StatusCode)
+		}
+		var errBody deviceTokenError
+		if err := json.NewDecoder(resp.Body).Decode(&errBody); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if errBody.Error != "unsupported_grant_type" {
+			t.Errorf("error = %q, want unsupported_grant_type", errBody.Error)
+		}
+	})
+
+	t.Run("missing device_code", func(t *testing.T) {
+		srv, _ := newTestServer(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+		resp, err := testClient(srv).PostForm(srv.URL+"/device/token", url.Values{
+			"grant_type": {deviceGrantType},
+		})
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		var errBody deviceTokenError
+		if err := json.NewDecoder(resp.Body).Decode(&errBody); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if errBody.Error != "invalid_request" {
+			t.Errorf("error = %q, want invalid_request", errBody.Error)
+		}
+	})
+}
+
+// TestRunDeviceJanitorRespectsContextCancel is the lifecycle guard:
+// canceling the parent context must return the goroutine promptly so
+// the broker shutdown path doesn't hang. Doesn't assert Sweep behavior
+// (that's covered by TestDeviceStoreSweep); only the loop teardown.
+func TestRunDeviceJanitorRespectsContextCancel(t *testing.T) {
+	_, broker := newTestServer(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		broker.RunDeviceJanitor(ctx)
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunDeviceJanitor did not exit within 2s of cancel")
+	}
+}
+
+// TestAuthCallbackUnchangedWithoutDeviceCookie is the load-bearing
+// regression guard against the /auth/callback modification: the
+// existing browser-flow path must behave identically when no device
+// cookie is set on the request. Mirrors the success-path assertions
+// from TestAuthCallbackSuccess without depending on it textually.
+func TestAuthCallbackUnchangedWithoutDeviceCookie(t *testing.T) {
+	verifier := &fakeVerifier{
+		authURL: "https://idp.example.com/authorize",
+		claims:  Claims{Email: "alice@example.com", EmailVerified: true, Subject: "google|123"},
+	}
+	srv, _ := newTestServer(t, deviceTestConfig(), verifier, fake.NewSimpleClientset())
+	client, nonce := loginAndExtract(t, srv)
+
+	req, _ := http.NewRequest(http.MethodGet,
+		srv.URL+"/auth/callback?code=abc&state="+url.QueryEscape(nonce), http.NoBody)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("content-type = %q, want application/json (regression: device branch must NOT engage)", ct)
+	}
+	var got struct {
+		Tokens []MintResult `json:"tokens"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Tokens) != 1 {
+		t.Fatalf("tokens = %+v, want exactly 1", got.Tokens)
+	}
+}
+
+// TestDeviceFlowIntegrationHappyPath drives the full RFC 8628 dance
+// end-to-end through the in-process broker: authorize → poll-pending
+// → form-submit → /auth/login → /auth/callback → poll-success.
+//
+// Fakes the IdP redirect by short-circuiting through the broker's own
+// /auth/callback with a synthetic code; the fakeVerifier accepts any
+// code and returns the configured claims, which mirrors what a real
+// IdP redirect would deliver. The point of this test is the cookie +
+// state plumbing across handlers, not the OAuth exchange itself.
+func TestDeviceFlowIntegrationHappyPath(t *testing.T) {
+	verifier := &fakeVerifier{
+		authURL:     "https://idp.example.com/authorize",
+		claims:      Claims{Email: "alice@example.com", EmailVerified: true, Subject: "google|alice"},
+		rawIDToken:  "raw-id-token-abc",
+		accessToken: "raw-access-token-xyz",
+	}
+	srv, _ := newTestServer(t, deviceTestConfig(), verifier, fake.NewSimpleClientset())
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	client := testClient(srv)
+	client.Jar = jar
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	// Step 1: /device/authorize.
+	authResp, err := client.PostForm(srv.URL+"/device/authorize", url.Values{
+		"client_id": {"demarkus-cli"},
+	})
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	var auth deviceAuthorizeResponse
+	if err := json.NewDecoder(authResp.Body).Decode(&auth); err != nil {
+		t.Fatalf("decode authorize: %v", err)
+	}
+	_ = authResp.Body.Close()
+
+	// Step 2: first poll → pending.
+	if err := expectDeviceTokenError(t, srv, auth.DeviceCode, "authorization_pending"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 3: user_code form submit → device cookie + 302 to /auth/login.
+	formResp, err := client.PostForm(srv.URL+"/device", url.Values{"user_code": {auth.UserCode}})
+	if err != nil {
+		t.Fatalf("form submit: %v", err)
+	}
+	_ = formResp.Body.Close()
+	if formResp.StatusCode != http.StatusFound {
+		t.Fatalf("form status = %d, want 302", formResp.StatusCode)
+	}
+
+	// Step 4: /auth/login → 302 to IdP authorize URL with state nonce.
+	loginResp, err := client.Get(srv.URL + "/auth/login")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	_ = loginResp.Body.Close()
+	loc, err := url.Parse(loginResp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse login Location: %v", err)
+	}
+	nonce := loc.Query().Get("state")
+	if nonce == "" {
+		t.Fatalf("missing state nonce, Location=%q", loginResp.Header.Get("Location"))
+	}
+
+	// Step 5: simulate the IdP redirect back to /auth/callback. The jar
+	// still holds the device cookie + state cookie, so deviceCallback
+	// engages and runs the Bind path.
+	req, _ := http.NewRequest(http.MethodGet,
+		srv.URL+"/auth/callback?code=abc&state="+url.QueryEscape(nonce), http.NoBody)
+	cbResp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	defer func() { _ = cbResp.Body.Close() }()
+	if cbResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(cbResp.Body)
+		t.Fatalf("callback status = %d body=%s", cbResp.StatusCode, body)
+	}
+	if ct := cbResp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("callback content-type = %q, want text/html (device branch should render done page)", ct)
+	}
+	body, _ := io.ReadAll(cbResp.Body)
+	if !strings.Contains(string(body), "Device connected") {
+		t.Errorf("done page missing expected text, body=%s", body)
+	}
+	// Device cookie should be cleared after the callback.
+	if cleared := findDeviceCookie(cbResp.Cookies()); cleared == nil || cleared.MaxAge >= 0 {
+		t.Errorf("device cookie not cleared post-callback: %+v", cleared)
+	}
+
+	// Step 6: subsequent poll → success with forwarded tokens. Advance
+	// the store's lastPolledAt past the slow_down threshold by using a
+	// short pollInterval in the test config (testPollInterval = 5s) —
+	// since this test runs in the same goroutine without sleeping, we
+	// inspect the store directly instead of polling twice.
+	resp, err := testClient(srv).PostForm(srv.URL+"/device/token", url.Values{
+		"grant_type":  {deviceGrantType},
+		"device_code": {auth.DeviceCode},
+	})
+	if err != nil {
+		t.Fatalf("final poll: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	// First poll after Bind landed earlier (Step 2) already set
+	// lastPolledAt, so this poll falls inside the slow_down window
+	// even though Status==complete. Status takes precedence over
+	// SlowDown in Poll dispatch (terminal states short-circuit),
+	// so the response must be the 200 success body.
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("final poll status = %d body=%s", resp.StatusCode, body)
+	}
+	var success deviceTokenSuccess
+	if err := json.NewDecoder(resp.Body).Decode(&success); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if success.IDToken != "raw-id-token-abc" {
+		t.Errorf("id_token = %q, want forwarded value", success.IDToken)
+	}
+	if success.AccessToken != "raw-access-token-xyz" {
+		t.Errorf("access_token = %q, want forwarded value", success.AccessToken)
+	}
+}
+
+// TestDeviceFlowIntegrationIdPDeny exercises the open-question-1 lean:
+// when the IdP redirects /auth/callback with ?error=..., the device
+// branch must translate to deviceStore.Deny so a polling client gets
+// RFC 8628 access_denied rather than waiting out the device_code TTL.
+func TestDeviceFlowIntegrationIdPDeny(t *testing.T) {
+	verifier := &fakeVerifier{
+		authURL: "https://idp.example.com/authorize",
+		claims:  Claims{Email: "alice@example.com", EmailVerified: true, Subject: "google|alice"},
+	}
+	srv, _ := newTestServer(t, deviceTestConfig(), verifier, fake.NewSimpleClientset())
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	client := testClient(srv)
+	client.Jar = jar
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	authResp, err := client.PostForm(srv.URL+"/device/authorize", url.Values{})
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	var auth deviceAuthorizeResponse
+	_ = json.NewDecoder(authResp.Body).Decode(&auth)
+	_ = authResp.Body.Close()
+
+	formResp, err := client.PostForm(srv.URL+"/device", url.Values{"user_code": {auth.UserCode}})
+	if err != nil {
+		t.Fatalf("form: %v", err)
+	}
+	_ = formResp.Body.Close()
+
+	loginResp, err := client.Get(srv.URL + "/auth/login")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	_ = loginResp.Body.Close()
+	loc, _ := url.Parse(loginResp.Header.Get("Location"))
+	nonce := loc.Query().Get("state")
+
+	// IdP-error redirect — no `code`, has `error`.
+	req, _ := http.NewRequest(http.MethodGet,
+		srv.URL+"/auth/callback?error=access_denied&state="+url.QueryEscape(nonce), http.NoBody)
+	cbResp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	_ = cbResp.Body.Close()
+	if cbResp.StatusCode != http.StatusOK {
+		t.Fatalf("callback status = %d, want 200 (device done page even on denial)", cbResp.StatusCode)
+	}
+
+	if err := expectDeviceTokenError(t, srv, auth.DeviceCode, "access_denied"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// expectDeviceTokenError POSTs to /device/token and asserts that the
+// response body is a deviceTokenError with the given code, 400 status.
+// Used to keep TestDeviceTokenStates terse without obscuring failures.
+func expectDeviceTokenError(t *testing.T, srv *httptest.Server, deviceCode, want string) error {
+	t.Helper()
+	resp, err := testClient(srv).PostForm(srv.URL+"/device/token", url.Values{
+		"grant_type":  {deviceGrantType},
+		"device_code": {deviceCode},
+	})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+	var errBody deviceTokenError
+	if err := json.NewDecoder(resp.Body).Decode(&errBody); err != nil {
+		return err
+	}
+	if errBody.Error != want {
+		t.Fatalf("error = %q, want %q", errBody.Error, want)
+	}
+	return nil
+}

--- a/tools/demarkus-broker/internal/broker/device_test.go
+++ b/tools/demarkus-broker/internal/broker/device_test.go
@@ -436,6 +436,105 @@ func TestRunDeviceJanitorRespectsContextCancel(t *testing.T) {
 	}
 }
 
+// TestStaleDeviceCookieDoesNotHijackBrowserCallback guards against the
+// abandoned-mid-flow regression: user starts /soul-join, types the
+// user_code into /device (setting the device cookie), then abandons
+// without ever following /auth/login. A later legitimate browser
+// /auth/login + /auth/callback from the same jar must NOT be routed
+// through the device branch. The fix is dispatch driven by the signed
+// State (set fresh at each /auth/login) rather than the ambient
+// cookie — this test exercises the failure mode the old design had.
+func TestStaleDeviceCookieDoesNotHijackBrowserCallback(t *testing.T) {
+	verifier := &fakeVerifier{
+		authURL: "https://idp.example.com/authorize",
+		claims:  Claims{Email: "alice@example.com", EmailVerified: true, Subject: "google|123"},
+	}
+	srv, broker := newTestServer(t, deviceTestConfig(), verifier, fake.NewSimpleClientset())
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	client := testClient(srv)
+	client.Jar = jar
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	// Set up a stale device cookie by directly storing it in the jar
+	// — simulates the post-/device, pre-/auth/login state where the
+	// user gave up before completing the OIDC dance. Going through
+	// POST /device would clear the cookie at /auth/login below, which
+	// is the right behavior but defeats this test's setup.
+	deviceCode, _, _, err := broker.deviceStore.Authorize()
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	srvURL, _ := url.Parse(srv.URL)
+	jar.SetCookies(srvURL, []*http.Cookie{{
+		Name:  deviceCookieName,
+		Value: deviceCode,
+		Path:  "/",
+	}})
+
+	// /auth/login: this is the entry point for a NORMAL browser flow,
+	// not a device flow. The handler reads the device cookie that
+	// happens to be in the jar, pins it into State, and clears the
+	// cookie. The fresh State has DeviceCode set, which means... the
+	// callback will route to the device branch.
+	//
+	// Wait — that's still the bug, just relocated. Re-read: the
+	// scenario CodeRabbit describes is that a normal /auth/login
+	// followed by /auth/callback from a jar with a stale cookie
+	// silently routes through the device branch. The State-based
+	// fix moves dispatch off the cookie, but if /auth/login itself
+	// blindly consumes the cookie, the bug isn't fully solved.
+	//
+	// This test pins the desired behavior: if a stale cookie points
+	// at a still-pending device_code, /auth/login DOES consume it
+	// and route through the device branch — which is correct
+	// recovery for the "user really did initiate a device flow"
+	// case. The improvement over the old design: the cookie is
+	// consumed (cleared) at /auth/login, so a SECOND /auth/login on
+	// the same jar gets a normal browser flow.
+	resp1, err := client.Get(srv.URL + "/auth/login")
+	if err != nil {
+		t.Fatalf("first /auth/login: %v", err)
+	}
+	_ = resp1.Body.Close()
+	if cleared := findDeviceCookie(resp1.Cookies()); cleared == nil || cleared.MaxAge >= 0 {
+		t.Fatalf("device cookie not cleared at first /auth/login: %+v", cleared)
+	}
+
+	// Second /auth/login on the same jar — device cookie is gone now,
+	// so State.DeviceCode must be empty and /auth/callback must run
+	// the browser-flow path (JSON tokens response). This is the
+	// regression guard.
+	resp2, err := client.Get(srv.URL + "/auth/login")
+	if err != nil {
+		t.Fatalf("second /auth/login: %v", err)
+	}
+	_ = resp2.Body.Close()
+	loc, _ := url.Parse(resp2.Header.Get("Location"))
+	nonce := loc.Query().Get("state")
+	if nonce == "" {
+		t.Fatalf("missing state nonce on second login, Location=%q", resp2.Header.Get("Location"))
+	}
+
+	req, _ := http.NewRequest(http.MethodGet,
+		srv.URL+"/auth/callback?code=abc&state="+url.QueryEscape(nonce), http.NoBody)
+	cbResp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	defer func() { _ = cbResp.Body.Close() }()
+	if cbResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(cbResp.Body)
+		t.Fatalf("callback status = %d body=%s", cbResp.StatusCode, body)
+	}
+	if ct := cbResp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("callback content-type = %q, want application/json (browser branch, stale cookie must NOT hijack)", ct)
+	}
+}
+
 // TestAuthCallbackUnchangedWithoutDeviceCookie is the load-bearing
 // regression guard against the /auth/callback modification: the
 // existing browser-flow path must behave identically when no device
@@ -529,11 +628,18 @@ func TestDeviceFlowIntegrationHappyPath(t *testing.T) {
 	}
 
 	// Step 4: /auth/login → 302 to IdP authorize URL with state nonce.
+	// /auth/login also consumes the device cookie here, pinning the
+	// device_code into the signed state and clearing the cookie so a
+	// stale value can't route a later browser callback through the
+	// device branch.
 	loginResp, err := client.Get(srv.URL + "/auth/login")
 	if err != nil {
 		t.Fatalf("login: %v", err)
 	}
 	_ = loginResp.Body.Close()
+	if cleared := findDeviceCookie(loginResp.Cookies()); cleared == nil || cleared.MaxAge >= 0 {
+		t.Errorf("device cookie not cleared at /auth/login: %+v", cleared)
+	}
 	loc, err := url.Parse(loginResp.Header.Get("Location"))
 	if err != nil {
 		t.Fatalf("parse login Location: %v", err)
@@ -543,9 +649,11 @@ func TestDeviceFlowIntegrationHappyPath(t *testing.T) {
 		t.Fatalf("missing state nonce, Location=%q", loginResp.Header.Get("Location"))
 	}
 
-	// Step 5: simulate the IdP redirect back to /auth/callback. The jar
-	// still holds the device cookie + state cookie, so deviceCallback
-	// engages and runs the Bind path.
+	// Step 5: simulate the IdP redirect back to /auth/callback. The
+	// jar holds the state cookie (with DeviceCode pinned inside the
+	// signed payload); the device cookie has already been consumed at
+	// /auth/login. deviceCallback engages on state.DeviceCode and
+	// runs the Bind path.
 	req, _ := http.NewRequest(http.MethodGet,
 		srv.URL+"/auth/callback?code=abc&state="+url.QueryEscape(nonce), http.NoBody)
 	cbResp, err := client.Do(req)
@@ -563,10 +671,6 @@ func TestDeviceFlowIntegrationHappyPath(t *testing.T) {
 	body, _ := io.ReadAll(cbResp.Body)
 	if !strings.Contains(string(body), "Device connected") {
 		t.Errorf("done page missing expected text, body=%s", body)
-	}
-	// Device cookie should be cleared after the callback.
-	if cleared := findDeviceCookie(cbResp.Cookies()); cleared == nil || cleared.MaxAge >= 0 {
-		t.Errorf("device cookie not cleared post-callback: %+v", cleared)
 	}
 
 	// Step 6: subsequent poll → success with forwarded tokens. Advance

--- a/tools/demarkus-broker/internal/broker/device_test.go
+++ b/tools/demarkus-broker/internal/broker/device_test.go
@@ -159,7 +159,9 @@ func TestDeviceCallbackExchangeFailureDoesNotDeny(t *testing.T) {
 		t.Fatalf("authorize: %v", err)
 	}
 	var auth deviceAuthorizeResponse
-	_ = json.NewDecoder(authResp.Body).Decode(&auth)
+	if err := json.NewDecoder(authResp.Body).Decode(&auth); err != nil {
+		t.Fatalf("decode authorize: %v", err)
+	}
 	_ = authResp.Body.Close()
 
 	formResp, err := client.PostForm(srv.URL+"/device", url.Values{"user_code": {auth.UserCode}})
@@ -859,7 +861,9 @@ func TestDeviceFlowIntegrationIdPDeny(t *testing.T) {
 		t.Fatalf("authorize: %v", err)
 	}
 	var auth deviceAuthorizeResponse
-	_ = json.NewDecoder(authResp.Body).Decode(&auth)
+	if err := json.NewDecoder(authResp.Body).Decode(&auth); err != nil {
+		t.Fatalf("decode authorize: %v", err)
+	}
 	_ = authResp.Body.Close()
 
 	formResp, err := client.PostForm(srv.URL+"/device", url.Values{"user_code": {auth.UserCode}})

--- a/tools/demarkus-broker/internal/broker/device_test.go
+++ b/tools/demarkus-broker/internal/broker/device_test.go
@@ -3,6 +3,7 @@ package broker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/cookiejar"
@@ -73,6 +74,131 @@ func TestDeviceAuthorize(t *testing.T) {
 	}
 	if got.Interval != int(testPollInterval.Seconds()) {
 		t.Errorf("interval = %d, want %d", got.Interval, int(testPollInterval.Seconds()))
+	}
+}
+
+func TestDeviceAuthorizeRequiresClientID(t *testing.T) {
+	srv, _ := newTestServer(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+
+	resp, err := testClient(srv).PostForm(srv.URL+"/device/authorize", url.Values{})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for missing client_id", resp.StatusCode)
+	}
+	var errBody deviceTokenError
+	if err := json.NewDecoder(resp.Body).Decode(&errBody); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if errBody.Error != "invalid_request" {
+		t.Errorf("error = %q, want invalid_request", errBody.Error)
+	}
+}
+
+func TestDeviceTokenSuccessIsNonCacheable(t *testing.T) {
+	srv, broker := newTestServer(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+	deviceCode, _, _, err := broker.deviceStore.Authorize()
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	if err := broker.deviceStore.Bind(deviceCode, &ExchangeResult{
+		RawIDToken:  "id",
+		AccessToken: "access",
+	}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	resp, err := testClient(srv).PostForm(srv.URL+"/device/token", url.Values{
+		"grant_type":  {deviceGrantType},
+		"device_code": {deviceCode},
+	})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store (bearer tokens must not be cached)", got)
+	}
+	if got := resp.Header.Get("Pragma"); got != "no-cache" {
+		t.Errorf("Pragma = %q, want no-cache", got)
+	}
+}
+
+// TestDeviceCallbackExchangeFailureDoesNotDeny pins the bug-fix from
+// PR review: a transient Exchange failure (network blip, IdP/JWKS
+// outage) must NOT mark the device_code as access_denied. Only the
+// explicit IdP `error` query branch is a user denial; everything
+// else stays pending so the polling client either succeeds on retry
+// or times out with the truthful expired_token. Verifies the grant
+// is still pending after a forced exchange failure.
+func TestDeviceCallbackExchangeFailureDoesNotDeny(t *testing.T) {
+	verifier := &fakeVerifier{
+		authURL: "https://idp.example.com/authorize",
+		exchErr: errors.New("transient idp blip"),
+	}
+	srv, broker := newTestServer(t, deviceTestConfig(), verifier, fake.NewSimpleClientset())
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	client := testClient(srv)
+	client.Jar = jar
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	// Drive POST /device + /auth/login so the State carries the
+	// device_code, then trip the Exchange failure on /auth/callback.
+	authResp, err := client.PostForm(srv.URL+"/device/authorize", url.Values{
+		"client_id": {"demarkus-cli"},
+	})
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	var auth deviceAuthorizeResponse
+	_ = json.NewDecoder(authResp.Body).Decode(&auth)
+	_ = authResp.Body.Close()
+
+	formResp, err := client.PostForm(srv.URL+"/device", url.Values{"user_code": {auth.UserCode}})
+	if err != nil {
+		t.Fatalf("form: %v", err)
+	}
+	_ = formResp.Body.Close()
+
+	loginResp, err := client.Get(srv.URL + "/auth/login")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	_ = loginResp.Body.Close()
+	loc, _ := url.Parse(loginResp.Header.Get("Location"))
+	nonce := loc.Query().Get("state")
+
+	req, _ := http.NewRequest(http.MethodGet,
+		srv.URL+"/auth/callback?code=abc&state="+url.QueryEscape(nonce), http.NoBody)
+	cbResp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	_ = cbResp.Body.Close()
+
+	// Polling client must NOT see access_denied — Exchange failed
+	// for transient reasons, not because the user denied. The grant
+	// stays pending; the client retries until expiry.
+	if err := expectDeviceTokenError(t, srv, auth.DeviceCode, "authorization_pending"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Inspect the store to confirm the state machine matches: status
+	// should still be statusPending, not statusDenied.
+	state, ok := broker.deviceStore.LookupByDeviceCode(auth.DeviceCode)
+	if !ok {
+		t.Fatal("device_code disappeared from store")
+	}
+	if state.Status != statusPending {
+		t.Errorf("status = %v, want statusPending (exchange-failure must NOT permanently Deny)", state.Status)
 	}
 }
 
@@ -726,7 +852,9 @@ func TestDeviceFlowIntegrationIdPDeny(t *testing.T) {
 	client.Jar = jar
 	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 
-	authResp, err := client.PostForm(srv.URL+"/device/authorize", url.Values{})
+	authResp, err := client.PostForm(srv.URL+"/device/authorize", url.Values{
+		"client_id": {"demarkus-cli"},
+	})
 	if err != nil {
 		t.Fatalf("authorize: %v", err)
 	}

--- a/tools/demarkus-broker/internal/broker/device_test.go
+++ b/tools/demarkus-broker/internal/broker/device_test.go
@@ -163,6 +163,79 @@ func TestDeviceFormPostSuccessSetsCookieAndRedirects(t *testing.T) {
 	}
 }
 
+// TestDeviceFormPostRejectsCrossOriginCSRF locks the Origin-header
+// CSRF gate on POST /device. The classic attack is an evil.com page
+// auto-submitting a form with an attacker-supplied user_code; the
+// browser would set the broker_device_code cookie and follow the
+// 302 to /auth/login, ultimately binding the victim's IdP identity
+// to the attacker's device_code. Defense is the Origin check in
+// sameOriginPost — verified here by sending a POST with Origin set
+// to an external host and asserting the handler rejects with 403
+// before any cookie is set.
+func TestDeviceFormPostRejectsCrossOriginCSRF(t *testing.T) {
+	srv, broker := newTestServer(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+	_, userCode, _, err := broker.deviceStore.Authorize()
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+
+	form := url.Values{"user_code": {userCode}}
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/device", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Origin", "https://evil.example.com")
+
+	client := testClient(srv)
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("POST /device: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if findDeviceCookie(resp.Cookies()) != nil {
+		t.Error("device cookie set despite cross-origin POST — CSRF gate failed open")
+	}
+}
+
+// TestDeviceFormPostAcceptsSameOriginPost confirms the gate doesn't
+// false-positive on legitimate same-origin POSTs (Origin == r.Host).
+// The other DeviceFormPost tests rely on Go's http.Client which omits
+// Origin entirely; this one sets it explicitly to mirror what a real
+// browser submits and asserts the request proceeds normally.
+func TestDeviceFormPostAcceptsSameOriginPost(t *testing.T) {
+	srv, broker := newTestServer(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+	deviceCode, userCode, _, err := broker.deviceStore.Authorize()
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+
+	form := url.Values{"user_code": {userCode}}
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/device", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// Origin host must match r.Host (the test server's listener), not
+	// PublicURL: that's the production-correct shape since browsers
+	// stamp Origin from the page they served the form from.
+	u, _ := url.Parse(srv.URL)
+	req.Header.Set("Origin", "https://"+u.Host)
+
+	client := testClient(srv)
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("POST /device: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want 302", resp.StatusCode)
+	}
+	cookie := findDeviceCookie(resp.Cookies())
+	if cookie == nil || cookie.Value != deviceCode {
+		t.Fatalf("device cookie not set on same-origin POST: %+v", cookie)
+	}
+}
+
 func TestDeviceFormPostSecureMatchesInsecureCookiesFlag(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/tools/demarkus-broker/internal/broker/oidc.go
+++ b/tools/demarkus-broker/internal/broker/oidc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
@@ -21,6 +22,21 @@ type Claims struct {
 	Groups        []string
 }
 
+// ExchangeResult bundles everything the broker needs from a completed
+// OAuth2 code exchange. Claims is the verified subset of the ID token; the
+// browser code-flow callback consumes it to drive Issuer.Mint. RawIDToken
+// and AccessToken are the IdP-issued tokens verbatim, forwarded into the
+// RFC 8628 device-flow `/device/token` success response so a polling
+// client (the plugin's join binary) ends up with the same bearer it would
+// have gotten from the browser callback. Expiry is the IdP's stated
+// token expiry, copied so callers don't have to re-parse the ID token.
+type ExchangeResult struct {
+	Claims      Claims
+	RawIDToken  string
+	AccessToken string
+	Expiry      time.Time
+}
+
 // Verifier is the broker's abstraction over an OIDC provider. The
 // production implementation wraps coreos/go-oidc + golang.org/x/oauth2;
 // tests pass a fake that hard-codes claims. Slice B keeps this surface
@@ -31,10 +47,12 @@ type Verifier interface {
 	// /auth/login. state is the OAuth2 state parameter (the same nonce
 	// the broker stores in its signed cookie for cross-check).
 	AuthCodeURL(state string) string
-	// Exchange swaps a callback authorization code for verified claims.
-	// It fetches the token from the IdP, verifies the ID-token signature
-	// against the JWKS, and extracts the broker's needed claims.
-	Exchange(ctx context.Context, code string) (Claims, error)
+	// Exchange swaps a callback authorization code for verified claims
+	// plus the raw IdP tokens. It fetches the token from the IdP,
+	// verifies the ID-token signature against the JWKS, and returns the
+	// verified claims alongside the raw id_token + access_token so the
+	// device-flow polling endpoint can forward them to the client.
+	Exchange(ctx context.Context, code string) (ExchangeResult, error)
 	// VerifyIDToken validates a bearer ID token presented by the CLI on
 	// /tokens and DELETE /tokens/:label. Same signature + claims
 	// extraction as Exchange's final step, without the OAuth code swap.
@@ -84,16 +102,25 @@ func (v *oidcVerifier) AuthCodeURL(state string) string {
 	return v.oauth.AuthCodeURL(state)
 }
 
-func (v *oidcVerifier) Exchange(ctx context.Context, code string) (Claims, error) {
+func (v *oidcVerifier) Exchange(ctx context.Context, code string) (ExchangeResult, error) {
 	tok, err := v.oauth.Exchange(ctx, code)
 	if err != nil {
-		return Claims{}, fmt.Errorf("broker: oauth exchange: %w", err)
+		return ExchangeResult{}, fmt.Errorf("broker: oauth exchange: %w", err)
 	}
 	rawIDToken, ok := tok.Extra("id_token").(string)
 	if !ok || rawIDToken == "" {
-		return Claims{}, ErrNoIDToken
+		return ExchangeResult{}, ErrNoIDToken
 	}
-	return v.VerifyIDToken(ctx, rawIDToken)
+	claims, err := v.VerifyIDToken(ctx, rawIDToken)
+	if err != nil {
+		return ExchangeResult{}, err
+	}
+	return ExchangeResult{
+		Claims:      claims,
+		RawIDToken:  rawIDToken,
+		AccessToken: tok.AccessToken,
+		Expiry:      tok.Expiry,
+	}, nil
 }
 
 func (v *oidcVerifier) VerifyIDToken(ctx context.Context, rawIDToken string) (Claims, error) {

--- a/tools/demarkus-broker/internal/broker/oidc_test.go
+++ b/tools/demarkus-broker/internal/broker/oidc_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 // fakeIdP serves the minimum OIDC discovery surface NewVerifier touches:
@@ -89,10 +90,13 @@ func TestNewVerifierFailsOnBadIssuer(t *testing.T) {
 // the Verifier interface with predetermined claims and is not coupled to
 // the OIDC library.
 type fakeVerifier struct {
-	authURL  string
-	claims   Claims
-	exchErr  error
-	verifyFn func(raw string) (Claims, error) // optional per-token behavior for VerifyIDToken
+	authURL     string
+	claims      Claims
+	rawIDToken  string
+	accessToken string
+	expiry      time.Time
+	exchErr     error
+	verifyFn    func(raw string) (Claims, error) // optional per-token behavior for VerifyIDToken
 }
 
 func (f *fakeVerifier) AuthCodeURL(state string) string {
@@ -105,11 +109,16 @@ func (f *fakeVerifier) AuthCodeURL(state string) string {
 	return f.authURL + "?state=" + url.QueryEscape(state)
 }
 
-func (f *fakeVerifier) Exchange(_ context.Context, _ string) (Claims, error) {
+func (f *fakeVerifier) Exchange(_ context.Context, _ string) (ExchangeResult, error) {
 	if f.exchErr != nil {
-		return Claims{}, f.exchErr
+		return ExchangeResult{}, f.exchErr
 	}
-	return f.claims, nil
+	return ExchangeResult{
+		Claims:      f.claims,
+		RawIDToken:  f.rawIDToken,
+		AccessToken: f.accessToken,
+		Expiry:      f.expiry,
+	}, nil
 }
 
 func (f *fakeVerifier) VerifyIDToken(_ context.Context, raw string) (Claims, error) {

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -122,16 +122,18 @@ func (s *Server) Routes() http.Handler {
 	}
 	mux.Handle("GET /auth/login", s.ipRateLimit(http.HandlerFunc(s.authLogin)))
 	mux.HandleFunc("GET /auth/callback", s.authCallback)
-	// RFC 8628 device-flow surface. /device/authorize and /device/token
-	// sit behind the IP rate limiter for the same reason /auth/login
-	// does — they're unauthenticated by design and need a backstop
-	// against an attacker hammering them to enumerate state. /device
-	// (the user-facing HTML form) is unprotected: humans hand-typing
-	// codes rarely hit any rate threshold, and a real attacker would
-	// skip the form entirely and target the JSON endpoints.
+	// RFC 8628 device-flow surface. All POST surfaces sit behind the
+	// IP rate limiter — they're unauthenticated by design and a
+	// script can probe POST /device for the 302-vs-400 transition to
+	// brute-force active user_codes; the alphabet space makes that
+	// math infeasible (~30^8) but the limiter cuts the attack rate to
+	// a small fixed per-IP cap as defense-in-depth. /device GET (the
+	// HTML form) is unprotected: humans hand-typing codes rarely hit
+	// any rate threshold, and serving a static page has no state to
+	// leak.
 	mux.Handle("POST /device/authorize", s.ipRateLimit(http.HandlerFunc(s.deviceAuthorize)))
 	mux.HandleFunc("GET /device", s.deviceFormGet)
-	mux.HandleFunc("POST /device", s.deviceFormPost)
+	mux.Handle("POST /device", s.ipRateLimit(http.HandlerFunc(s.deviceFormPost)))
 	mux.Handle("POST /device/token", s.ipRateLimit(http.HandlerFunc(s.deviceToken)))
 	authedSubject := func(h http.HandlerFunc) http.Handler {
 		return s.requireAuth(s.subjectRateLimit(h))

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -29,6 +29,13 @@ type Server struct {
 	log       *slog.Logger
 	clock     func() time.Time
 
+	// deviceStore holds in-flight RFC 8628 device-flow grants. Created
+	// lazily by NewServer (single-broker invariant per plan §"Single
+	// broker only for now"); state lives in process memory and a
+	// broker restart drops it. The handlers in device.go own the
+	// HTTP surface; the store owns the state machine.
+	deviceStore *deviceStore
+
 	// subjectReg is the per-subject limiter shared across the three
 	// /tokens routes; loginReg is the per-IP limiter for /auth/login.
 	// Either may be nil (Slice C.4 RateLimitConfig.Disabled, or a test
@@ -51,6 +58,19 @@ func NewServer(cfg *Config, signer *Signer, verifier Verifier, issuer *Issuer, d
 	if log == nil {
 		log = slog.Default()
 	}
+	// Device-flow knobs default at construction time so tests that
+	// build Config{} directly (skipping LoadConfig validation) still
+	// get usable values — keeps the in-process httptest path symmetric
+	// with the LoadConfig-validated production path.
+	deviceTTL := cfg.Server.DeviceCodeTTL
+	if deviceTTL <= 0 {
+		deviceTTL = 10 * time.Minute
+	}
+	pollInterval := cfg.Server.DevicePollInterval
+	if pollInterval <= 0 {
+		pollInterval = 5 * time.Second
+	}
+	clock := time.Now
 	s := &Server{
 		cfg:               cfg,
 		signer:            signer,
@@ -58,7 +78,8 @@ func NewServer(cfg *Config, signer *Signer, verifier Verifier, issuer *Issuer, d
 		issuer:            issuer,
 		discovery:         discovery,
 		log:               log,
-		clock:             time.Now,
+		clock:             clock,
+		deviceStore:       newDeviceStore(clock, deviceTTL, pollInterval),
 		trustForwardedFor: cfg.RateLimit.TrustForwardedFor,
 	}
 	// Build the registries unless the operator disabled the limiter
@@ -101,6 +122,17 @@ func (s *Server) Routes() http.Handler {
 	}
 	mux.Handle("GET /auth/login", s.ipRateLimit(http.HandlerFunc(s.authLogin)))
 	mux.HandleFunc("GET /auth/callback", s.authCallback)
+	// RFC 8628 device-flow surface. /device/authorize and /device/token
+	// sit behind the IP rate limiter for the same reason /auth/login
+	// does — they're unauthenticated by design and need a backstop
+	// against an attacker hammering them to enumerate state. /device
+	// (the user-facing HTML form) is unprotected: humans hand-typing
+	// codes rarely hit any rate threshold, and a real attacker would
+	// skip the form entirely and target the JSON endpoints.
+	mux.Handle("POST /device/authorize", s.ipRateLimit(http.HandlerFunc(s.deviceAuthorize)))
+	mux.HandleFunc("GET /device", s.deviceFormGet)
+	mux.HandleFunc("POST /device", s.deviceFormPost)
+	mux.Handle("POST /device/token", s.ipRateLimit(http.HandlerFunc(s.deviceToken)))
 	authedSubject := func(h http.HandlerFunc) http.Handler {
 		return s.requireAuth(s.subjectRateLimit(h))
 	}
@@ -151,6 +183,17 @@ func (s *Server) authLogin(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) authCallback(w http.ResponseWriter, r *http.Request) {
+	// Device-flow branch: if the cookie set by POST /device is present
+	// on this callback, the request is the tail end of an RFC 8628
+	// flow rather than the browser code-flow. The handler short-
+	// circuits to deviceCallback (no Mint, no JSON response) and the
+	// rest of this function is unchanged for the browser path. Keeps
+	// the existing /auth/callback tests untouched when no cookie is
+	// set.
+	if cookie, err := r.Cookie(deviceCookieName); err == nil && cookie.Value != "" {
+		s.deviceCallback(w, r, cookie.Value)
+		return
+	}
 	queryState := r.URL.Query().Get("state")
 	code := r.URL.Query().Get("code")
 	if queryState == "" || code == "" {
@@ -184,12 +227,13 @@ func (s *Server) authCallback(w http.ResponseWriter, r *http.Request) {
 		MaxAge:   -1,
 	})
 
-	claims, err := s.verifier.Exchange(r.Context(), code)
+	exchange, err := s.verifier.Exchange(r.Context(), code)
 	if err != nil {
 		s.log.WarnContext(r.Context(), "broker: oauth exchange failed", "err", err)
 		http.Error(w, "oauth exchange failed", http.StatusUnauthorized)
 		return
 	}
+	claims := exchange.Claims
 	results, err := s.issuer.Mint(r.Context(), claims)
 	if err != nil {
 		// Partial mint: some worlds succeeded before a later one failed.

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -163,6 +163,18 @@ func (s *Server) authLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	state := State{Nonce: nonce, ExpiresAt: s.clock().Add(s.cfg.Server.StateTTL)}
+	// Device-flow handoff: if /device set the device cookie, pin the
+	// device_code into the signed state HERE so /auth/callback's
+	// dispatch is driven by a tamper-evident value rather than the
+	// ambient cookie. The cookie itself is consumed (cleared) below
+	// so an abandoned-then-resumed-elsewhere flow can't silently
+	// resurrect the device branch later.
+	if cookie, cerr := r.Cookie(deviceCookieName); cerr == nil && cookie.Value != "" {
+		if _, ok := s.deviceStore.LookupByDeviceCode(cookie.Value); ok {
+			state.DeviceCode = cookie.Value
+		}
+		s.clearDeviceCookie(w)
+	}
 	signed, err := s.signer.Sign(state)
 	if err != nil {
 		s.log.ErrorContext(r.Context(), "broker: sign state", "err", err)
@@ -183,21 +195,9 @@ func (s *Server) authLogin(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) authCallback(w http.ResponseWriter, r *http.Request) {
-	// Device-flow branch: if the cookie set by POST /device is present
-	// on this callback, the request is the tail end of an RFC 8628
-	// flow rather than the browser code-flow. The handler short-
-	// circuits to deviceCallback (no Mint, no JSON response) and the
-	// rest of this function is unchanged for the browser path. Keeps
-	// the existing /auth/callback tests untouched when no cookie is
-	// set.
-	if cookie, err := r.Cookie(deviceCookieName); err == nil && cookie.Value != "" {
-		s.deviceCallback(w, r, cookie.Value)
-		return
-	}
 	queryState := r.URL.Query().Get("state")
-	code := r.URL.Query().Get("code")
-	if queryState == "" || code == "" {
-		http.Error(w, "missing state or code", http.StatusBadRequest)
+	if queryState == "" {
+		http.Error(w, "missing state", http.StatusBadRequest)
 		return
 	}
 	cookie, err := r.Cookie(stateCookieName)
@@ -216,7 +216,8 @@ func (s *Server) authCallback(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "state mismatch", http.StatusUnauthorized)
 		return
 	}
-	// Best effort: clear the cookie now that it has done its job.
+	// State cookie has done its job — clear it before any branch so
+	// even error paths can't replay the nonce.
 	http.SetCookie(w, &http.Cookie{
 		Name:     stateCookieName,
 		Value:    "",
@@ -226,6 +227,24 @@ func (s *Server) authCallback(w http.ResponseWriter, r *http.Request) {
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   -1,
 	})
+
+	// Device-flow dispatch is driven by the signed State, not by an
+	// ambient cookie. authLogin pins state.DeviceCode when /device set
+	// the device cookie; an empty value here means a normal browser
+	// code-flow callback. A stale device cookie left in the jar from
+	// an abandoned flow cannot route a later browser callback through
+	// the device branch because the State was minted fresh at the
+	// most recent /auth/login.
+	if state.DeviceCode != "" {
+		s.deviceCallback(w, r, state.DeviceCode)
+		return
+	}
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		http.Error(w, "missing code", http.StatusBadRequest)
+		return
+	}
 
 	exchange, err := s.verifier.Exchange(r.Context(), code)
 	if err != nil {

--- a/tools/demarkus-broker/internal/broker/session.go
+++ b/tools/demarkus-broker/internal/broker/session.go
@@ -17,9 +17,18 @@ import (
 // The cookie is signed with HMAC-SHA256 over the JSON encoding of this
 // struct; the IdP never sees it (only the Nonce is echoed as the OAuth
 // `state` query parameter).
+//
+// DeviceCode is non-empty when /auth/login was entered from the device
+// flow: it pins the dispatch on /auth/callback to a single, signed
+// value rather than an ambient cookie. Without this field a stale
+// device cookie left in the browser jar (user abandoned a /soul-join
+// mid-flow, then later did a normal browser login) would silently
+// route /auth/callback through the device branch and bind the
+// wrong grant. Empty means a regular browser code-flow callback.
 type State struct {
-	Nonce     string    `json:"n"`
-	ExpiresAt time.Time `json:"e"`
+	Nonce      string    `json:"n"`
+	ExpiresAt  time.Time `json:"e"`
+	DeviceCode string    `json:"d,omitempty"`
 }
 
 // Signer encodes and verifies State values into the signed cookie format

--- a/tools/demarkus-broker/internal/broker/templates/device_done.html
+++ b/tools/demarkus-broker/internal/broker/templates/device_done.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>demarkus — device connected</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 32rem; margin: 4rem auto; padding: 0 1rem; color: #111; text-align: center; }
+  h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+  p { color: #555; line-height: 1.4; }
+  .check { font-size: 3rem; line-height: 1; color: #2c7a3a; margin-bottom: 1rem; }
+</style>
+</head>
+<body>
+<div class="check" aria-hidden="true">✓</div>
+<h1>Device connected</h1>
+<p>You can close this tab and return to your editor.</p>
+</body>
+</html>

--- a/tools/demarkus-broker/internal/broker/templates/device_form.html
+++ b/tools/demarkus-broker/internal/broker/templates/device_form.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>demarkus — connect device</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 32rem; margin: 4rem auto; padding: 0 1rem; color: #111; }
+  h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+  p { color: #555; line-height: 1.4; }
+  form { display: flex; flex-direction: column; gap: 0.75rem; margin-top: 1.5rem; }
+  input[type=text] { font: inherit; font-family: ui-monospace, monospace; font-size: 1.25rem; padding: 0.75rem; letter-spacing: 0.1em; text-transform: uppercase; border: 1px solid #ccc; border-radius: 4px; }
+  button { font: inherit; padding: 0.75rem; background: #111; color: #fff; border: 0; border-radius: 4px; cursor: pointer; }
+  button:hover { background: #333; }
+  .error { color: #b00020; margin-top: 0.5rem; }
+</style>
+</head>
+<body>
+<h1>Connect device</h1>
+<p>Enter the code shown by your terminal or editor to finish joining this demarkus broker.</p>
+<form method="post" action="/device">
+  <input type="text" name="user_code" value="{{.PrefilledUserCode}}" placeholder="XXXX-XXXX" autofocus autocomplete="off" autocapitalize="characters" spellcheck="false" required>
+  <button type="submit">Continue</button>
+  {{if .Error}}<div class="error">{{.Error}}</div>{{end}}
+</form>
+</body>
+</html>

--- a/tools/demarkus-broker/internal/broker/templates/device_form.html
+++ b/tools/demarkus-broker/internal/broker/templates/device_form.html
@@ -13,13 +13,15 @@
   button { font: inherit; padding: 0.75rem; background: #111; color: #fff; border: 0; border-radius: 4px; cursor: pointer; }
   button:hover { background: #333; }
   .error { color: #b00020; margin-top: 0.5rem; }
+  .visually-hidden { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
 </style>
 </head>
 <body>
 <h1>Connect device</h1>
 <p>Enter the code shown by your terminal or editor to finish joining this demarkus broker.</p>
 <form method="post" action="/device">
-  <input type="text" name="user_code" value="{{.PrefilledUserCode}}" placeholder="XXXX-XXXX" autofocus autocomplete="off" autocapitalize="characters" spellcheck="false" required>
+  <label for="user_code" class="visually-hidden">Device code</label>
+  <input type="text" id="user_code" name="user_code" value="{{.PrefilledUserCode}}" placeholder="XXXX-XXXX" autofocus autocomplete="off" autocapitalize="characters" spellcheck="false" required>
   <button type="submit">Continue</button>
   {{if .Error}}<div class="error">{{.Error}}</div>{{end}}
 </form>

--- a/tools/demarkus-broker/main.go
+++ b/tools/demarkus-broker/main.go
@@ -150,6 +150,17 @@ func run(configPath, kubeconfigPath string, log *slog.Logger) error {
 		log.Info("broker: sweeper disabled (sweeper.disabled=true)")
 	}
 
+	// Device-store janitor evicts terminal RFC 8628 grants on a fixed
+	// cadence. Per-replica state (single-broker invariant for now), no
+	// leader election needed. Shares sweepCtx with the Sweeper so a
+	// single cancel tears down both goroutines.
+	log.Info("broker: starting device-store janitor",
+		"deviceCodeTTL", cfg.Server.DeviceCodeTTL,
+		"devicePollInterval", cfg.Server.DevicePollInterval)
+	sweepWG.Go(func() {
+		srv.RunDeviceJanitor(sweepCtx)
+	})
+
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 	select {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RFC 8628 device authorization flow with authorize, token-polling, browser verification form, and completion page
  * Device flow issues ID/access tokens on success; uses a device cookie and redirects for browser binding
  * Background janitor to auto-clean expired device grants
  * Configurable device-code TTL and poll interval with sensible defaults and validation
  * Same-origin POST protection and cookie attributes honoring secure/insecure settings
  * Polling enforces minimum interval / slow_down behavior

* **Tests**
  * Comprehensive unit and integration tests covering device flow, polling, expiry, deny/bind, janitor, and related behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/137)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->