### PR TITLE
feat(tools):  Add broker-signed refresh tokens and RFC 7009 revocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,15 @@ jobs:
             ZmFrZS10b2tlbi1oYXNo
       - name: Upgrade-wipe regression — demarkus-broker
         run: |
+          # PR4 broker requires a parseable ECDSA P-256 PEM for
+          # oidc.brokerSigningKey — OIDCConfig.validate now parses
+          # the key at LoadConfig (parse-at-validate). Generate an
+          # ephemeral key per run, hand it to helm via --set-file
+          # (multi-line value, ${{ }}-safe), and let the trap rm
+          # it. The PEM never lives in the repo or shell history.
+          SIGNING_KEY_FILE="$(mktemp)"
+          trap 'rm -f "$SIGNING_KEY_FILE"' EXIT
+          openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out "$SIGNING_KEY_FILE"
           bash deploy/helm/test-upgrade-wipe.sh \
             deploy/helm/demarkus-broker \
             demarkus-broker \
@@ -190,4 +199,4 @@ jobs:
             --set oidc.clientSecret=test-secret \
             --set oidc.redirectURL=https://broker.example/auth/callback \
             --set server.publicURL=https://broker.example \
-            --set oidc.brokerSigningKey=test-pem-placeholder
+            --set-file oidc.brokerSigningKey="$SIGNING_KEY_FILE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,4 +189,5 @@ jobs:
             --set oidc.clientID=test-client \
             --set oidc.clientSecret=test-secret \
             --set oidc.redirectURL=https://broker.example/auth/callback \
-            --set server.publicURL=https://broker.example
+            --set server.publicURL=https://broker.example \
+            --set oidc.brokerSigningKey=test-pem-placeholder

--- a/deploy/helm/demarkus-broker/README.md
+++ b/deploy/helm/demarkus-broker/README.md
@@ -27,12 +27,19 @@ Secrets and tracking ownership in a broker-namespace issuances Secret.
 ## Quick install (development)
 
 Put sensitive values in a values file rather than on the command line —
-`--set` values leak into shell history and `ps` output:
+`--set` values leak into shell history and `ps` output. The values
+file also keeps the multi-line broker signing PEM readable:
 
 ```yaml
 # broker-secrets.values.yaml — do not commit
 oidc:
   clientSecret: "YOUR_CLIENT_SECRET"
+  # PR4: ECDSA P-256 key for broker-signed id_tokens. Generate with:
+  #   openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256
+  brokerSigningKey: |
+    -----BEGIN PRIVATE KEY-----
+    YOUR_PEM_LINES_HERE
+    -----END PRIVATE KEY-----
 ```
 
 ```bash

--- a/deploy/helm/demarkus-broker/README.md
+++ b/deploy/helm/demarkus-broker/README.md
@@ -34,8 +34,8 @@ file also keeps the multi-line broker signing PEM readable:
 # broker-secrets.values.yaml — do not commit
 oidc:
   clientSecret: "YOUR_CLIENT_SECRET"
-  # PR4: ECDSA P-256 key for broker-signed id_tokens. Generate with:
-  #   openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256
+  # ECDSA P-256 key for broker-signed id_tokens. Generate with:
+  #   openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out broker-key.pem
   brokerSigningKey: |
     -----BEGIN PRIVATE KEY-----
     YOUR_PEM_LINES_HERE

--- a/deploy/helm/demarkus-broker/templates/_helpers.tpl
+++ b/deploy/helm/demarkus-broker/templates/_helpers.tpl
@@ -66,6 +66,10 @@ Names for the chart-managed Secrets.
 {{- default (printf "%s-issuances" (include "demarkus-broker.fullname" .)) .Values.server.issuancesSecret -}}
 {{- end -}}
 
+{{- define "demarkus-broker.refreshTokensSecretName" -}}
+{{- default (printf "%s-refresh-tokens" (include "demarkus-broker.fullname" .)) .Values.server.refreshTokensSecret -}}
+{{- end -}}
+
 {{/*
 Cookie key resolution. Order of precedence:
   1. .Values.server.cookieKey (operator-supplied literal)

--- a/deploy/helm/demarkus-broker/templates/deployment.yaml
+++ b/deploy/helm/demarkus-broker/templates/deployment.yaml
@@ -66,6 +66,21 @@ spec:
                   name: {{ . | quote }}
                   key: {{ $.Values.oidc.existingSecretRef.key | quote }}
             {{- end }}
+            {{- /* PR4 broker signing key. Same env-var-override pattern
+                   as OIDC_CLIENT_SECRET. The chart's mutual-exclusion
+                   guard in secret-config.yaml means existingSigningKeyRef
+                   is set iff the in-config brokerSigningKey is blank;
+                   broker.applyEnvOverrides reads BROKER_SIGNING_KEY
+                   before validate(). The PEM travels through the env
+                   var as a multi-line string — kubelet preserves
+                   newlines under secretKeyRef. */}}
+            {{- with .Values.oidc.existingSigningKeyRef.name }}
+            - name: BROKER_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ . | quote }}
+                  key: {{ $.Values.oidc.existingSigningKeyRef.key | quote }}
+            {{- end }}
           ports:
             - name: http
               protocol: TCP

--- a/deploy/helm/demarkus-broker/templates/rbac-broker-ns.yaml
+++ b/deploy/helm/demarkus-broker/templates/rbac-broker-ns.yaml
@@ -8,9 +8,13 @@
      resourceName" caveat means create effectively allows any Lease in
      this namespace — acceptable scope since the namespace is broker-owned.
 
-   - secrets: the chart-created issuances Secret. Only get/update needed
-     since the chart's secret-issuances.yaml seeds it at install time; the
-     broker never needs to bootstrap it at runtime. */ -}}
+   - secrets: the chart-created issuances + refresh-tokens Secrets.
+     Only get/update needed since the chart seeds both at install
+     time (secret-issuances.yaml + secret-refresh-tokens.yaml); the
+     broker never needs to bootstrap either at runtime. The
+     resource-policy: keep annotation on both means helm upgrade
+     never re-templates them, so the broker SA's update verb is
+     the only path that mutates them after install. */ -}}
 {{- $brokerNs := include "demarkus-broker.brokerNamespace" . -}}
 {{- $name := include "demarkus-broker.fullname" . -}}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -27,7 +31,9 @@ rules:
     verbs: ["get", "create", "update"]
   - apiGroups: [""]
     resources: ["secrets"]
-    resourceNames: [{{ include "demarkus-broker.issuancesSecretName" . | quote }}]
+    resourceNames:
+      - {{ include "demarkus-broker.issuancesSecretName" . | quote }}
+      - {{ include "demarkus-broker.refreshTokensSecretName" . | quote }}
     verbs: ["get", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/helm/demarkus-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-config.yaml
@@ -32,6 +32,17 @@ it contains both the OIDC client secret and the cookie HMAC key.
 {{- if and .Values.oidc.existingSecretRef.name (not .Values.oidc.existingSecretRef.key) -}}
 {{- fail "oidc.existingSecretRef.key is required when oidc.existingSecretRef.name is set" -}}
 {{- end -}}
+{{- /* Same mutual-exclusion shape for the broker signing key (PR4).
+       The render-time guard catches ambiguity before pod startup. */ -}}
+{{- if and .Values.oidc.brokerSigningKey .Values.oidc.existingSigningKeyRef.name -}}
+{{- fail "oidc.brokerSigningKey and oidc.existingSigningKeyRef.name are mutually exclusive; set exactly one" -}}
+{{- end -}}
+{{- if and (not .Values.oidc.brokerSigningKey) (not .Values.oidc.existingSigningKeyRef.name) -}}
+{{- fail "oidc.brokerSigningKey or oidc.existingSigningKeyRef.name is required" -}}
+{{- end -}}
+{{- if and .Values.oidc.existingSigningKeyRef.name (not .Values.oidc.existingSigningKeyRef.key) -}}
+{{- fail "oidc.existingSigningKeyRef.key is required when oidc.existingSigningKeyRef.name is set" -}}
+{{- end -}}
 {{- $cookieKey := include "demarkus-broker.resolveCookieKey" . -}}
 apiVersion: v1
 kind: Secret
@@ -50,6 +61,9 @@ stringData:
       stateTTL: {{ .Values.server.stateTTL | quote }}
       brokerNamespace: {{ include "demarkus-broker.brokerNamespace" . | quote }}
       issuancesSecret: {{ include "demarkus-broker.issuancesSecretName" . | quote }}
+      refreshTokensSecret: {{ include "demarkus-broker.refreshTokensSecretName" . | quote }}
+      refreshTokenTTL: {{ .Values.server.refreshTokenTTL | quote }}
+      idTokenTTL: {{ .Values.server.idTokenTTL | quote }}
       publicURL: {{ required "server.publicURL is required" .Values.server.publicURL | quote }}
       insecureCookies: {{ .Values.server.insecureCookies }}
     oidc:
@@ -63,6 +77,11 @@ stringData:
              runtime value. */}}
       clientSecret: {{ default "" .Values.oidc.clientSecret | quote }}
       redirectURL: {{ required "oidc.redirectURL is required" .Values.oidc.redirectURL | quote }}
+      {{- /* Same env-var-override pattern as clientSecret: cleartext PEM
+             renders into the config Secret; existingSigningKeyRef leaves
+             it blank and main.go reads BROKER_SIGNING_KEY at startup. */}}
+      brokerSigningKey: |
+{{ default "" .Values.oidc.brokerSigningKey | indent 8 }}
     worlds:
 {{- range .Values.worlds }}
       {{- /* Wrap .allow with `default (dict)` because Go templates panic on

--- a/deploy/helm/demarkus-broker/templates/secret-refresh-tokens.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-refresh-tokens.yaml
@@ -1,0 +1,41 @@
+{{/*
+Refresh-tokens Secret. The broker writes the sha256(refresh_token) ->
+record map here at runtime; this template only seeds an empty Secret
+on first install so the broker has a target to write to. Same
+helm-correctness invariants as secret-issuances.yaml:
+
+  1. `helm.sh/resource-policy: keep` — once created, helm uninstall
+     does NOT delete this Secret. Reinstalling the chart picks up
+     the same refresh-token state, so users keep their sessions
+     across chart lifecycle events.
+
+  2. `lookup`-skip — on `helm upgrade`, the lookup branch returns
+     the existing live Secret, so the template renders nothing.
+     helm sees the resource was removed from the rendered manifest
+     and would normally garbage-collect it; the resource-policy:
+     keep annotation on the LIVE Secret prevents that. Net effect:
+     chart updates never touch the broker's runtime state.
+
+  `lookup` returns nil during `helm template` (no cluster context),
+  so offline renders always emit the empty Secret. helm-unittest
+  assertions see the empty Secret and can verify the resource-
+  policy annotation.
+
+PR4 (universe onboarding §6). Mirrors the issuances Secret on
+purpose so operators get the same audit experience for both the
+world-token and refresh-token state.
+*/}}
+{{- $brokerNs := include "demarkus-broker.brokerNamespace" . -}}
+{{- if not (lookup "v1" "Secret" $brokerNs (include "demarkus-broker.refreshTokensSecretName" .)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "demarkus-broker.refreshTokensSecretName" . }}
+  namespace: {{ $brokerNs }}
+  labels:
+    {{- include "demarkus-broker.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+type: Opaque
+data: {}
+{{- end }}

--- a/deploy/helm/demarkus-broker/tests/deployment_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/deployment_test.yaml
@@ -9,6 +9,10 @@ set:
   oidc.clientID: broker-app
   oidc.clientSecret: shh
   oidc.redirectURL: https://broker.example.com/auth/callback
+  # PR4 requires a signing-key surface — suite-wide default keeps
+  # every test in this file rendering. Individual tests override
+  # when targeting the signing-key surface specifically.
+  oidc.brokerSigningKey: "test-pem-placeholder"
   server.publicURL: https://broker.example.com
 tests:
   - it: renders a Deployment with two replicas and rolling update strategy
@@ -135,6 +139,31 @@ tests:
               secretKeyRef:
                 name: my-oidc-secret
                 key: clientSecret
+
+  - it: BROKER_SIGNING_KEY env absent when only brokerSigningKey cleartext set
+    template: deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: BROKER_SIGNING_KEY
+
+  - it: BROKER_SIGNING_KEY env mounted via secretKeyRef when existingSigningKeyRef.name set
+    template: deployment.yaml
+    set:
+      oidc.brokerSigningKey: ""
+      oidc.existingSigningKeyRef.name: my-broker-signing
+      oidc.existingSigningKeyRef.key: signing-key.pem
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BROKER_SIGNING_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-broker-signing
+                key: signing-key.pem
 
   - it: topologySpread matchLabels populated from selector labels, not values empty default
     template: deployment.yaml

--- a/deploy/helm/demarkus-broker/tests/rbac_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/rbac_test.yaml
@@ -9,6 +9,10 @@ set:
   oidc.clientID: broker-app
   oidc.clientSecret: shh
   oidc.redirectURL: https://broker.example.com/auth/callback
+  # PR4 requires a signing-key surface in chart-render; rbac tests
+  # don't exercise it but the chart fails fast without it.
+  oidc.brokerSigningKey: "test-pem-placeholder"
+  server.publicURL: https://broker.example.com
 tests:
   - it: broker-namespace Role + RoleBinding render in brokerNamespace
     template: rbac-broker-ns.yaml
@@ -47,7 +51,7 @@ tests:
           path: rules[0].verbs
           value: ["get", "create", "update"]
 
-  - it: broker-ns Role secrets rule pinned to get/update on issuancesSecret only
+  - it: broker-ns Role secrets rule pinned to get/update on issuances + refresh-tokens Secrets
     template: rbac-broker-ns.yaml
     documentIndex: 0
     asserts:
@@ -59,7 +63,9 @@ tests:
           value: ["secrets"]
       - equal:
           path: rules[1].resourceNames
-          value: ["RELEASE-NAME-demarkus-broker-issuances"]
+          value:
+            - "RELEASE-NAME-demarkus-broker-issuances"
+            - "RELEASE-NAME-demarkus-broker-refresh-tokens"
       - equal:
           path: rules[1].verbs
           value: ["get", "update"]

--- a/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
@@ -216,14 +216,19 @@ tests:
   - it: cleartext brokerSigningKey renders into the config Secret
     set:
       oidc.clientSecret: shh
+      # Synthetic sentinel — NOT a real PEM. The chart template
+      # only quotes/indents whatever string the operator supplies;
+      # the broker binary's parse-at-validate would reject this,
+      # which is fine because helm-unittest never starts a pod.
+      # Avoids triggering secret-scanner heuristics on `BEGIN
+      # PRIVATE KEY` markers in a test fixture.
       oidc.brokerSigningKey: |
-        -----BEGIN PRIVATE KEY-----
-        MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0w
-        -----END PRIVATE KEY-----
+        TEST_BROKER_SIGNING_KEY_LINE_1
+        TEST_BROKER_SIGNING_KEY_LINE_2
     asserts:
       - matchRegex:
           path: stringData["config.yaml"]
-          pattern: '-----BEGIN PRIVATE KEY-----'
+          pattern: 'TEST_BROKER_SIGNING_KEY_LINE_1'
 
   - it: existingSigningKeyRef path leaves brokerSigningKey blank in rendered config
     set:

--- a/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
@@ -7,6 +7,10 @@ set:
   oidc.issuer: https://accounts.example.com
   oidc.clientID: broker-app
   oidc.redirectURL: https://broker.example.com/auth/callback
+  # PR4: brokerSigningKey is required; suite-wide default keeps every
+  # test in this file rendering. Individual tests that target the
+  # broker-signing-key surface override this in their own `set:` block.
+  oidc.brokerSigningKey: "test-pem-placeholder"
   server.publicURL: https://broker.example.com
 tests:
   - it: rendered Secret has metadata.namespace explicitly set to release namespace
@@ -164,3 +168,101 @@ tests:
       - matchRegex:
           path: stringData["config.yaml"]
           pattern: 'publicURL: "mark://team-a.cluster.local:6309"'
+
+  # PR4 surfaces: refresh-token TTL / id_token TTL / refresh-tokens
+  # Secret name / broker signing key (cleartext + existingRef + mutex).
+  - it: refreshTokenTTL defaults to 90d (2160h) in the rendered config
+    set:
+      oidc.clientSecret: shh
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'refreshTokenTTL: "2160h"'
+
+  - it: refreshTokenTTL operator override flows through to rendered config
+    set:
+      oidc.clientSecret: shh
+      server.refreshTokenTTL: 720h
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'refreshTokenTTL: "720h"'
+
+  - it: idTokenTTL defaults to 15m in the rendered config
+    set:
+      oidc.clientSecret: shh
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'idTokenTTL: "15m"'
+
+  - it: refreshTokensSecret defaults to the chart-derived name
+    set:
+      oidc.clientSecret: shh
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'refreshTokensSecret: "RELEASE-NAME-demarkus-broker-refresh-tokens"'
+
+  - it: refreshTokensSecret operator override flows through to rendered config
+    set:
+      oidc.clientSecret: shh
+      server.refreshTokensSecret: my-refresh-tokens
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'refreshTokensSecret: "my-refresh-tokens"'
+
+  - it: cleartext brokerSigningKey renders into the config Secret
+    set:
+      oidc.clientSecret: shh
+      oidc.brokerSigningKey: |
+        -----BEGIN PRIVATE KEY-----
+        MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0w
+        -----END PRIVATE KEY-----
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: '-----BEGIN PRIVATE KEY-----'
+
+  - it: existingSigningKeyRef path leaves brokerSigningKey blank in rendered config
+    set:
+      oidc.clientSecret: shh
+      oidc.brokerSigningKey: ""
+      oidc.existingSigningKeyRef.name: broker-signing-key
+      oidc.existingSigningKeyRef.key: signing-key.pem
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'brokerSigningKey: \|\s*\n\s*\n'
+      - notMatchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'BEGIN PRIVATE KEY'
+
+  - it: fail-render when both brokerSigningKey cleartext AND existingSigningKeyRef.name set
+    set:
+      oidc.clientSecret: shh
+      oidc.brokerSigningKey: "some-pem"
+      oidc.existingSigningKeyRef.name: my-signing-secret
+      oidc.existingSigningKeyRef.key: signing-key.pem
+    asserts:
+      - failedTemplate:
+          errorMessage: "oidc.brokerSigningKey and oidc.existingSigningKeyRef.name are mutually exclusive; set exactly one"
+
+  - it: fail-render when neither brokerSigningKey nor existingSigningKeyRef.name set
+    set:
+      oidc.clientSecret: shh
+      oidc.brokerSigningKey: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "oidc.brokerSigningKey or oidc.existingSigningKeyRef.name is required"
+
+  - it: fail-render when existingSigningKeyRef.name set but key is blank
+    set:
+      oidc.clientSecret: shh
+      oidc.brokerSigningKey: ""
+      oidc.existingSigningKeyRef.name: my-signing-secret
+      oidc.existingSigningKeyRef.key: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "oidc.existingSigningKeyRef.key is required when oidc.existingSigningKeyRef.name is set"

