### PR TITLE
fix(tool):  Implement refresh token lifecycle backed by Kubernetes Secret

### DIFF
--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -75,6 +75,18 @@ type ServerConfig struct {
 	// Default 5s; matches the `interval` value the authorize response
 	// emits to clients.
 	DevicePollInterval time.Duration `yaml:"devicePollInterval"`
+	// RefreshTokensSecret is the broker-namespace Secret holding the
+	// JSON map of sha256(refresh_token) → record. Read+patched on every
+	// /device/token refresh-grant call and /token/revoke. Required for
+	// universe-onboarding PR4; defaulted in validate when omitted so
+	// existing dev configs upgrade without an explicit value.
+	RefreshTokensSecret string `yaml:"refreshTokensSecret"`
+	// RefreshTokenTTL is the lifetime of a newly-issued refresh token.
+	// Default 90 days. Tokens past their TTL are rejected at refresh
+	// time and reaped by the periodic Sweeper. Operators tighten this
+	// for short-lived deployments or relax it for headless CI tooling
+	// where a 90-day re-login is acceptable.
+	RefreshTokenTTL time.Duration `yaml:"refreshTokenTTL"`
 }
 
 // OIDCConfig describes the OIDC client registration at the IdP. Discovery

--- a/tools/demarkus-broker/internal/broker/device.go
+++ b/tools/demarkus-broker/internal/broker/device.go
@@ -60,12 +60,16 @@ type deviceAuthorizeResponse struct {
 // deviceTokenSuccess mirrors RFC 8628 §3.5 success — the same shape as
 // an OAuth2 token endpoint response when the polling completes. We
 // forward the IdP's raw id_token + access_token verbatim; refresh_token
-// is intentionally omitted in PR3 and lands in PR4.
+// lands at PR4 (broker-minted opaque token; see refresh.go). On a
+// successful device-code completion every response carries all four
+// token fields — omitempty stays on RefreshToken purely as belt-and-
+// suspenders against a degenerate Bind path that didn't mint one.
 type deviceTokenSuccess struct {
-	AccessToken string `json:"access_token"`
-	IDToken     string `json:"id_token"`
-	TokenType   string `json:"token_type"`
-	ExpiresIn   int    `json:"expires_in"`
+	AccessToken  string `json:"access_token"`
+	IDToken      string `json:"id_token"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
 }
 
 // deviceTokenError is the standard OAuth2 error response shape (RFC
@@ -218,10 +222,11 @@ func (s *Server) deviceToken(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-store")
 		w.Header().Set("Pragma", "no-cache")
 		writeJSON(w, http.StatusOK, deviceTokenSuccess{
-			AccessToken: out.Result.AccessToken,
-			IDToken:     out.Result.RawIDToken,
-			TokenType:   "Bearer",
-			ExpiresIn:   expiresIn,
+			AccessToken:  out.Result.AccessToken,
+			IDToken:      out.Result.RawIDToken,
+			RefreshToken: out.RefreshToken,
+			TokenType:    "Bearer",
+			ExpiresIn:    expiresIn,
 		})
 	case out.Status == statusExpired:
 		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "expired_token"})
@@ -317,7 +322,21 @@ func (s *Server) deviceCallback(w http.ResponseWriter, r *http.Request, deviceCo
 		s.renderDeviceDone(w, r)
 		return
 	}
-	if err := s.deviceStore.Bind(deviceCode, &exchange); err != nil {
+	// Mint the refresh token BEFORE Bind so a Secret-side failure
+	// keeps the grant pending — the polling client retries on the
+	// next interval, the user re-runs soul-join, and no orphan
+	// statusComplete state goes out without its refresh token.
+	// Orphaned refresh-tokens Secret entries (mint succeeded, Bind
+	// then races a sweep) age out on Sweep, same posture as the
+	// issuances Secret's partial-failure recovery.
+	rawRefresh, err := s.refreshStore.Issue(r.Context(), exchange.Claims, s.cfg.Server.RefreshTokenTTL)
+	if err != nil {
+		s.log.WarnContext(r.Context(), "broker: device callback refresh mint failed",
+			"err", err, "subject", hashSubject(exchange.Claims.Subject))
+		s.renderDeviceDone(w, r)
+		return
+	}
+	if err := s.deviceStore.Bind(deviceCode, &exchange, rawRefresh); err != nil {
 		s.log.WarnContext(r.Context(), "broker: device bind failed",
 			"err", err, "subject", hashSubject(exchange.Claims.Subject))
 		s.renderDeviceDone(w, r)

--- a/tools/demarkus-broker/internal/broker/device_store.go
+++ b/tools/demarkus-broker/internal/broker/device_store.go
@@ -68,6 +68,13 @@ type deviceCodeState struct {
 	// Populated by Bind on successful IdP exchange; consumed by Poll
 	// to build the statusComplete response. Zero values otherwise.
 	Result ExchangeResult
+	// RefreshToken is the raw opaque refresh token minted at Bind time
+	// by the broker's refreshStore. Stashed here so that idempotent
+	// polling (a buggy client polling multiple times after completion
+	// resolves) returns the SAME refresh_token rather than minting a
+	// fresh one each poll. Empty until Bind sets it; cleared on Sweep
+	// alongside the state itself.
+	RefreshToken string
 }
 
 // pollResult is what the /device/token handler dispatches on. SlowDown
@@ -79,6 +86,11 @@ type pollResult struct {
 	Status   deviceStatus
 	SlowDown bool
 	Result   ExchangeResult // only set when Status == statusComplete
+	// RefreshToken is the raw opaque refresh token bound to this grant.
+	// Set only when Status == statusComplete and a refresh token was
+	// minted at Bind time. Forwarded verbatim into the /device/token
+	// success response; subsequent polls return the same value.
+	RefreshToken string
 }
 
 // errDeviceCodeNotFound is returned by Bind / Poll / Deny when the
@@ -226,16 +238,25 @@ func (s *deviceStore) LookupByDeviceCode(deviceCode string) (deviceCodeState, bo
 }
 
 // Bind transitions a pending grant to statusComplete and stashes the
-// IdP exchange result for the polling client to pick up. Called from
-// /auth/callback's device-cookie branch after the OAuth exchange
-// succeeds. Takes a pointer to avoid copying ExchangeResult (~120
-// bytes) through the call site; the store still owns its copy via
-// the dereference into deviceCodeState.Result. Returns
-// errDeviceCodeNotFound for unknown codes and errDeviceCodeTerminal
-// if the grant has already resolved (already complete, expired, or
-// denied) — the callback handler treats the terminal case as a
-// no-op, since whatever already resolved is the authoritative outcome.
-func (s *deviceStore) Bind(deviceCode string, result *ExchangeResult) error {
+// IdP exchange result + the broker-minted refresh token for the
+// polling client to pick up. Called from /auth/callback's device-cookie
+// branch after the OAuth exchange succeeds. Takes a pointer to
+// ExchangeResult to avoid copying ~120 bytes through the call site;
+// the store still owns its copy via the dereference into
+// deviceCodeState.Result.
+//
+// refreshToken may be empty during early callers; the caller is
+// expected to mint and pass it. An empty value is stored verbatim and
+// surfaced as an empty refresh_token in the polling response. PR4's
+// deviceCallback always mints before Bind, so production paths never
+// pass empty.
+//
+// Returns errDeviceCodeNotFound for unknown codes and
+// errDeviceCodeTerminal if the grant has already resolved (already
+// complete, expired, or denied) — the callback handler treats the
+// terminal case as a no-op, since whatever already resolved is the
+// authoritative outcome.
+func (s *deviceStore) Bind(deviceCode string, result *ExchangeResult, refreshToken string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	state, ok := s.codes[deviceCode]
@@ -251,6 +272,7 @@ func (s *deviceStore) Bind(deviceCode string, result *ExchangeResult) error {
 	}
 	state.Status = statusComplete
 	state.Result = *result
+	state.RefreshToken = refreshToken
 	return nil
 }
 
@@ -303,6 +325,7 @@ func (s *deviceStore) Poll(deviceCode string) pollResult {
 		out := pollResult{Status: state.Status}
 		if state.Status == statusComplete {
 			out.Result = state.Result
+			out.RefreshToken = state.RefreshToken
 		}
 		return out
 	}

--- a/tools/demarkus-broker/internal/broker/device_store_test.go
+++ b/tools/demarkus-broker/internal/broker/device_store_test.go
@@ -136,7 +136,7 @@ func TestDeviceStoreLookupByUserCode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Authorize: %v", err)
 		}
-		if err := store.Bind(deviceCode, &ExchangeResult{}); err != nil {
+		if err := store.Bind(deviceCode, &ExchangeResult{}, ""); err != nil {
 			t.Fatalf("Bind: %v", err)
 		}
 		if _, ok := store.LookupByUserCode(userCode); ok {
@@ -157,7 +157,7 @@ func TestDeviceStoreBind(t *testing.T) {
 			RawIDToken:  "id-token",
 			AccessToken: "access-token",
 		}
-		if err := store.Bind(deviceCode, &result); err != nil {
+		if err := store.Bind(deviceCode, &result, "refresh-raw"); err != nil {
 			t.Fatalf("Bind: %v", err)
 		}
 		out := store.Poll(deviceCode)
@@ -170,11 +170,14 @@ func TestDeviceStoreBind(t *testing.T) {
 		if out.Result.AccessToken != "access-token" {
 			t.Fatalf("forwarded access_token mismatch: %q", out.Result.AccessToken)
 		}
+		if out.RefreshToken != "refresh-raw" {
+			t.Fatalf("forwarded refresh_token = %q, want refresh-raw", out.RefreshToken)
+		}
 	})
 
 	t.Run("unknown device code returns not-found", func(t *testing.T) {
 		store, _ := newTestDeviceStore(t)
-		err := store.Bind("nonexistent", &ExchangeResult{})
+		err := store.Bind("nonexistent", &ExchangeResult{}, "")
 		if !errors.Is(err, errDeviceCodeNotFound) {
 			t.Fatalf("err: got %v want errDeviceCodeNotFound", err)
 		}
@@ -186,10 +189,10 @@ func TestDeviceStoreBind(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Authorize: %v", err)
 		}
-		if err := store.Bind(deviceCode, &ExchangeResult{RawIDToken: "first"}); err != nil {
+		if err := store.Bind(deviceCode, &ExchangeResult{RawIDToken: "first"}, ""); err != nil {
 			t.Fatalf("first Bind: %v", err)
 		}
-		err = store.Bind(deviceCode, &ExchangeResult{RawIDToken: "second"})
+		err = store.Bind(deviceCode, &ExchangeResult{RawIDToken: "second"}, "")
 		if !errors.Is(err, errDeviceCodeTerminal) {
 			t.Fatalf("second Bind: got %v want errDeviceCodeTerminal", err)
 		}
@@ -207,7 +210,7 @@ func TestDeviceStoreBind(t *testing.T) {
 			t.Fatalf("Authorize: %v", err)
 		}
 		clock.Advance(testExpiresIn + time.Second)
-		err = store.Bind(deviceCode, &ExchangeResult{})
+		err = store.Bind(deviceCode, &ExchangeResult{}, "")
 		if !errors.Is(err, errDeviceCodeTerminal) {
 			t.Fatalf("err: got %v want errDeviceCodeTerminal", err)
 		}
@@ -236,7 +239,7 @@ func TestDeviceStoreDeny(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Authorize: %v", err)
 		}
-		if err := store.Bind(deviceCode, &ExchangeResult{RawIDToken: "id"}); err != nil {
+		if err := store.Bind(deviceCode, &ExchangeResult{RawIDToken: "id"}, ""); err != nil {
 			t.Fatalf("Bind: %v", err)
 		}
 		err = store.Deny(deviceCode)
@@ -256,7 +259,7 @@ func TestDeviceStorePoll(t *testing.T) {
 		if out := store.Poll(deviceCode); out.Status != statusPending || out.SlowDown {
 			t.Fatalf("first poll: got %+v want pending", out)
 		}
-		if err := store.Bind(deviceCode, &ExchangeResult{Claims: Claims{Email: "a@b"}}); err != nil {
+		if err := store.Bind(deviceCode, &ExchangeResult{Claims: Claims{Email: "a@b"}}, ""); err != nil {
 			t.Fatalf("Bind: %v", err)
 		}
 		out := store.Poll(deviceCode)

--- a/tools/demarkus-broker/internal/broker/device_test.go
+++ b/tools/demarkus-broker/internal/broker/device_test.go
@@ -106,7 +106,7 @@ func TestDeviceTokenSuccessIsNonCacheable(t *testing.T) {
 	if err := broker.deviceStore.Bind(deviceCode, &ExchangeResult{
 		RawIDToken:  "id",
 		AccessToken: "access",
-	}); err != nil {
+	}, "refresh-raw"); err != nil {
 		t.Fatalf("Bind: %v", err)
 	}
 	resp, err := testClient(srv).PostForm(srv.URL+"/device/token", url.Values{
@@ -472,7 +472,7 @@ func TestDeviceTokenStates(t *testing.T) {
 			Claims:      Claims{Email: "alice@example.com"},
 			RawIDToken:  "raw-id-token",
 			AccessToken: "raw-access-token",
-		}); err != nil {
+		}, "raw-refresh-token"); err != nil {
 			t.Fatalf("Bind: %v", err)
 		}
 		resp, err := testClient(srv).PostForm(srv.URL+"/device/token", url.Values{
@@ -496,6 +496,9 @@ func TestDeviceTokenStates(t *testing.T) {
 		}
 		if success.AccessToken != "raw-access-token" {
 			t.Errorf("access_token = %q, want raw-access-token", success.AccessToken)
+		}
+		if success.RefreshToken != "raw-refresh-token" {
+			t.Errorf("refresh_token = %q, want raw-refresh-token", success.RefreshToken)
 		}
 		if success.TokenType != "Bearer" {
 			t.Errorf("token_type = %q, want Bearer", success.TokenType)
@@ -832,6 +835,84 @@ func TestDeviceFlowIntegrationHappyPath(t *testing.T) {
 	}
 	if success.AccessToken != "raw-access-token-xyz" {
 		t.Errorf("access_token = %q, want forwarded value", success.AccessToken)
+	}
+	// PR4 contract: every device-code completion mints a refresh token.
+	// 32 bytes hex = 64 chars. The deviceCallback flow Issued at Bind
+	// time; the polling response forwards it verbatim.
+	if len(success.RefreshToken) != 64 {
+		t.Errorf("refresh_token len = %d, want 64 hex chars: %q", len(success.RefreshToken), success.RefreshToken)
+	}
+}
+
+// TestDeviceCallbackRefreshMintFailureLeavesPending pins PR4's
+// "never ship anything broken" posture: when the refresh-token mint
+// fails after a successful OAuth exchange, deviceCallback MUST leave
+// the device-code grant in statusPending so the polling client retries
+// (or eventually sees expired_token). Translating to access_denied or
+// hand-rolling a half-bound state would silently leak an IdP-verified
+// claim into a state the polling client can't recover from.
+func TestDeviceCallbackRefreshMintFailureLeavesPending(t *testing.T) {
+	verifier := &fakeVerifier{
+		authURL:    "https://idp.example.com/authorize",
+		claims:     Claims{Email: "alice@example.com", EmailVerified: true, Subject: "google|alice"},
+		rawIDToken: "id",
+	}
+	srv, broker := newTestServer(t, deviceTestConfig(), verifier, fake.NewSimpleClientset())
+	// Force refresh-mint failures: randFn always errors.
+	broker.refreshStore.randFn = func(_ []byte) (int, error) {
+		return 0, errors.New("simulated refresh mint failure")
+	}
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	client := testClient(srv)
+	client.Jar = jar
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	authResp, err := client.PostForm(srv.URL+"/device/authorize", url.Values{
+		"client_id": {"demarkus-cli"},
+	})
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	var auth deviceAuthorizeResponse
+	if err := json.NewDecoder(authResp.Body).Decode(&auth); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	_ = authResp.Body.Close()
+
+	formResp, err := client.PostForm(srv.URL+"/device", url.Values{"user_code": {auth.UserCode}})
+	if err != nil {
+		t.Fatalf("form: %v", err)
+	}
+	_ = formResp.Body.Close()
+
+	loginResp, err := client.Get(srv.URL + "/auth/login")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	_ = loginResp.Body.Close()
+	loc, _ := url.Parse(loginResp.Header.Get("Location"))
+	nonce := loc.Query().Get("state")
+
+	req, _ := http.NewRequest(http.MethodGet,
+		srv.URL+"/auth/callback?code=abc&state="+url.QueryEscape(nonce), http.NoBody)
+	cbResp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	_ = cbResp.Body.Close()
+	if cbResp.StatusCode != http.StatusOK {
+		t.Fatalf("callback status = %d, want 200 (done page renders on mint failure too)", cbResp.StatusCode)
+	}
+
+	// Grant must still be pending, NOT access_denied (that's reserved
+	// for IdP-side denial) and NOT statusComplete (we never minted
+	// the refresh token to put in the success body).
+	if err := expectDeviceTokenError(t, srv, auth.DeviceCode, "authorization_pending"); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/tools/demarkus-broker/internal/broker/device_test.go
+++ b/tools/demarkus-broker/internal/broker/device_test.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
@@ -837,10 +838,15 @@ func TestDeviceFlowIntegrationHappyPath(t *testing.T) {
 		t.Errorf("access_token = %q, want forwarded value", success.AccessToken)
 	}
 	// PR4 contract: every device-code completion mints a refresh token.
-	// 32 bytes hex = 64 chars. The deviceCallback flow Issued at Bind
-	// time; the polling response forwards it verbatim.
-	if len(success.RefreshToken) != 64 {
-		t.Errorf("refresh_token len = %d, want 64 hex chars: %q", len(success.RefreshToken), success.RefreshToken)
+	// 32 bytes hex = 64 chars; assert hex validity too so a 64-byte
+	// garbage string can't masquerade as a real token in a future
+	// regression.
+	decoded, err := hex.DecodeString(success.RefreshToken)
+	if err != nil {
+		t.Errorf("refresh_token is not valid hex: %v (raw=%q)", err, success.RefreshToken)
+	}
+	if len(decoded) != refreshTokenBytes {
+		t.Errorf("refresh_token decoded len = %d, want %d", len(decoded), refreshTokenBytes)
 	}
 }
 

--- a/tools/demarkus-broker/internal/broker/issuer.go
+++ b/tools/demarkus-broker/internal/broker/issuer.go
@@ -602,6 +602,18 @@ func mutateSecret(ctx context.Context, k8s kubernetes.Interface, namespace, name
 			return err
 		}
 		if apierrors.IsNotFound(getErr) {
+			// No-op closure on an absent Secret: don't materialize an
+			// empty Secret as a side effect. Refresh-store Revoke and
+			// Sweep both return existing-unchanged when there's
+			// nothing to do; without this guard the first such call
+			// would create a `{key: nil}` Secret that the next call
+			// then has to read back. The no-write contract is
+			// observable (helm-rendered Secrets, audit logs), so
+			// preserving "absent stays absent" is part of the
+			// store's behavior, not an internal detail.
+			if len(next) == 0 {
+				return nil
+			}
 			fresh := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,

--- a/tools/demarkus-broker/internal/broker/issuer.go
+++ b/tools/demarkus-broker/internal/broker/issuer.go
@@ -502,19 +502,19 @@ func (i *Issuer) lookupWorld(name string) *WorldConfig {
 }
 
 func (i *Issuer) appendToWorldSecret(ctx context.Context, w *WorldConfig, label string, entry *token.Entry) error {
-	return i.mutateSecret(ctx, w.Namespace, w.TokensSecret, TokensSecretKey, func(existing []byte) ([]byte, error) {
+	return mutateSecret(ctx, i.k8s, w.Namespace, w.TokensSecret, TokensSecretKey, func(existing []byte) ([]byte, error) {
 		return token.AppendBytes(existing, label, entry)
 	})
 }
 
 func (i *Issuer) removeFromWorldSecret(ctx context.Context, w *WorldConfig, label string) error {
-	return i.mutateSecret(ctx, w.Namespace, w.TokensSecret, TokensSecretKey, func(existing []byte) ([]byte, error) {
+	return mutateSecret(ctx, i.k8s, w.Namespace, w.TokensSecret, TokensSecretKey, func(existing []byte) ([]byte, error) {
 		return token.RemoveBytes(existing, label)
 	})
 }
 
 func (i *Issuer) appendIssuance(ctx context.Context, iss *Issuance) error {
-	return i.mutateSecret(ctx, i.cfg.Server.BrokerNamespace, i.cfg.Server.IssuancesSecret, IssuancesSecretKey, func(existing []byte) ([]byte, error) {
+	return mutateSecret(ctx, i.k8s, i.cfg.Server.BrokerNamespace, i.cfg.Server.IssuancesSecret, IssuancesSecretKey, func(existing []byte) ([]byte, error) {
 		var current Issuances
 		if len(existing) > 0 {
 			if err := json.Unmarshal(existing, &current); err != nil {
@@ -537,7 +537,7 @@ func (i *Issuer) appendIssuance(ctx context.Context, iss *Issuance) error {
 }
 
 func (i *Issuer) removeIssuance(ctx context.Context, label string) error {
-	return i.mutateSecret(ctx, i.cfg.Server.BrokerNamespace, i.cfg.Server.IssuancesSecret, IssuancesSecretKey, func(existing []byte) ([]byte, error) {
+	return mutateSecret(ctx, i.k8s, i.cfg.Server.BrokerNamespace, i.cfg.Server.IssuancesSecret, IssuancesSecretKey, func(existing []byte) ([]byte, error) {
 		if len(existing) == 0 {
 			return existing, nil
 		}
@@ -580,9 +580,16 @@ func (i *Issuer) readIssuances(ctx context.Context) (Issuances, error) {
 // the named key set to the mutate-result on empty input. Retries
 // resourceVersion conflicts up to maxConflictRetries; surfaces all other
 // errors immediately.
-func (i *Issuer) mutateSecret(ctx context.Context, namespace, name, key string, mutate func([]byte) ([]byte, error)) error {
+//
+// Free function rather than a method on any one type so the broker's
+// Issuer and refreshStore can share the same Secret-mutation contract
+// without duplicating the conflict-retry loop. See /guidelines.md
+// "Don't Duplicate Logic" — the prior shape had the loop only on
+// *Issuer; the refresh-tokens Secret needed identical semantics, so the
+// helper became a package-level free function.
+func mutateSecret(ctx context.Context, k8s kubernetes.Interface, namespace, name, key string, mutate func([]byte) ([]byte, error)) error {
 	for range maxConflictRetries {
-		secret, getErr := i.k8s.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+		secret, getErr := k8s.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 		if getErr != nil && !apierrors.IsNotFound(getErr) {
 			return fmt.Errorf("get secret %s/%s: %w", namespace, name, getErr)
 		}
@@ -603,7 +610,7 @@ func (i *Issuer) mutateSecret(ctx context.Context, namespace, name, key string, 
 				Type: corev1.SecretTypeOpaque,
 				Data: map[string][]byte{key: next},
 			}
-			_, createErr := i.k8s.CoreV1().Secrets(namespace).Create(ctx, fresh, metav1.CreateOptions{})
+			_, createErr := k8s.CoreV1().Secrets(namespace).Create(ctx, fresh, metav1.CreateOptions{})
 			if createErr == nil {
 				return nil
 			}
@@ -616,7 +623,7 @@ func (i *Issuer) mutateSecret(ctx context.Context, namespace, name, key string, 
 			secret.Data = make(map[string][]byte, 1)
 		}
 		secret.Data[key] = next
-		_, updateErr := i.k8s.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{})
+		_, updateErr := k8s.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{})
 		if updateErr == nil {
 			return nil
 		}

--- a/tools/demarkus-broker/internal/broker/refresh.go
+++ b/tools/demarkus-broker/internal/broker/refresh.go
@@ -1,0 +1,288 @@
+package broker
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+// RefreshTokensSecretKey is the key inside the broker-namespace
+// refresh-tokens Secret holding the JSON map of sha256(refresh_token)
+// → record. Stable so operators can grep the rendered Secret without
+// chasing a version-specific key name.
+const RefreshTokensSecretKey = "refresh_tokens.json"
+
+// defaultRefreshTokensSecret is the production-safe Secret name
+// applied when ServerConfig.RefreshTokensSecret is omitted. Keeps
+// test configs and dev deployments self-consistent without forcing
+// every operator to set the field.
+const defaultRefreshTokensSecret = "demarkus-broker-refresh-tokens"
+
+// defaultRefreshTokenTTL is the production-safe lifetime applied
+// when ServerConfig.RefreshTokenTTL is omitted. 90 days matches the
+// industry-standard refresh lifetime (Google / Auth0 / Okta defaults
+// sit in the 60-180d range). Operators tighten via config.
+const defaultRefreshTokenTTL = 90 * 24 * time.Hour
+
+// refreshTokenBytes is the raw entropy size of an opaque refresh
+// token before hex encoding. 32 bytes (256 bits) is the standard
+// posture for opaque OAuth2 refresh tokens; together with the
+// sha256-on-disk hash, a Secret-data exfiltration cannot be turned
+// into a mint without solving sha256 pre-image on 256-bit input —
+// infeasible by construction.
+const refreshTokenBytes = 32
+
+// ErrRefreshTokenInvalid is the sentinel for every "this refresh
+// token will not mint anything" condition: unknown, tampered,
+// expired, or revoked. Callers translate to RFC 6749 §5.2
+// invalid_grant on the /device/token refresh branch. One sentinel
+// rather than four so the broker does not leak which failure mode
+// triggered the rejection — a tampered token and an expired token
+// must be indistinguishable to a polling client.
+var ErrRefreshTokenInvalid = errors.New("broker: refresh token invalid or expired")
+
+// refreshTokenRecord is the broker-side row stored in the
+// refresh-tokens Secret. The raw token NEVER touches disk — only its
+// sha256 hash is the map key, and the record itself holds no token
+// material. A Secret-data leak reveals identity (email + sub) and
+// timestamps but cannot be turned into a working refresh token
+// without breaking sha256 pre-image resistance.
+//
+// Claims is the verified subset of the device-flow ID token captured
+// at /auth/callback time. PR4's refresh branch (Step 3) reconstructs
+// the response from this snapshot, re-signing a fresh id_token with
+// the broker's key so the bearer-validation downstream sees a token
+// with `exp` in the future. See the parent plan §"Out of Scope" for
+// why the broker does NOT round-trip back to the IdP on refresh.
+type refreshTokenRecord struct {
+	// KeyHash is sha256-hex of the raw token. Stored alongside the
+	// record (and used as the map key) so log lines and JSON dumps
+	// have a stable, non-reversible identifier independent of the
+	// containing map key. Duplicate-by-design.
+	KeyHash    string    `json:"keyHash"`
+	Claims     Claims    `json:"claims"`
+	IssuedAt   time.Time `json:"issuedAt"`
+	ExpiresAt  time.Time `json:"expiresAt"`
+	LastUsedAt time.Time `json:"lastUsedAt,omitzero"`
+}
+
+// refreshTokens is the on-disk shape of the broker's refresh-tokens
+// Secret data[refresh_tokens.json]: a map keyed by sha256 hex.
+// Map vs. slice (issuances uses a slice) reflects access pattern —
+// every Refresh and Revoke is an O(1) hash lookup; a slice would
+// force an O(N) scan on every poll, and a 90-day TTL means N can
+// reach several thousand on a busy broker.
+type refreshTokens struct {
+	Entries map[string]refreshTokenRecord `json:"entries"`
+}
+
+// refreshStore is the broker's refresh-token lifecycle layer.
+// All state lives in a single broker-namespace Secret; mutations go
+// through the shared optimistic-concurrency mutateSecret helper.
+// Multi-replica brokers converge under conflict retry — same posture
+// as the issuances Secret.
+//
+// Single-Secret scaling cap is documented in
+// /plans/universe-onboarding-pr4.md §Risks ("Secret-storage scaling"):
+// ~5000 active records at 90-day TTL before the 1 MiB etcd Secret
+// limit becomes the wall. Phase-7 follow-up is a sharded or
+// CRD-backed store; the API surface here stays stable across that
+// migration.
+type refreshStore struct {
+	cfg    *Config
+	k8s    kubernetes.Interface
+	clock  func() time.Time
+	randFn func([]byte) (int, error)
+}
+
+// newRefreshStore wires a refreshStore with real time.Now and
+// crypto/rand. Tests override clock and randFn on the returned
+// struct for deterministic behavior — same pattern as NewIssuer.
+func newRefreshStore(cfg *Config, k8s kubernetes.Interface) *refreshStore {
+	return &refreshStore{
+		cfg:    cfg,
+		k8s:    k8s,
+		clock:  time.Now,
+		randFn: rand.Read,
+	}
+}
+
+// Issue mints a fresh opaque refresh token, stashes its hashed record
+// in the Secret, and returns the raw token for the caller to hand
+// back to the polling client. ttl must be > 0; callers (the
+// /device/token success branch in Step 2) pass
+// ServerConfig.RefreshTokenTTL.
+//
+// The raw token is hex-encoded 32-byte randomness (64 chars). The
+// caller is responsible for treating it as bearer credential material
+// — no logging, no retries that would surface it in error messages.
+func (s *refreshStore) Issue(ctx context.Context, claims Claims, ttl time.Duration) (string, error) {
+	if ttl <= 0 {
+		return "", fmt.Errorf("refresh ttl must be > 0 (got %s)", ttl)
+	}
+	buf := make([]byte, refreshTokenBytes)
+	if _, err := s.randFn(buf); err != nil {
+		return "", fmt.Errorf("generate refresh token entropy: %w", err)
+	}
+	raw := hex.EncodeToString(buf)
+	keyHash := hashRefreshToken(raw)
+	now := s.clock()
+	record := refreshTokenRecord{
+		KeyHash:   keyHash,
+		Claims:    claims,
+		IssuedAt:  now,
+		ExpiresAt: now.Add(ttl),
+	}
+	err := mutateSecret(ctx, s.k8s, s.cfg.Server.BrokerNamespace, s.cfg.Server.RefreshTokensSecret, RefreshTokensSecretKey, func(existing []byte) ([]byte, error) {
+		store, err := decodeRefreshTokens(existing)
+		if err != nil {
+			return nil, err
+		}
+		// sha256 collision on a 32-random-byte pre-image is
+		// astronomically improbable. The check exists so a
+		// hypothetical collision fails loudly rather than silently
+		// rotating one record over another.
+		if _, exists := store.Entries[keyHash]; exists {
+			return nil, fmt.Errorf("refresh token hash collision on %s", keyHash[:8])
+		}
+		store.Entries[keyHash] = record
+		return json.Marshal(store)
+	})
+	if err != nil {
+		return "", err
+	}
+	return raw, nil
+}
+
+// Refresh validates the supplied raw token against the store. On
+// success, updates the record's LastUsedAt timestamp (one
+// extra Secret RMW per call — acceptable for the human-scale rate of
+// refresh) and returns the stored record so the caller can rebuild a
+// response from the cached Claims. On any "not minting" condition
+// returns ErrRefreshTokenInvalid; I/O failures propagate.
+func (s *refreshStore) Refresh(ctx context.Context, rawToken string) (refreshTokenRecord, error) {
+	if rawToken == "" {
+		return refreshTokenRecord{}, ErrRefreshTokenInvalid
+	}
+	keyHash := hashRefreshToken(rawToken)
+	var out refreshTokenRecord
+	err := mutateSecret(ctx, s.k8s, s.cfg.Server.BrokerNamespace, s.cfg.Server.RefreshTokensSecret, RefreshTokensSecretKey, func(existing []byte) ([]byte, error) {
+		// Reset on each retry — a conflict-driven re-run must not
+		// leak state from the prior closure invocation.
+		out = refreshTokenRecord{}
+		store, err := decodeRefreshTokens(existing)
+		if err != nil {
+			return nil, err
+		}
+		record, ok := store.Entries[keyHash]
+		if !ok {
+			return nil, ErrRefreshTokenInvalid
+		}
+		now := s.clock()
+		if !record.ExpiresAt.IsZero() && now.After(record.ExpiresAt) {
+			return nil, ErrRefreshTokenInvalid
+		}
+		record.LastUsedAt = now
+		store.Entries[keyHash] = record
+		out = record
+		return json.Marshal(store)
+	})
+	if err != nil {
+		return refreshTokenRecord{}, err
+	}
+	return out, nil
+}
+
+// Revoke drops a token from the store. Idempotent per RFC 7009 §2.2:
+// revoking an unknown or already-revoked token is not an error. An
+// absent Secret is the "store is empty" case and also a no-op.
+func (s *refreshStore) Revoke(ctx context.Context, rawToken string) error {
+	if rawToken == "" {
+		return nil
+	}
+	keyHash := hashRefreshToken(rawToken)
+	return mutateSecret(ctx, s.k8s, s.cfg.Server.BrokerNamespace, s.cfg.Server.RefreshTokensSecret, RefreshTokensSecretKey, func(existing []byte) ([]byte, error) {
+		if len(existing) == 0 {
+			return existing, nil
+		}
+		store, err := decodeRefreshTokens(existing)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := store.Entries[keyHash]; !ok {
+			return existing, nil
+		}
+		delete(store.Entries, keyHash)
+		return json.Marshal(store)
+	})
+}
+
+// Sweep removes every expired entry in one pass. Returns the count
+// of records swept so the caller can log it. Absent Secret and empty
+// map are both no-ops returning (0, nil). Designed to be called from
+// the existing Sweeper's per-tick loop alongside the issuances
+// sweep — Step 5 wires it.
+func (s *refreshStore) Sweep(ctx context.Context) (int, error) {
+	var swept int
+	err := mutateSecret(ctx, s.k8s, s.cfg.Server.BrokerNamespace, s.cfg.Server.RefreshTokensSecret, RefreshTokensSecretKey, func(existing []byte) ([]byte, error) {
+		// Reset on each retry — same rationale as Refresh.
+		swept = 0
+		if len(existing) == 0 {
+			return existing, nil
+		}
+		store, err := decodeRefreshTokens(existing)
+		if err != nil {
+			return nil, err
+		}
+		if len(store.Entries) == 0 {
+			return existing, nil
+		}
+		now := s.clock()
+		for k := range store.Entries {
+			rec := store.Entries[k]
+			if !rec.ExpiresAt.IsZero() && now.After(rec.ExpiresAt) {
+				delete(store.Entries, k)
+				swept++
+			}
+		}
+		if swept == 0 {
+			return existing, nil
+		}
+		return json.Marshal(store)
+	})
+	return swept, err
+}
+
+// hashRefreshToken returns the sha256-hex of the raw token. Used as
+// the Secret-map key and the record's KeyHash field. sha256 is the
+// canonical opaque-token hashing choice (matches RFC 9068's
+// recommendation for `at_hash`-style derivations) and ships in the
+// stdlib — no third-party crypto dependency.
+func hashRefreshToken(raw string) string {
+	h := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(h[:])
+}
+
+// decodeRefreshTokens parses the on-disk Secret body. An empty input
+// (Secret-not-yet-created or empty data key) returns an empty
+// initialized store so callers can mutate without nil-map panics.
+func decodeRefreshTokens(existing []byte) (refreshTokens, error) {
+	if len(existing) == 0 {
+		return refreshTokens{Entries: make(map[string]refreshTokenRecord)}, nil
+	}
+	var out refreshTokens
+	if err := json.Unmarshal(existing, &out); err != nil {
+		return refreshTokens{}, fmt.Errorf("decode refresh tokens: %w", err)
+	}
+	if out.Entries == nil {
+		out.Entries = make(map[string]refreshTokenRecord)
+	}
+	return out, nil
+}

--- a/tools/demarkus-broker/internal/broker/refresh_test.go
+++ b/tools/demarkus-broker/internal/broker/refresh_test.go
@@ -1,0 +1,412 @@
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// testRefreshSecret is the operator-visible name for the broker's
+// refresh-tokens Secret in tests. Distinct from testIssuancesNS so a
+// stray cross-Secret read in the refreshStore would land on a
+// missing Secret and surface as an obvious test failure rather than
+// silently picking up issuance bytes.
+const testRefreshSecret = "broker-refresh-tokens"
+
+// testRefreshConfig builds a Config sufficient for refreshStore
+// tests. Reuses the issuance-test config fields so a future cross-
+// store interaction (Step 2 onward) shares one base config helper.
+func testRefreshConfig() *Config {
+	c := testConfig()
+	c.Server.RefreshTokensSecret = testRefreshSecret
+	c.Server.RefreshTokenTTL = 24 * time.Hour
+	return c
+}
+
+func newRefreshStoreForTest(t *testing.T, k8s *fake.Clientset) *refreshStore {
+	t.Helper()
+	s := newRefreshStore(testRefreshConfig(), k8s)
+	s.clock = func() time.Time { return time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC) }
+	return s
+}
+
+func TestRefreshStoreIssueRoundTrip(t *testing.T) {
+	k8s := fake.NewSimpleClientset()
+	s := newRefreshStoreForTest(t, k8s)
+	ctx := context.Background()
+
+	claims := Claims{Subject: "user-1", Email: "alice@example.com", EmailVerified: true, Groups: []string{"eng"}}
+	raw, err := s.Issue(ctx, claims, s.cfg.Server.RefreshTokenTTL)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if len(raw) != refreshTokenBytes*2 {
+		t.Errorf("raw token length = %d, want %d hex chars", len(raw), refreshTokenBytes*2)
+	}
+
+	rec, err := s.Refresh(ctx, raw)
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if rec.Claims.Subject != claims.Subject {
+		t.Errorf("Claims.Subject = %q, want %q", rec.Claims.Subject, claims.Subject)
+	}
+	if rec.Claims.Email != claims.Email {
+		t.Errorf("Claims.Email = %q, want %q", rec.Claims.Email, claims.Email)
+	}
+	if rec.Claims.EmailVerified != claims.EmailVerified {
+		t.Errorf("Claims.EmailVerified = %v", rec.Claims.EmailVerified)
+	}
+	if len(rec.Claims.Groups) != 1 || rec.Claims.Groups[0] != "eng" {
+		t.Errorf("Claims.Groups = %v", rec.Claims.Groups)
+	}
+	if rec.KeyHash != hashRefreshToken(raw) {
+		t.Errorf("KeyHash mismatch")
+	}
+	if rec.IssuedAt.IsZero() {
+		t.Errorf("IssuedAt zero")
+	}
+	if !rec.ExpiresAt.Equal(rec.IssuedAt.Add(24 * time.Hour)) {
+		t.Errorf("ExpiresAt = %v, want IssuedAt + 24h", rec.ExpiresAt)
+	}
+	if rec.LastUsedAt.IsZero() {
+		t.Errorf("LastUsedAt zero after Refresh")
+	}
+}
+
+func TestRefreshStoreIssueRejectsZeroTTL(t *testing.T) {
+	k8s := fake.NewSimpleClientset()
+	s := newRefreshStoreForTest(t, k8s)
+	if _, err := s.Issue(context.Background(), Claims{}, 0); err == nil {
+		t.Fatalf("Issue with ttl=0 should error")
+	}
+	if _, err := s.Issue(context.Background(), Claims{}, -time.Second); err == nil {
+		t.Fatalf("Issue with negative ttl should error")
+	}
+}
+
+func TestRefreshStoreRefreshErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(t *testing.T, s *refreshStore, raw string) (string, time.Time)
+	}{
+		{"unknown token", func(_ *testing.T, _ *refreshStore, _ string) (string, time.Time) {
+			// Same length as a real token, never issued.
+			return strings.Repeat("0", refreshTokenBytes*2), time.Time{}
+		}},
+		{"tampered token (one byte off)", func(_ *testing.T, _ *refreshStore, raw string) (string, time.Time) {
+			// Flip the first hex character to a guaranteed-different value.
+			flipped := []byte(raw)
+			if flipped[0] == 'f' {
+				flipped[0] = '0'
+			} else {
+				flipped[0] = 'f'
+			}
+			return string(flipped), time.Time{}
+		}},
+		{"empty token", func(_ *testing.T, _ *refreshStore, _ string) (string, time.Time) {
+			return "", time.Time{}
+		}},
+		{"expired token", func(_ *testing.T, s *refreshStore, raw string) (string, time.Time) {
+			// Jump clock past ExpiresAt.
+			base := s.clock()
+			s.clock = func() time.Time { return base.Add(25 * time.Hour) }
+			return raw, base.Add(25 * time.Hour)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8s := fake.NewSimpleClientset()
+			s := newRefreshStoreForTest(t, k8s)
+			ctx := context.Background()
+			raw, err := s.Issue(ctx, Claims{Subject: "u", Email: "a@b.com", EmailVerified: true}, time.Hour)
+			if err != nil {
+				t.Fatalf("setup Issue: %v", err)
+			}
+			input, _ := tt.fn(t, s, raw)
+			if _, err := s.Refresh(ctx, input); !errors.Is(err, ErrRefreshTokenInvalid) {
+				t.Fatalf("Refresh(%q) err = %v, want ErrRefreshTokenInvalid", input, err)
+			}
+		})
+	}
+}
+
+func TestRefreshStoreRevoke(t *testing.T) {
+	t.Run("revoke valid then refresh fails", func(t *testing.T) {
+		k8s := fake.NewSimpleClientset()
+		s := newRefreshStoreForTest(t, k8s)
+		ctx := context.Background()
+		raw, err := s.Issue(ctx, Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+		if err != nil {
+			t.Fatalf("Issue: %v", err)
+		}
+		if err := s.Revoke(ctx, raw); err != nil {
+			t.Fatalf("Revoke: %v", err)
+		}
+		if _, err := s.Refresh(ctx, raw); !errors.Is(err, ErrRefreshTokenInvalid) {
+			t.Fatalf("Refresh after Revoke err = %v, want ErrRefreshTokenInvalid", err)
+		}
+	})
+	t.Run("revoke unknown is no-op", func(t *testing.T) {
+		k8s := fake.NewSimpleClientset()
+		s := newRefreshStoreForTest(t, k8s)
+		// Secret may or may not exist — Revoke must not error either way.
+		if err := s.Revoke(context.Background(), strings.Repeat("0", refreshTokenBytes*2)); err != nil {
+			t.Fatalf("Revoke unknown (no Secret): %v", err)
+		}
+		// Now after an Issue + Revoke, revoke-unknown still succeeds.
+		raw, err := s.Issue(context.Background(), Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+		if err != nil {
+			t.Fatalf("Issue: %v", err)
+		}
+		if err := s.Revoke(context.Background(), raw); err != nil {
+			t.Fatalf("Revoke real: %v", err)
+		}
+		if err := s.Revoke(context.Background(), raw); err != nil {
+			t.Fatalf("Revoke again (idempotent): %v", err)
+		}
+	})
+	t.Run("revoke empty is no-op", func(t *testing.T) {
+		k8s := fake.NewSimpleClientset()
+		s := newRefreshStoreForTest(t, k8s)
+		if err := s.Revoke(context.Background(), ""); err != nil {
+			t.Fatalf("Revoke empty: %v", err)
+		}
+	})
+}
+
+func TestRefreshStoreSweep(t *testing.T) {
+	t.Run("removes expired only", func(t *testing.T) {
+		k8s := fake.NewSimpleClientset()
+		s := newRefreshStoreForTest(t, k8s)
+		ctx := context.Background()
+		base := s.clock()
+
+		// Mint one short-lived (1h) and one long-lived (48h) token.
+		shortRaw, err := s.Issue(ctx, Claims{Email: "short@x.com", EmailVerified: true}, time.Hour)
+		if err != nil {
+			t.Fatalf("Issue short: %v", err)
+		}
+		longRaw, err := s.Issue(ctx, Claims{Email: "long@x.com", EmailVerified: true}, 48*time.Hour)
+		if err != nil {
+			t.Fatalf("Issue long: %v", err)
+		}
+
+		// Advance clock past the short one's ExpiresAt but not the long one's.
+		s.clock = func() time.Time { return base.Add(2 * time.Hour) }
+
+		n, err := s.Sweep(ctx)
+		if err != nil {
+			t.Fatalf("Sweep: %v", err)
+		}
+		if n != 1 {
+			t.Errorf("Sweep returned %d, want 1", n)
+		}
+		// Short is gone, long survives.
+		if _, err := s.Refresh(ctx, shortRaw); !errors.Is(err, ErrRefreshTokenInvalid) {
+			t.Errorf("expected expired token swept; Refresh err=%v", err)
+		}
+		if _, err := s.Refresh(ctx, longRaw); err != nil {
+			t.Errorf("long-lived token must survive sweep: %v", err)
+		}
+	})
+	t.Run("no-op on empty store", func(t *testing.T) {
+		k8s := fake.NewSimpleClientset()
+		s := newRefreshStoreForTest(t, k8s)
+		n, err := s.Sweep(context.Background())
+		if err != nil {
+			t.Fatalf("Sweep: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("Sweep on empty returned %d, want 0", n)
+		}
+	})
+	t.Run("no-op when nothing expired", func(t *testing.T) {
+		k8s := fake.NewSimpleClientset()
+		s := newRefreshStoreForTest(t, k8s)
+		_, err := s.Issue(context.Background(), Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+		if err != nil {
+			t.Fatalf("Issue: %v", err)
+		}
+		n, err := s.Sweep(context.Background())
+		if err != nil {
+			t.Fatalf("Sweep: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("Sweep returned %d, want 0 (nothing expired yet)", n)
+		}
+	})
+}
+
+func TestRefreshStoreSecretShape(t *testing.T) {
+	k8s := fake.NewSimpleClientset()
+	s := newRefreshStoreForTest(t, k8s)
+	ctx := context.Background()
+
+	raw, err := s.Issue(ctx, Claims{Subject: "u1", Email: "a@example.com", EmailVerified: true, Groups: []string{"g"}}, time.Hour)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	sec, err := k8s.CoreV1().Secrets(s.cfg.Server.BrokerNamespace).Get(ctx, testRefreshSecret, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get Secret: %v", err)
+	}
+	body := sec.Data[RefreshTokensSecretKey]
+	if len(body) == 0 {
+		t.Fatalf("Secret data[%s] empty", RefreshTokensSecretKey)
+	}
+	// Raw token MUST NEVER appear in the persisted Secret.
+	if strings.Contains(string(body), raw) {
+		t.Fatalf("raw refresh token leaked into Secret body")
+	}
+
+	var parsed refreshTokens
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	keyHash := hashRefreshToken(raw)
+	rec, ok := parsed.Entries[keyHash]
+	if !ok {
+		t.Fatalf("entries missing keyHash %s", keyHash)
+	}
+	if rec.KeyHash != keyHash {
+		t.Errorf("record.KeyHash = %q, want %q", rec.KeyHash, keyHash)
+	}
+	if rec.Claims.Email != "a@example.com" {
+		t.Errorf("claims.email = %q", rec.Claims.Email)
+	}
+}
+
+// TestRefreshStoreConcurrentRefresh issues sequentially (the fake
+// clientset doesn't enforce optimistic-concurrency on Update, so
+// parallel Issues without a conflict-emitting reactor would last-
+// writer-wins and lose entries) then refreshes in parallel under
+// -race. The race detector is the load-bearing check: any
+// unsynchronized read or write inside refreshStore surfaces here.
+func TestRefreshStoreConcurrentRefresh(t *testing.T) {
+	k8s := fake.NewSimpleClientset()
+	s := newRefreshStoreForTest(t, k8s)
+	ctx := context.Background()
+
+	const n = 50
+	tokens := make([]string, n)
+	for i := range n {
+		raw, err := s.Issue(ctx, Claims{Subject: fmt.Sprintf("u%d", i), Email: fmt.Sprintf("u%d@x.com", i), EmailVerified: true}, time.Hour)
+		if err != nil {
+			t.Fatalf("setup Issue[%d]: %v", i, err)
+		}
+		tokens[i] = raw
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	errs := make(chan error, n)
+	for i := range n {
+		go func(idx int) {
+			defer wg.Done()
+			rec, err := s.Refresh(ctx, tokens[idx])
+			if err != nil {
+				errs <- fmt.Errorf("Refresh[%d]: %w", idx, err)
+				return
+			}
+			wantEmail := fmt.Sprintf("u%d@x.com", idx)
+			if rec.Claims.Email != wantEmail {
+				errs <- fmt.Errorf("Refresh[%d] email = %q, want %q", idx, rec.Claims.Email, wantEmail)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("%v", err)
+	}
+}
+
+// TestRefreshStoreIssueConflictRetries exercises mutateSecret's
+// optimistic-concurrency retry loop end-to-end through refreshStore.
+// A reactor injects two consecutive Conflicts on Update; the third
+// attempt must succeed and the issued token must be retrievable.
+// Mirrors TestMintConflictRetries' shape for the issuances Secret.
+func TestRefreshStoreIssueConflictRetries(t *testing.T) {
+	k8s := fake.NewSimpleClientset()
+	var conflicts int32
+	k8s.PrependReactor("update", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ua, ok := action.(k8stesting.UpdateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		if ua.GetNamespace() != testBrokerNS {
+			return false, nil, nil
+		}
+		if atomic.LoadInt32(&conflicts) < 2 {
+			atomic.AddInt32(&conflicts, 1)
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "secrets"}, testRefreshSecret, errors.New("simulated"))
+		}
+		return false, nil, nil
+	})
+	// Seed the Secret so the first Issue hits Update (not Create) —
+	// the conflict path lives on Update.
+	seed := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: testRefreshSecret, Namespace: testBrokerNS},
+		Data:       map[string][]byte{},
+	}
+	if _, err := k8s.CoreV1().Secrets(testBrokerNS).Create(context.Background(), seed, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	s := newRefreshStoreForTest(t, k8s)
+	raw, err := s.Issue(context.Background(), Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if atomic.LoadInt32(&conflicts) != 2 {
+		t.Errorf("simulated conflicts = %d, want 2", atomic.LoadInt32(&conflicts))
+	}
+	if _, err := s.Refresh(context.Background(), raw); err != nil {
+		t.Errorf("Refresh after retried Issue: %v", err)
+	}
+}
+
+func TestRefreshStoreCollisionRetry(t *testing.T) {
+	// Inject a randFn that yields the same bytes on the first call,
+	// then real randomness afterward. The first Issue stores the
+	// collision-candidate; the second must detect the duplicate hash
+	// and fail loudly rather than overwrite.
+	k8s := fake.NewSimpleClientset()
+	s := newRefreshStoreForTest(t, k8s)
+	fixed := make([]byte, refreshTokenBytes)
+	for i := range fixed {
+		fixed[i] = byte(i)
+	}
+	calls := 0
+	s.randFn = func(b []byte) (int, error) {
+		calls++
+		copy(b, fixed)
+		return len(b), nil
+	}
+	ctx := context.Background()
+	if _, err := s.Issue(ctx, Claims{Email: "a@b.com", EmailVerified: true}, time.Hour); err != nil {
+		t.Fatalf("first Issue: %v", err)
+	}
+	if _, err := s.Issue(ctx, Claims{Email: "a@b.com", EmailVerified: true}, time.Hour); err == nil {
+		t.Fatalf("second Issue with identical randomness should fail with collision")
+	}
+	if calls != 2 {
+		t.Errorf("randFn calls = %d, want 2", calls)
+	}
+}

--- a/tools/demarkus-broker/internal/broker/refresh_test.go
+++ b/tools/demarkus-broker/internal/broker/refresh_test.go
@@ -168,6 +168,12 @@ func TestRefreshStoreRevoke(t *testing.T) {
 		if err := s.Revoke(context.Background(), strings.Repeat("0", refreshTokenBytes*2)); err != nil {
 			t.Fatalf("Revoke unknown (no Secret): %v", err)
 		}
+		// No-write contract: Revoke against an absent Secret must NOT
+		// materialize the Secret as a side effect. Verifies the
+		// mutateSecret skip-on-empty-result guard.
+		if _, err := k8s.CoreV1().Secrets(s.cfg.Server.BrokerNamespace).Get(context.Background(), testRefreshSecret, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+			t.Errorf("Secret should not exist after no-op Revoke; Get err = %v", err)
+		}
 		// Now after an Issue + Revoke, revoke-unknown still succeeds.
 		raw, err := s.Issue(context.Background(), Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
 		if err != nil {
@@ -185,6 +191,10 @@ func TestRefreshStoreRevoke(t *testing.T) {
 		s := newRefreshStoreForTest(t, k8s)
 		if err := s.Revoke(context.Background(), ""); err != nil {
 			t.Fatalf("Revoke empty: %v", err)
+		}
+		// Same no-write contract as the unknown-token case.
+		if _, err := k8s.CoreV1().Secrets(s.cfg.Server.BrokerNamespace).Get(context.Background(), testRefreshSecret, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+			t.Errorf("Secret should not exist after empty-token Revoke; Get err = %v", err)
 		}
 	})
 }
@@ -233,6 +243,11 @@ func TestRefreshStoreSweep(t *testing.T) {
 		}
 		if n != 0 {
 			t.Errorf("Sweep on empty returned %d, want 0", n)
+		}
+		// No-write contract: Sweep against an absent Secret must
+		// NOT materialize the Secret as a side effect.
+		if _, err := k8s.CoreV1().Secrets(s.cfg.Server.BrokerNamespace).Get(context.Background(), testRefreshSecret, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+			t.Errorf("Secret should not exist after no-op Sweep; Get err = %v", err)
 		}
 	})
 	t.Run("no-op when nothing expired", func(t *testing.T) {

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -36,6 +36,14 @@ type Server struct {
 	// HTTP surface; the store owns the state machine.
 	deviceStore *deviceStore
 
+	// refreshStore owns the Secret-backed map of sha256(refresh_token)
+	// → record. Wired by NewServer with the configured (or defaulted)
+	// broker-namespace Secret. Survives broker restarts unlike
+	// deviceStore. Universe-onboarding PR4. The k8s client lives on
+	// the Issuer; NewServer passes it through so the store and the
+	// issuer share one client.
+	refreshStore *refreshStore
+
 	// subjectReg is the per-subject limiter shared across the three
 	// /tokens routes; loginReg is the per-IP limiter for /auth/login.
 	// Either may be nil (Slice C.4 RateLimitConfig.Disabled, or a test
@@ -61,7 +69,8 @@ func NewServer(cfg *Config, signer *Signer, verifier Verifier, issuer *Issuer, d
 	// Device-flow knobs default at construction time so tests that
 	// build Config{} directly (skipping LoadConfig validation) still
 	// get usable values — keeps the in-process httptest path symmetric
-	// with the LoadConfig-validated production path.
+	// with the LoadConfig-validated production path. Same shape for
+	// refresh-flow knobs (PR4).
 	deviceTTL := cfg.Server.DeviceCodeTTL
 	if deviceTTL <= 0 {
 		deviceTTL = 10 * time.Minute
@@ -69,6 +78,12 @@ func NewServer(cfg *Config, signer *Signer, verifier Verifier, issuer *Issuer, d
 	pollInterval := cfg.Server.DevicePollInterval
 	if pollInterval <= 0 {
 		pollInterval = 5 * time.Second
+	}
+	if cfg.Server.RefreshTokensSecret == "" {
+		cfg.Server.RefreshTokensSecret = defaultRefreshTokensSecret
+	}
+	if cfg.Server.RefreshTokenTTL <= 0 {
+		cfg.Server.RefreshTokenTTL = defaultRefreshTokenTTL
 	}
 	clock := time.Now
 	s := &Server{
@@ -80,6 +95,7 @@ func NewServer(cfg *Config, signer *Signer, verifier Verifier, issuer *Issuer, d
 		log:               log,
 		clock:             clock,
 		deviceStore:       newDeviceStore(clock, deviceTTL, pollInterval),
+		refreshStore:      newRefreshStore(cfg, issuer.k8s),
 		trustForwardedFor: cfg.RateLimit.TrustForwardedFor,
 	}
 	// Build the registries unless the operator disabled the limiter


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device authentication now issues refresh tokens with configurable storage and TTL; broker manages refresh-token lifecycle (issue, validate, revoke, sweep).
* **Bug Fixes**
  * Prevents completing device sessions without a refresh token when token minting fails; logs and leaves grant pending.
* **Tests**
  * Extensive tests added for refresh token behaviors, concurrency, collision handling, and failure modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/138)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->