### PR TITLE
fix(broker):  Add GET /me/install endpoint for per-user install bundlesai

### DIFF
--- a/deploy/helm/demarkus-broker/README.md
+++ b/deploy/helm/demarkus-broker/README.md
@@ -24,6 +24,72 @@ Secrets and tracking ownership in a broker-namespace issuances Secret.
   cert-manager-managed TLS Certificate.
 - TopologySpreadConstraints to keep replicas off the same node.
 
+## Endpoint surface
+
+| Method | Path | Auth | Notes |
+| --- | --- | --- | --- |
+| `GET` | `/healthz`, `/readyz` | none | Liveness / readiness probes. |
+| `GET` | `/.well-known/openid-configuration` | none | Broker discovery doc; proxies the IdP's doc with `issuer`, `device_authorization_endpoint`, `token_endpoint`, and `jwks_uri` rewritten to the broker. 5-minute TTL. |
+| `GET` | `/.well-known/jwks.json` | none | Public ECDSA P-256 key for broker-signed `id_token`s (refresh-grant output). |
+| `GET` | `/auth/login` | none | OIDC code-flow login redirect. IP rate-limited. |
+| `GET` | `/auth/callback` | OIDC state cookie | OIDC code-flow callback; mints per-world tokens; dispatches device-flow handoffs by signed state. |
+| `POST` | `/device/authorize`, `/device/token` | none | RFC 8628 device flow. IP rate-limited. `/device/token` accepts both `grant_type=urn:ietf:params:oauth:grant-type:device_code` and `grant_type=refresh_token`. |
+| `GET`, `POST` | `/device` | none | HTML user-code entry form. |
+| `POST` | `/token/revoke` | possession | RFC 7009 refresh-token revocation. IP rate-limited. |
+| `GET` | `/tokens` | Bearer id_token | Caller's issuance records. Per-subject rate-limited. |
+| `DELETE` | `/tokens/{label}` | Bearer id_token | Owner-only revoke. Per-subject rate-limited. |
+| `POST` | `/tokens/{label}/rotate` | Bearer id_token | Owner-only rotate. Per-subject rate-limited. |
+| `GET` | `/me/install` | Bearer id_token | Per-user install bundle (universe onboarding). Per-subject rate-limited. |
+
+### `/me/install`
+
+Returns the caller's full install bundle — one entry per world the
+verified identity is authorized for AND that has a non-empty
+`publicURL` configured. Each call mints a fresh access token per
+returned world; raw token material is never recoverable from the
+issuances Secret, so reuse is not possible. Old tokens stay valid
+until their `expiresAt`; the sweeper retires them.
+
+```
+GET /me/install
+Authorization: Bearer <id_token>
+
+200 OK
+Content-Type: application/json
+Cache-Control: no-store
+Pragma: no-cache
+{
+  "worlds": [
+    {
+      "name": "team-a",
+      "publicURL": "mark://team-a.example:6309",
+      "label": "usr_b23fbc20",
+      "accessToken": "<raw token>",
+      "expiresAt": "2026-05-16T18:00:00Z"
+    }
+  ]
+}
+```
+
+Notes:
+- **Worlds without `publicURL` are excluded.** A world with an empty
+  `worlds[].publicURL` is structurally un-installable (the client has
+  no address to wire) so the broker filters it BEFORE mint — no
+  issuance record is written for excluded worlds.
+- **Empty `worlds: []` is a 200, not a 403.** An authenticated identity
+  with zero installable worlds (no allowlist match, or every match
+  filtered by the `publicURL` rule) returns `200 + worlds: []` so
+  consumers can distinguish auth failure from authz emptiness.
+- **Partial failures return 200.** If some worlds minted but a later
+  one failed (k8s blip, RBAC denial on one world's tokens Secret), the
+  response carries the successful entries plus a
+  `"partialFailure": "one_or_more_worlds_failed"` field — same shape
+  as `/auth/callback` for the equivalent condition.
+- **The bearer accepts both broker-signed and IdP-signed id_tokens.**
+  Broker-signed tokens come from the device-flow refresh grant; IdP-
+  signed tokens come from the device-flow completion. The broker's
+  composite verifier dispatches by `kid`.
+
 ## Quick install (development)
 
 Put sensitive values in a values file rather than on the command line —

--- a/deploy/helm/demarkus-broker/README.md
+++ b/deploy/helm/demarkus-broker/README.md
@@ -50,7 +50,7 @@ returned world; raw token material is never recoverable from the
 issuances Secret, so reuse is not possible. Old tokens stay valid
 until their `expiresAt`; the sweeper retires them.
 
-```
+```http
 GET /me/install
 Authorization: Bearer <id_token>
 

--- a/tools/demarkus-broker/internal/broker/install.go
+++ b/tools/demarkus-broker/internal/broker/install.go
@@ -1,0 +1,198 @@
+package broker
+
+import (
+	"errors"
+	"net/http"
+	"time"
+)
+
+// installResponse is the JSON shape returned by GET /me/install. The
+// field names — name, publicURL, label, accessToken, expiresAt — are the
+// wire contract shared with tools/demarkus-join (PR6) and the plugin
+// slash commands (PR7); keep them stable.
+//
+// PartialFailure is omitted when zero or all worlds minted successfully.
+// When a subset succeeded, it carries a stable client-safe code (full
+// error detail stays in the broker log) so the consumer can surface a
+// "your install completed for some worlds but not others — try again"
+// message without parsing free-form error text.
+type installResponse struct {
+	Worlds         []installWorld `json:"worlds"`
+	PartialFailure string         `json:"partialFailure,omitempty"`
+}
+
+// installWorld is one row of the install bundle. PublicURL is always
+// populated (worlds without a PublicURL are filtered out before mint
+// by the MintFiltered predicate in meInstall — see install.go's
+// filtering comment). Label is included so /tokens/{label}/rotate and
+// DELETE /tokens/{label} are actionable from the install bundle
+// without a second round trip to GET /tokens.
+type installWorld struct {
+	Name        string    `json:"name"`
+	PublicURL   string    `json:"publicURL"`
+	Label       string    `json:"label"`
+	AccessToken string    `json:"accessToken"`
+	ExpiresAt   time.Time `json:"expiresAt"`
+}
+
+// meInstall handles GET /me/install. Authenticated via requireAuth
+// upstream; rate-limited per-subject by subjectRateLimit. The endpoint
+// returns the caller's full install bundle — one entry per world the
+// identity is authorized for AND that has a PublicURL configured.
+//
+// Side effect: every call MINTS A FRESH ACCESS TOKEN per returned
+// world. Raw token material is never recoverable from the issuances
+// Secret (only the hash lives on disk), so there is no reuse path —
+// the alternative would be "no token returned" which defeats the
+// purpose of /me/install. Old tokens stay valid until ExpiresAt; the
+// Sweeper retires them. GET (vs POST) matches the OAuth /me-style
+// convention; the mint side-effect is the price of the convention,
+// not a sign of REST-idempotent semantics.
+//
+// Response shape:
+//
+//	200 OK
+//	Content-Type: application/json
+//	Cache-Control: no-store
+//	Pragma: no-cache
+//	{
+//	  "worlds": [
+//	    {
+//	      "name": "team-a",
+//	      "publicURL": "mark://world-a.example:6309",
+//	      "label": "usr_b23fbc20",
+//	      "accessToken": "<raw token>",
+//	      "expiresAt": "2026-05-16T18:00:00Z"
+//	    }
+//	  ]
+//	}
+//
+// Empty-worlds policy: an authenticated identity with zero authorized
+// worlds (or with all authorized worlds filtered by the PublicURL
+// predicate) returns 200 + worlds: []. NOT 403. The user IS
+// authenticated; the absence of installable worlds is an authz-config
+// emptiness story, not an auth-failure story. The plugin layer needs
+// to distinguish these so it can surface a "no worlds authorized for
+// your identity" message rather than retrying auth.
+//
+// Partial failure: when some worlds minted successfully but a later
+// one failed (k8s API blip, RBAC denial on one world's Secret, etc.),
+// returns 200 + the successful worlds + a "partialFailure" code.
+// Matches /auth/callback's shape for the same condition so consumers
+// have one error model across the two mint paths.
+func (s *Server) meInstall(w http.ResponseWriter, r *http.Request) {
+	claims, ok := claimsFromCtx(r.Context())
+	if !ok {
+		// Programming error: route registered without requireAuth
+		// upstream. Fail closed with 500 so a future route-table
+		// edit that drops requireAuth surfaces immediately rather
+		// than serving a bundle to anonymous callers.
+		s.log.ErrorContext(r.Context(), "broker: meInstall missing claims in context — middleware miswired")
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	// Filter at mint time, not after. A world without a PublicURL is
+	// structurally un-installable (the plugin has no address to wire
+	// the client at) — minting a token for it would write an
+	// issuance record we'd then discard from the response, churning
+	// the issuances Secret toward its 5000-record cap for zero
+	// behavioral gain. MintFiltered drops the world before any
+	// Secret is touched.
+	keep := func(world *WorldConfig) bool { return world.PublicURL != "" }
+	results, mintErr := s.issuer.MintFiltered(r.Context(), claims, keep)
+
+	// no-store + no-cache: response body carries raw access tokens
+	// that must not be cached by intermediaries, browser disk caches,
+	// or proxies. Set BEFORE WriteHeader (writeJSON flushes headers)
+	// so the directives actually land on the wire.
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+
+	if mintErr != nil {
+		// Partial mint: some worlds succeeded before a later one
+		// failed. Same shape as /auth/callback so consumers see one
+		// error model across the two mint paths.
+		if len(results) > 0 {
+			s.log.WarnContext(r.Context(), "broker: /me/install partial mint",
+				"err", mintErr, "subject", hashSubject(claims.Subject), "minted", len(results))
+			writeJSON(w, http.StatusOK, installResponse{
+				Worlds:         s.toInstallWorlds(results),
+				PartialFailure: "one_or_more_worlds_failed",
+			})
+			return
+		}
+		if errors.Is(mintErr, ErrNotAuthorized) {
+			// Authenticated identity with zero authorized worlds (or
+			// every authorized world filtered by the PublicURL
+			// predicate). 200 + worlds: [] — see the empty-worlds
+			// policy in the function doc comment.
+			s.log.InfoContext(r.Context(), "broker: /me/install no installable worlds for identity",
+				"subject", hashSubject(claims.Subject))
+			writeJSON(w, http.StatusOK, installResponse{Worlds: []installWorld{}})
+			return
+		}
+		if errors.Is(mintErr, ErrEmailUnverified) {
+			// Defense in depth. The production Verifier rejects
+			// unverified identities at the bearer-validation layer
+			// (requireAuth), so this branch is structurally
+			// unreachable in production wiring — but a future
+			// Verifier impl or a test double might admit an
+			// unverified identity, and the cost of an unverified
+			// install bundle slipping through is the same as an
+			// unverified /auth/callback mint.
+			s.log.InfoContext(r.Context(), "broker: /me/install rejected unverified identity",
+				"subject", hashSubject(claims.Subject))
+			http.Error(w, "email not verified", http.StatusForbidden)
+			return
+		}
+		s.log.ErrorContext(r.Context(), "broker: /me/install mint failed",
+			"err", mintErr, "subject", hashSubject(claims.Subject))
+		http.Error(w, "mint failed", http.StatusInternalServerError)
+		return
+	}
+	s.log.InfoContext(r.Context(), "broker: /me/install succeeded",
+		"subject", hashSubject(claims.Subject), "worlds", len(results))
+	writeJSON(w, http.StatusOK, installResponse{Worlds: s.toInstallWorlds(results)})
+}
+
+// toInstallWorlds joins each MintResult with its world's PublicURL by
+// walking s.cfg.Worlds. O(N*M) with N = mint results, M = configured
+// worlds; both are bounded to dozens in realistic deployments and the
+// path is called at most once per session per user.
+//
+// MintFiltered's predicate already excluded worlds without a
+// PublicURL, so the lookup is guaranteed to find a non-empty value for
+// every result. A world that vanished from config between
+// MintFiltered's iteration and this join (an operator hot-reload
+// removing a world mid-request) would surface as an empty PublicURL;
+// that's a config-time race rather than a runtime fault, and we
+// prefer "publish the row with an empty publicURL" over hiding it —
+// the consumer (tools/demarkus-join) skips empty entries; the user
+// sees a "no worlds installed for X" message; logs and metrics keep
+// the partial-failure trail. The alternative would be a second mint-
+// path failure leg and a more confusing partial-failure response.
+func (s *Server) toInstallWorlds(results []MintResult) []installWorld {
+	out := make([]installWorld, 0, len(results))
+	for _, r := range results {
+		out = append(out, installWorld{
+			Name:        r.World,
+			PublicURL:   s.lookupPublicURL(r.World),
+			Label:       r.Label,
+			AccessToken: r.RawToken,
+			ExpiresAt:   r.ExpiresAt,
+		})
+	}
+	return out
+}
+
+// lookupPublicURL returns the configured PublicURL for the named world
+// or "" if the world is not in cfg.Worlds. See toInstallWorlds for the
+// empty-result handling rationale.
+func (s *Server) lookupPublicURL(name string) string {
+	for j := range s.cfg.Worlds {
+		if s.cfg.Worlds[j].Name == name {
+			return s.cfg.Worlds[j].PublicURL
+		}
+	}
+	return ""
+}

--- a/tools/demarkus-broker/internal/broker/install_test.go
+++ b/tools/demarkus-broker/internal/broker/install_test.go
@@ -1,0 +1,394 @@
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// installTestConfig returns a single-world fixture with team-a's
+// PublicURL set so the happy-path tests exercise the publication side
+// without the PublicURL-filter excluding everything.
+func installTestConfig() *Config {
+	cfg := testConfig()
+	cfg.Worlds[0].PublicURL = "mark://team-a.cluster.local:6309"
+	return cfg
+}
+
+// installTestConfigTwoWorlds adds team-b (same domain allow, different
+// PublicURL) so multi-world ordering, filtering, and partial-failure
+// tests have a deterministic two-world fixture.
+func installTestConfigTwoWorlds() *Config {
+	cfg := installTestConfig()
+	cfg.Worlds = append(cfg.Worlds, WorldConfig{
+		Name:         "team-b",
+		Namespace:    "team-b",
+		TokensSecret: "team-b-tokens",
+		PublicURL:    "mark://team-b.cluster.local:6309",
+		Allow:        AllowConfig{Domains: []string{"example.com"}},
+		DefaultToken: TokenScope{
+			Paths:        []string{"/team-b/*"},
+			Operations:   []string{"read"},
+			ExpiresAfter: 12 * time.Hour,
+		},
+	})
+	return cfg
+}
+
+func aliceClaims() Claims {
+	return Claims{Email: "alice@example.com", EmailVerified: true, Subject: "google|alice"}
+}
+
+// installReq constructs an authenticated GET /me/install request
+// against the supplied test server. The fakeVerifier under the default
+// newTestServer ignores the bearer's contents and returns its preset
+// claims; any non-empty string works.
+func installReq(t *testing.T, srv *httptest.Server, bearer string) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/me/install", http.NoBody)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := testClient(srv).Do(req)
+	if err != nil {
+		t.Fatalf("GET /me/install: %v", err)
+	}
+	return resp
+}
+
+func decodeInstall(t *testing.T, resp *http.Response) installResponse {
+	t.Helper()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	_ = resp.Body.Close()
+	var got installResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body=%s: %v", body, err)
+	}
+	return got
+}
+
+func TestMeInstallHappyPathSingleWorld(t *testing.T) {
+	cfg := installTestConfig()
+	verifier := &fakeVerifier{claims: aliceClaims()}
+	srv, _ := newTestServer(t, cfg, verifier, fake.NewSimpleClientset())
+
+	resp := installReq(t, srv, "id-token")
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body=%s", resp.StatusCode, body)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	got := decodeInstall(t, resp)
+	if got.PartialFailure != "" {
+		t.Errorf("PartialFailure = %q, want empty on happy path", got.PartialFailure)
+	}
+	if len(got.Worlds) != 1 {
+		t.Fatalf("worlds = %+v, want 1 entry", got.Worlds)
+	}
+	w := got.Worlds[0]
+	if w.Name != "team-a" {
+		t.Errorf("Name = %q, want team-a", w.Name)
+	}
+	if w.PublicURL != "mark://team-a.cluster.local:6309" {
+		t.Errorf("PublicURL = %q, want configured URL", w.PublicURL)
+	}
+	if !strings.HasPrefix(w.Label, LabelPrefix) {
+		t.Errorf("Label %q missing %q prefix", w.Label, LabelPrefix)
+	}
+	if w.AccessToken == "" {
+		t.Errorf("AccessToken empty")
+	}
+	if w.ExpiresAt.IsZero() {
+		t.Errorf("ExpiresAt zero")
+	}
+}
+
+func TestMeInstallMultiWorldOrdering(t *testing.T) {
+	// cfg.Worlds is iterated in declaration order by authorizedWorlds;
+	// MintFiltered preserves that, and toInstallWorlds maps results in
+	// place. Pin the contract: response worlds order matches cfg.Worlds.
+	cfg := installTestConfigTwoWorlds()
+	verifier := &fakeVerifier{claims: aliceClaims()}
+	srv, _ := newTestServer(t, cfg, verifier, fake.NewSimpleClientset())
+
+	resp := installReq(t, srv, "id-token")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	got := decodeInstall(t, resp)
+	if len(got.Worlds) != 2 {
+		t.Fatalf("worlds = %+v, want 2 entries", got.Worlds)
+	}
+	if got.Worlds[0].Name != "team-a" || got.Worlds[1].Name != "team-b" {
+		t.Errorf("ordering = [%s,%s], want [team-a,team-b] (cfg.Worlds declaration order)",
+			got.Worlds[0].Name, got.Worlds[1].Name)
+	}
+	if got.Worlds[1].PublicURL != "mark://team-b.cluster.local:6309" {
+		t.Errorf("team-b PublicURL = %q, want configured URL", got.Worlds[1].PublicURL)
+	}
+}
+
+func TestMeInstallFiltersWorldsWithoutPublicURL(t *testing.T) {
+	// Two-world fixture: alice qualifies for both, team-b has no
+	// PublicURL configured. /me/install must:
+	//   1. Return only team-a in the response body.
+	//   2. NOT write an issuance record for team-b — the filter has to
+	//      run BEFORE mint so the issuances Secret isn't churned with
+	//      records for un-installable worlds.
+	cfg := installTestConfigTwoWorlds()
+	cfg.Worlds[1].PublicURL = "" // team-b is un-installable
+	k8s := fake.NewSimpleClientset()
+	verifier := &fakeVerifier{claims: aliceClaims()}
+	srv, _ := newTestServer(t, cfg, verifier, k8s)
+
+	resp := installReq(t, srv, "id-token")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	got := decodeInstall(t, resp)
+	if len(got.Worlds) != 1 || got.Worlds[0].Name != "team-a" {
+		t.Errorf("worlds = %+v, want only team-a", got.Worlds)
+	}
+	// team-b's tokens Secret must not exist — predicate filtered before
+	// mint touched it.
+	if _, err := k8s.CoreV1().Secrets("team-b").Get(context.Background(), "team-b-tokens", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("team-b Secret unexpectedly created: %v", err)
+	}
+	// Issuances Secret must contain only team-a.
+	iss, err := k8s.CoreV1().Secrets(testBrokerNS).Get(context.Background(), testIssuancesNS, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get issuances Secret: %v", err)
+	}
+	body := string(iss.Data[IssuancesSecretKey])
+	if !strings.Contains(body, `"world":"team-a"`) {
+		t.Errorf("issuances Secret missing team-a entry: %s", body)
+	}
+	if strings.Contains(body, `"world":"team-b"`) {
+		t.Errorf("issuances Secret has team-b entry despite filter: %s", body)
+	}
+}
+
+func TestMeInstallNoBearerReturns401(t *testing.T) {
+	srv, _ := newTestServer(t, installTestConfig(), &fakeVerifier{claims: aliceClaims()}, fake.NewSimpleClientset())
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/me/install", http.NoBody)
+	resp, err := testClient(srv).Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestMeInstallBadBearerReturns401(t *testing.T) {
+	verifier := &fakeVerifier{verifyFn: func(string) (Claims, error) {
+		return Claims{}, errors.New("invalid token")
+	}}
+	srv, _ := newTestServer(t, installTestConfig(), verifier, fake.NewSimpleClientset())
+
+	resp := installReq(t, srv, "garbage")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestMeInstallEmptyWorldsReturns200EmptySlice(t *testing.T) {
+	// alice is authenticated but mallory@evil.example is not authorized
+	// for any world — the empty-worlds policy: 200 + worlds:[], NOT 403.
+	// The plugin layer needs to distinguish "auth failed" from "authz
+	// emptiness" so it can surface the right error to the user.
+	verifier := &fakeVerifier{claims: Claims{Email: "mallory@evil.example", EmailVerified: true, Subject: "g|mallory"}}
+	srv, _ := newTestServer(t, installTestConfig(), verifier, fake.NewSimpleClientset())
+
+	resp := installReq(t, srv, "id-token")
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200 (NOT 403). body=%s", resp.StatusCode, body)
+	}
+	got := decodeInstall(t, resp)
+	if got.Worlds == nil {
+		t.Errorf("Worlds = nil, want non-nil empty slice (JSON `[]`, not `null`)")
+	}
+	if len(got.Worlds) != 0 {
+		t.Errorf("Worlds = %+v, want []", got.Worlds)
+	}
+	if got.PartialFailure != "" {
+		t.Errorf("PartialFailure = %q, want empty", got.PartialFailure)
+	}
+}
+
+func TestMeInstallAllWorldsFilteredReturns200Empty(t *testing.T) {
+	// User IS authorized for team-a but team-a has no PublicURL. Same
+	// empty-worlds shape as the unauthorized case — the plugin can't
+	// tell auth-failed from authz-empty, and we don't want it to: both
+	// surface as "no installable worlds" in the UI.
+	cfg := installTestConfig()
+	cfg.Worlds[0].PublicURL = ""
+	verifier := &fakeVerifier{claims: aliceClaims()}
+	srv, _ := newTestServer(t, cfg, verifier, fake.NewSimpleClientset())
+
+	resp := installReq(t, srv, "id-token")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	got := decodeInstall(t, resp)
+	if len(got.Worlds) != 0 {
+		t.Errorf("Worlds = %+v, want []", got.Worlds)
+	}
+}
+
+func TestMeInstallUnverifiedEmailReturns403(t *testing.T) {
+	// Defense-in-depth gate: the production Verifier rejects unverified
+	// identities at the bearer-validation layer (requireAuth), but a
+	// test double or a future Verifier impl might admit one. /me/install
+	// must surface this as 403 so an unverified install bundle can never
+	// land in plugin hands.
+	verifier := &fakeVerifier{claims: Claims{Email: "alice@example.com", EmailVerified: false, Subject: "g|alice"}}
+	srv, _ := newTestServer(t, installTestConfig(), verifier, fake.NewSimpleClientset())
+
+	resp := installReq(t, srv, "id-token")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestMeInstallPartialFailureReturns200WithFlag(t *testing.T) {
+	// Two-world fixture, alice qualifies for both. team-b's Update is
+	// RBAC-denied. Response must be 200 + the team-a entry + a
+	// partialFailure code — same shape as /auth/callback so consumers
+	// have one error model for both mint paths.
+	cfg := installTestConfigTwoWorlds()
+	k8s := fake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-b-tokens", Namespace: "team-b"},
+		Data:       map[string][]byte{TokensSecretKey: {}},
+	})
+	k8s.PrependReactor("update", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ua, ok := action.(k8stesting.UpdateAction)
+		if !ok || ua.GetNamespace() != "team-b" {
+			return false, nil, nil
+		}
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Resource: "secrets"},
+			"team-b-tokens",
+			errors.New("denied"),
+		)
+	})
+	verifier := &fakeVerifier{claims: aliceClaims()}
+	srv, _ := newTestServer(t, cfg, verifier, k8s)
+
+	resp := installReq(t, srv, "id-token")
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200 + partialFailure. body=%s", resp.StatusCode, body)
+	}
+	got := decodeInstall(t, resp)
+	if got.PartialFailure == "" {
+		t.Errorf("PartialFailure empty, want a stable code")
+	}
+	if len(got.Worlds) != 1 || got.Worlds[0].Name != "team-a" {
+		t.Errorf("worlds = %+v, want only team-a (partial mint)", got.Worlds)
+	}
+}
+
+func TestMeInstallHardFailureReturns500(t *testing.T) {
+	// First world's Update is RBAC-denied with NO successful mints
+	// preceding it. zero results → hard failure path, 500.
+	cfg := installTestConfig()
+	k8s := fake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-a-tokens", Namespace: "team-a"},
+		Data:       map[string][]byte{TokensSecretKey: {}},
+	})
+	k8s.PrependReactor("update", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ua, ok := action.(k8stesting.UpdateAction)
+		if !ok || ua.GetNamespace() != "team-a" {
+			return false, nil, nil
+		}
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, "team-a-tokens", errors.New("denied"))
+	})
+	verifier := &fakeVerifier{claims: aliceClaims()}
+	srv, _ := newTestServer(t, cfg, verifier, k8s)
+
+	resp := installReq(t, srv, "id-token")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", resp.StatusCode)
+	}
+}
+
+func TestMeInstallSetsNoStoreHeaders(t *testing.T) {
+	// Bearer tokens in the response body must not be cached by browsers,
+	// proxies, or intermediaries. The Cache-Control + Pragma directives
+	// have to be set BEFORE WriteHeader; this test catches the
+	// regression where they'd be set after writeJSON flushes headers
+	// (silently dropped). Asserted on the success path; the empty-worlds
+	// and partial-failure paths use the same writeJSON helper after the
+	// same Set calls so they're transitively covered.
+	cfg := installTestConfig()
+	verifier := &fakeVerifier{claims: aliceClaims()}
+	srv, _ := newTestServer(t, cfg, verifier, fake.NewSimpleClientset())
+
+	resp := installReq(t, srv, "id-token")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", got)
+	}
+	if got := resp.Header.Get("Pragma"); got != "no-cache" {
+		t.Errorf("Pragma = %q, want no-cache", got)
+	}
+}
+
+func TestMeInstallAcceptsBrokerSignedBearer(t *testing.T) {
+	// Regression guard against PR4's compositeVerifier dispatch: a
+	// refresh-renewed bearer signed by the broker's own key must
+	// validate through requireAuth without hitting the IdP primary leg.
+	// Wires the test server with an IDTokenSigner so the broker's
+	// compositeVerifier is composed for real.
+	cfg := installTestConfig()
+	idTokenSigner := newTestIDTokenSigner(t)
+	// Primary verifier blows up if invoked — proving the broker-signed
+	// bearer never falls through to the IdP leg.
+	primary := &fakeVerifier{verifyFn: func(string) (Claims, error) {
+		return Claims{}, errors.New("primary verifier must not be invoked for broker-signed bearers")
+	}}
+	srv, _ := newTestServerWithSigner(t, cfg, primary, fake.NewSimpleClientset(), idTokenSigner)
+
+	raw, err := idTokenSigner.Sign(aliceClaims(), cfg.Server.PublicURL, time.Hour, time.Now())
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	resp := installReq(t, srv, raw)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d (broker-signed bearer should validate). body=%s", resp.StatusCode, body)
+	}
+	got := decodeInstall(t, resp)
+	if len(got.Worlds) != 1 || got.Worlds[0].Name != "team-a" {
+		t.Errorf("worlds = %+v, want team-a", got.Worlds)
+	}
+}