--- a/deploy/helm/demarkus-broker/tests/secret-refresh-tokens_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/secret-refresh-tokens_test.yaml
@@ -1,0 +1,56 @@
+suite: secret-refresh-tokens
+templates:
+  - secret-refresh-tokens.yaml
+release:
+  namespace: broker-ns
+set:
+  oidc.issuer: https://accounts.example.com
+  oidc.clientID: broker-app
+  oidc.clientSecret: shh
+  oidc.redirectURL: https://broker.example.com/auth/callback
+  oidc.brokerSigningKey: "test-pem-placeholder"
+  server.publicURL: https://broker.example.com
+tests:
+  - it: refresh-tokens Secret renders as an empty Opaque Secret on offline template
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-demarkus-broker-refresh-tokens
+      - equal:
+          path: type
+          value: Opaque
+      - equal:
+          path: data
+          value: {}
+
+  - it: helm.sh/resource-policy keep annotation pinned so helm upgrade/uninstall do not wipe refresh-token state
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: metadata.namespace tracks demarkus-broker.brokerNamespace helper
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: broker-ns
+
+  - it: server.brokerNamespace override moves the refresh-tokens Secret to that namespace
+    set:
+      server.brokerNamespace: alt-broker-ns
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: alt-broker-ns
+
+  - it: server.refreshTokensSecret override overrides the default name
+    set:
+      server.refreshTokensSecret: "my-custom-refresh"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-custom-refresh

--- a/deploy/helm/demarkus-broker/values.yaml
+++ b/deploy/helm/demarkus-broker/values.yaml
@@ -69,6 +69,27 @@ server:
   # attribute is honored end-to-end.
   insecureCookies: false
 
+  # Refresh-token lifetime emitted on each device-code completion
+  # (universe onboarding PR4). 90 days matches industry defaults
+  # (Google / Auth0 / Okta sit in 60-180d). Operators tighten for
+  # short-lived deployments or relax for headless CI tooling where
+  # repeated re-login is operationally painful. Tokens past their TTL
+  # are rejected at refresh time and reaped by the periodic Sweeper.
+  refreshTokenTTL: 2160h  # 90d
+
+  # Broker-signed id_token lifetime on the /device/token refresh-grant
+  # path (PR4). 15m balances bounded compromise window against PR5
+  # /me/install request budget. Must be strictly less than
+  # refreshTokenTTL — a bearer that outlives its refresh credential
+  # cannot be renewed.
+  idTokenTTL: 15m
+
+  # Secret name for the broker's refresh-token store (PR4). Holds the
+  # JSON map of sha256(refresh_token) -> record. Default derived from
+  # the release name. Created with helm.sh/resource-policy: keep so
+  # chart lifecycle events never invalidate live refresh tokens.
+  refreshTokensSecret: ""
+
 oidc:
   # OIDC discovery URL (e.g. https://accounts.google.com).
   issuer: ""
@@ -96,6 +117,39 @@ oidc:
   # Public URL of /auth/callback. Must exactly match the redirect URI
   # registered with the IdP.
   redirectURL: ""
+
+  # Broker-side ECDSA P-256 private key (PR4). The broker signs
+  # id_tokens on /device/token refresh-grant responses with this key
+  # and serves the matching public key at /.well-known/jwks.json. Two
+  # modes — exactly the same shape as clientSecret:
+  #
+  #   1. Cleartext via brokerSigningKey: a multi-line PEM literal
+  #      (PKCS#8 `-----BEGIN PRIVATE KEY-----` or SEC1
+  #      `-----BEGIN EC PRIVATE KEY-----`). Easiest install path; the
+  #      value lives in helm release history. Only acceptable for dev /
+  #      kind clusters.
+  #
+  #   2. existingSigningKeyRef — production path. Chart leaves the
+  #      field blank in the config Secret and mounts the PEM into the
+  #      broker pod from an externally-managed Kubernetes Secret
+  #      (External Secrets Operator, Sealed Secrets, kubectl-created).
+  #
+  # Generate a fresh key with:
+  #   openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256
+  #
+  # Rotation: swap the value and bounce the broker. Every refresh
+  # token minted by the prior key still verifies (refreshStore is
+  # opaque-token-only — the key signs the id_token, not the refresh
+  # token), but every broker-signed id_token in flight is invalidated.
+  # Cleaner rotation (overlapping keys + JWKS rollover) is deferred to
+  # a future PR.
+  brokerSigningKey: ""
+  existingSigningKeyRef:
+    # Name of the operator-managed Secret holding the PEM. Empty
+    # disables this mode.
+    name: ""
+    # Data key inside the Secret holding the PEM.
+    key: signing-key.pem
 
 # Per-world authorization. Each entry produces one Role + RoleBinding in
 # the world's namespace (RBAC slice) granting the broker SA get/patch on

--- a/deploy/kind/up.sh
+++ b/deploy/kind/up.sh
@@ -95,6 +95,33 @@ require() {
 require kind
 require helm
 require kubectl
+require openssl
+
+# ensure_broker_signing_key generates a fresh ECDSA P-256 PEM and
+# applies it as a Kubernetes Secret named `broker-signing-key`
+# (data key `signing-key.pem`) in the given namespace. PR4 review
+# called out checked-in test PEMs as a hygiene problem; this keeps
+# the key material ephemeral — generated once per harness run, never
+# committed to the repo. The chart's existingSigningKeyRef picks
+# the Secret up via secretKeyRef, mounting BROKER_SIGNING_KEY into
+# the broker pod at startup.
+#
+# Idempotent: re-runs replace the Secret in place, so a `up.sh`
+# rerun against an existing cluster rotates the broker's signing
+# key. This is desirable for kind — the cluster is ephemeral and
+# rotation surfaces any kid-pinning bugs in PR5+.
+ensure_broker_signing_key() {
+  local ns="$1"
+  echo "--- generating ephemeral broker signing key (ECDSA P-256) for namespace $ns"
+  local tmpfile
+  tmpfile=$(mktemp)
+  openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out "$tmpfile" 2>/dev/null
+  kubectl create namespace "$ns" --dry-run=client -o yaml | kubectl apply -f -
+  kubectl -n "$ns" create secret generic broker-signing-key \
+    --from-file=signing-key.pem="$tmpfile" \
+    --dry-run=client -o yaml | kubectl apply -f -
+  rm -f "$tmpfile"
+}
 
 if kind get clusters | grep -qx "$CLUSTER"; then
   echo "--- kind cluster '$CLUSTER' already exists, reusing"
@@ -171,6 +198,8 @@ if [[ "$WITH_ARGO" == "true" ]]; then
     kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
     kubectl -n "$NAMESPACE" apply -f "$MOCK_OIDC_MANIFEST"
     kubectl -n "$NAMESPACE" rollout status deployment/mock-oauth2-server --timeout=120s
+
+    ensure_broker_signing_key "$NAMESPACE"
 
     echo "--- installing demarkus-broker chart $BROKER_CHART_VERSION (multi-world wiring)"
     # helm --wait blocks on /readyz, which only flips green after OIDC
@@ -346,6 +375,8 @@ if [[ "$WITH_BROKER" == "true" ]]; then
   echo "--- applying mock-oauth2-server (OIDC issuer for broker discovery)"
   kubectl -n "$NAMESPACE" apply -f "$MOCK_OIDC_MANIFEST"
   kubectl -n "$NAMESPACE" rollout status deployment/mock-oauth2-server --timeout=120s
+
+  ensure_broker_signing_key "$NAMESPACE"
 
   echo "--- installing demarkus-broker chart $BROKER_CHART_VERSION"
   # helm install --wait blocks on the broker's readiness probe, which hits

--- a/deploy/kind/up.sh
+++ b/deploy/kind/up.sh
@@ -115,12 +115,24 @@ ensure_broker_signing_key() {
   echo "--- generating ephemeral broker signing key (ECDSA P-256) for namespace $ns"
   local tmpfile
   tmpfile=$(mktemp)
-  openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out "$tmpfile" 2>/dev/null
+  # Function-scoped RETURN trap: cleanup runs whether the function
+  # exits normally OR via `set -e` propagation when a downstream
+  # command (openssl / kubectl) fails. Without this, a mid-function
+  # abort would leave the private-key PEM in /tmp until the
+  # next tmpfiles sweep — visible to any local process during the
+  # window. RETURN is function-local in bash, so this does not
+  # clobber outer EXIT/ERR traps.
+  trap 'rm -f "$tmpfile"' RETURN
+  # No `2>/dev/null` on openssl — a real failure here (missing
+  # P-256 support on the host openssl build, /tmp disk pressure)
+  # needs to surface in the harness log; silencing it would turn
+  # a recoverable misconfiguration into "broker pod fails to
+  # start" minutes later with no breadcrumb.
+  openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out "$tmpfile"
   kubectl create namespace "$ns" --dry-run=client -o yaml | kubectl apply -f -
   kubectl -n "$ns" create secret generic broker-signing-key \
     --from-file=signing-key.pem="$tmpfile" \
     --dry-run=client -o yaml | kubectl apply -f -
-  rm -f "$tmpfile"
 }
 
 if kind get clusters | grep -qx "$CLUSTER"; then

--- a/deploy/kind/values-broker-argo.yaml
+++ b/deploy/kind/values-broker-argo.yaml
@@ -41,6 +41,14 @@ oidc:
   # one whose cookie scope (Path=/auth/callback) matches the actual
   # request URL.
   redirectURL: http://localhost:8080/auth/callback
+  # PR4: broker-signed id_token key. Static test PEM (ECDSA P-256)
+  # baked into the kind harness — never used in production.
+  brokerSigningKey: |
+    -----BEGIN PRIVATE KEY-----
+    MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgmMCAYqh5RzyaZx8p
+    SQ/L9kZ+DsUvLMlrOQY6g8FU1B+hRANCAARk+xu8qwMJE4LOa6T4DnOY1OwYgTaK
+    r6wbg3zjA+29GDfnROA7cyYqguU2Hp9N6zrg8WFpynEqaRjGFvW6HbUF
+    -----END PRIVATE KEY-----
 
 # One entry per Argo-templated world. The TokensSecret name matches
 # the demarkus-server chart's `<release>-demarkus-server-tokens`

--- a/deploy/kind/values-broker-argo.yaml
+++ b/deploy/kind/values-broker-argo.yaml
@@ -41,14 +41,12 @@ oidc:
   # one whose cookie scope (Path=/auth/callback) matches the actual
   # request URL.
   redirectURL: http://localhost:8080/auth/callback
-  # PR4: broker-signed id_token key. Static test PEM (ECDSA P-256)
-  # baked into the kind harness — never used in production.
-  brokerSigningKey: |
-    -----BEGIN PRIVATE KEY-----
-    MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgmMCAYqh5RzyaZx8p
-    SQ/L9kZ+DsUvLMlrOQY6g8FU1B+hRANCAARk+xu8qwMJE4LOa6T4DnOY1OwYgTaK
-    r6wbg3zjA+29GDfnROA7cyYqguU2Hp9N6zrg8WFpynEqaRjGFvW6HbUF
-    -----END PRIVATE KEY-----
+  # Broker-signed id_token key: kept out of the repo. See
+  # values-broker.yaml for the harness wiring.
+  brokerSigningKey: ""
+  existingSigningKeyRef:
+    name: broker-signing-key
+    key: signing-key.pem
 
 # One entry per Argo-templated world. The TokensSecret name matches
 # the demarkus-server chart's `<release>-demarkus-server-tokens`

--- a/deploy/kind/values-broker.yaml
+++ b/deploy/kind/values-broker.yaml
@@ -24,16 +24,16 @@ oidc:
   clientID: demarkus-broker-kind
   clientSecret: dev-secret
   redirectURL: http://localhost:8080/auth/callback
-  # PR4: broker-signed id_token key. Static test PEM (ECDSA P-256)
-  # baked into the kind harness — never used in production. Generated
-  # once with `openssl genpkey -algorithm EC -pkeyopt
-  # ec_paramgen_curve:P-256` and pinned for reproducible kind builds.
-  brokerSigningKey: |
-    -----BEGIN PRIVATE KEY-----
-    MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgmMCAYqh5RzyaZx8p
-    SQ/L9kZ+DsUvLMlrOQY6g8FU1B+hRANCAARk+xu8qwMJE4LOa6T4DnOY1OwYgTaK
-    r6wbg3zjA+29GDfnROA7cyYqguU2Hp9N6zrg8WFpynEqaRjGFvW6HbUF
-    -----END PRIVATE KEY-----
+  # Broker-signed id_token key: kept out of the repo. up.sh
+  # generates a fresh ECDSA P-256 key per harness run and applies
+  # it as a Kubernetes Secret named `broker-signing-key` in the
+  # broker namespace BEFORE helm install. The chart picks it up
+  # via existingSigningKeyRef and mounts BROKER_SIGNING_KEY into
+  # the broker pod.
+  brokerSigningKey: ""
+  existingSigningKeyRef:
+    name: broker-signing-key
+    key: signing-key.pem
 
 # Wire to the Stage 1 world (release `world-default` in namespace `demarkus`).
 # tokensSecret name matches the demarkus-server chart's fullname template:

--- a/deploy/kind/values-broker.yaml
+++ b/deploy/kind/values-broker.yaml
@@ -24,6 +24,16 @@ oidc:
   clientID: demarkus-broker-kind
   clientSecret: dev-secret
   redirectURL: http://localhost:8080/auth/callback
+  # PR4: broker-signed id_token key. Static test PEM (ECDSA P-256)
+  # baked into the kind harness — never used in production. Generated
+  # once with `openssl genpkey -algorithm EC -pkeyopt
+  # ec_paramgen_curve:P-256` and pinned for reproducible kind builds.
+  brokerSigningKey: |
+    -----BEGIN PRIVATE KEY-----
+    MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgmMCAYqh5RzyaZx8p
+    SQ/L9kZ+DsUvLMlrOQY6g8FU1B+hRANCAARk+xu8qwMJE4LOa6T4DnOY1OwYgTaK
+    r6wbg3zjA+29GDfnROA7cyYqguU2Hp9N6zrg8WFpynEqaRjGFvW6HbUF
+    -----END PRIVATE KEY-----
 
 # Wire to the Stage 1 world (release `world-default` in namespace `demarkus`).
 # tokensSecret name matches the demarkus-server chart's fullname template:

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -431,6 +431,13 @@ func (c *Config) validate() error {
 // four required fields. All five are operator-supplied and missing
 // any one of them makes the broker incapable of completing a login
 // or signing a refresh-grant response.
+//
+// BrokerSigningKey is parsed (not just checked for emptiness)
+// because a malformed PEM would otherwise survive LoadConfig and
+// only surface in main.run after OIDC discovery + kube client setup
+// have already burned several seconds and produced noisier logs.
+// Parsing here costs a microsecond and lets the operator-facing
+// error reference oidc.brokerSigningKey directly.
 func (o *OIDCConfig) validate() error {
 	switch {
 	case o.Issuer == "":
@@ -443,6 +450,9 @@ func (o *OIDCConfig) validate() error {
 		return fmt.Errorf("oidc.redirectURL is required")
 	case o.BrokerSigningKey == "":
 		return fmt.Errorf("oidc.brokerSigningKey is required")
+	}
+	if _, err := NewIDTokenSigner([]byte(o.BrokerSigningKey)); err != nil {
+		return fmt.Errorf("oidc.brokerSigningKey is invalid: %w", err)
 	}
 	return nil
 }

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -87,6 +87,15 @@ type ServerConfig struct {
 	// for short-lived deployments or relax it for headless CI tooling
 	// where a 90-day re-login is acceptable.
 	RefreshTokenTTL time.Duration `yaml:"refreshTokenTTL"`
+	// IDTokenTTL is the lifetime applied to broker-signed id_tokens
+	// emitted on the /device/token refresh-grant path. Default
+	// 15 minutes — short enough that a compromised id_token's
+	// useful window stays bounded, long enough that downstream
+	// requests (PR5 /me/install) complete without racing the
+	// expiry. Operators tighten via config; the refresh-grant
+	// itself stretches the effective session lifetime via fresh
+	// id_tokens minted on each poll.
+	IDTokenTTL time.Duration `yaml:"idTokenTTL"`
 }
 
 // OIDCConfig describes the OIDC client registration at the IdP. Discovery
@@ -101,6 +110,18 @@ type OIDCConfig struct {
 	// RedirectURL is the public URL of /auth/callback. Must exactly match
 	// the redirect URI registered with the IdP.
 	RedirectURL string `yaml:"redirectURL"`
+	// BrokerSigningKey is the PEM-encoded ECDSA P-256 private key
+	// the broker uses to sign id_tokens on the /device/token
+	// refresh-grant path (PR4). PKCS#8 (`-----BEGIN PRIVATE KEY-----`)
+	// or SEC1 (`-----BEGIN EC PRIVATE KEY-----`) formats accepted.
+	// Required when any refresh-grant request might be issued —
+	// production wiring requires it always; tests construct
+	// Config{} directly and let NewServer skip key-dependent routes
+	// when blank. Operators supply via Kubernetes Secret mounted as
+	// a file; the chart renders the field's value from a
+	// secretKeyRef so the key never round-trips through helm
+	// release history.
+	BrokerSigningKey string `yaml:"brokerSigningKey"`
 }
 
 // WorldConfig describes one demarkus world the broker is authorized to
@@ -302,17 +323,26 @@ func LoadConfig(path string) (*Config, error) {
 }
 
 // applyEnvOverrides lets a small set of high-sensitivity fields come from
-// environment variables instead of the on-disk config. Today only
-// OIDC_CLIENT_SECRET is supported, so production deployments can keep the
-// OAuth client secret in an externally-managed Kubernetes Secret (External
-// Secrets Operator, Sealed Secrets, Vault) mounted via secretKeyRef rather
-// than baked into the chart-rendered config Secret where it would leak
-// into helm release history. The env var wins over the file value when
-// both are set; an empty env var is treated as unset so an accidentally
-// cleared variable doesn't blank out a file-supplied value at runtime.
+// environment variables instead of the on-disk config. Supported:
+//
+//   - OIDC_CLIENT_SECRET: the OAuth client secret.
+//   - BROKER_SIGNING_KEY: the ECDSA P-256 PEM the broker uses to
+//     sign id_tokens on the refresh-grant path (PR4). Multi-line
+//     PEMs travel fine through env vars under k8s secretKeyRef.
+//
+// Production deployments keep these in externally-managed
+// Kubernetes Secrets (External Secrets Operator, Sealed Secrets,
+// Vault) mounted via secretKeyRef rather than baked into the chart-
+// rendered config Secret where they would leak into helm release
+// history. The env var wins over the file value when both are set;
+// an empty env var is treated as unset so an accidentally cleared
+// variable doesn't blank out a file-supplied value at runtime.
 func (c *Config) applyEnvOverrides() {
 	if v := os.Getenv("OIDC_CLIENT_SECRET"); v != "" {
 		c.OIDC.ClientSecret = v
+	}
+	if v := os.Getenv("BROKER_SIGNING_KEY"); v != "" {
+		c.OIDC.BrokerSigningKey = v
 	}
 }
 
@@ -352,17 +382,11 @@ func (c *Config) validate() error {
 	if err := c.Server.applyDeviceFlowDefaults(); err != nil {
 		return err
 	}
-	if c.OIDC.Issuer == "" {
-		return fmt.Errorf("oidc.issuer is required")
+	if err := c.Server.applyRefreshDefaults(); err != nil {
+		return err
 	}
-	if c.OIDC.ClientID == "" {
-		return fmt.Errorf("oidc.clientID is required")
-	}
-	if c.OIDC.ClientSecret == "" {
-		return fmt.Errorf("oidc.clientSecret is required")
-	}
-	if c.OIDC.RedirectURL == "" {
-		return fmt.Errorf("oidc.redirectURL is required")
+	if err := c.OIDC.validate(); err != nil {
+		return err
 	}
 	if len(c.Worlds) == 0 {
 		return fmt.Errorf("at least one world is required")
@@ -399,6 +423,59 @@ func (c *Config) validate() error {
 		c.Sweeper.LeaseName = "demarkus-broker-sweeper"
 	}
 	return c.RateLimit.applyDefaultsAndValidate()
+}
+
+// validate enforces the OIDCConfig invariants. Extracted from
+// Config.validate so the outer function stays inside the gocyclo
+// budget after PR4 added BrokerSigningKey alongside the existing
+// four required fields. All five are operator-supplied and missing
+// any one of them makes the broker incapable of completing a login
+// or signing a refresh-grant response.
+func (o *OIDCConfig) validate() error {
+	switch {
+	case o.Issuer == "":
+		return fmt.Errorf("oidc.issuer is required")
+	case o.ClientID == "":
+		return fmt.Errorf("oidc.clientID is required")
+	case o.ClientSecret == "":
+		return fmt.Errorf("oidc.clientSecret is required")
+	case o.RedirectURL == "":
+		return fmt.Errorf("oidc.redirectURL is required")
+	case o.BrokerSigningKey == "":
+		return fmt.Errorf("oidc.brokerSigningKey is required")
+	}
+	return nil
+}
+
+// applyRefreshDefaults fills in PR4 refresh-flow defaults and rejects
+// degenerate combinations. Extracted from Config.validate to keep
+// the outer function inside the gocyclo budget; same shape as
+// applyDeviceFlowDefaults. The Secret name and TTL knobs are
+// applied to the validated config so NewServer / LoadConfig
+// downstream see the resolved values regardless of YAML presence.
+func (s *ServerConfig) applyRefreshDefaults() error {
+	if s.RefreshTokensSecret == "" {
+		s.RefreshTokensSecret = defaultRefreshTokensSecret
+	}
+	if s.RefreshTokenTTL == 0 {
+		s.RefreshTokenTTL = defaultRefreshTokenTTL
+	}
+	if s.RefreshTokenTTL < 0 {
+		return fmt.Errorf("server.refreshTokenTTL must be > 0 (got %s)", s.RefreshTokenTTL)
+	}
+	if s.IDTokenTTL == 0 {
+		s.IDTokenTTL = defaultIDTokenTTL
+	}
+	if s.IDTokenTTL < 0 {
+		return fmt.Errorf("server.idTokenTTL must be > 0 (got %s)", s.IDTokenTTL)
+	}
+	// id_token TTL > refresh_token TTL is a degenerate config: the
+	// refresh credential would expire before the bearer it mints,
+	// so the refresh round-trip would never produce a usable token.
+	if s.IDTokenTTL >= s.RefreshTokenTTL {
+		return fmt.Errorf("server.idTokenTTL (%s) must be < server.refreshTokenTTL (%s) — a bearer that outlives its refresh credential cannot be renewed", s.IDTokenTTL, s.RefreshTokenTTL)
+	}
+	return nil
 }
 
 // applyDeviceFlowDefaults fills in PR3 device-flow defaults and rejects

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -20,6 +20,7 @@ oidc:
   clientID: client-abc
   clientSecret: shh
   redirectURL: https://broker.example.com/auth/callback
+  brokerSigningKey: "test-pem-placeholder"
 worlds:
   - name: team-a
     namespace: team-a
@@ -396,6 +397,90 @@ func TestLoadConfig(t *testing.T) {
 				want := "mark://team-a.cluster.local:6309"
 				if c.Worlds[0].PublicURL != want {
 					t.Errorf("PublicURL = %q, want %q", c.Worlds[0].PublicURL, want)
+				}
+			},
+		},
+		{
+			// PR4: brokerSigningKey is required so a refresh-grant
+			// request never falls through to a "feature missing"
+			// runtime error. validate() only checks non-emptiness;
+			// the PEM parsing happens at NewIDTokenSigner.
+			name:    "brokerSigningKey required",
+			body:    strings.Replace(validConfig, "  brokerSigningKey: \"test-pem-placeholder\"\n", "", 1),
+			wantErr: "oidc.brokerSigningKey is required",
+		},
+		{
+			// PR4: refreshTokenTTL defaults to 90 days when
+			// omitted — matches plan §"refresh tokens at 90-day TTL."
+			name: "refreshTokenTTL default applied",
+			body: validConfig,
+			validate: func(t *testing.T, c *Config) {
+				want := 90 * 24 * time.Hour
+				if c.Server.RefreshTokenTTL != want {
+					t.Errorf("RefreshTokenTTL = %s, want %s", c.Server.RefreshTokenTTL, want)
+				}
+			},
+		},
+		{
+			name: "refreshTokenTTL operator override",
+			body: strings.Replace(validConfig,
+				"publicURL: \"https://broker.example.com\"",
+				"publicURL: \"https://broker.example.com\"\n  refreshTokenTTL: 720h", 1),
+			validate: func(t *testing.T, c *Config) {
+				want := 720 * time.Hour
+				if c.Server.RefreshTokenTTL != want {
+					t.Errorf("RefreshTokenTTL = %s, want %s", c.Server.RefreshTokenTTL, want)
+				}
+			},
+		},
+		{
+			name: "idTokenTTL default applied",
+			body: validConfig,
+			validate: func(t *testing.T, c *Config) {
+				want := 15 * time.Minute
+				if c.Server.IDTokenTTL != want {
+					t.Errorf("IDTokenTTL = %s, want %s", c.Server.IDTokenTTL, want)
+				}
+			},
+		},
+		{
+			// idTokenTTL ≥ refreshTokenTTL is degenerate — the
+			// refresh credential would expire before the bearer it
+			// mints. validate() rejects.
+			name: "idTokenTTL must be less than refreshTokenTTL",
+			body: strings.Replace(validConfig,
+				"publicURL: \"https://broker.example.com\"",
+				"publicURL: \"https://broker.example.com\"\n  idTokenTTL: 100h\n  refreshTokenTTL: 50h", 1),
+			wantErr: "idTokenTTL",
+		},
+		{
+			name:    "refreshTokenTTL negative rejected",
+			body:    strings.Replace(validConfig, "publicURL: \"https://broker.example.com\"", "publicURL: \"https://broker.example.com\"\n  refreshTokenTTL: -1h", 1),
+			wantErr: "server.refreshTokenTTL must be > 0",
+		},
+		{
+			name:    "idTokenTTL negative rejected",
+			body:    strings.Replace(validConfig, "publicURL: \"https://broker.example.com\"", "publicURL: \"https://broker.example.com\"\n  idTokenTTL: -1m", 1),
+			wantErr: "server.idTokenTTL must be > 0",
+		},
+		{
+			name: "refreshTokensSecret default applied",
+			body: validConfig,
+			validate: func(t *testing.T, c *Config) {
+				want := defaultRefreshTokensSecret
+				if c.Server.RefreshTokensSecret != want {
+					t.Errorf("RefreshTokensSecret = %q, want %q", c.Server.RefreshTokensSecret, want)
+				}
+			},
+		},
+		{
+			name: "refreshTokensSecret operator override",
+			body: strings.Replace(validConfig,
+				"publicURL: \"https://broker.example.com\"",
+				"publicURL: \"https://broker.example.com\"\n  refreshTokensSecret: my-refresh-tokens", 1),
+			validate: func(t *testing.T, c *Config) {
+				if c.Server.RefreshTokensSecret != "my-refresh-tokens" {
+					t.Errorf("RefreshTokensSecret = %q", c.Server.RefreshTokensSecret)
 				}
 			},
 		},

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -1,6 +1,11 @@
 package broker
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -8,7 +13,12 @@ import (
 	"time"
 )
 
-const validConfig = `
+// validConfigTemplate carries a sentinel where the broker signing
+// key block goes. init() substitutes an ephemeral PEM generated
+// per-test-binary so no checked-in PEM appears in the source tree
+// (which would trigger secret scanners) and so parse-at-validate
+// (added in PR4 review) actually sees a parseable key.
+const validConfigTemplate = `
 server:
   addr: ":8080"
   cookieKey: "dGVzdC1rZXk="
@@ -20,7 +30,7 @@ oidc:
   clientID: client-abc
   clientSecret: shh
   redirectURL: https://broker.example.com/auth/callback
-  brokerSigningKey: "test-pem-placeholder"
+__SIGNING_KEY_BLOCK__
 worlds:
   - name: team-a
     namespace: team-a
@@ -32,6 +42,38 @@ worlds:
       operations: ["read", "publish"]
       expiresAfter: 24h
 `
+
+// validConfig is the rendered template with a fresh signing-key
+// block. Tests that exercise the "brokerSigningKey is required"
+// path use validConfigNoSigningKey directly so they don't rely on
+// brittle string replacements against the embedded PEM.
+var (
+	validConfig             string
+	validConfigNoSigningKey string
+)
+
+func init() {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		panic("config_test: generate test signing key: " + err.Error())
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		panic("config_test: marshal test signing key: " + err.Error())
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	// YAML literal block inside the `oidc:` map: brokerSigningKey
+	// header at 2-space indent, PEM body at 4-space indent.
+	var b strings.Builder
+	b.WriteString("  brokerSigningKey: |\n")
+	for line := range strings.SplitSeq(strings.TrimSpace(string(pemBytes)), "\n") {
+		b.WriteString("    ")
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	validConfig = strings.Replace(validConfigTemplate, "__SIGNING_KEY_BLOCK__\n", b.String(), 1)
+	validConfigNoSigningKey = strings.Replace(validConfigTemplate, "__SIGNING_KEY_BLOCK__\n", "", 1)
+}
 
 const validWorldBlock = `worlds:
   - name: team-a
@@ -55,6 +97,14 @@ func writeConfig(t *testing.T, body string) string {
 }
 
 func TestLoadConfig(t *testing.T) {
+	// applyEnvOverrides reads BROKER_SIGNING_KEY and
+	// OIDC_CLIENT_SECRET from the process environment. Without
+	// clearing them, a CI runner that exports either var (or a
+	// developer who set them locally) silently masks YAML-missing
+	// test cases. t.Setenv restores the prior value at test end so
+	// peer tests that DO want a real env value still work.
+	t.Setenv("BROKER_SIGNING_KEY", "")
+	t.Setenv("OIDC_CLIENT_SECRET", "")
 	tests := []struct {
 		name     string
 		body     string
@@ -403,11 +453,24 @@ func TestLoadConfig(t *testing.T) {
 		{
 			// PR4: brokerSigningKey is required so a refresh-grant
 			// request never falls through to a "feature missing"
-			// runtime error. validate() only checks non-emptiness;
-			// the PEM parsing happens at NewIDTokenSigner.
+			// runtime error. validate() now parses the PEM too
+			// (see OIDCConfig.validate doc), but missing-field
+			// short-circuits before parse so the error message
+			// matches the "is required" surface, not the parse
+			// error.
 			name:    "brokerSigningKey required",
-			body:    strings.Replace(validConfig, "  brokerSigningKey: \"test-pem-placeholder\"\n", "", 1),
+			body:    validConfigNoSigningKey,
 			wantErr: "oidc.brokerSigningKey is required",
+		},
+		{
+			// PR4 review: malformed PEM is now caught at LoadConfig
+			// (parse-at-validate) instead of bubbling up later
+			// from main.run's NewIDTokenSigner. Operator-facing
+			// error references oidc.brokerSigningKey directly.
+			name: "brokerSigningKey invalid PEM rejected",
+			body: strings.Replace(validConfigTemplate, "__SIGNING_KEY_BLOCK__\n",
+				"  brokerSigningKey: \"not-a-pem\"\n", 1),
+			wantErr: "oidc.brokerSigningKey is invalid",
 		},
 		{
 			// PR4: refreshTokenTTL defaults to 90 days when

--- a/tools/demarkus-broker/internal/broker/device.go
+++ b/tools/demarkus-broker/internal/broker/device.go
@@ -3,6 +3,7 @@ package broker
 import (
 	"context"
 	"embed"
+	"errors"
 	"html/template"
 	"net/http"
 	"net/url"
@@ -23,6 +24,12 @@ const deviceCookieName = "broker_device_code"
 // client must send to /device/token. Reproduced as a constant so a typo
 // in the handler can't silently accept arbitrary grant types.
 const deviceGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+
+// refreshGrantType is the RFC 6749 §6 grant_type identifier the
+// /device/token handler dispatches on for refresh requests.
+// Reproduced as a constant for the same reason as deviceGrantType:
+// the dispatch must reject typos rather than silently fall through.
+const refreshGrantType = "refresh_token"
 
 //go:embed templates/device_form.html templates/device_done.html
 var deviceTemplatesFS embed.FS
@@ -188,20 +195,34 @@ func (s *Server) deviceFormPost(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/auth/login", http.StatusFound)
 }
 
-// deviceToken implements POST /device/token (RFC 8628 §3.4 + §3.5).
-// The polling client sends the same device_code on each call; the
-// broker responds with authorization_pending until /auth/callback
-// runs the OAuth exchange and Binds the result, then returns the
-// success payload (raw IdP id_token + access_token) on the next poll.
+// deviceToken implements POST /device/token. RFC 8628 §3.4+§3.5
+// (device-code polling) and RFC 6749 §6 (refresh grant) share the
+// same endpoint URL but are dispatched on the grant_type form
+// parameter; the strict switch rejects anything else so a typo on
+// the client side cannot accidentally exercise either branch's
+// surface.
 func (s *Server) deviceToken(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "invalid_request"})
 		return
 	}
-	if got := r.PostFormValue("grant_type"); got != deviceGrantType {
+	switch r.PostFormValue("grant_type") {
+	case deviceGrantType:
+		s.deviceTokenDeviceFlow(w, r)
+	case refreshGrantType:
+		s.deviceTokenRefresh(w, r)
+	default:
 		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "unsupported_grant_type"})
-		return
 	}
+}
+
+// deviceTokenDeviceFlow handles the RFC 8628 §3.4 device-code poll.
+// The polling client sends the same device_code on each call; the
+// broker responds with authorization_pending until /auth/callback
+// runs the OAuth exchange and Binds the result, then returns the
+// success payload (raw IdP id_token + access_token + broker-minted
+// refresh_token) on the next poll.
+func (s *Server) deviceTokenDeviceFlow(w http.ResponseWriter, r *http.Request) {
 	deviceCode := r.PostFormValue("device_code")
 	if deviceCode == "" {
 		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "invalid_request"})
@@ -237,6 +258,72 @@ func (s *Server) deviceToken(w http.ResponseWriter, r *http.Request) {
 	default:
 		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "authorization_pending"})
 	}
+}
+
+// deviceTokenRefresh handles RFC 6749 §6 refresh_token exchange.
+// Validates the supplied refresh_token against the broker's
+// Secret-backed refreshStore, mints a fresh broker-signed id_token
+// from the cached Claims, and returns the response with the SAME
+// refresh_token (PR4 does not rotate — see plan §Out of Scope).
+//
+// access_token == id_token: PR5's /me/install consumes the id_token
+// as a bearer, the broker's compositeVerifier accepts it on either
+// field, and an empty access_token would force clients to learn a
+// per-broker quirk. Same string in both fields keeps the
+// OIDC-client-library default codepath working.
+//
+// Error mapping:
+//   - Missing refresh_token form param → invalid_request
+//   - refreshStore rejects (unknown / expired / revoked) →
+//     invalid_grant per RFC 6749 §5.2
+//   - Signing failure (programming error) → 500 server_error
+//   - id-token-signer not wired (operator misconfig) → 500
+//     server_error; PR4 wiring requires it always
+func (s *Server) deviceTokenRefresh(w http.ResponseWriter, r *http.Request) {
+	if s.idTokenSigner == nil {
+		// Broker started without a signing key — refresh grant
+		// cannot mint a verifiable id_token. Surface 500 rather
+		// than silently returning an empty token; LoadConfig
+		// validation in Step 6 makes this unreachable in
+		// production, but keep the guard so a test misconfig
+		// fails loudly.
+		s.log.ErrorContext(r.Context(), "broker: refresh grant requested but id_token signer not wired")
+		writeJSON(w, http.StatusInternalServerError, deviceTokenError{Error: "server_error"})
+		return
+	}
+	rawRefresh := r.PostFormValue("refresh_token")
+	if rawRefresh == "" {
+		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "invalid_request"})
+		return
+	}
+	record, err := s.refreshStore.Refresh(r.Context(), rawRefresh)
+	if err != nil {
+		if errors.Is(err, ErrRefreshTokenInvalid) {
+			writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "invalid_grant"})
+			return
+		}
+		s.log.ErrorContext(r.Context(), "broker: refresh store read failed", "err", err)
+		writeJSON(w, http.StatusInternalServerError, deviceTokenError{Error: "server_error"})
+		return
+	}
+	now := s.clock()
+	idToken, err := s.idTokenSigner.Sign(record.Claims, s.cfg.Server.PublicURL, s.cfg.Server.IDTokenTTL, now)
+	if err != nil {
+		s.log.ErrorContext(r.Context(), "broker: refresh sign id_token failed",
+			"err", err, "subject", hashSubject(record.Claims.Subject))
+		writeJSON(w, http.StatusInternalServerError, deviceTokenError{Error: "server_error"})
+		return
+	}
+	expiresIn := max(int(s.cfg.Server.IDTokenTTL.Seconds()), 0)
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	writeJSON(w, http.StatusOK, deviceTokenSuccess{
+		AccessToken:  idToken,
+		IDToken:      idToken,
+		RefreshToken: rawRefresh,
+		TokenType:    "Bearer",
+		ExpiresIn:    expiresIn,
+	})
 }
 
 // renderDeviceForm writes the user_code entry HTML. Templates are