--- a/tools/demarkus-broker/internal/broker/issuer.go
+++ b/tools/demarkus-broker/internal/broker/issuer.go
@@ -107,7 +107,37 @@ var ErrNotFound = errors.New("broker: label not found in issuances")
 // the partial results are returned alongside the error so the caller can
 // hand back what was actually minted — the unfinished worlds are not
 // reflected in either Secret.
+//
+// Mint is the no-filter shape used by /auth/callback; surfaces that need
+// to narrow the candidate worlds before mint (e.g. /me/install, which
+// drops worlds without a PublicURL so the issuances Secret is not
+// polluted with records the install bundle would then drop anyway) call
+// MintFiltered with a predicate. Mint is preserved as a back-compat
+// wrapper so existing call sites are untouched.
 func (i *Issuer) Mint(ctx context.Context, claims Claims) ([]MintResult, error) {
+	return i.MintFiltered(ctx, claims, nil)
+}
+
+// MintFiltered is Mint with an optional per-world predicate applied
+// after the AllowConfig authorization check and before any Secret is
+// written. A nil keep is "accept all" — equivalent to Mint.
+//
+// Filter ordering matters: keep runs AFTER authorizedWorlds so the
+// caller can reason about the predicate's input as "worlds this
+// identity is already permitted to use." A keep that filters every
+// authorized world to zero returns ErrNotAuthorized — same shape as
+// "no worlds matched the identity in the first place" so the HTTP
+// layer (e.g. /me/install) can map a single error sentinel to the
+// "200 with worlds: []" response regardless of which branch produced
+// the empty set.
+//
+// The predicate gates issuance entirely: filtered worlds get NO entry
+// in either the world's tokens Secret or the broker's issuances
+// Secret. This is the right shape for /me/install where a
+// PublicURL-less world is structurally un-installable; leaving a
+// stale issuance per call would churn the issuances Secret toward
+// its 5000-record cap without ever producing a usable token.
+func (i *Issuer) MintFiltered(ctx context.Context, claims Claims, keep func(*WorldConfig) bool) ([]MintResult, error) {
 	// Defense in depth: the production Verifier rejects unverified claims
 	// before Mint is reached, but a test double (or future Verifier impl)
 	// might not. Authorization by email domain is meaningless on an
@@ -138,6 +168,18 @@ func (i *Issuer) Mint(ctx context.Context, claims Claims) ([]MintResult, error) 
 	worlds := i.authorizedWorlds(claims)
 	if len(worlds) == 0 {
 		return nil, ErrNotAuthorized
+	}
+	if keep != nil {
+		filtered := worlds[:0]
+		for _, w := range worlds {
+			if keep(w) {
+				filtered = append(filtered, w)
+			}
+		}
+		worlds = filtered
+		if len(worlds) == 0 {
+			return nil, ErrNotAuthorized
+		}
 	}
 	now := i.clock()
 	results := make([]MintResult, 0, len(worlds))

--- a/tools/demarkus-broker/internal/broker/issuer_test.go
+++ b/tools/demarkus-broker/internal/broker/issuer_test.go
@@ -1094,3 +1094,212 @@ func TestRotateLabelMissingWorldErrors(t *testing.T) {
 		t.Errorf("error %q does not name the orphaned world", err)
 	}
 }