--- a/tools/demarkus-broker/internal/broker/device_test.go
+++ b/tools/demarkus-broker/internal/broker/device_test.go
@@ -922,6 +922,228 @@ func TestDeviceCallbackRefreshMintFailureLeavesPending(t *testing.T) {
 	}
 }
 
+// TestDeviceTokenRefreshGrant exercises the PR4 refresh-grant
+// branch end-to-end: Issue a refresh token via deviceCallback, then
+// POST /device/token with grant_type=refresh_token and verify the
+// response carries a fresh broker-signed id_token whose claims
+// match the original device-flow identity.
+func TestDeviceTokenRefreshGrant(t *testing.T) {
+	verifier := &fakeVerifier{
+		authURL:    "https://idp.example.com/authorize",
+		claims:     Claims{Email: "alice@example.com", EmailVerified: true, Subject: "google|alice", Groups: []string{"eng"}},
+		rawIDToken: "raw-id-token-abc",
+	}
+	signer := newTestIDTokenSigner(t)
+	cfg := deviceTestConfig()
+	cfg.Server.IDTokenTTL = 5 * time.Minute
+	srv, broker := newTestServerWithSigner(t, cfg, verifier, fake.NewSimpleClientset(), signer)
+
+	// Complete a device flow up to Bind by driving the store
+	// directly — the full /auth/callback dance is covered by
+	// TestDeviceFlowIntegrationHappyPath.
+	deviceCode, _, _, err := broker.deviceStore.Authorize()
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	rawRefresh, err := broker.refreshStore.Issue(context.Background(),
+		verifier.claims, broker.cfg.Server.RefreshTokenTTL)
+	if err != nil {
+		t.Fatalf("refresh Issue: %v", err)
+	}
+	if err := broker.deviceStore.Bind(deviceCode,
+		&ExchangeResult{Claims: verifier.claims, RawIDToken: "raw-id-token-abc"},
+		rawRefresh); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+
+	// Refresh-grant exchange.
+	resp, err := testClient(srv).PostForm(srv.URL+"/device/token", url.Values{
+		"grant_type":    {refreshGrantType},
+		"refresh_token": {rawRefresh},
+	})
+	if err != nil {
+		t.Fatalf("POST /device/token refresh: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("refresh status = %d body=%s", resp.StatusCode, body)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", got)
+	}
+	var out deviceTokenSuccess
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.IDToken == "" {
+		t.Fatal("id_token empty after refresh")
+	}
+	if out.IDToken != out.AccessToken {
+		t.Errorf("id_token != access_token; PR4 contract is same JWT in both fields")
+	}
+	// Refresh response returns the SAME refresh_token; PR4 does
+	// not rotate (plan §Out of Scope).
+	if out.RefreshToken != rawRefresh {
+		t.Errorf("refresh_token rotated: got %q, want %q", out.RefreshToken, rawRefresh)
+	}
+	if out.TokenType != "Bearer" {
+		t.Errorf("token_type = %q", out.TokenType)
+	}
+	if out.ExpiresIn <= 0 || out.ExpiresIn > int((5*time.Minute).Seconds())+1 {
+		t.Errorf("expires_in = %d, want ~%d", out.ExpiresIn, int((5 * time.Minute).Seconds()))
+	}
+
+	// Verify the broker-signed id_token round-trips through the
+	// broker's own signer with the original claims intact.
+	gotClaims, err := signer.VerifyIDToken(out.IDToken, cfg.Server.PublicURL, time.Now())
+	if err != nil {
+		t.Fatalf("VerifyIDToken: %v", err)
+	}
+	if gotClaims.Email != verifier.claims.Email {
+		t.Errorf("Email = %q, want %q", gotClaims.Email, verifier.claims.Email)
+	}
+	if gotClaims.Subject != verifier.claims.Subject {
+		t.Errorf("Subject = %q", gotClaims.Subject)
+	}
+	if len(gotClaims.Groups) != 1 || gotClaims.Groups[0] != "eng" {
+		t.Errorf("Groups = %v", gotClaims.Groups)
+	}
+}
+
+func TestDeviceTokenRefreshErrors(t *testing.T) {
+	signer := newTestIDTokenSigner(t)
+	tests := []struct {
+		name string
+		form url.Values
+		want string
+	}{
+		{
+			"missing refresh_token",
+			url.Values{"grant_type": {refreshGrantType}},
+			"invalid_request",
+		},
+		{
+			"empty refresh_token",
+			url.Values{"grant_type": {refreshGrantType}, "refresh_token": {""}},
+			"invalid_request",
+		},
+		{
+			"unknown refresh_token",
+			url.Values{"grant_type": {refreshGrantType}, "refresh_token": {strings.Repeat("0", refreshTokenBytes*2)}},
+			"invalid_grant",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, _ := newTestServerWithSigner(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), signer)
+			resp, err := testClient(srv).PostForm(srv.URL+"/device/token", tt.form)
+			if err != nil {
+				t.Fatalf("POST: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", resp.StatusCode)
+			}
+			var body deviceTokenError
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if body.Error != tt.want {
+				t.Errorf("error = %q, want %q", body.Error, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeviceTokenRefreshRejectsRevoked(t *testing.T) {
+	// End-to-end: Issue a token, Revoke it, attempt to Refresh.
+	// Must return invalid_grant — the same shape as unknown.
+	signer := newTestIDTokenSigner(t)
+	srv, broker := newTestServerWithSigner(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), signer)
+	rawRefresh, err := broker.refreshStore.Issue(context.Background(),
+		Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if err := broker.refreshStore.Revoke(context.Background(), rawRefresh); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	resp, err := testClient(srv).PostForm(srv.URL+"/device/token", url.Values{
+		"grant_type":    {refreshGrantType},
+		"refresh_token": {rawRefresh},
+	})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	var body deviceTokenError
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body.Error != "invalid_grant" {
+		t.Errorf("error = %q, want invalid_grant", body.Error)
+	}
+}
+
+func TestDeviceTokenRefreshCrossGrantIsolation(t *testing.T) {
+	// A refresh_token must NOT be accepted at the device_code
+	// branch, and a device_code must NOT be accepted at the
+	// refresh branch. The dispatch policy in deviceToken pins this;
+	// the test guards against accidental field-coupling regressions.
+	signer := newTestIDTokenSigner(t)
+	srv, broker := newTestServerWithSigner(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), signer)
+
+	// Issue a refresh token; try it on the device_code branch.
+	rawRefresh, err := broker.refreshStore.Issue(context.Background(),
+		Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+	if err != nil {
+		t.Fatalf("Issue refresh: %v", err)
+	}
+	resp1, err := testClient(srv).PostForm(srv.URL+"/device/token", url.Values{
+		"grant_type":  {deviceGrantType},
+		"device_code": {rawRefresh},
+	})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp1.Body.Close() }()
+	if resp1.StatusCode != http.StatusBadRequest {
+		t.Fatalf("device-branch with refresh_token: status = %d, want 400", resp1.StatusCode)
+	}
+	// deviceTokenDeviceFlow returns expired_token for unknown
+	// device codes (matches RFC 8628 — never leak whether a code
+	// existed). A real refresh token sent here looks unknown.
+	var err1 deviceTokenError
+	_ = json.NewDecoder(resp1.Body).Decode(&err1)
+	if err1.Error != "expired_token" {
+		t.Errorf("device-branch error = %q, want expired_token", err1.Error)
+	}
+
+	// And the reverse: device_code on the refresh branch.
+	deviceCode, _, _, err := broker.deviceStore.Authorize()
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	resp2, err := testClient(srv).PostForm(srv.URL+"/device/token", url.Values{
+		"grant_type":    {refreshGrantType},
+		"refresh_token": {deviceCode},
+	})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp2.Body.Close() }()
+	if resp2.StatusCode != http.StatusBadRequest {
+		t.Fatalf("refresh-branch with device_code: status = %d, want 400", resp2.StatusCode)
+	}
+	var err2 deviceTokenError
+	_ = json.NewDecoder(resp2.Body).Decode(&err2)
+	if err2.Error != "invalid_grant" {
+		t.Errorf("refresh-branch error = %q, want invalid_grant", err2.Error)
+	}
+}
+
 // TestDeviceFlowIntegrationIdPDeny exercises the open-question-1 lean:
 // when the IdP redirects /auth/callback with ?error=..., the device
 // branch must translate to deviceStore.Deny so a polling client gets

--- a/tools/demarkus-broker/internal/broker/discovery.go
+++ b/tools/demarkus-broker/internal/broker/discovery.go
@@ -49,15 +49,17 @@ const maxDiscoveryBodySize = 1 << 20 // 1 MiB
 // same client without per-IdP discovery logic. See plan §"Why broker is
 // the device-flow shim, not plugin going IdP-direct".
 //
-// What is NOT yet end-to-end correct in PR2: jwks_uri stays pointed at
-// the IdP (proxied through unchanged), but issuer is overridden to the
-// broker. Until PR4 mints broker-signed id_tokens with a broker-hosted
-// jwks_uri, strict OIDC-client validation against this discovery doc
-// would reject id_tokens that came signed by the IdP and carry the IdP's
-// own `iss` claim. The plugin's device-flow client (PR6) consumes only
-// device_authorization_endpoint + token_endpoint from this doc, so the
-// mismatch does not affect it; the gap closes in PR4 when broker
-// re-signs.
+// PR4 swap: jwks_uri now also points at the broker, because the
+// broker signs id_tokens on the refresh-grant path. A strict client
+// validating an id_token against this discovery doc's iss
+// (= brokerURL) will fetch the broker's JWKS — which serves the
+// broker's signing key. The transition window remains: id_tokens
+// minted at device-code completion (PR3 path) are still IdP-signed
+// and carry the IdP's `iss`, so the broker's compositeVerifier
+// falls through to the IdP JWKS for those. Clients consuming the
+// id_token as a bearer against /me/install (PR5) get a uniform
+// "broker-issuer, broker-key" surface from refresh-renewed
+// tokens — the discovery doc is consistent with what they verify.
 type Discovery struct {
 	brokerURL    string
 	idpDiscovery string
@@ -238,13 +240,21 @@ func (d *Discovery) refresh(ctx context.Context) error {
 	return nil
 }
 
-// applyDiscoveryOverrides parses the upstream JSON, rewrites the three
-// broker-hosted endpoints, and re-marshals. Decoded into map[string]any
-// so unknown IdP-specific fields (Google's
+// applyDiscoveryOverrides parses the upstream JSON, rewrites the
+// broker-hosted endpoints, and re-marshals. Decoded into
+// map[string]any so unknown IdP-specific fields (Google's
 // `code_challenge_methods_supported`, Auth0's `mfa_challenge_endpoint`,
 // Okta's request_object_signing_alg lists, etc.) round-trip through
-// without us tracking each one in a typed struct — proxying everything
-// else verbatim is the point of this layer.
+// without us tracking each one in a typed struct — proxying
+// everything else verbatim is the point of this layer.
+//
+// PR4 swap: jwks_uri now points at the broker because the broker
+// re-signs id_tokens on the refresh-grant path. The broker still
+// accepts IdP-signed id_tokens via compositeVerifier's fallback
+// path, but a strict client reading this discovery doc will fetch
+// the broker's JWKS to verify any token issued by the iss declared
+// here — which is also the broker. The semantic loop matches:
+// broker as both issuer and key authority.
 func applyDiscoveryOverrides(raw []byte, brokerURL string) ([]byte, error) {
 	var doc map[string]any
 	if err := json.Unmarshal(raw, &doc); err != nil {
@@ -253,6 +263,7 @@ func applyDiscoveryOverrides(raw []byte, brokerURL string) ([]byte, error) {
 	doc["issuer"] = brokerURL
 	doc["device_authorization_endpoint"] = brokerURL + "/device/authorize"
 	doc["token_endpoint"] = brokerURL + "/device/token"
+	doc["jwks_uri"] = brokerURL + "/.well-known/jwks.json"
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetIndent("", "  ")

--- a/tools/demarkus-broker/internal/broker/discovery_test.go
+++ b/tools/demarkus-broker/internal/broker/discovery_test.go
@@ -148,6 +148,11 @@ func TestDiscoveryOverridesBrokerEndpoints(t *testing.T) {
 		// token_endpoint moved to the broker — clients poll their
 		// device-code exchange here, broker mediates with the IdP.
 		{"token_endpoint", "https://broker.example.com/device/token"},
+		// jwks_uri moved to the broker (PR4) because the broker now
+		// signs id_tokens on the refresh-grant path. A strict client
+		// fetching the broker's JWKS gets the broker's signing key,
+		// matching the issuer the discovery doc advertises.
+		{"jwks_uri", "https://broker.example.com/.well-known/jwks.json"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.field, func(t *testing.T) {
@@ -160,10 +165,12 @@ func TestDiscoveryOverridesBrokerEndpoints(t *testing.T) {
 }
 
 func TestDiscoveryProxiesUnOverriddenFields(t *testing.T) {
-	// Round-trips fields the broker does NOT take over: jwks_uri,
+	// Round-trips fields the broker does NOT take over:
 	// userinfo_endpoint, authorization_endpoint, plus IdP-specific
 	// metadata arrays. Tests both presence and exact value so a
 	// regression that silently drops or rewrites these surfaces here.
+	// jwks_uri WAS in this list pre-PR4 but moved to the override
+	// set when the broker started signing id_tokens.
 	idp := newFakeDiscoveryIdP(t)
 	d, _ := newTestDiscovery(t, idp, time.Minute)
 	doc := serveAndDecode(t, d)
@@ -171,7 +178,6 @@ func TestDiscoveryProxiesUnOverriddenFields(t *testing.T) {
 		field string
 		want  any
 	}{
-		{"jwks_uri", "https://idp.example.com/.well-known/jwks.json"},
 		{"userinfo_endpoint", "https://idp.example.com/userinfo"},
 		{"authorization_endpoint", "https://idp.example.com/authorize"},
 	}

--- a/tools/demarkus-broker/internal/broker/idtoken.go
+++ b/tools/demarkus-broker/internal/broker/idtoken.go
@@ -1,0 +1,242 @@
+package broker
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+)
+
+// idTokenSignatureAlgorithm pins broker-signed id_tokens to ECDSA
+// P-256 with SHA-256 (RFC 7518 ES256). Choice rationale:
+//   - Mandatory in OIDC core (every conformant client library
+//     implements it).
+//   - Compact wire format (~64-byte signature) keeps refresh
+//     responses small on slow links.
+//   - No PKCS#1 v1.5 footguns; deterministic-k variants are widely
+//     audited.
+//
+// Pinned as a constant so the verifier's allowlist and the signer's
+// emission can never drift.
+const idTokenSignatureAlgorithm = jose.ES256
+
+// defaultIDTokenTTL is the lifetime applied to broker-signed
+// id_tokens when ServerConfig.IDTokenTTL is omitted. 15 minutes
+// balances two pulls: short enough that the polling client refreshes
+// within a working session boundary (compromise window stays
+// bounded), long enough that PR5's /me/install request can complete
+// without racing the expiry. Operators tighten via config.
+const defaultIDTokenTTL = 15 * time.Minute
+
+// ErrIDTokenKidUnknown is returned by IDTokenSigner.VerifyIDToken
+// when the JWT header's `kid` is not the broker's current signing
+// kid. Callers (the compositeVerifier) translate this into a
+// fall-through to the IdP-signed verification path — the token was
+// not minted by this broker, so the broker's public key cannot
+// validate it.
+var ErrIDTokenKidUnknown = errors.New("broker: id_token kid unknown to broker signer")
+
+// IDTokenSigner mints and verifies the broker-signed JWTs returned
+// by /device/token on the refresh-grant path (PR4). One signer per
+// broker process, configured from a PEM-encoded ECDSA P-256 private
+// key supplied via OIDCConfig.BrokerSigningKey.
+//
+// The signer also owns the JWK published at
+// /.well-known/jwks.json (PublicJWK) — keeping mint and publish on
+// the same type guarantees the kid the broker signs with is the kid
+// it advertises.
+//
+// Key rotation is out of scope for PR4: there is one key, one kid,
+// and rotation requires a config bump + broker restart. The
+// roadmap calls for a published-old + published-new transition
+// window once the operational pain becomes real.
+type IDTokenSigner struct {
+	priv   *ecdsa.PrivateKey
+	pub    *ecdsa.PublicKey
+	kid    string
+	signer jose.Signer
+}
+
+// brokerIDTokenClaims is the broker's local claims shape — what we
+// emit on Sign and unmarshal on Verify. Embeds the standard JWT
+// registered claims (iss, sub, aud, exp, iat) and adds the OIDC
+// email/groups extensions the broker propagates from the cached
+// identity. JSON tags pin the wire names to the IETF spec; the
+// nested jwt.Claims handles its own marshaling.
+type brokerIDTokenClaims struct {
+	jwt.Claims
+	Email         string   `json:"email,omitempty"`
+	EmailVerified bool     `json:"email_verified,omitempty"`
+	Groups        []string `json:"groups,omitempty"`
+}
+
+// NewIDTokenSigner parses the PEM-encoded private key and prepares
+// the underlying jose.Signer. The PEM must be PKCS#8 — the standard
+// OpenSSL output (`openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256`).
+// SEC1 (`-----BEGIN EC PRIVATE KEY-----`) is also accepted because
+// some operator tooling still emits it. Anything else fails fast.
+//
+// kid is derived from the SHA-256 hash of the marshaled public key
+// (RFC 7638-flavored — not exact JWK thumbprint, but stable across
+// restarts and unique to the keypair). Truncated to 16 hex chars to
+// keep JWT headers compact.
+func NewIDTokenSigner(pemBytes []byte) (*IDTokenSigner, error) {
+	if len(pemBytes) == 0 {
+		return nil, errors.New("broker: id_token signing key is empty")
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, errors.New("broker: id_token signing key is not PEM-encoded")
+	}
+	var priv *ecdsa.PrivateKey
+	switch block.Type {
+	case "PRIVATE KEY":
+		anyKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("broker: parse PKCS#8 private key: %w", err)
+		}
+		ec, ok := anyKey.(*ecdsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("broker: PKCS#8 key is %T, want *ecdsa.PrivateKey", anyKey)
+		}
+		priv = ec
+	case "EC PRIVATE KEY":
+		ec, err := x509.ParseECPrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("broker: parse SEC1 EC private key: %w", err)
+		}
+		priv = ec
+	default:
+		return nil, fmt.Errorf("broker: unexpected PEM block type %q (want PRIVATE KEY or EC PRIVATE KEY)", block.Type)
+	}
+	if priv.Curve != elliptic.P256() {
+		return nil, fmt.Errorf("broker: id_token signing key must use P-256 curve (got %s)", priv.Curve.Params().Name)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("broker: marshal public key: %w", err)
+	}
+	sum := sha256.Sum256(pubDER)
+	kid := base64.RawURLEncoding.EncodeToString(sum[:8])
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: idTokenSignatureAlgorithm, Key: priv},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", kid),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("broker: build jose signer: %w", err)
+	}
+	return &IDTokenSigner{
+		priv:   priv,
+		pub:    &priv.PublicKey,
+		kid:    kid,
+		signer: signer,
+	}, nil
+}
+
+// Sign produces a fresh broker-signed id_token for the given claims.
+// The token's iss + aud are the broker's PublicURL (the issuer the
+// /.well-known/openid-configuration override advertises) so a
+// strict client validates iss against the discovery doc and aud
+// against itself. ttl must be > 0; callers pass
+// ServerConfig.IDTokenTTL.
+//
+// Returns the compact JWS serialization (three base64url segments
+// separated by dots) — the standard JWT wire format.
+func (s *IDTokenSigner) Sign(claims Claims, brokerURL string, ttl time.Duration, now time.Time) (string, error) {
+	if ttl <= 0 {
+		return "", fmt.Errorf("broker: id_token ttl must be > 0 (got %s)", ttl)
+	}
+	c := brokerIDTokenClaims{
+		Claims: jwt.Claims{
+			Issuer:   brokerURL,
+			Subject:  claims.Subject,
+			Audience: jwt.Audience{brokerURL},
+			Expiry:   jwt.NewNumericDate(now.Add(ttl)),
+			IssuedAt: jwt.NewNumericDate(now),
+		},
+		Email:         claims.Email,
+		EmailVerified: claims.EmailVerified,
+		Groups:        claims.Groups,
+	}
+	raw, err := jwt.Signed(s.signer).Claims(c).Serialize()
+	if err != nil {
+		return "", fmt.Errorf("broker: sign id_token: %w", err)
+	}
+	return raw, nil
+}
+
+// VerifyIDToken validates a broker-signed JWT against the broker's
+// public key and standard claim invariants (iss == brokerURL, aud
+// includes brokerURL, exp not in the past).
+//
+// Dispatch policy (consumed by compositeVerifier):
+//
+//   - Any failure BEFORE we confirm the broker kid match returns
+//     ErrIDTokenKidUnknown — parse failure, missing headers, wrong
+//     algorithm, kid mismatch. Those are all "not a broker-shaped
+//     JWT" signals that should defer to the IdP-signed path.
+//
+//   - Any failure AFTER kid match is terminal — bad signature, bad
+//     claims, expired. A kid-matching token that fails later checks
+//     is either tampered or stale; falling through to the IdP path
+//     would mask a real failure and let a forged token through if
+//     the IdP's verifier was permissive.
+//
+// `now` is taken from a clock so tests can pin expiry behavior; the
+// callers in compositeVerifier supply the wall clock.
+func (s *IDTokenSigner) VerifyIDToken(raw, brokerURL string, now time.Time) (Claims, error) {
+	parsed, err := jwt.ParseSigned(raw, []jose.SignatureAlgorithm{idTokenSignatureAlgorithm})
+	if err != nil {
+		// Malformed JWS, wrong algorithm, or just a non-JWT string —
+		// none of which are broker-shaped tokens. Defer to IdP.
+		return Claims{}, ErrIDTokenKidUnknown
+	}
+	if len(parsed.Headers) == 0 || parsed.Headers[0].KeyID != s.kid {
+		return Claims{}, ErrIDTokenKidUnknown
+	}
+	var c brokerIDTokenClaims
+	if err := parsed.Claims(s.pub, &c); err != nil {
+		return Claims{}, fmt.Errorf("broker: verify id_token signature: %w", err)
+	}
+	err = c.ValidateWithLeeway(jwt.Expected{
+		Issuer:      brokerURL,
+		AnyAudience: jwt.Audience{brokerURL},
+		Time:        now,
+	}, jwt.DefaultLeeway)
+	if err != nil {
+		return Claims{}, fmt.Errorf("broker: validate id_token claims: %w", err)
+	}
+	return Claims{
+		Subject:       c.Subject,
+		Email:         c.Email,
+		EmailVerified: c.EmailVerified,
+		Groups:        c.Groups,
+	}, nil
+}
+
+// PublicJWK returns the JSON Web Key the broker advertises at
+// /.well-known/jwks.json. Use="sig" + Algorithm="ES256" + the
+// matching kid lets a strict OIDC client look up the right key from
+// the JWKS by header `kid`. The private half is never exposed.
+func (s *IDTokenSigner) PublicJWK() jose.JSONWebKey {
+	return jose.JSONWebKey{
+		Key:       s.pub,
+		KeyID:     s.kid,
+		Algorithm: string(idTokenSignatureAlgorithm),
+		Use:       "sig",
+	}
+}
+
+// KeyID returns the broker's signing kid. Surfaced so tests can
+// assert header-level invariants without crafting a full JWT, and so
+// future debugging logs can correlate broker-signed tokens back to
+// the active key. Stable across the signer's lifetime.
+func (s *IDTokenSigner) KeyID() string { return s.kid }

--- a/tools/demarkus-broker/internal/broker/idtoken_test.go
+++ b/tools/demarkus-broker/internal/broker/idtoken_test.go
@@ -1,0 +1,259 @@
+package broker
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// generateTestSigningKey produces a fresh ECDSA P-256 private key
+// encoded as PKCS#8 PEM. Used across every test that needs a
+// broker-side signer; ephemeral per test so failures don't leak
+// fixture key material into other tests.
+func generateTestSigningKey(t *testing.T) []byte {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal PKCS8: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}
+
+// generateTestSigningKeySEC1 produces the same key in the legacy
+// SEC1 ("EC PRIVATE KEY") PEM shape — exercises the alternative
+// branch of NewIDTokenSigner that accepts both PKCS#8 and SEC1.
+func generateTestSigningKeySEC1(t *testing.T) []byte {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal SEC1: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})
+}
+
+func newTestIDTokenSigner(t *testing.T) *IDTokenSigner {
+	t.Helper()
+	s, err := NewIDTokenSigner(generateTestSigningKey(t))
+	if err != nil {
+		t.Fatalf("NewIDTokenSigner: %v", err)
+	}
+	return s
+}
+
+func TestIDTokenSignerSignVerifyRoundTrip(t *testing.T) {
+	s := newTestIDTokenSigner(t)
+	brokerURL := "https://broker.example.com"
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	claims := Claims{
+		Subject:       "google|alice",
+		Email:         "alice@example.com",
+		EmailVerified: true,
+		Groups:        []string{"eng", "ops"},
+	}
+	raw, err := s.Sign(claims, brokerURL, 15*time.Minute, now)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	// Compact JWS: three base64url segments separated by dots.
+	if got := strings.Count(raw, "."); got != 2 {
+		t.Errorf("token = %q has %d dots, want 2", raw, got)
+	}
+
+	got, err := s.VerifyIDToken(raw, brokerURL, now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("VerifyIDToken: %v", err)
+	}
+	if got.Subject != claims.Subject {
+		t.Errorf("Subject = %q", got.Subject)
+	}
+	if got.Email != claims.Email {
+		t.Errorf("Email = %q", got.Email)
+	}
+	if !got.EmailVerified {
+		t.Errorf("EmailVerified false")
+	}
+	if len(got.Groups) != 2 || got.Groups[0] != "eng" || got.Groups[1] != "ops" {
+		t.Errorf("Groups = %v", got.Groups)
+	}
+}
+
+func TestIDTokenSignerSignRejectsZeroTTL(t *testing.T) {
+	s := newTestIDTokenSigner(t)
+	if _, err := s.Sign(Claims{}, "https://b", 0, time.Now()); err == nil {
+		t.Fatalf("zero ttl should error")
+	}
+	if _, err := s.Sign(Claims{}, "https://b", -time.Second, time.Now()); err == nil {
+		t.Fatalf("negative ttl should error")
+	}
+}
+
+func TestIDTokenSignerVerifyRejectsExpired(t *testing.T) {
+	s := newTestIDTokenSigner(t)
+	now := time.Now()
+	raw, err := s.Sign(Claims{Subject: "u"}, "https://b", time.Minute, now)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	// 10 minutes after exp + the default 1-minute leeway should
+	// reliably trip ErrExpired.
+	_, err = s.VerifyIDToken(raw, "https://b", now.Add(10*time.Minute))
+	if err == nil {
+		t.Fatalf("expired token verified ok, want error")
+	}
+}
+
+func TestIDTokenSignerVerifyRejectsWrongIssuer(t *testing.T) {
+	s := newTestIDTokenSigner(t)
+	now := time.Now()
+	raw, err := s.Sign(Claims{Subject: "u"}, "https://b1.example.com", time.Minute, now)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if _, err := s.VerifyIDToken(raw, "https://b2.example.com", now); err == nil {
+		t.Fatalf("wrong issuer accepted")
+	}
+}
+
+func TestIDTokenSignerVerifyRejectsForeignKid(t *testing.T) {
+	// Token signed by signer A is presented to signer B; B must
+	// return ErrIDTokenKidUnknown so the composite verifier knows
+	// to fall through to the IdP path.
+	a := newTestIDTokenSigner(t)
+	b := newTestIDTokenSigner(t)
+	if a.KeyID() == b.KeyID() {
+		t.Fatalf("two ephemeral signers collided on kid — astronomically unlikely, test wiring broken")
+	}
+	now := time.Now()
+	raw, err := a.Sign(Claims{Subject: "u"}, "https://b", time.Minute, now)
+	if err != nil {
+		t.Fatalf("Sign on A: %v", err)
+	}
+	_, err = b.VerifyIDToken(raw, "https://b", now)
+	if !errors.Is(err, ErrIDTokenKidUnknown) {
+		t.Fatalf("err = %v, want ErrIDTokenKidUnknown", err)
+	}
+}
+
+func TestIDTokenSignerVerifyRejectsBadSignature(t *testing.T) {
+	s := newTestIDTokenSigner(t)
+	now := time.Now()
+	raw, err := s.Sign(Claims{Subject: "u"}, "https://b", time.Minute, now)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	// Flip a character in the signature segment. Compact JWS is
+	// "header.payload.sig"; flipping any byte in the trailing
+	// segment breaks the signature without changing kid.
+	parts := strings.SplitN(raw, ".", 3)
+	if len(parts) != 3 {
+		t.Fatalf("token format unexpected: %q", raw)
+	}
+	tampered := []byte(parts[2])
+	if tampered[0] == 'A' {
+		tampered[0] = 'B'
+	} else {
+		tampered[0] = 'A'
+	}
+	bad := parts[0] + "." + parts[1] + "." + string(tampered)
+	if _, err := s.VerifyIDToken(bad, "https://b", now); err == nil {
+		t.Fatalf("tampered signature accepted")
+	}
+}
+
+func TestNewIDTokenSignerErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []byte
+		errSub string
+	}{
+		{"empty", nil, "empty"},
+		{"not PEM", []byte("not-pem-data"), "not PEM-encoded"},
+		{"wrong block type", pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte{0x01}}), "unexpected PEM block type"},
+		{"non-ECDSA PKCS8", rsaTestKeyPEM(t), "want *ecdsa.PrivateKey"},
+		{"P-384 curve", p384TestKeyPEM(t), "P-256 curve"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewIDTokenSigner(tt.input)
+			if err == nil {
+				t.Fatalf("expected error containing %q", tt.errSub)
+			}
+			if !strings.Contains(err.Error(), tt.errSub) {
+				t.Errorf("err = %q, want substring %q", err.Error(), tt.errSub)
+			}
+		})
+	}
+}
+
+func TestNewIDTokenSignerAcceptsSEC1(t *testing.T) {
+	// Legacy SEC1 PEM ("EC PRIVATE KEY") is also a valid input.
+	if _, err := NewIDTokenSigner(generateTestSigningKeySEC1(t)); err != nil {
+		t.Fatalf("SEC1 rejected: %v", err)
+	}
+}
+
+func TestIDTokenSignerPublicJWK(t *testing.T) {
+	s := newTestIDTokenSigner(t)
+	jwk := s.PublicJWK()
+	if jwk.KeyID != s.KeyID() {
+		t.Errorf("jwk.KeyID = %q, signer.KeyID = %q", jwk.KeyID, s.KeyID())
+	}
+	if jwk.Algorithm != string(idTokenSignatureAlgorithm) {
+		t.Errorf("jwk.Algorithm = %q, want %q", jwk.Algorithm, idTokenSignatureAlgorithm)
+	}
+	if jwk.Use != "sig" {
+		t.Errorf("jwk.Use = %q, want sig", jwk.Use)
+	}
+	if _, ok := jwk.Key.(*ecdsa.PublicKey); !ok {
+		t.Errorf("jwk.Key type = %T, want *ecdsa.PublicKey", jwk.Key)
+	}
+	// PublicJWK MUST NOT carry the private half.
+	if !jwk.IsPublic() {
+		t.Errorf("PublicJWK leaks private key material")
+	}
+}
+
+// rsaTestKeyPEM returns a small RSA PKCS#8 PEM — only proving
+// non-ECDSA-key rejection in NewIDTokenSigner. 1024 bits is well
+// below production posture but the bit count is irrelevant here;
+// the test asserts a type check, not crypto strength.
+func rsaTestKeyPEM(t *testing.T) []byte {
+	t.Helper()
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("rsa gen: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(rsaKey)
+	if err != nil {
+		t.Fatalf("marshal rsa: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}
+
+func p384TestKeyPEM(t *testing.T) []byte {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate P-384: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal P-384: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}

--- a/tools/demarkus-broker/internal/broker/jwks.go
+++ b/tools/demarkus-broker/internal/broker/jwks.go
@@ -1,0 +1,46 @@
+package broker
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-jose/go-jose/v4"
+)
+
+// jwksHandler serves the broker's JSON Web Key Set at
+// /.well-known/jwks.json. The endpoint is public and unauthenticated
+// (matching the OIDC discovery doc's posture) so any OAuth/OIDC
+// client library can fetch the verification key for broker-signed
+// id_tokens. PR4 publishes exactly one key; rotation (multiple
+// concurrent keys with overlapping kids) is a phase-7 follow-up.
+type jwksHandler struct {
+	signer *IDTokenSigner
+	body   []byte
+}
+
+// newJWKSHandler renders the JWKS once at construction. The signer's
+// kid is stable across the broker's lifetime (no rotation in PR4),
+// so a one-time render avoids any per-request marshaling overhead.
+// Re-rendering on signer change is a phase-7 concern.
+func newJWKSHandler(signer *IDTokenSigner) (*jwksHandler, error) {
+	set := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{signer.PublicJWK()}}
+	body, err := json.MarshalIndent(set, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return &jwksHandler{signer: signer, body: body}, nil
+}
+
+// ServeHTTP writes the rendered JWKS body. Method enforcement is
+// already handled by the mux's `GET /.well-known/jwks.json` pattern,
+// so the handler itself only writes the body.
+func (h *jwksHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	// Cache-Control matches the discovery doc's TTL window (300s,
+	// kept as a literal because Cache-Control values are part of
+	// the HTTP wire contract — coupling to defaultDiscoveryTTL via
+	// a computed value would silently drift if either side changed).
+	// Public (not private) because the JWKS is not user-scoped.
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	_, _ = w.Write(h.body)
+}

--- a/tools/demarkus-broker/internal/broker/jwks_test.go
+++ b/tools/demarkus-broker/internal/broker/jwks_test.go
@@ -1,0 +1,93 @@
+package broker
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-jose/go-jose/v4"
+)
+
+func TestJWKSHandlerServesPublicKey(t *testing.T) {
+	signer := newTestIDTokenSigner(t)
+	h, err := newJWKSHandler(signer)
+	if err != nil {
+		t.Fatalf("newJWKSHandler: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", http.NoBody)
+	h.ServeHTTP(rec, req)
+	resp := rec.Result()
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q", ct)
+	}
+	if cc := resp.Header.Get("Cache-Control"); !strings.Contains(cc, "max-age=300") {
+		t.Errorf("Cache-Control = %q, want max-age=300", cc)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var set jose.JSONWebKeySet
+	if err := json.Unmarshal(body, &set); err != nil {
+		t.Fatalf("decode JWKS: %v", err)
+	}
+	if len(set.Keys) != 1 {
+		t.Fatalf("keys count = %d, want 1", len(set.Keys))
+	}
+	jwk := set.Keys[0]
+	if jwk.KeyID != signer.KeyID() {
+		t.Errorf("kid = %q, want %q", jwk.KeyID, signer.KeyID())
+	}
+	if jwk.Algorithm != string(idTokenSignatureAlgorithm) {
+		t.Errorf("alg = %q", jwk.Algorithm)
+	}
+	if jwk.Use != "sig" {
+		t.Errorf("use = %q", jwk.Use)
+	}
+	if !jwk.IsPublic() {
+		t.Errorf("served JWK leaks private key material")
+	}
+}
+
+func TestJWKSHandlerVerifiesAgainstSignedToken(t *testing.T) {
+	// End-to-end: a client can fetch the JWKS, find the key by
+	// kid, and verify a broker-signed token against it. This is
+	// the contract every OIDC client library executes — guarding
+	// it pins the broker's interop with strict implementations.
+	signer := newTestIDTokenSigner(t)
+	h, err := newJWKSHandler(signer)
+	if err != nil {
+		t.Fatalf("newJWKSHandler: %v", err)
+	}
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := srv.Client().Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	var set jose.JSONWebKeySet
+	if err := json.Unmarshal(body, &set); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	keys := set.Key(signer.KeyID())
+	if len(keys) != 1 {
+		t.Fatalf("Key(%q) = %d hits, want 1", signer.KeyID(), len(keys))
+	}
+	// Public key must validate a freshly-signed token. We avoid
+	// re-implementing JWT parsing here; the round-trip is already
+	// exercised by TestIDTokenSignerSignVerifyRoundTrip. This test
+	// asserts the served JWK is the SAME key the signer holds.
+	if signer.PublicJWK().KeyID != keys[0].KeyID {
+		t.Errorf("served key kid does not match signer kid")
+	}
+}

--- a/tools/demarkus-broker/internal/broker/oidc.go
+++ b/tools/demarkus-broker/internal/broker/oidc.go
@@ -90,6 +90,14 @@ type oidcVerifier struct {
 // The library is provider-agnostic: any RFC-compliant OIDC IdP with
 // discovery works. "google" is just the first one we've validated.
 func NewVerifier(ctx context.Context, cfg *OIDCConfig) (Verifier, error) {
+	// nil-guard: NewVerifier is an error-returning API; a nil cfg
+	// should surface as a structured error rather than a constructor
+	// panic deep in the OIDC stack. Belt-and-suspenders — production
+	// wiring always passes &cfg.OIDC after LoadConfig, but tests and
+	// future callers benefit from the explicit boundary.
+	if cfg == nil {
+		return nil, fmt.Errorf("broker: oidc config is required")
+	}
 	provider, err := oidc.NewProvider(ctx, cfg.Issuer)
 	if err != nil {
 		return nil, fmt.Errorf("broker: oidc discovery for %s: %w", cfg.Issuer, err)

--- a/tools/demarkus-broker/internal/broker/oidc.go
+++ b/tools/demarkus-broker/internal/broker/oidc.go
@@ -10,6 +10,11 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// Ensure compositeVerifier satisfies the Verifier interface at
+// compile time. A drift between the interface and the implementation
+// would otherwise be caught only by callers, several files away.
+var _ Verifier = (*compositeVerifier)(nil)
+
 // Claims is the subset of OIDC ID-token claims the broker actually consumes.
 // Subject + Email + EmailVerified are required to mint. Groups is optional
 // and used by the per-world group allowlist (Slice C.1); IdPs that don't
@@ -75,13 +80,16 @@ type oidcVerifier struct {
 	verifier *oidc.IDTokenVerifier
 }
 
-// NewVerifier builds an OIDC Verifier from the broker's OIDCConfig. The
-// constructor performs OIDC discovery (one HTTP call to the issuer) so it
-// can fail fast at broker startup rather than on the first user login.
+// NewVerifier builds an OIDC Verifier from the broker's OIDCConfig.
+// Takes a pointer because OIDCConfig grew to 80+ bytes after PR4's
+// BrokerSigningKey addition (gocritic hugeParam threshold). The
+// constructor performs OIDC discovery (one HTTP call to the issuer)
+// so it can fail fast at broker startup rather than on the first
+// user login.
 //
 // The library is provider-agnostic: any RFC-compliant OIDC IdP with
 // discovery works. "google" is just the first one we've validated.
-func NewVerifier(ctx context.Context, cfg OIDCConfig) (Verifier, error) {
+func NewVerifier(ctx context.Context, cfg *OIDCConfig) (Verifier, error) {
 	provider, err := oidc.NewProvider(ctx, cfg.Issuer)
 	if err != nil {
 		return nil, fmt.Errorf("broker: oidc discovery for %s: %w", cfg.Issuer, err)
@@ -145,4 +153,68 @@ func (v *oidcVerifier) VerifyIDToken(ctx context.Context, rawIDToken string) (Cl
 		EmailVerified: raw.EmailVerified,
 		Groups:        raw.Groups,
 	}, nil
+}
+
+// compositeVerifier multiplexes id_token verification across the
+// broker's own signing key (PR4 refresh-grant minted tokens) and the
+// IdP's JWKS (device-code-completion tokens still IdP-signed,
+// pre-rotation legacy tokens, etc.). On AuthCodeURL + Exchange the
+// composite is a transparent pass-through to the IdP-backed
+// Verifier — only VerifyIDToken multiplexes.
+//
+// Dispatch policy: try the broker key first because it never
+// touches the network (kid match short-circuits or fails cheaply).
+// On ErrIDTokenKidUnknown (the token wasn't minted by this broker)
+// fall through to the IdP path. Any other broker-side verification
+// error (signature fail, bad iss, expired) is terminal — we do not
+// silently retry against the IdP, since a kid-matching token that
+// fails downstream checks indicates a tampered or stale broker
+// token, not an IdP token.
+//
+// idTokenSigner is required (non-nil) in production wiring; tests
+// that don't exercise broker-signed tokens may pass nil and the
+// composite degrades to a transparent pass-through.
+type compositeVerifier struct {
+	primary       Verifier
+	idTokenSigner *IDTokenSigner
+	brokerURL     string
+	clock         func() time.Time
+}
+
+// newCompositeVerifier wraps an existing Verifier (the IdP-backed
+// one) with the broker's own signer. brokerURL is the iss + aud the
+// broker emits on its tokens; the verifier checks them on the
+// broker-leg path.
+func newCompositeVerifier(primary Verifier, signer *IDTokenSigner, brokerURL string) *compositeVerifier {
+	return &compositeVerifier{
+		primary:       primary,
+		idTokenSigner: signer,
+		brokerURL:     brokerURL,
+		clock:         time.Now,
+	}
+}
+
+func (c *compositeVerifier) AuthCodeURL(state string) string {
+	return c.primary.AuthCodeURL(state)
+}
+
+func (c *compositeVerifier) Exchange(ctx context.Context, code string) (ExchangeResult, error) {
+	return c.primary.Exchange(ctx, code)
+}
+
+func (c *compositeVerifier) VerifyIDToken(ctx context.Context, raw string) (Claims, error) {
+	if c.idTokenSigner != nil {
+		claims, err := c.idTokenSigner.VerifyIDToken(raw, c.brokerURL, c.clock())
+		if err == nil {
+			return claims, nil
+		}
+		if !errors.Is(err, ErrIDTokenKidUnknown) {
+			// Broker recognized the kid as its own but the
+			// signature / claims failed. Falling through to the
+			// IdP path here would mask a real failure (e.g. a
+			// tampered broker token sneaking in via IdP's JWKS).
+			return Claims{}, err
+		}
+	}
+	return c.primary.VerifyIDToken(ctx, raw)
 }

--- a/tools/demarkus-broker/internal/broker/oidc_test.go
+++ b/tools/demarkus-broker/internal/broker/oidc_test.go
@@ -86,6 +86,20 @@ func TestNewVerifierFailsOnBadIssuer(t *testing.T) {
 	}
 }
 
+// TestNewVerifierRejectsNilConfig pins the boundary check added in
+// PR4 review: NewVerifier is an error-returning API and must
+// surface a structured error rather than crash deep in the OIDC
+// stack when callers hand it a nil *OIDCConfig.
+func TestNewVerifierRejectsNilConfig(t *testing.T) {
+	_, err := NewVerifier(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil cfg, got nil")
+	}
+	if !strings.Contains(err.Error(), "oidc config is required") {
+		t.Errorf("err = %v, want 'oidc config is required'", err)
+	}
+}
+
 // fakeVerifier is the test double issuer/server tests use. It implements
 // the Verifier interface with predetermined claims and is not coupled to
 // the OIDC library.

--- a/tools/demarkus-broker/internal/broker/oidc_test.go
+++ b/tools/demarkus-broker/internal/broker/oidc_test.go
@@ -45,7 +45,7 @@ func TestNewVerifierDiscoversAndBuildsAuthURL(t *testing.T) {
 		ClientSecret: "secret",
 		RedirectURL:  "https://broker.example.com/auth/callback",
 	}
-	v, err := NewVerifier(context.Background(), cfg)
+	v, err := NewVerifier(context.Background(), &cfg)
 	if err != nil {
 		t.Fatalf("NewVerifier: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestNewVerifierDiscoversAndBuildsAuthURL(t *testing.T) {
 }
 
 func TestNewVerifierFailsOnBadIssuer(t *testing.T) {
-	_, err := NewVerifier(context.Background(), OIDCConfig{
+	_, err := NewVerifier(context.Background(), &OIDCConfig{
 		Issuer:       "http://127.0.0.1:1", // unreachable
 		ClientID:     "x",
 		ClientSecret: "y",
@@ -126,4 +126,124 @@ func (f *fakeVerifier) VerifyIDToken(_ context.Context, raw string) (Claims, err
 		return f.verifyFn(raw)
 	}
 	return f.claims, nil
+}
+
+func TestCompositeVerifierPassThroughAuthAndExchange(t *testing.T) {
+	primary := &fakeVerifier{
+		authURL:    "https://idp.example.com/authorize",
+		claims:     Claims{Email: "alice@x.com", EmailVerified: true, Subject: "g|alice"},
+		rawIDToken: "primary-raw",
+	}
+	c := newCompositeVerifier(primary, newTestIDTokenSigner(t), "https://broker.example.com")
+
+	if got := c.AuthCodeURL("nonce-1"); !strings.Contains(got, "nonce-1") {
+		t.Errorf("AuthCodeURL = %q, want primary's URL with state", got)
+	}
+	res, err := c.Exchange(context.Background(), "code")
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if res.RawIDToken != "primary-raw" {
+		t.Errorf("Exchange forwarded to primary returned %q", res.RawIDToken)
+	}
+}
+
+func TestCompositeVerifierVerifiesBrokerSigned(t *testing.T) {
+	primary := &fakeVerifier{verifyFn: func(string) (Claims, error) {
+		return Claims{}, fmt.Errorf("primary should not be invoked for broker-signed tokens")
+	}}
+	signer := newTestIDTokenSigner(t)
+	c := newCompositeVerifier(primary, signer, "https://broker.example.com")
+	c.clock = func() time.Time { return time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC) }
+
+	raw, err := signer.Sign(Claims{
+		Subject: "g|alice", Email: "alice@x.com", EmailVerified: true,
+	}, "https://broker.example.com", time.Minute, c.clock())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	claims, err := c.VerifyIDToken(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("VerifyIDToken: %v", err)
+	}
+	if claims.Email != "alice@x.com" {
+		t.Errorf("Email = %q", claims.Email)
+	}
+}
+
+func TestCompositeVerifierFallsThroughOnUnknownKid(t *testing.T) {
+	// Token signed by a DIFFERENT signer carries an unknown kid;
+	// composite must fall through to the primary (IdP) verifier.
+	otherSigner := newTestIDTokenSigner(t)
+	raw, err := otherSigner.Sign(Claims{Email: "carol@x.com"}, "https://broker.example.com", time.Minute, time.Now())
+	if err != nil {
+		t.Fatalf("Sign on other signer: %v", err)
+	}
+	fallbackHit := false
+	primary := &fakeVerifier{verifyFn: func(string) (Claims, error) {
+		fallbackHit = true
+		return Claims{Email: "from-primary@x.com", EmailVerified: true}, nil
+	}}
+	brokerSigner := newTestIDTokenSigner(t)
+	c := newCompositeVerifier(primary, brokerSigner, "https://broker.example.com")
+
+	claims, err := c.VerifyIDToken(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("VerifyIDToken: %v", err)
+	}
+	if !fallbackHit {
+		t.Errorf("primary not invoked for unknown-kid token")
+	}
+	if claims.Email != "from-primary@x.com" {
+		t.Errorf("Email = %q, want from-primary path", claims.Email)
+	}
+}
+
+func TestCompositeVerifierDoesNotFallThroughOnBrokerSignatureFail(t *testing.T) {
+	// A token with the BROKER's kid but a tampered signature must
+	// NOT fall through to the IdP — otherwise a forged token whose
+	// kid points at the broker's would silently sneak through if
+	// the IdP's verifier was permissive. This pins the dispatch
+	// policy from the compositeVerifier doc comment.
+	signer := newTestIDTokenSigner(t)
+	now := time.Now()
+	raw, err := signer.Sign(Claims{Subject: "u"}, "https://broker.example.com", time.Minute, now)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	// Tamper a signature byte.
+	parts := strings.SplitN(raw, ".", 3)
+	if len(parts) != 3 {
+		t.Fatalf("unexpected token shape")
+	}
+	tamperedSig := []byte(parts[2])
+	if tamperedSig[0] == 'A' {
+		tamperedSig[0] = 'B'
+	} else {
+		tamperedSig[0] = 'A'
+	}
+	bad := parts[0] + "." + parts[1] + "." + string(tamperedSig)
+
+	primary := &fakeVerifier{verifyFn: func(string) (Claims, error) {
+		t.Fatal("primary must not be invoked on broker-side signature failure")
+		return Claims{}, nil
+	}}
+	c := newCompositeVerifier(primary, signer, "https://broker.example.com")
+	if _, err := c.VerifyIDToken(context.Background(), bad); err == nil {
+		t.Fatalf("tampered broker-signed token accepted")
+	}
+}
+
+func TestCompositeVerifierNilSignerIsPassThrough(t *testing.T) {
+	primary := &fakeVerifier{verifyFn: func(string) (Claims, error) {
+		return Claims{Email: "from-primary@x.com"}, nil
+	}}
+	c := newCompositeVerifier(primary, nil, "https://broker.example.com")
+	claims, err := c.VerifyIDToken(context.Background(), "any-token")
+	if err != nil {
+		t.Fatalf("VerifyIDToken: %v", err)
+	}
+	if claims.Email != "from-primary@x.com" {
+		t.Errorf("Email = %q", claims.Email)
+	}
 }

--- a/tools/demarkus-broker/internal/broker/ratelimit_test.go
+++ b/tools/demarkus-broker/internal/broker/ratelimit_test.go
@@ -185,7 +185,7 @@ func TestSubjectRateLimitMissingClaimsIs500(t *testing.T) {
 	// as 500 + an error log rather than silently disabling the limit
 	// (which would be the worst-of-both: production looks fine, but
 	// a misbehaving caller gets unbounded throughput).
-	srv := NewServer(testConfigWithRateLimit(), newTestSigner(t), &fakeVerifier{}, NewIssuer(testConfig(), fake.NewSimpleClientset()), nil, nil)
+	srv := NewServer(testConfigWithRateLimit(), newTestSigner(t), &fakeVerifier{}, NewIssuer(testConfig(), fake.NewSimpleClientset()), nil, nil, nil)
 	h := srv.subjectRateLimit(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Error("handler reached despite missing claims")
 		w.WriteHeader(http.StatusOK)

--- a/tools/demarkus-broker/internal/broker/refresh.go
+++ b/tools/demarkus-broker/internal/broker/refresh.go
@@ -83,7 +83,7 @@ type refreshTokens struct {
 	Entries map[string]refreshTokenRecord `json:"entries"`
 }
 
-// refreshStore is the broker's refresh-token lifecycle layer.
+// RefreshStore is the broker's refresh-token lifecycle layer.
 // All state lives in a single broker-namespace Secret; mutations go
 // through the shared optimistic-concurrency mutateSecret helper.
 // Multi-replica brokers converge under conflict retry — same posture
@@ -95,18 +95,20 @@ type refreshTokens struct {
 // limit becomes the wall. Phase-7 follow-up is a sharded or
 // CRD-backed store; the API surface here stays stable across that
 // migration.
-type refreshStore struct {
+type RefreshStore struct {
 	cfg    *Config
 	k8s    kubernetes.Interface
 	clock  func() time.Time
 	randFn func([]byte) (int, error)
 }
 
-// newRefreshStore wires a refreshStore with real time.Now and
+// NewRefreshStore wires a *RefreshStore with real time.Now and
 // crypto/rand. Tests override clock and randFn on the returned
 // struct for deterministic behavior — same pattern as NewIssuer.
-func newRefreshStore(cfg *Config, k8s kubernetes.Interface) *refreshStore {
-	return &refreshStore{
+// Exported because main.go and the Sweeper share a single
+// instance with the Server (PR4 Step 5).
+func NewRefreshStore(cfg *Config, k8s kubernetes.Interface) *RefreshStore {
+	return &RefreshStore{
 		cfg:    cfg,
 		k8s:    k8s,
 		clock:  time.Now,
@@ -123,7 +125,7 @@ func newRefreshStore(cfg *Config, k8s kubernetes.Interface) *refreshStore {
 // The raw token is hex-encoded 32-byte randomness (64 chars). The
 // caller is responsible for treating it as bearer credential material
 // — no logging, no retries that would surface it in error messages.
-func (s *refreshStore) Issue(ctx context.Context, claims Claims, ttl time.Duration) (string, error) {
+func (s *RefreshStore) Issue(ctx context.Context, claims Claims, ttl time.Duration) (string, error) {
 	if ttl <= 0 {
 		return "", fmt.Errorf("refresh ttl must be > 0 (got %s)", ttl)
 	}
@@ -167,7 +169,7 @@ func (s *refreshStore) Issue(ctx context.Context, claims Claims, ttl time.Durati
 // refresh) and returns the stored record so the caller can rebuild a
 // response from the cached Claims. On any "not minting" condition
 // returns ErrRefreshTokenInvalid; I/O failures propagate.
-func (s *refreshStore) Refresh(ctx context.Context, rawToken string) (refreshTokenRecord, error) {
+func (s *RefreshStore) Refresh(ctx context.Context, rawToken string) (refreshTokenRecord, error) {
 	if rawToken == "" {
 		return refreshTokenRecord{}, ErrRefreshTokenInvalid
 	}
@@ -203,7 +205,7 @@ func (s *refreshStore) Refresh(ctx context.Context, rawToken string) (refreshTok
 // Revoke drops a token from the store. Idempotent per RFC 7009 §2.2:
 // revoking an unknown or already-revoked token is not an error. An
 // absent Secret is the "store is empty" case and also a no-op.
-func (s *refreshStore) Revoke(ctx context.Context, rawToken string) error {
+func (s *RefreshStore) Revoke(ctx context.Context, rawToken string) error {
 	if rawToken == "" {
 		return nil
 	}
@@ -229,7 +231,7 @@ func (s *refreshStore) Revoke(ctx context.Context, rawToken string) error {
 // map are both no-ops returning (0, nil). Designed to be called from
 // the existing Sweeper's per-tick loop alongside the issuances
 // sweep — Step 5 wires it.
-func (s *refreshStore) Sweep(ctx context.Context) (int, error) {
+func (s *RefreshStore) Sweep(ctx context.Context) (int, error) {
 	var swept int
 	err := mutateSecret(ctx, s.k8s, s.cfg.Server.BrokerNamespace, s.cfg.Server.RefreshTokensSecret, RefreshTokensSecretKey, func(existing []byte) ([]byte, error) {
 		// Reset on each retry — same rationale as Refresh.

--- a/tools/demarkus-broker/internal/broker/refresh_test.go
+++ b/tools/demarkus-broker/internal/broker/refresh_test.go
@@ -22,12 +22,12 @@ import (
 
 // testRefreshSecret is the operator-visible name for the broker's
 // refresh-tokens Secret in tests. Distinct from testIssuancesNS so a
-// stray cross-Secret read in the refreshStore would land on a
+// stray cross-Secret read in the RefreshStore would land on a
 // missing Secret and surface as an obvious test failure rather than
 // silently picking up issuance bytes.
 const testRefreshSecret = "broker-refresh-tokens"
 
-// testRefreshConfig builds a Config sufficient for refreshStore
+// testRefreshConfig builds a Config sufficient for RefreshStore
 // tests. Reuses the issuance-test config fields so a future cross-
 // store interaction (Step 2 onward) shares one base config helper.
 func testRefreshConfig() *Config {
@@ -37,9 +37,9 @@ func testRefreshConfig() *Config {
 	return c
 }
 
-func newRefreshStoreForTest(t *testing.T, k8s *fake.Clientset) *refreshStore {
+func newRefreshStoreForTest(t *testing.T, k8s *fake.Clientset) *RefreshStore {
 	t.Helper()
-	s := newRefreshStore(testRefreshConfig(), k8s)
+	s := NewRefreshStore(testRefreshConfig(), k8s)
 	s.clock = func() time.Time { return time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC) }
 	return s
 }
@@ -102,13 +102,13 @@ func TestRefreshStoreIssueRejectsZeroTTL(t *testing.T) {
 func TestRefreshStoreRefreshErrors(t *testing.T) {
 	tests := []struct {
 		name string
-		fn   func(t *testing.T, s *refreshStore, raw string) (string, time.Time)
+		fn   func(t *testing.T, s *RefreshStore, raw string) (string, time.Time)
 	}{
-		{"unknown token", func(_ *testing.T, _ *refreshStore, _ string) (string, time.Time) {
+		{"unknown token", func(_ *testing.T, _ *RefreshStore, _ string) (string, time.Time) {
 			// Same length as a real token, never issued.
 			return strings.Repeat("0", refreshTokenBytes*2), time.Time{}
 		}},
-		{"tampered token (one byte off)", func(_ *testing.T, _ *refreshStore, raw string) (string, time.Time) {
+		{"tampered token (one byte off)", func(_ *testing.T, _ *RefreshStore, raw string) (string, time.Time) {
 			// Flip the first hex character to a guaranteed-different value.
 			flipped := []byte(raw)
 			if flipped[0] == 'f' {
@@ -118,10 +118,10 @@ func TestRefreshStoreRefreshErrors(t *testing.T) {
 			}
 			return string(flipped), time.Time{}
 		}},
-		{"empty token", func(_ *testing.T, _ *refreshStore, _ string) (string, time.Time) {
+		{"empty token", func(_ *testing.T, _ *RefreshStore, _ string) (string, time.Time) {
 			return "", time.Time{}
 		}},
-		{"expired token", func(_ *testing.T, s *refreshStore, raw string) (string, time.Time) {
+		{"expired token", func(_ *testing.T, s *RefreshStore, raw string) (string, time.Time) {
 			// Jump clock past ExpiresAt.
 			base := s.clock()
 			s.clock = func() time.Time { return base.Add(25 * time.Hour) }
@@ -312,7 +312,7 @@ func TestRefreshStoreSecretShape(t *testing.T) {
 // parallel Issues without a conflict-emitting reactor would last-
 // writer-wins and lose entries) then refreshes in parallel under
 // -race. The race detector is the load-bearing check: any
-// unsynchronized read or write inside refreshStore surfaces here.
+// unsynchronized read or write inside RefreshStore surfaces here.
 func TestRefreshStoreConcurrentRefresh(t *testing.T) {
 	k8s := fake.NewSimpleClientset()
 	s := newRefreshStoreForTest(t, k8s)
@@ -353,7 +353,7 @@ func TestRefreshStoreConcurrentRefresh(t *testing.T) {
 }
 
 // TestRefreshStoreIssueConflictRetries exercises mutateSecret's
-// optimistic-concurrency retry loop end-to-end through refreshStore.
+// optimistic-concurrency retry loop end-to-end through RefreshStore.
 // A reactor injects two consecutive Conflicts on Update; the third
 // attempt must succeed and the issued token must be retrievable.
 // Mirrors TestMintConflictRetries' shape for the issuances Secret.

--- a/tools/demarkus-broker/internal/broker/revoke.go
+++ b/tools/demarkus-broker/internal/broker/revoke.go
@@ -1,0 +1,65 @@
+package broker
+
+import "net/http"
+
+// tokenRevoke implements POST /token/revoke per RFC 7009. Drops the
+// supplied refresh token from the broker's refreshStore so a future
+// /device/token refresh-grant rejects it with invalid_grant.
+//
+// RFC 7009 semantics this handler implements:
+//
+//   - §2.1: only `token` is required; `token_type_hint` is optional
+//     and may be ignored. The broker accepts the param for spec
+//     conformance but does not validate it — refreshStore.Revoke is
+//     a sha256 point-lookup, so no hint is needed to find the entry.
+//
+//   - §2.2: revoking an unknown / already-revoked token MUST NOT
+//     return an error. Surfacing 404 or 400 on unknown tokens would
+//     turn this endpoint into an enumeration oracle. refreshStore
+//     is idempotent by construction.
+//
+//   - §2.2: response is 200 (or 204). We pick 204 No Content
+//     because the body is always empty.
+//
+// Missing or empty `token` form param is the one case where we
+// surface 400 invalid_request — the request itself is malformed,
+// which RFC 7009 §2.1 calls out as a separate error class from
+// the "unknown token" no-op case.
+//
+// Anonymous endpoint: no bearer auth required. Possession of the
+// token is the authorization. The IP rate limiter is the protection
+// against an attacker who knows a token guessing additional ones
+// (the sha256 space makes guessing infeasible, but the limiter is
+// defense-in-depth same as on /device/authorize).
+//
+// Note: the broker is the resource server for the world tokens
+// (those go through DELETE /tokens/{label}, not this endpoint).
+// /token/revoke applies only to refresh tokens minted by /device/token.
+func (s *Server) tokenRevoke(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "invalid_request"})
+		return
+	}
+	rawToken := r.PostFormValue("token")
+	if rawToken == "" {
+		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "invalid_request"})
+		return
+	}
+	// token_type_hint is read but intentionally not validated — the
+	// store lookup is by hash and the hint adds no value. Read the
+	// form value anyway so the handler is observably aware of the
+	// param's existence; a future debug log can pick it up.
+	_ = r.PostFormValue("token_type_hint")
+
+	if err := s.refreshStore.Revoke(r.Context(), rawToken); err != nil {
+		// refreshStore.Revoke errors are I/O-only — the store layer
+		// already absorbs "token unknown" as a no-op. A propagated
+		// error here means the Secret read or write failed; surface
+		// 500 rather than 204 so the caller knows the revocation
+		// did not land.
+		s.log.ErrorContext(r.Context(), "broker: revoke refresh token failed", "err", err)
+		http.Error(w, "revoke failed", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/tools/demarkus-broker/internal/broker/revoke.go
+++ b/tools/demarkus-broker/internal/broker/revoke.go
@@ -56,9 +56,12 @@ func (s *Server) tokenRevoke(w http.ResponseWriter, r *http.Request) {
 		// already absorbs "token unknown" as a no-op. A propagated
 		// error here means the Secret read or write failed; surface
 		// 500 rather than 204 so the caller knows the revocation
-		// did not land.
+		// did not land. JSON shape matches the rest of the OAuth2
+		// surface (RFC 7009 §2.2.1 + RFC 6749 §5.2 — error responses
+		// are application/json with an `error` field); the prior
+		// text/plain response was the odd one out.
 		s.log.ErrorContext(r.Context(), "broker: revoke refresh token failed", "err", err)
-		http.Error(w, "revoke failed", http.StatusInternalServerError)
+		writeJSON(w, http.StatusInternalServerError, deviceTokenError{Error: "server_error"})
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/tools/demarkus-broker/internal/broker/revoke_test.go
+++ b/tools/demarkus-broker/internal/broker/revoke_test.go
@@ -1,0 +1,126 @@
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestTokenRevokeValid(t *testing.T) {
+	srv, broker := newTestServerWithSigner(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
+	rawRefresh, err := broker.refreshStore.Issue(context.Background(),
+		Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	resp, err := testClient(srv).PostForm(srv.URL+"/token/revoke", url.Values{"token": {rawRefresh}})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s, want 204", resp.StatusCode, body)
+	}
+	// Subsequent refresh of the revoked token must fail.
+	if _, err := broker.refreshStore.Refresh(context.Background(), rawRefresh); !errors.Is(err, ErrRefreshTokenInvalid) {
+		t.Errorf("Refresh after Revoke err = %v, want ErrRefreshTokenInvalid", err)
+	}
+}
+
+func TestTokenRevokeUnknownTokenIsNoOp(t *testing.T) {
+	// RFC 7009 §2.2: revocation of an unknown / invalid token must
+	// not signal back to the caller. Anything other than 204 turns
+	// the endpoint into an enumeration oracle.
+	srv, _ := newTestServerWithSigner(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
+	resp, err := testClient(srv).PostForm(srv.URL+"/token/revoke", url.Values{"token": {strings.Repeat("0", refreshTokenBytes*2)}})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("unknown-token status = %d, want 204 (RFC 7009 §2.2)", resp.StatusCode)
+	}
+}
+
+func TestTokenRevokeRejectsMissingToken(t *testing.T) {
+	tests := []struct {
+		name string
+		form url.Values
+	}{
+		{"no token param", url.Values{}},
+		{"empty token param", url.Values{"token": {""}}},
+		{"token_type_hint without token", url.Values{"token_type_hint": {"refresh_token"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, _ := newTestServerWithSigner(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
+			resp, err := testClient(srv).PostForm(srv.URL+"/token/revoke", tt.form)
+			if err != nil {
+				t.Fatalf("POST: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", resp.StatusCode)
+			}
+			var body deviceTokenError
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if body.Error != "invalid_request" {
+				t.Errorf("error = %q, want invalid_request", body.Error)
+			}
+		})
+	}
+}
+
+func TestTokenRevokeAcceptsTokenTypeHint(t *testing.T) {
+	// token_type_hint is optional per RFC 7009 §2.1 and the broker
+	// accepts it without validating. This test asserts the hint
+	// does not cause rejection (regression guard against an over-
+	// eager future validator).
+	srv, broker := newTestServerWithSigner(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
+	rawRefresh, err := broker.refreshStore.Issue(context.Background(),
+		Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	resp, err := testClient(srv).PostForm(srv.URL+"/token/revoke", url.Values{
+		"token":           {rawRefresh},
+		"token_type_hint": {"refresh_token"},
+	})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", resp.StatusCode)
+	}
+}
+
+func TestTokenRevokeIdempotent(t *testing.T) {
+	srv, broker := newTestServerWithSigner(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
+	rawRefresh, err := broker.refreshStore.Issue(context.Background(),
+		Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	for i := range 3 {
+		resp, err := testClient(srv).PostForm(srv.URL+"/token/revoke", url.Values{"token": {rawRefresh}})
+		if err != nil {
+			t.Fatalf("POST #%d: %v", i, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			t.Errorf("POST #%d status = %d, want 204", i, resp.StatusCode)
+		}
+	}
+}

--- a/tools/demarkus-broker/internal/broker/revoke_test.go
+++ b/tools/demarkus-broker/internal/broker/revoke_test.go
@@ -11,7 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestTokenRevokeValid(t *testing.T) {
@@ -122,5 +124,47 @@ func TestTokenRevokeIdempotent(t *testing.T) {
 		if resp.StatusCode != http.StatusNoContent {
 			t.Errorf("POST #%d status = %d, want 204", i, resp.StatusCode)
 		}
+	}
+}
+
+// TestTokenRevokeServerErrorIsJSON pins the PR4-review fix: the
+// store-failure 500 branch must serve JSON (matching RFC 7009
+// §2.2.1 + the rest of the OAuth2 surface), not the text/plain
+// shape `http.Error` would emit. We force an upstream k8s failure
+// via a reactor so the Revoke I/O path errors out.
+func TestTokenRevokeServerErrorIsJSON(t *testing.T) {
+	k8s := fake.NewSimpleClientset()
+	srv, broker := newTestServerWithSigner(t, deviceTestConfig(), &fakeVerifier{}, k8s, newTestIDTokenSigner(t))
+	// Mint a token so refreshStore.Revoke reaches the Update step
+	// (the no-Secret-exists path returns nil and skips the failure
+	// surface).
+	rawRefresh, err := broker.refreshStore.Issue(context.Background(),
+		Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	// Reactor that forces every secrets Get to fail. After enough
+	// retries mutateSecret surrenders and propagates the error.
+	k8s.PrependReactor("get", "secrets", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("simulated k8s outage")
+	})
+
+	resp, err := testClient(srv).PostForm(srv.URL+"/token/revoke", url.Values{"token": {rawRefresh}})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json (RFC 7009 §2.2.1)", ct)
+	}
+	var body deviceTokenError
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Error != "server_error" {
+		t.Errorf("error = %q, want server_error", body.Error)
 	}
 }

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -89,6 +89,18 @@ func NewServer(cfg *Config, signer *Signer, verifier Verifier, issuer *Issuer, d
 	if log == nil {
 		log = slog.Default()
 	}
+	// Discovery overrides jwks_uri to the broker (PR4); a discovery
+	// doc that advertises /.well-known/jwks.json with no handler
+	// mounted is a broken-by-construction surface — strict OIDC
+	// clients will fail at key-discovery time. Production wiring
+	// guarantees both are present (LoadConfig requires
+	// BrokerSigningKey when validate runs), so this guard is for
+	// programming errors at construction. Panic rather than return
+	// an error because NewServer's signature is error-less and the
+	// invariant is impossible to recover from at runtime.
+	if discovery != nil && idTokenSigner == nil {
+		panic("broker: NewServer with discovery != nil requires idTokenSigner; otherwise the well-known doc would advertise jwks_uri at a route that is not registered")
+	}
 	// Device-flow knobs default at construction time so tests that
 	// build Config{} directly (skipping LoadConfig validation) still
 	// get usable values — keeps the in-process httptest path symmetric

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -36,13 +37,28 @@ type Server struct {
 	// HTTP surface; the store owns the state machine.
 	deviceStore *deviceStore
 
-	// refreshStore owns the Secret-backed map of sha256(refresh_token)
+	// RefreshStore owns the Secret-backed map of sha256(refresh_token)
 	// → record. Wired by NewServer with the configured (or defaulted)
 	// broker-namespace Secret. Survives broker restarts unlike
 	// deviceStore. Universe-onboarding PR4. The k8s client lives on
 	// the Issuer; NewServer passes it through so the store and the
 	// issuer share one client.
-	refreshStore *refreshStore
+	refreshStore *RefreshStore
+
+	// idTokenSigner mints broker-signed id_tokens on the
+	// /device/token refresh-grant path and serves its public key at
+	// /.well-known/jwks.json. May be nil in tests that don't
+	// exercise the refresh-grant surface; production wiring always
+	// supplies one (NewServer.LoadConfig validates the PEM at
+	// startup). Same signer satisfies both sign and verify (broker
+	// is the only relying party for its own tokens).
+	idTokenSigner *IDTokenSigner
+
+	// jwks holds the pre-rendered JWKS body served at
+	// /.well-known/jwks.json. Nil when idTokenSigner is nil;
+	// Routes() skips the registration in that case so existing
+	// tests that pass nil signers behave unchanged.
+	jwks *jwksHandler
 
 	// subjectReg is the per-subject limiter shared across the three
 	// /tokens routes; loginReg is the per-IP limiter for /auth/login.
@@ -57,12 +73,19 @@ type Server struct {
 	trustForwardedFor bool
 }
 
-// NewServer wires a Server. The caller is responsible for constructing the
-// Signer, Verifier, Issuer, and Discovery in advance — keeps this
-// constructor cheap enough for tests to call directly. discovery is
-// optional: tests that don't exercise the well-known route pass nil and
-// Routes() skips registering it.
-func NewServer(cfg *Config, signer *Signer, verifier Verifier, issuer *Issuer, discovery *Discovery, log *slog.Logger) *Server {
+// NewServer wires a Server. The caller is responsible for constructing
+// the Signer, Verifier, Issuer, Discovery, and (optionally)
+// IDTokenSigner in advance — keeps this constructor cheap enough for
+// tests to call directly. discovery and idTokenSigner are optional:
+// tests that don't exercise those surfaces pass nil and Routes() skips
+// the corresponding registrations.
+//
+// When idTokenSigner is non-nil, NewServer composes the supplied
+// Verifier with the broker-key verification leg (see
+// compositeVerifier in oidc.go) — callers don't have to wrap
+// manually, and tests that pass &fakeVerifier{} get broker-signed
+// verification "for free" against the supplied signer.
+func NewServer(cfg *Config, signer *Signer, verifier Verifier, issuer *Issuer, discovery *Discovery, idTokenSigner *IDTokenSigner, log *slog.Logger) *Server {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -85,6 +108,15 @@ func NewServer(cfg *Config, signer *Signer, verifier Verifier, issuer *Issuer, d
 	if cfg.Server.RefreshTokenTTL <= 0 {
 		cfg.Server.RefreshTokenTTL = defaultRefreshTokenTTL
 	}
+	if cfg.Server.IDTokenTTL <= 0 {
+		cfg.Server.IDTokenTTL = defaultIDTokenTTL
+	}
+	// Wrap the supplied Verifier with the broker-key leg whenever a
+	// signer is wired. Callers never see the wrapping — Server.verifier
+	// is the composite under the same Verifier interface.
+	if idTokenSigner != nil {
+		verifier = newCompositeVerifier(verifier, idTokenSigner, cfg.Server.PublicURL)
+	}
 	clock := time.Now
 	s := &Server{
 		cfg:               cfg,
@@ -92,11 +124,24 @@ func NewServer(cfg *Config, signer *Signer, verifier Verifier, issuer *Issuer, d
 		verifier:          verifier,
 		issuer:            issuer,
 		discovery:         discovery,
+		idTokenSigner:     idTokenSigner,
 		log:               log,
 		clock:             clock,
 		deviceStore:       newDeviceStore(clock, deviceTTL, pollInterval),
-		refreshStore:      newRefreshStore(cfg, issuer.k8s),
+		refreshStore:      NewRefreshStore(cfg, issuer.k8s),
 		trustForwardedFor: cfg.RateLimit.TrustForwardedFor,
+	}
+	if idTokenSigner != nil {
+		jwks, err := newJWKSHandler(idTokenSigner)
+		if err != nil {
+			// Marshal failure is purely a programming error — the
+			// JWK struct cannot legitimately fail to serialize.
+			// Panic rather than hide the surface as silently
+			// missing; the broker is unsafe to serve refresh
+			// grants without a verifiable JWKS.
+			panic(fmt.Sprintf("broker: render JWKS at startup: %v", err))
+		}
+		s.jwks = jwks
 	}
 	// Build the registries unless the operator disabled the limiter
 	// entirely. newRateLimitRegistry returns nil for zero/negative
@@ -136,6 +181,14 @@ func (s *Server) Routes() http.Handler {
 	if s.discovery != nil {
 		mux.Handle("GET /.well-known/openid-configuration", s.discovery.Handler())
 	}
+	// JWKS: served only when the broker has a signing key. Public,
+	// unauthenticated, no rate limit — same posture as the OIDC
+	// discovery doc (every OAuth client library expects the JWKS
+	// available without auth so it can validate id_tokens against
+	// the issuer the discovery doc advertises).
+	if s.jwks != nil {
+		mux.Handle("GET /.well-known/jwks.json", s.jwks)
+	}
 	mux.Handle("GET /auth/login", s.ipRateLimit(http.HandlerFunc(s.authLogin)))
 	mux.HandleFunc("GET /auth/callback", s.authCallback)
 	// RFC 8628 device-flow surface. All POST surfaces sit behind the
@@ -151,6 +204,11 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("GET /device", s.deviceFormGet)
 	mux.Handle("POST /device", s.ipRateLimit(http.HandlerFunc(s.deviceFormPost)))
 	mux.Handle("POST /device/token", s.ipRateLimit(http.HandlerFunc(s.deviceToken)))
+	// RFC 7009 token revocation. Unauthenticated (possession of
+	// the token IS the authz signal) under the IP limiter for
+	// defense-in-depth. PR4 only operates on refresh tokens; the
+	// world tokens have their own DELETE /tokens/{label} surface.
+	mux.Handle("POST /token/revoke", s.ipRateLimit(http.HandlerFunc(s.tokenRevoke)))
 	authedSubject := func(h http.HandlerFunc) http.Handler {
 		return s.requireAuth(s.subjectRateLimit(h))
 	}
@@ -159,6 +217,14 @@ func (s *Server) Routes() http.Handler {
 	mux.Handle("POST /tokens/{label}/rotate", authedSubject(s.rotateToken))
 	return mux
 }
+
+// RefreshStore exposes the broker's refresh-token store so the
+// Sweeper (constructed in main.go alongside the Issuer-driven
+// issuance sweeper) can share a single instance. Returns nil only
+// if NewServer somehow skipped construction — not a production
+// path. Kept as a method (not a public field) so the lifecycle
+// remains "Server owns construction; callers borrow."
+func (s *Server) RefreshStore() *RefreshStore { return s.refreshStore }
 
 func (s *Server) healthz(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)

--- a/tools/demarkus-broker/internal/broker/server_test.go
+++ b/tools/demarkus-broker/internal/broker/server_test.go
@@ -44,17 +44,35 @@ func newTestServer(t *testing.T, cfg *Config, verifier Verifier, k8s *fake.Clien
 	t.Helper()
 	signer := newTestSigner(t)
 	issuer := newIssuer(t, cfg, k8s)
+	// Default: no id-token signer wired. Refresh-grant tests use
+	// newTestServerWithSigner so existing tests don't acquire an
+	// extra (unobservable) construction cost they don't care about.
 	// Leave the server's clock at the default time.Now — pinning it to
 	// the issuer's fixed date would expire the OIDC state cookie under
 	// any real wall-clock that is later than that date, breaking the
 	// callback tests. The issuer's clock stays pinned so token-expiry
 	// assertions in issuer tests remain deterministic.
-	brokerSrv = NewServer(cfg, signer, verifier, issuer, nil, nil)
+	brokerSrv = NewServer(cfg, signer, verifier, issuer, nil, nil, nil)
 	// NewTLSServer (not NewServer): the state cookie is set with
 	// Secure=true and Path=/auth/callback, attributes only enforceable
 	// over HTTPS. Without TLS we'd be relying on manual AddCookie calls
 	// in tests, which bypass jar policy and mask regressions where the
 	// cookie scope was accidentally widened.
+	testSrv = httptest.NewTLSServer(brokerSrv.Routes())
+	t.Cleanup(testSrv.Close)
+	return testSrv, brokerSrv
+}
+
+// newTestServerWithSigner is the test helper for refresh-grant /
+// JWKS / broker-signed verification tests. Identical shape to
+// newTestServer but wires an ephemeral IDTokenSigner so /device/token
+// refresh, /.well-known/jwks.json, and the composite-verifier
+// broker-leg are all live.
+func newTestServerWithSigner(t *testing.T, cfg *Config, verifier Verifier, k8s *fake.Clientset, signer *IDTokenSigner) (testSrv *httptest.Server, brokerSrv *Server) {
+	t.Helper()
+	cookieSigner := newTestSigner(t)
+	issuer := newIssuer(t, cfg, k8s)
+	brokerSrv = NewServer(cfg, cookieSigner, verifier, issuer, nil, signer, nil)
 	testSrv = httptest.NewTLSServer(brokerSrv.Routes())
 	t.Cleanup(testSrv.Close)
 	return testSrv, brokerSrv
@@ -97,7 +115,7 @@ func TestWellKnownDiscoveryRouteRegistered(t *testing.T) {
 		t.Fatalf("NewDiscovery: %v", err)
 	}
 	cfg := testConfig()
-	srv := NewServer(cfg, newTestSigner(t), &fakeVerifier{}, NewIssuer(cfg, fake.NewSimpleClientset()), d, nil)
+	srv := NewServer(cfg, newTestSigner(t), &fakeVerifier{}, NewIssuer(cfg, fake.NewSimpleClientset()), d, nil, nil)
 	tsrv := httptest.NewServer(srv.Routes())
 	t.Cleanup(tsrv.Close)
 
@@ -783,7 +801,7 @@ func TestRotateTokenUnauthenticated(t *testing.T) {
 // Sanity guard so the clock override on Server is exercised at least once.
 func TestServerClockExposed(t *testing.T) {
 	cfg := testConfig()
-	s := NewServer(cfg, newTestSigner(t), &fakeVerifier{}, NewIssuer(cfg, fake.NewSimpleClientset()), nil, nil)
+	s := NewServer(cfg, newTestSigner(t), &fakeVerifier{}, NewIssuer(cfg, fake.NewSimpleClientset()), nil, nil, nil)
 	fixed := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	s.clock = func() time.Time { return fixed }
 	if !s.clock().Equal(fixed) {

--- a/tools/demarkus-broker/internal/broker/server_test.go
+++ b/tools/demarkus-broker/internal/broker/server_test.go
@@ -93,6 +93,35 @@ func TestHealthAndReady(t *testing.T) {
 	}
 }
 
+// TestNewServerPanicsOnDiscoveryWithoutSigner pins the construction
+// invariant added in PR4 review: a Discovery doc that advertises
+// jwks_uri at a route the broker doesn't serve is broken-by-
+// construction. NewServer panics rather than silently produce a
+// half-wired surface.
+func TestNewServerPanicsOnDiscoveryWithoutSigner(t *testing.T) {
+	idpMux := http.NewServeMux()
+	idpMux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"issuer":"https://idp.example.com"}`)
+	})
+	idp := httptest.NewServer(idpMux)
+	t.Cleanup(idp.Close)
+	d, err := NewDiscovery(context.Background(), DiscoveryConfig{
+		BrokerURL: "https://broker.example.com",
+		IdPIssuer: idp.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewDiscovery: %v", err)
+	}
+	cfg := testConfig()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for discovery != nil + idTokenSigner == nil")
+		}
+	}()
+	NewServer(cfg, newTestSigner(t), &fakeVerifier{}, NewIssuer(cfg, fake.NewSimpleClientset()), d, nil, nil)
+}
+
 // TestWellKnownDiscoveryRouteRegistered guards the Routes() composition:
 // when a Discovery is wired into NewServer, the broker mux exposes it at
 // /.well-known/openid-configuration. The discovery_test.go suite covers
@@ -115,7 +144,11 @@ func TestWellKnownDiscoveryRouteRegistered(t *testing.T) {
 		t.Fatalf("NewDiscovery: %v", err)
 	}
 	cfg := testConfig()
-	srv := NewServer(cfg, newTestSigner(t), &fakeVerifier{}, NewIssuer(cfg, fake.NewSimpleClientset()), d, nil, nil)
+	// PR4 invariant: discovery != nil requires a non-nil
+	// IDTokenSigner so the jwks_uri override the discovery doc
+	// advertises actually has a handler mounted. NewServer panics
+	// otherwise.
+	srv := NewServer(cfg, newTestSigner(t), &fakeVerifier{}, NewIssuer(cfg, fake.NewSimpleClientset()), d, newTestIDTokenSigner(t), nil)
 	tsrv := httptest.NewServer(srv.Routes())
 	t.Cleanup(tsrv.Close)
 

--- a/tools/demarkus-broker/internal/broker/sweeper.go
+++ b/tools/demarkus-broker/internal/broker/sweeper.go
@@ -36,10 +36,11 @@ import (
 // coordination.k8s.io/Lease runs the sweep loop. The other replicas
 // keep serving Mint/List/Revoke (those don't need a leader).
 type Sweeper struct {
-	issuer   *Issuer
-	interval time.Duration
-	clock    func() time.Time
-	log      *slog.Logger
+	issuer       *Issuer
+	refreshStore *RefreshStore
+	interval     time.Duration
+	clock        func() time.Time
+	log          *slog.Logger
 	// sweepHook fires after each sweep pass when non-nil. Test-only
 	// observability point so the leader-election test can count which
 	// replica's loop is running without scraping logs or polling the
@@ -52,11 +53,18 @@ type Sweeper struct {
 // timings live in RunLeaderElected. A nil logger falls back to slog
 // default so callers building one for ad-hoc tests don't have to plumb
 // a handler through.
-func NewSweeper(i *Issuer, interval time.Duration, log *slog.Logger) *Sweeper {
+//
+// refreshStore is optional: when non-nil the per-tick loop also
+// sweeps expired refresh tokens from the broker's refresh-tokens
+// Secret (PR4 Step 5). Passing nil keeps the sweeper limited to
+// the issuance surface — the pre-PR4 behavior. Production wiring
+// passes the same *RefreshStore that the Server holds so both
+// share a consistent view of the Secret.
+func NewSweeper(i *Issuer, refreshStore *RefreshStore, interval time.Duration, log *slog.Logger) *Sweeper {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &Sweeper{issuer: i, interval: interval, clock: time.Now, log: log}
+	return &Sweeper{issuer: i, refreshStore: refreshStore, interval: interval, clock: time.Now, log: log}
 }
 
 // RunLeaderElected blocks until ctx is canceled, running the sweep loop
@@ -209,6 +217,19 @@ func (s *Sweeper) sweep(ctx context.Context) error {
 		s.log.InfoContext(ctx, "broker: swept",
 			"label", iss.Label, "world", iss.World,
 			"subject", hashSubject(iss.Email), "reason", reason)
+	}
+	// Refresh-token sweep runs after issuances so a transient
+	// failure here does not roll back the issuance-side progress.
+	// Non-fatal: the issuance sweep is the leader-elected critical
+	// path; refresh-token cleanup is best-effort with the next tick
+	// catching anything missed.
+	if s.refreshStore != nil {
+		swept, err := s.refreshStore.Sweep(ctx)
+		if err != nil {
+			s.log.ErrorContext(ctx, "broker: refresh token sweep failed", "err", err)
+		} else if swept > 0 {
+			s.log.InfoContext(ctx, "broker: swept refresh tokens", "count", swept)
+		}
 	}
 	return nil
 }

--- a/tools/demarkus-broker/internal/broker/sweeper_test.go
+++ b/tools/demarkus-broker/internal/broker/sweeper_test.go
@@ -144,7 +144,7 @@ func TestSweepRetiresExpiredKeepsFresh(t *testing.T) {
 	})
 
 	issuer := newIssuer(t, testConfig(), k8s)
-	s := NewSweeper(issuer, time.Hour, nil)
+	s := NewSweeper(issuer, nil, time.Hour, nil)
 	s.clock = func() time.Time { return now }
 
 	if err := s.sweep(context.Background()); err != nil {
@@ -204,7 +204,7 @@ func TestSweepPrunesDrift(t *testing.T) {
 	})
 
 	issuer := newIssuer(t, testConfig(), k8s)
-	s := NewSweeper(issuer, time.Hour, nil)
+	s := NewSweeper(issuer, nil, time.Hour, nil)
 	s.clock = func() time.Time { return now }
 
 	if err := s.sweep(context.Background()); err != nil {
@@ -246,7 +246,7 @@ func TestSweepSkipsUnconfiguredWorld(t *testing.T) {
 	})
 
 	issuer := newIssuer(t, testConfig(), k8s)
-	s := NewSweeper(issuer, time.Hour, nil)
+	s := NewSweeper(issuer, nil, time.Hour, nil)
 	s.clock = func() time.Time { return now }
 
 	if err := s.sweep(context.Background()); err != nil {
@@ -267,7 +267,7 @@ func TestSweepEmptyIssuancesIsNoop(t *testing.T) {
 	// touching any world Secret.
 	k8s := fake.NewSimpleClientset()
 	issuer := newIssuer(t, testConfig(), k8s)
-	s := NewSweeper(issuer, time.Hour, nil)
+	s := NewSweeper(issuer, nil, time.Hour, nil)
 	if err := s.sweep(context.Background()); err != nil {
 		t.Fatalf("sweep on empty state: %v", err)
 	}
@@ -278,6 +278,57 @@ func TestSweepEmptyIssuancesIsNoop(t *testing.T) {
 	}
 	if len(list.Items) != 0 {
 		t.Errorf("empty sweep created team-a Secrets: %d", len(list.Items))
+	}
+}
+
+func TestSweepRemovesExpiredRefreshTokens(t *testing.T) {
+	// PR4 Step 5: when the Sweeper is wired with a *RefreshStore,
+	// its per-tick pass must also remove expired refresh-token
+	// records from the broker-namespace Secret. The issuance leg
+	// is exercised in the surrounding tests; this one targets the
+	// new code path in isolation.
+	k8s := fake.NewSimpleClientset()
+	cfg := testRefreshConfig()
+	rs := NewRefreshStore(cfg, k8s)
+	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	rs.clock = func() time.Time { return base }
+
+	short, err := rs.Issue(context.Background(), Claims{Email: "short@x.com", EmailVerified: true}, time.Hour)
+	if err != nil {
+		t.Fatalf("Issue short: %v", err)
+	}
+	long, err := rs.Issue(context.Background(), Claims{Email: "long@x.com", EmailVerified: true}, 48*time.Hour)
+	if err != nil {
+		t.Fatalf("Issue long: %v", err)
+	}
+
+	// Advance the store's clock past the short token's ExpiresAt
+	// but not the long one's.
+	rs.clock = func() time.Time { return base.Add(2 * time.Hour) }
+
+	issuer := newIssuer(t, cfg, k8s)
+	s := NewSweeper(issuer, rs, time.Hour, nil)
+	if err := s.sweep(context.Background()); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+
+	if _, err := rs.Refresh(context.Background(), short); err == nil {
+		t.Errorf("expired token survived sweep")
+	}
+	if _, err := rs.Refresh(context.Background(), long); err != nil {
+		t.Errorf("long-lived token swept by accident: %v", err)
+	}
+}
+
+func TestSweepNoRefreshStoreIsNoop(t *testing.T) {
+	// Backward-compat with pre-PR4 callers: Sweeper constructed
+	// without a RefreshStore must not panic when its per-tick loop
+	// reaches the refresh-sweep block. Exercises the nil-skip.
+	k8s := fake.NewSimpleClientset()
+	issuer := newIssuer(t, testConfig(), k8s)
+	s := NewSweeper(issuer, nil, time.Hour, nil)
+	if err := s.sweep(context.Background()); err != nil {
+		t.Fatalf("sweep with nil refreshStore: %v", err)
 	}
 }
 
@@ -298,7 +349,7 @@ func TestSweeperLeaderElection(t *testing.T) {
 	// with its own counter.
 	makeReplica := func(identity string) (*Sweeper, *atomic.Int32) {
 		var count atomic.Int32
-		s := NewSweeper(newIssuer(t, cfg, k8s), 30*time.Millisecond, nil)
+		s := NewSweeper(newIssuer(t, cfg, k8s), nil, 30*time.Millisecond, nil)
 		s.sweepHook = func() { count.Add(1) }
 		_ = identity // wired into RunLeaderElected below
 		return s, &count

--- a/tools/demarkus-broker/main.go
+++ b/tools/demarkus-broker/main.go
@@ -75,7 +75,7 @@ func run(configPath, kubeconfigPath string, log *slog.Logger) error {
 	// to start rather than failing the first user login. coreos/go-oidc
 	// does not use this context for ongoing JWKS refresh (it builds its
 	// own background context internally), so a plain Background suffices.
-	verifier, err := broker.NewVerifier(context.Background(), cfg.OIDC)
+	verifier, err := broker.NewVerifier(context.Background(), &cfg.OIDC)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,19 @@ func run(configPath, kubeconfigPath string, log *slog.Logger) error {
 		return err
 	}
 
-	srv := broker.NewServer(cfg, signer, verifier, issuer, discovery, log)
+	// Broker-side ECDSA signer for the /device/token refresh-grant
+	// path (PR4). Required because PR4 ships broker-signed
+	// id_tokens with a broker-hosted JWKS — without this, refresh
+	// responses can't be verified by /me/install in PR5. Parsed
+	// once at startup; an invalid PEM fails the pod fast rather
+	// than the first refresh.
+	idTokenSigner, err := broker.NewIDTokenSigner([]byte(cfg.OIDC.BrokerSigningKey))
+	if err != nil {
+		return err
+	}
+	log.Info("broker: id_token signer ready", "kid", idTokenSigner.KeyID())
+
+	srv := broker.NewServer(cfg, signer, verifier, issuer, discovery, idTokenSigner, log)
 	if cfg.RateLimit.Disabled {
 		log.Info("broker: rate limit disabled (rateLimit.disabled=true)")
 	} else {
@@ -138,7 +150,11 @@ func run(configPath, kubeconfigPath string, log *slog.Logger) error {
 	defer cancelSweep()
 	var sweepWG sync.WaitGroup
 	if !cfg.Sweeper.Disabled {
-		sweeper := broker.NewSweeper(issuer, cfg.Sweeper.Interval, log)
+		// Share the Server's refresh-token store so the sweeper
+		// operates on the same in-memory cache + Secret view the
+		// /device/token refresh-grant handler does. Server owns
+		// the lifecycle; Sweeper just borrows.
+		sweeper := broker.NewSweeper(issuer, srv.RefreshStore(), cfg.Sweeper.Interval, log)
 		identity := brokerIdentity()
 		log.Info("broker: starting sweeper",
 			"interval", cfg.Sweeper.Interval, "leaseName", cfg.Sweeper.LeaseName,

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -6,6 +6,7 @@ replace github.com/latebit/demarkus/protocol => ../protocol
 
 require (
 	github.com/coreos/go-oidc/v3 v3.18.0
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/latebit/demarkus/protocol v0.0.0-00010101000000-000000000000
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/time v0.14.0
@@ -20,7 +21,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refresh-token grant with configurable TTLs, token revocation endpoint (RFC 7009), broker-issued ID tokens and a public JWKS endpoint.
  * Installer/chart: configurable broker signing key (inline or secret) and a persistent refresh-tokens Secret preserved across upgrades.

* **Documentation**
  * Updated chart install guidance with secure values-file examples for signing keys.

* **Tests**
  * Expanded unit and chart tests covering signing, JWKS, refresh flow, revocation, and RBAC/template behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->