+
+// twoWorldConfig returns testConfig() with team-b appended; team-b
+// matches the same example.com domain as team-a so an alice@example.com
+// caller qualifies for both. Shared by the MintFiltered tests, which all
+// need a multi-world fixture to exercise the predicate's discrimination.
+func twoWorldConfig() *Config {
+	cfg := testConfig()
+	cfg.Worlds = append(cfg.Worlds, WorldConfig{
+		Name:         "team-b",
+		Namespace:    "team-b",
+		TokensSecret: "team-b-tokens",
+		Allow:        AllowConfig{Domains: []string{"example.com"}},
+		DefaultToken: TokenScope{
+			Paths:        []string{"/team-b/*"},
+			Operations:   []string{"read"},
+			ExpiresAfter: 12 * time.Hour,
+		},
+	})
+	return cfg
+}
+
+func TestMintFilteredNilPredicateMatchesMint(t *testing.T) {
+	// Regression guard for the back-compat shim: Mint must remain a thin
+	// wrapper that produces the same MintResult slice (in the same
+	// order, with the same scopes) as MintFiltered(nil). Same single-world
+	// fixture as TestMintCreatesBothSecrets so the assertion compares
+	// shape, not contents, against an independently-minted reference.
+	claims := Claims{Email: "alice@example.com", EmailVerified: true}
+
+	k8sA := fake.NewSimpleClientset()
+	a := newIssuer(t, testConfig(), k8sA)
+	viaMint, err := a.Mint(context.Background(), claims)
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+
+	k8sB := fake.NewSimpleClientset()
+	b := newIssuer(t, testConfig(), k8sB)
+	viaFiltered, err := b.MintFiltered(context.Background(), claims, nil)
+	if err != nil {
+		t.Fatalf("MintFiltered(nil): %v", err)
+	}
+
+	if len(viaMint) != len(viaFiltered) {
+		t.Fatalf("len mismatch: Mint=%d MintFiltered(nil)=%d", len(viaMint), len(viaFiltered))
+	}
+	for i := range viaMint {
+		// Raw tokens differ (fresh random per call) but world + expiry
+		// shape must match exactly.
+		if viaMint[i].World != viaFiltered[i].World {
+			t.Errorf("[%d] World mismatch: Mint=%q MintFiltered(nil)=%q", i, viaMint[i].World, viaFiltered[i].World)
+		}
+		if !viaMint[i].ExpiresAt.Equal(viaFiltered[i].ExpiresAt) {
+			t.Errorf("[%d] ExpiresAt mismatch: Mint=%v MintFiltered(nil)=%v", i, viaMint[i].ExpiresAt, viaFiltered[i].ExpiresAt)
+		}
+	}
+}
+
+func TestMintFilteredPredicateSkipsWorlds(t *testing.T) {
+	// Two-world fixture: alice qualifies for both team-a and team-b. The
+	// predicate accepts only team-b. Result must contain exactly the
+	// kept world; the filtered world must have NO entry in either
+	// tokens.toml or the issuances Secret.
+	cfg := twoWorldConfig()
+	k8s := fake.NewSimpleClientset()
+	i := newIssuer(t, cfg, k8s)
+
+	keep := func(w *WorldConfig) bool { return w.Name == "team-b" }
+	results, err := i.MintFiltered(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true}, keep)
+	if err != nil {
+		t.Fatalf("MintFiltered: %v", err)
+	}
+	if len(results) != 1 || results[0].World != "team-b" {
+		t.Fatalf("results = %+v, want only team-b", results)
+	}
+
+	// team-a's tokens Secret must not exist — predicate filtered before mint.
+	if _, err := k8s.CoreV1().Secrets("team-a").Get(context.Background(), "team-a-tokens", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("team-a Secret unexpectedly created: %v", err)
+	}
+	// Issuances Secret must contain only team-b.
+	live, err := i.List(context.Background(), "alice@example.com")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(live) != 1 || live[0].World != "team-b" {
+		t.Errorf("issuances = %+v, want only team-b", live)
+	}
+}
+
+func TestMintFilteredPredicateRejectsAll(t *testing.T) {
+	// Authorized worlds is non-empty but the predicate rejects every
+	// one of them. The result must be ErrNotAuthorized — same sentinel
+	// as "zero authorized worlds in the first place" — so the HTTP
+	// caller can map both cases to a single response (200 + worlds: []
+	// for /me/install).
+	cfg := twoWorldConfig()
+	k8s := fake.NewSimpleClientset()
+	i := newIssuer(t, cfg, k8s)
+
+	_, err := i.MintFiltered(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true}, func(_ *WorldConfig) bool { return false })
+	if !errors.Is(err, ErrNotAuthorized) {
+		t.Errorf("err = %v, want ErrNotAuthorized", err)
+	}
+	assertNoSecretsWritten(t, k8s)
+	// Issuances Secret must not have been touched either (assertNoSecretsWritten
+	// covers team-a; team-b's Secret object is also asserted absent below).
+	if _, err := k8s.CoreV1().Secrets("team-b").Get(context.Background(), "team-b-tokens", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("team-b Secret unexpectedly created on reject-all predicate: %v", err)
+	}
+}
+
+func TestMintFilteredPartialFailurePassesThroughPredicate(t *testing.T) {
+	// Predicate keeps both worlds (PublicURL-style filter is a no-op
+	// here), and team-b's mint fails via an RBAC-denied Update. Same
+	// shape as TestMintRBACDeniedNoPartialState but exercised through
+	// MintFiltered to confirm the predicate doesn't alter the partial-
+	// failure contract: team-a's MintResult comes back paired with the
+	// team-b error.
+	cfg := twoWorldConfig()
+	k8s := fake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-b-tokens", Namespace: "team-b"},
+		Data:       map[string][]byte{TokensSecretKey: {}},
+	})
+	k8s.PrependReactor("update", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ua, ok := action.(k8stesting.UpdateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		if ua.GetNamespace() == "team-b" {
+			return true, nil, apierrors.NewForbidden(
+				schema.GroupResource{Resource: "secrets"},
+				"team-b-tokens",
+				errors.New("broker SA lacks update on team-b/team-b-tokens"),
+			)
+		}
+		return false, nil, nil
+	})
+	i := newIssuer(t, cfg, k8s)
+
+	results, err := i.MintFiltered(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true}, func(_ *WorldConfig) bool { return true })
+	if err == nil {
+		t.Fatal("MintFiltered returned nil err, want RBAC-denied wrapped")
+	}
+	if len(results) != 1 || results[0].World != "team-a" {
+		t.Fatalf("results = %+v, want only team-a (partial mint)", results)
+	}
+	if !strings.Contains(err.Error(), "team-b") {
+		t.Errorf("err %q does not name the failing world team-b", err)
+	}
+}
+
+func TestMintFilteredRejectsUnauthorizedBeforePredicate(t *testing.T) {
+	// Predicate must never run when AllowConfig already rejected the
+	// caller — otherwise a buggy predicate could be tricked into
+	// running against fabricated WorldConfig pointers. Use a panicking
+	// predicate to make a regression loud: if the predicate fires,
+	// the test panics; if MintFiltered short-circuits on
+	// ErrNotAuthorized before the predicate, the test passes.
+	cfg := testConfig()
+	// alice@example.com is authorized; mallory@evil.example is not.
+	k8s := fake.NewSimpleClientset()
+	i := newIssuer(t, cfg, k8s)
+
+	panicKeep := func(_ *WorldConfig) bool { panic("predicate must not run when AllowConfig rejected the caller") }
+	_, err := i.MintFiltered(context.Background(), Claims{Email: "mallory@evil.example", EmailVerified: true}, panicKeep)
+	if !errors.Is(err, ErrNotAuthorized) {
+		t.Errorf("err = %v, want ErrNotAuthorized", err)
+	}
+}
+
+func TestMintFilteredSeesAuthorizedWorldsOnly(t *testing.T) {
+	// Predicate input is the post-Allow set, not the raw cfg.Worlds.
+	// Two worlds: team-a allows example.com, team-b allows other.example.
+	// alice@example.com qualifies only for team-a, so the predicate
+	// should be called exactly once with team-a — never with team-b.
+	// Pinning this contract lets /me/install reason about the predicate
+	// input as "worlds the identity is already permitted to use."
+	cfg := testConfig()
+	cfg.Worlds = append(cfg.Worlds, WorldConfig{
+		Name:         "team-b",
+		Namespace:    "team-b",
+		TokensSecret: "team-b-tokens",
+		Allow:        AllowConfig{Domains: []string{"other.example"}},
+		DefaultToken: TokenScope{
+			Paths:        []string{"/team-b/*"},
+			Operations:   []string{"read"},
+			ExpiresAfter: 12 * time.Hour,
+		},
+	})
+	k8s := fake.NewSimpleClientset()
+	i := newIssuer(t, cfg, k8s)
+
+	var seen []string
+	keep := func(w *WorldConfig) bool {
+		seen = append(seen, w.Name)
+		return true
+	}
+	results, err := i.MintFiltered(context.Background(), Claims{Email: "alice@example.com", EmailVerified: true}, keep)
+	if err != nil {
+		t.Fatalf("MintFiltered: %v", err)
+	}
+	if !slices.Equal(seen, []string{"team-a"}) {
+		t.Errorf("predicate saw %v, want [team-a] only", seen)
+	}
+	if len(results) != 1 || results[0].World != "team-a" {
+		t.Errorf("results = %+v, want only team-a", results)
+	}
+}

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -227,6 +227,14 @@ func (s *Server) Routes() http.Handler {
 	mux.Handle("GET /tokens", authedSubject(s.listTokens))
 	mux.Handle("DELETE /tokens/{label}", authedSubject(s.deleteToken))
 	mux.Handle("POST /tokens/{label}/rotate", authedSubject(s.rotateToken))
+	// /me/install: per-user install bundle. Same auth + per-subject
+	// rate-limit composition as the /tokens routes — the caller is an
+	// authenticated identity and the bucket is shared across the
+	// /tokens routes so a misbehaving client can't fan out across
+	// endpoints to evade the limit. GET (not POST) matches the OAuth
+	// /me-style convention; the per-call mint side-effect is
+	// documented in meInstall's doc comment.
+	mux.Handle("GET /me/install", authedSubject(s.meInstall))
 	return mux
 }
 

--- a/tools/demarkus-broker/main.go
+++ b/tools/demarkus-broker/main.go
@@ -7,10 +7,12 @@
 // domain/groups/emails allowlists (Slice C.1), browser code-flow for
 // /auth/login + /auth/callback, bearer-token (ID token) authentication
 // for /tokens, DELETE /tokens/:label, and POST /tokens/:label/rotate
-// (Slice C.3), leader-elected expiry/drift sweeper (Slice C.2), and
+// (Slice C.3), leader-elected expiry/drift sweeper (Slice C.2),
 // per-subject + per-IP rate limiting (Slice C.4) via in-memory token
 // buckets keyed by hashSubject(claims.Subject) on authed routes and
-// source IP on /auth/login.
+// source IP on /auth/login, RFC 8628 device flow + broker-signed
+// refresh tokens + RFC 7009 revoke (universe-onboarding PRs 3-4), and
+// GET /me/install per-user install bundle (universe-onboarding PR5).
 package main
 
 import (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/me/install` endpoint returning per-world install bundles with freshly-minted access tokens, deterministic ordering, and filtering to worlds with public URLs; sets Cache-Control: no-store and Pragma: no-cache.

* **Documentation**
  * Expanded broker docs with route specs, auth requirements, accepted id_token types, `/me/install` payload examples, and response semantics (empty installs, partialFailure).

* **Tests**
  * Added extensive tests covering happy paths, filtering, auth, partial/hard failures, headers, and token validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->