### PR TITLE
feat(broker):  Implement MCP write-tool handlers for broker gateway

### DIFF
--- a/tools/demarkus-broker/internal/broker/mcp_gateway.go
+++ b/tools/demarkus-broker/internal/broker/mcp_gateway.go
@@ -91,11 +91,18 @@ func (g *mcpGateway) registerTools() {
 // from the map use notImplementedHandler. Method (rather than a
 // package-level var) so the handlers carry the gateway receiver
 // without indirection through a global.
+//
+// Slice 2 added the three read verbs; Slice 3 adds the three
+// write verbs. The 7 federation tools still fall through to the
+// placeholder until Slices 4–5.
 func (g *mcpGateway) toolHandlers() map[string]mcpserver.ToolHandlerFunc {
 	return map[string]mcpserver.ToolHandlerFunc{
 		"mark_fetch":    g.handleMarkFetch,
 		"mark_list":     g.handleMarkList,
 		"mark_versions": g.handleMarkVersions,
+		"mark_publish":  g.handleMarkPublish,
+		"mark_append":   g.handleMarkAppend,
+		"mark_archive":  g.handleMarkArchive,
 	}
 }
 

--- a/tools/demarkus-broker/internal/broker/mcp_gateway_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_gateway_test.go
@@ -239,22 +239,22 @@ func TestMCPGatewayToolsCallReturnsPlaceholderForUnimplemented(t *testing.T) {
 		t.Fatalf("initialize response missing %s header — cannot drive tools/call", mcpSessionHeader)
 	}
 
-	// Slice 2 lights up mark_fetch / mark_list / mark_versions; the
-	// other 10 tools still hit notImplementedHandler. Calling one of
-	// them (mark_publish) must return a structured tool error
-	// (isError: true) with a message naming the tool. Tools land in
-	// later slices; updating this test (to pick a still-unimplemented
-	// tool, or deleting it once all 13 are real) is the canary.
+	// Slice 3 lights up the three write verbs alongside Slice 2's
+	// three read verbs; the 7 federation tools (mark_discover,
+	// mark_resolve, mark_index, mark_backlinks, mark_graph,
+	// mark_graph_export, mark_graph_publish) still hit
+	// notImplementedHandler. Calling one of those (mark_discover)
+	// must return a structured tool error with a message naming the
+	// tool. Updating this test as the placeholders peel off is the
+	// canary; deleting it once all 13 are real closes the loop.
 	resp := mcpRequest(t, ts.URL, "alice-token", sessionID, map[string]any{
 		"jsonrpc": "2.0",
 		"id":      3,
 		"method":  "tools/call",
 		"params": map[string]any{
-			"name": "mark_publish",
+			"name": "mark_discover",
 			"arguments": map[string]any{
-				"url":              "mark://team-a/foo.md",
-				"body":             "hello",
-				"expected_version": float64(0),
+				"url": "mark://team-a/",
 			},
 		},
 	})
@@ -276,7 +276,7 @@ func TestMCPGatewayToolsCallReturnsPlaceholderForUnimplemented(t *testing.T) {
 	if first, ok := contents[0].(map[string]any); ok {
 		text, _ = first["text"].(string)
 	}
-	if !strings.Contains(text, "mark_publish") || !strings.Contains(text, "not yet implemented") {
+	if !strings.Contains(text, "mark_discover") || !strings.Contains(text, "not yet implemented") {
 		t.Errorf("placeholder message = %q, want it to mention the tool name + \"not yet implemented\"", text)
 	}
 }

--- a/tools/demarkus-broker/internal/broker/mcp_tools_read.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_read.go
@@ -113,35 +113,18 @@ func (g *mcpGateway) mintFuncFor(claims Claims, worldName string) mintFunc {
 	}
 }
 
-// readOp is the small enum the dispatcher consumes to choose
-// Fetch/List/Versions on the worldDispatcher. Defined as an enum
-// rather than three near-identical methods so the retry loop
-// (cache hit → 401 → invalidate → re-mint → retry) stays in one
-// place across all three read verbs.
-type readOp int
+// worldOp is the closure form of a dispatcher call. The handler
+// captures the per-verb args (path, body, expectedVersion, meta)
+// in its closure; the retry loop only knows about token. This
+// keeps dispatchWithAuth verb-agnostic — Slice 2's three read
+// verbs and Slice 3's three write verbs share the same auth-race
+// machinery without an enum + switch threaded through every call
+// site.
+type worldOp func(token string) (fetch.Result, error)
 
-const (
-	opFetch readOp = iota
-	opList
-	opVersions
-)
-
-func (o readOp) String() string {
-	switch o {
-	case opFetch:
-		return "fetch"
-	case opList:
-		return "list"
-	case opVersions:
-		return "versions"
-	default:
-		return "unknown"
-	}
-}
-
-// dispatchRead pulls or lazy-mints the world token for (email,
-// worldName), then invokes the dispatcher op. On a world response
-// of `unauthorized`:
+// dispatchWithAuth pulls or lazy-mints the world token for (email,
+// worldName), then invokes op. On a world response of
+// `unauthorized`:
 //
 //   - cache hit: the token the world has changed under us
 //     (operator hand-revoked, sweeper retired, world Secret reset
@@ -161,7 +144,7 @@ func (o readOp) String() string {
 // forwarded verbatim to the caller per the byte-for-byte proxy
 // contract. Transport errors short-circuit immediately — they're
 // not auth races.
-func (g *mcpGateway) dispatchRead(ctx context.Context, claims Claims, worldName, path string, op readOp) (fetch.Result, error) {
+func (g *mcpGateway) dispatchWithAuth(ctx context.Context, claims Claims, worldName string, op worldOp) (fetch.Result, error) {
 	mcpCfg := g.srv.cfg.Server.MCP
 	maxAttempts := mcpCfg.FirstMintMaxAttempts
 	if maxAttempts <= 0 {
@@ -181,7 +164,7 @@ func (g *mcpGateway) dispatchRead(ctx context.Context, claims Claims, worldName,
 		if err != nil {
 			return fetch.Result{}, err
 		}
-		result, err := g.dispatchOp(op, worldName, path, tok.raw)
+		result, err := op(tok.raw)
 		if err != nil {
 			// Transport-level failure — no auth race semantics
 			// apply. Return immediately; the caller maps it to
@@ -227,22 +210,6 @@ func (g *mcpGateway) dispatchRead(ctx context.Context, claims Claims, worldName,
 	}
 }
 
-// dispatchOp routes to the dispatcher method matching op. Kept
-// out of dispatchRead so the retry loop stays focused on the
-// auth-race lifecycle.
-func (g *mcpGateway) dispatchOp(op readOp, worldName, path, token string) (fetch.Result, error) {
-	switch op {
-	case opFetch:
-		return g.dispatcher.Fetch(worldName, path, token)
-	case opList:
-		return g.dispatcher.List(worldName, path, token)
-	case opVersions:
-		return g.dispatcher.Versions(worldName, path, token)
-	default:
-		return fetch.Result{}, fmt.Errorf("broker: unknown read op %d", op)
-	}
-}
-
 // handleMarkFetch implements the mark_fetch tool against the
 // brokered world. Output format mirrors the local
 // client/cmd/demarkus-mcp emission for parity (plan v5
@@ -265,7 +232,9 @@ func (g *mcpGateway) handleMarkFetch(ctx context.Context, req mcp.CallToolReques
 		// the middleware.
 		return mcp.NewToolResultError("internal: missing identity on tool-call context"), nil
 	}
-	result, err := g.dispatchRead(ctx, claims, worldName, path, opFetch)
+	result, err := g.dispatchWithAuth(ctx, claims, worldName, func(token string) (fetch.Result, error) {
+		return g.dispatcher.Fetch(worldName, path, token)
+	})
 	if err != nil {
 		return g.toolErrorFor("fetch", worldName, err), nil
 	}
@@ -289,7 +258,9 @@ func (g *mcpGateway) handleMarkList(ctx context.Context, req mcp.CallToolRequest
 	if !ok {
 		return mcp.NewToolResultError("internal: missing identity on tool-call context"), nil
 	}
-	result, err := g.dispatchRead(ctx, claims, worldName, path, opList)
+	result, err := g.dispatchWithAuth(ctx, claims, worldName, func(token string) (fetch.Result, error) {
+		return g.dispatcher.List(worldName, path, token)
+	})
 	if err != nil {
 		return g.toolErrorFor("list", worldName, err), nil
 	}
@@ -312,7 +283,9 @@ func (g *mcpGateway) handleMarkVersions(ctx context.Context, req mcp.CallToolReq
 	if !ok {
 		return mcp.NewToolResultError("internal: missing identity on tool-call context"), nil
 	}
-	result, err := g.dispatchRead(ctx, claims, worldName, path, opVersions)
+	result, err := g.dispatchWithAuth(ctx, claims, worldName, func(token string) (fetch.Result, error) {
+		return g.dispatcher.Versions(worldName, path, token)
+	})
 	if err != nil {
 		return g.toolErrorFor("versions", worldName, err), nil
 	}

--- a/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
@@ -27,16 +27,34 @@ type fakeDispatcher struct {
 	fetchFn    func(worldName, path, token string) (fetch.Result, error)
 	listFn     func(worldName, path, token string) (fetch.Result, error)
 	versionsFn func(worldName, path, token string) (fetch.Result, error)
+	publishFn  func(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
+	appendFn   func(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
+	archiveFn  func(worldName, path, token string) (fetch.Result, error)
 
 	fetchCalls    []dispatchCall
 	listCalls     []dispatchCall
 	versionsCalls []dispatchCall
+	publishCalls  []writeCall
+	appendCalls   []writeCall
+	archiveCalls  []dispatchCall
 }
 
 type dispatchCall struct {
 	worldName string
 	path      string
 	token     string
+}
+
+// writeCall records a Publish/Append invocation. Captures the
+// body + expected_version + meta so tests can assert what the
+// broker forwarded to the world.
+type writeCall struct {
+	worldName       string
+	path            string
+	body            string
+	token           string
+	expectedVersion int
+	meta            map[string]string
 }
 
 func (f *fakeDispatcher) Fetch(worldName, path, token string) (fetch.Result, error) {
@@ -68,6 +86,48 @@ func (f *fakeDispatcher) Versions(worldName, path, token string) (fetch.Result, 
 	f.mu.Unlock()
 	if fn == nil {
 		return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK}}, nil
+	}
+	return fn(worldName, path, token)
+}
+
+func (f *fakeDispatcher) Publish(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error) {
+	f.mu.Lock()
+	f.publishCalls = append(f.publishCalls, writeCall{worldName, path, body, token, expectedVersion, meta})
+	fn := f.publishFn
+	f.mu.Unlock()
+	if fn == nil {
+		return fetch.Result{Response: protocol.Response{
+			Status:   protocol.StatusOK,
+			Metadata: map[string]string{"version": "1"},
+		}}, nil
+	}
+	return fn(worldName, path, body, token, expectedVersion, meta)
+}
+
+func (f *fakeDispatcher) Append(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error) {
+	f.mu.Lock()
+	f.appendCalls = append(f.appendCalls, writeCall{worldName, path, body, token, expectedVersion, meta})
+	fn := f.appendFn
+	f.mu.Unlock()
+	if fn == nil {
+		return fetch.Result{Response: protocol.Response{
+			Status:   protocol.StatusOK,
+			Metadata: map[string]string{"version": "2"},
+		}}, nil
+	}
+	return fn(worldName, path, body, token, expectedVersion, meta)
+}
+
+func (f *fakeDispatcher) Archive(worldName, path, token string) (fetch.Result, error) {
+	f.mu.Lock()
+	f.archiveCalls = append(f.archiveCalls, dispatchCall{worldName, path, token})
+	fn := f.archiveFn
+	f.mu.Unlock()
+	if fn == nil {
+		return fetch.Result{Response: protocol.Response{
+			Status:   protocol.StatusArchived,
+			Metadata: map[string]string{"version": "3"},
+		}}, nil
 	}
 	return fn(worldName, path, token)
 }

--- a/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
@@ -3,6 +3,7 @@ package broker
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -92,7 +93,7 @@ func (f *fakeDispatcher) Versions(worldName, path, token string) (fetch.Result, 
 
 func (f *fakeDispatcher) Publish(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error) {
 	f.mu.Lock()
-	f.publishCalls = append(f.publishCalls, writeCall{worldName, path, body, token, expectedVersion, meta})
+	f.publishCalls = append(f.publishCalls, writeCall{worldName, path, body, token, expectedVersion, cloneMeta(meta)})
 	fn := f.publishFn
 	f.mu.Unlock()
 	if fn == nil {
@@ -106,7 +107,7 @@ func (f *fakeDispatcher) Publish(worldName, path, body, token string, expectedVe
 
 func (f *fakeDispatcher) Append(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error) {
 	f.mu.Lock()
-	f.appendCalls = append(f.appendCalls, writeCall{worldName, path, body, token, expectedVersion, meta})
+	f.appendCalls = append(f.appendCalls, writeCall{worldName, path, body, token, expectedVersion, cloneMeta(meta)})
 	fn := f.appendFn
 	f.mu.Unlock()
 	if fn == nil {
@@ -116,6 +117,25 @@ func (f *fakeDispatcher) Append(worldName, path, body, token string, expectedVer
 		}}, nil
 	}
 	return fn(worldName, path, body, token, expectedVersion, meta)
+}
+
+// cloneMeta snapshots a publisher-metadata map so writeCall
+// records an immutable copy. PR #147 review (CodeRabbit): the
+// fakeDispatcher stored caller-owned maps by reference, so a
+// post-call mutation of the same map (legal under fetch.Client's
+// Publish signature — the client copies before sending, but a
+// future broker handler that reused a map between calls would
+// retroactively change recorded test history) could silently
+// invalidate assertions written against the captured value.
+// Cloning here is a test-only guard; production code paths still
+// pass the original map down to fetch.Client.
+func cloneMeta(meta map[string]string) map[string]string {
+	if meta == nil {
+		return nil
+	}
+	out := make(map[string]string, len(meta))
+	maps.Copy(out, meta)
+	return out
 }
 
 func (f *fakeDispatcher) Archive(worldName, path, token string) (fetch.Result, error) {

--- a/tools/demarkus-broker/internal/broker/mcp_tools_write.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_write.go
@@ -1,0 +1,202 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/latebit/demarkus/client/fetch"
+	"github.com/latebit/demarkus/protocol"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+// mcp_tools_write.go ships the three write-verb handlers
+// (mark_publish, mark_append, mark_archive) for Slice 3 of the
+// broker MCP gateway plan. All three reuse dispatchWithAuth so
+// the propagation-race retry + cache-hit-401 invalidation built
+// in Slice 2 work for writes too.
+//
+// Slice 3 deliberately ships on_conflict="fail" only for
+// mark_publish; the merge-candidate flow (on_conflict="merge")
+// lands in Slice 6 along with the hoisted client/merge package.
+// Until then the broker rejects on_conflict="merge" with a
+// pointer to Slice 6 so agents calling against the broker know
+// the surface gap and can either pass "fail" or wait. The
+// default flips to "merge" in Slice 6 to match the local
+// demarkus-mcp.
+
+// agentMetaFromClaims builds the publisher-metadata map every
+// write request carries. Mirrors the local demarkus-mcp's
+// agentMeta(ctx) shape — "agent": "<MCP client name from session>"
+// — but the broker has no session-level client info available on
+// the tool-call context, so we use the canonical email instead.
+// That makes the world's audit log show who initiated the write
+// even when the agent never tells the world its name; the
+// broker's existing audit log already correlates by email so the
+// two surfaces agree.
+func agentMetaFromClaims(claims Claims) map[string]string {
+	return map[string]string{"agent": canonicalEmail(claims.Email)}
+}
+
+// handleMarkPublish implements the mark_publish tool. on_conflict
+// defaults to "fail" in Slice 3; the "merge" branch (Slice 6)
+// returns a tool error pointing the caller at the planned
+// surface so the gap is loud, not silent.
+func (g *mcpGateway) handleMarkPublish(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
+	raw, err := req.RequireString("url")
+	if err != nil {
+		return mcp.NewToolResultError("url is required"), nil
+	}
+	body, err := req.RequireString("body")
+	if err != nil {
+		return mcp.NewToolResultError("body is required"), nil
+	}
+	worldName, path, err := parseToolURL(raw)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", err)), nil
+	}
+	expectedVersion, err := req.RequireInt("expected_version")
+	if err != nil {
+		return mcp.NewToolResultError("expected_version is required"), nil
+	}
+	// Validate before the on_conflict switch — both the "fail"
+	// branch and the future "merge" branch reject negative
+	// versions in the same shape, surfacing a clear local error
+	// instead of forwarding it to the world.
+	if expectedVersion < 0 {
+		return mcp.NewToolResultError("expected_version must be >= 0"), nil
+	}
+	onConflict := strings.TrimSpace(req.GetString("on_conflict", "fail"))
+	if onConflict == "" {
+		onConflict = "fail"
+	}
+	switch onConflict {
+	case "fail":
+		// Pass through to the dispatcher; the world returns
+		// `conflict` status when expectedVersion doesn't match,
+		// and we forward that verbatim.
+	case "merge":
+		// Slice 6 brings the structural-merge candidate flow.
+		// Until then, fail loud with a pointer to the planned
+		// landing point so the agent knows to retry with
+		// on_conflict="fail" (or wait for Slice 6).
+		return mcp.NewToolResultError("on_conflict=\"merge\" not yet supported by broker MCP gateway (Slice 6 of /plans/broker-https-gateway.md lands the merge-candidate flow); pass on_conflict=\"fail\" for now"), nil
+	default:
+		return mcp.NewToolResultError(fmt.Sprintf("invalid on_conflict %q: expected \"fail\" (\"merge\" lands in Slice 6)", onConflict)), nil
+	}
+
+	claims, ok := claimsFromCtx(ctx)
+	if !ok {
+		return mcp.NewToolResultError("internal: missing identity on tool-call context"), nil
+	}
+	meta := agentMetaFromClaims(claims)
+	result, err := g.dispatchWithAuth(ctx, claims, worldName, func(token string) (fetch.Result, error) {
+		return g.dispatcher.Publish(worldName, path, body, token, expectedVersion, meta)
+	})
+	if err != nil {
+		return g.toolErrorFor("publish", worldName, err), nil
+	}
+	return mcp.NewToolResultText(formatToolResult(result, "version", "modified", "server-version")), nil
+}
+
+// handleMarkAppend implements the mark_append tool. expected_version
+// is optional: when omitted or 0, the broker auto-resolves by
+// calling VERSIONS first and using `current` as the expected
+// version for the APPEND. Matches the local demarkus-mcp's
+// behavior so agents see the same convenience either way.
+//
+// The auto-resolve path issues two dispatch calls under one
+// session's cached token — the singleflight + sessionCache from
+// Slice 2 ensure only the very first call pays the mint round
+// trip; the VERSIONS + APPEND pair shares whatever's already
+// cached.
+func (g *mcpGateway) handleMarkAppend(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go
+	raw, err := req.RequireString("url")
+	if err != nil {
+		return mcp.NewToolResultError("url is required"), nil
+	}
+	body, err := req.RequireString("body")
+	if err != nil {
+		return mcp.NewToolResultError("body is required"), nil
+	}
+	worldName, path, err := parseToolURL(raw)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", err)), nil
+	}
+	expectedVersion := req.GetInt("expected_version", 0)
+	if expectedVersion < 0 {
+		return mcp.NewToolResultError("expected_version must be >= 0"), nil
+	}
+	claims, ok := claimsFromCtx(ctx)
+	if !ok {
+		return mcp.NewToolResultError("internal: missing identity on tool-call context"), nil
+	}
+	if expectedVersion == 0 {
+		// Auto-resolve via VERSIONS. Same dispatch wrapper as
+		// the actual append so a propagation-race or stale-
+		// cache 401 here is absorbed by the retry loop and
+		// doesn't fail the whole append call.
+		vResult, vErr := g.dispatchWithAuth(ctx, claims, worldName, func(token string) (fetch.Result, error) {
+			return g.dispatcher.Versions(worldName, path, token)
+		})
+		if vErr != nil {
+			return g.toolErrorFor("append (auto-resolve)", worldName, vErr), nil
+		}
+		if vResult.Response.Status != protocol.StatusOK {
+			return mcp.NewToolResultError(fmt.Sprintf("could not resolve version: %s", vResult.Response.Status)), nil
+		}
+		cur, exists := vResult.Response.Metadata["current"]
+		if !exists {
+			return mcp.NewToolResultError("could not resolve version: no current version in response"), nil
+		}
+		resolved, parseErr := strconv.Atoi(cur)
+		if parseErr != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("could not resolve version: invalid current version %q", cur)), nil
+		}
+		expectedVersion = resolved
+	}
+	meta := agentMetaFromClaims(claims)
+	result, err := g.dispatchWithAuth(ctx, claims, worldName, func(token string) (fetch.Result, error) {
+		return g.dispatcher.Append(worldName, path, body, token, expectedVersion, meta)
+	})
+	if err != nil {
+		return g.toolErrorFor("append", worldName, err), nil
+	}
+	return mcp.NewToolResultText(formatToolResult(result, "version", "modified", "server-version")), nil
+}
+
+// handleMarkArchive implements the mark_archive tool. ARCHIVE is
+// the demarkus protocol's destructive verb: status flips to
+// `archived` and the document stops appearing in LIST results,
+// but version history is preserved. Output keys mirror the local
+// demarkus-mcp choice (`version`).
+func (g *mcpGateway) handleMarkArchive(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go
+	raw, err := req.RequireString("url")
+	if err != nil {
+		return mcp.NewToolResultError("url is required"), nil
+	}
+	worldName, path, err := parseToolURL(raw)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", err)), nil
+	}
+	claims, ok := claimsFromCtx(ctx)
+	if !ok {
+		return mcp.NewToolResultError("internal: missing identity on tool-call context"), nil
+	}
+	result, err := g.dispatchWithAuth(ctx, claims, worldName, func(token string) (fetch.Result, error) {
+		return g.dispatcher.Archive(worldName, path, token)
+	})
+	if err != nil {
+		return g.toolErrorFor("archive", worldName, err), nil
+	}
+	return mcp.NewToolResultText(formatToolResult(result, "version")), nil
+}
+
+// Compile-time guard: the write handlers conform to mcp-go's
+// ToolHandlerFunc shape. Catches a signature regression at build
+// time instead of runtime registration.
+var _ mcpserver.ToolHandlerFunc = (*mcpGateway)(nil).handleMarkPublish
+var _ mcpserver.ToolHandlerFunc = (*mcpGateway)(nil).handleMarkAppend
+var _ mcpserver.ToolHandlerFunc = (*mcpGateway)(nil).handleMarkArchive

--- a/tools/demarkus-broker/internal/broker/mcp_tools_write_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_write_test.go
@@ -1,0 +1,543 @@
+package broker
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/latebit/demarkus/client/fetch"
+	"github.com/latebit/demarkus/protocol"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// TestHandleMarkPublishHappyPath drives the simplest publish:
+// known expected_version, default on_conflict, no validation
+// errors. Pins the byte-for-byte proxy contract — body + version
+// + modified pass through the broker unchanged.
+func TestHandleMarkPublishHappyPath(t *testing.T) {
+	cfg := mcpTestConfig()
+	d := &fakeDispatcher{
+		publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status: protocol.StatusOK,
+				Metadata: map[string]string{
+					"version":        "4",
+					"modified":       "2026-05-21T10:00:00Z",
+					"server-version": "1.0",
+				},
+			}}, nil
+		},
+	}
+	g := newGatewayWithDispatcher(t, cfg, d)
+	res, err := g.handleMarkPublish(withAliceClaims(context.Background()), callToolReq("mark_publish", map[string]any{
+		"url":              "mark://team-a/foo.md",
+		"body":             "# new content\n",
+		"expected_version": float64(3),
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkPublish: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("isError = true: %s", toolResultText(t, res))
+	}
+	text := toolResultText(t, res)
+	for _, want := range []string{"status: ok", "version: 4", "modified: 2026-05-21T10:00:00Z", "server-version: 1.0"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("response missing %q\nfull:\n%s", want, text)
+		}
+	}
+	if len(d.publishCalls) != 1 {
+		t.Fatalf("publish dispatch count = %d, want 1", len(d.publishCalls))
+	}
+	call := d.publishCalls[0]
+	if call.worldName != "team-a" {
+		t.Errorf("worldName = %q, want team-a", call.worldName)
+	}
+	if call.path != "/foo.md" {
+		t.Errorf("path = %q, want /foo.md", call.path)
+	}
+	if call.body != "# new content\n" {
+		t.Errorf("body = %q, want forwarded verbatim", call.body)
+	}
+	if call.expectedVersion != 3 {
+		t.Errorf("expectedVersion = %d, want 3", call.expectedVersion)
+	}
+	if call.meta["agent"] != "alice@example.com" {
+		t.Errorf("publisher meta agent = %q, want canonical email", call.meta["agent"])
+	}
+}
+
+func TestHandleMarkPublishMissingExpectedVersion(t *testing.T) {
+	// expected_version is a REQUIRED field on mark_publish (the
+	// auto-resolve convenience lives on mark_append only). Missing
+	// it must surface as a clear tool error, not be silently
+	// defaulted to 0 (which would mean "create-only" and confuse
+	// agents trying to update).
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), &fakeDispatcher{})
+	res, err := g.handleMarkPublish(withAliceClaims(context.Background()), callToolReq("mark_publish", map[string]any{
+		"url":  "mark://team-a/foo.md",
+		"body": "hello",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkPublish: %v", err)
+	}
+	if !res.IsError {
+		t.Error("isError = false on missing expected_version, want true")
+	}
+	if text := toolResultText(t, res); !strings.Contains(text, "expected_version") {
+		t.Errorf("tool error message = %q, want it to name expected_version", text)
+	}
+}
+
+func TestHandleMarkPublishNegativeExpectedVersion(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), &fakeDispatcher{})
+	res, err := g.handleMarkPublish(withAliceClaims(context.Background()), callToolReq("mark_publish", map[string]any{
+		"url":              "mark://team-a/foo.md",
+		"body":             "hello",
+		"expected_version": float64(-1),
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkPublish: %v", err)
+	}
+	if !res.IsError {
+		t.Error("isError = false on negative expected_version, want true")
+	}
+}
+
+func TestHandleMarkPublishConflictPassesThroughVerbatim(t *testing.T) {
+	// version-mismatch on the world surfaces as `conflict`
+	// status. The broker forwards verbatim — body + version +
+	// server-version unchanged — so the agent can act on the
+	// conflict envelope the same way against a brokered or
+	// direct-QUIC world.
+	cfg := mcpTestConfig()
+	d := &fakeDispatcher{
+		publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status: protocol.StatusConflict,
+				Metadata: map[string]string{
+					"version":        "7",
+					"server-version": "7",
+				},
+			}}, nil
+		},
+	}
+	g := newGatewayWithDispatcher(t, cfg, d)
+	res, err := g.handleMarkPublish(withAliceClaims(context.Background()), callToolReq("mark_publish", map[string]any{
+		"url":              "mark://team-a/foo.md",
+		"body":             "stale body",
+		"expected_version": float64(5),
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkPublish: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("isError = true on conflict (must forward verbatim, not turn into a tool error): %s", toolResultText(t, res))
+	}
+	text := toolResultText(t, res)
+	if !strings.Contains(text, "status: conflict") {
+		t.Errorf("expected status: conflict verbatim in output, got:\n%s", text)
+	}
+	if !strings.Contains(text, "server-version: 7") {
+		t.Errorf("expected server-version: 7 in output, got:\n%s", text)
+	}
+}
+
+func TestHandleMarkPublishOnConflictMergeRejectedUntilSlice6(t *testing.T) {
+	// Slice 3 deliberately does NOT ship the merge candidate
+	// flow (Slice 6 lands it). Agents calling with
+	// on_conflict="merge" need to know the surface gap so they
+	// can either pass "fail" or wait. Silently accepting and
+	// running the "fail" path would be a bait-and-switch — the
+	// agent thinks merge is being attempted when it isn't.
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), &fakeDispatcher{})
+	res, err := g.handleMarkPublish(withAliceClaims(context.Background()), callToolReq("mark_publish", map[string]any{
+		"url":              "mark://team-a/foo.md",
+		"body":             "hello",
+		"expected_version": float64(3),
+		"on_conflict":      "merge",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkPublish: %v", err)
+	}
+	if !res.IsError {
+		t.Error("isError = false on on_conflict=merge, want true (Slice 6)")
+	}
+	text := toolResultText(t, res)
+	if !strings.Contains(text, "Slice 6") {
+		t.Errorf("tool error %q must point at Slice 6 of the plan so agents know when to retry", text)
+	}
+}
+
+func TestHandleMarkPublishOnConflictUnknownRejected(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), &fakeDispatcher{})
+	res, err := g.handleMarkPublish(withAliceClaims(context.Background()), callToolReq("mark_publish", map[string]any{
+		"url":              "mark://team-a/foo.md",
+		"body":             "hello",
+		"expected_version": float64(3),
+		"on_conflict":      "explode",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkPublish: %v", err)
+	}
+	if !res.IsError {
+		t.Error("isError = false on unknown on_conflict, want true")
+	}
+}
+
+func TestHandleMarkPublishNotPermittedSurfacesAsToolError(t *testing.T) {
+	// World-side RBAC failure (token lacks `publish` op or the
+	// path is outside the token's allowed paths) returns
+	// `not-permitted`. The plan v5 contract says it forwards
+	// through the proxy as a regular response, NOT a tool error
+	// — the local demarkus-mcp behaves the same way (just shows
+	// "status: not-permitted" in the formatted text). Pin that.
+	cfg := mcpTestConfig()
+	d := &fakeDispatcher{
+		publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status: protocol.StatusNotPermitted,
+			}}, nil
+		},
+	}
+	g := newGatewayWithDispatcher(t, cfg, d)
+	res, err := g.handleMarkPublish(withAliceClaims(context.Background()), callToolReq("mark_publish", map[string]any{
+		"url":              "mark://team-a/foo.md",
+		"body":             "hello",
+		"expected_version": float64(0),
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkPublish: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("isError = true on not-permitted (proxy contract: forward verbatim): %s", toolResultText(t, res))
+	}
+	if text := toolResultText(t, res); !strings.Contains(text, "status: not-permitted") {
+		t.Errorf("expected not-permitted in output, got:\n%s", text)
+	}
+}
+
+func TestHandleMarkPublishTransportErrorFailsLoud(t *testing.T) {
+	// Transport-layer failures (world unreachable, QUIC dial
+	// timeout, etc.) surface as the dispatcher returning a
+	// non-nil error. That MUST become a tool error so the agent
+	// distinguishes "the world said no" from "we never reached
+	// the world." Pin the distinction.
+	cfg := mcpTestConfig()
+	d := &fakeDispatcher{
+		publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
+			return fetch.Result{}, errors.New("dial team-a.team-a.svc.cluster.local:6309: connection refused")
+		},
+	}
+	g := newGatewayWithDispatcher(t, cfg, d)
+	res, err := g.handleMarkPublish(withAliceClaims(context.Background()), callToolReq("mark_publish", map[string]any{
+		"url":              "mark://team-a/foo.md",
+		"body":             "hello",
+		"expected_version": float64(0),
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkPublish: %v", err)
+	}
+	if !res.IsError {
+		t.Error("isError = false on transport error, want true")
+	}
+}
+
+// TestHandleMarkAppendHappyPath drives an append with an
+// explicit expected_version. Same byte-for-byte forwarding
+// invariant as publish.
+func TestHandleMarkAppendHappyPath(t *testing.T) {
+	cfg := mcpTestConfig()
+	d := &fakeDispatcher{
+		appendFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status: protocol.StatusOK,
+				Metadata: map[string]string{
+					"version":        "8",
+					"modified":       "2026-05-21T11:00:00Z",
+					"server-version": "1.0",
+				},
+			}}, nil
+		},
+	}
+	g := newGatewayWithDispatcher(t, cfg, d)
+	res, err := g.handleMarkAppend(withAliceClaims(context.Background()), callToolReq("mark_append", map[string]any{
+		"url":              "mark://team-a/journal.md",
+		"body":             "## new entry\n",
+		"expected_version": float64(7),
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkAppend: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("isError = true: %s", toolResultText(t, res))
+	}
+	if len(d.appendCalls) != 1 {
+		t.Fatalf("append calls = %d, want 1", len(d.appendCalls))
+	}
+	if got := d.appendCalls[0].expectedVersion; got != 7 {
+		t.Errorf("dispatcher saw expectedVersion=%d, want 7", got)
+	}
+	if got := d.appendCalls[0].body; got != "## new entry\n" {
+		t.Errorf("dispatcher saw body=%q, want forwarded verbatim", got)
+	}
+}
+
+func TestHandleMarkAppendAutoResolvesViaVersions(t *testing.T) {
+	// expected_version omitted → broker fetches VERSIONS, reads
+	// `current`, and uses that for APPEND. The local
+	// demarkus-mcp does the same; pin parity.
+	cfg := mcpTestConfig()
+	var versionsHits, appendHits int32
+	d := &fakeDispatcher{
+		versionsFn: func(_, _, _ string) (fetch.Result, error) {
+			atomic.AddInt32(&versionsHits, 1)
+			return fetch.Result{Response: protocol.Response{
+				Status: protocol.StatusOK,
+				Metadata: map[string]string{
+					"total":   "12",
+					"current": "12",
+				},
+			}}, nil
+		},
+		appendFn: func(_, _, _, _ string, expectedVersion int, _ map[string]string) (fetch.Result, error) {
+			atomic.AddInt32(&appendHits, 1)
+			if expectedVersion != 12 {
+				t.Errorf("append dispatched with expectedVersion=%d, want 12 (resolved from VERSIONS)", expectedVersion)
+			}
+			return fetch.Result{Response: protocol.Response{
+				Status: protocol.StatusOK,
+				Metadata: map[string]string{
+					"version":        "13",
+					"server-version": "1.0",
+				},
+			}}, nil
+		},
+	}
+	g := newGatewayWithDispatcher(t, cfg, d)
+	res, err := g.handleMarkAppend(withAliceClaims(context.Background()), callToolReq("mark_append", map[string]any{
+		"url":  "mark://team-a/journal.md",
+		"body": "## entry\n",
+		// expected_version intentionally omitted
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkAppend: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("isError = true: %s", toolResultText(t, res))
+	}
+	if v := atomic.LoadInt32(&versionsHits); v != 1 {
+		t.Errorf("versions dispatch count = %d, want 1", v)
+	}
+	if a := atomic.LoadInt32(&appendHits); a != 1 {
+		t.Errorf("append dispatch count = %d, want 1", a)
+	}
+}
+
+func TestHandleMarkAppendVersionsFailureBubbles(t *testing.T) {
+	// VERSIONS auto-resolve hits an unreachable world or the
+	// world returns non-ok. Either way the broker must NOT
+	// silently proceed with expected_version=0 (which would
+	// mean "create-only" and overwrite intent). Surface as a
+	// tool error so the agent can retry with an explicit
+	// version.
+	cfg := mcpTestConfig()
+	d := &fakeDispatcher{
+		versionsFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+		},
+	}
+	g := newGatewayWithDispatcher(t, cfg, d)
+	res, err := g.handleMarkAppend(withAliceClaims(context.Background()), callToolReq("mark_append", map[string]any{
+		"url":  "mark://team-a/journal.md",
+		"body": "## entry\n",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkAppend: %v", err)
+	}
+	if !res.IsError {
+		t.Error("isError = false when VERSIONS auto-resolve returns not-found, want true")
+	}
+	if len(d.appendCalls) != 0 {
+		t.Errorf("append dispatched %d times after VERSIONS failure, want 0", len(d.appendCalls))
+	}
+}
+
+func TestHandleMarkAppendMissingBody(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), &fakeDispatcher{})
+	res, err := g.handleMarkAppend(withAliceClaims(context.Background()), callToolReq("mark_append", map[string]any{
+		"url":              "mark://team-a/foo.md",
+		"expected_version": float64(1),
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkAppend: %v", err)
+	}
+	if !res.IsError {
+		t.Error("isError = false on missing body, want true")
+	}
+}
+
+func TestHandleMarkArchiveHappyPath(t *testing.T) {
+	cfg := mcpTestConfig()
+	d := &fakeDispatcher{
+		archiveFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusArchived,
+				Metadata: map[string]string{"version": "9"},
+			}}, nil
+		},
+	}
+	g := newGatewayWithDispatcher(t, cfg, d)
+	res, err := g.handleMarkArchive(withAliceClaims(context.Background()), callToolReq("mark_archive", map[string]any{
+		"url": "mark://team-a/obsolete.md",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkArchive: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("isError = true: %s", toolResultText(t, res))
+	}
+	text := toolResultText(t, res)
+	if !strings.Contains(text, "status: archived") {
+		t.Errorf("expected status: archived in output, got:\n%s", text)
+	}
+	if !strings.Contains(text, "version: 9") {
+		t.Errorf("expected version: 9 in output, got:\n%s", text)
+	}
+	if len(d.archiveCalls) != 1 {
+		t.Errorf("archive dispatch count = %d, want 1", len(d.archiveCalls))
+	}
+}
+
+func TestHandleMarkArchiveUnknownWorldSurfacesAsToolError(t *testing.T) {
+	cfg := mcpTestConfig()
+	pool := newWorldPool(cfg, fetch.Options{})
+	g := newGatewayWithDispatcher(t, cfg, pool)
+	res, err := g.handleMarkArchive(withAliceClaims(context.Background()), callToolReq("mark_archive", map[string]any{
+		"url": "mark://team-b/foo.md",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkArchive: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("isError = false on unknown world, want true")
+	}
+}
+
+// TestWriteHandlersInheritPropagationRaceRetry uses an explicit
+// fresh-mint 401 → ok scenario against publish to prove the
+// retry logic carries through from dispatchWithAuth into writes.
+// This is the load-bearing reason for the Slice 3 refactor —
+// without dispatchWithAuth, writes would need their own retry
+// loop and could silently regress.
+func TestWriteHandlersInheritPropagationRaceRetry(t *testing.T) {
+	cfg := mcpTestConfig()
+	// Tight retry knobs so the test runs fast.
+	cfg.Server.MCP.FirstMintMaxAttempts = 3
+	cfg.Server.MCP.FirstMintInitialBackoff = 1
+	cfg.Server.MCP.FirstMintMaxBackoff = 2
+
+	var attempts int32
+	d := &fakeDispatcher{
+		publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
+			n := atomic.AddInt32(&attempts, 1)
+			if n == 1 {
+				return fetch.Result{Response: protocol.Response{Status: protocol.StatusUnauthorized}}, nil
+			}
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusOK,
+				Metadata: map[string]string{"version": "1"},
+			}}, nil
+		},
+	}
+	g := newGatewayWithDispatcher(t, cfg, d)
+	res, err := g.handleMarkPublish(withAliceClaims(context.Background()), callToolReq("mark_publish", map[string]any{
+		"url":              "mark://team-a/foo.md",
+		"body":             "hello",
+		"expected_version": float64(0),
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkPublish: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("isError = true after retry should have succeeded: %s", toolResultText(t, res))
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Errorf("publish attempts = %d, want 2 (one 401 then ok)", got)
+	}
+}
+
+// TestMCPGatewayMarkPublishEndToEnd drives mark_publish through
+// the full Streamable HTTP transport including gatewayAuth and
+// session keying. The Slice 2 end-to-end test covers the read
+// surface; this one pins the wire-shape contract for writes.
+func TestMCPGatewayMarkPublishEndToEnd(t *testing.T) {
+	cfg := mcpTestConfig()
+	d := &fakeDispatcher{
+		publishFn: func(_, _, body, _ string, _ int, _ map[string]string) (fetch.Result, error) {
+			if body != "## entry via gateway\n" {
+				t.Errorf("dispatcher saw body=%q, want forwarded verbatim", body)
+			}
+			return fetch.Result{Response: protocol.Response{
+				Status: protocol.StatusOK,
+				Metadata: map[string]string{
+					"version":  "1",
+					"modified": "2026-05-21T11:00:00Z",
+				},
+			}}, nil
+		},
+	}
+	verifier := &fakeVerifier{claims: Claims{
+		Subject: "google|alice", Email: "alice@example.com", EmailVerified: true,
+	}}
+	signer := newTestSigner(t)
+	issuer := newIssuer(t, cfg, fake.NewSimpleClientset())
+	brokerSrv := NewServer(cfg, signer, verifier, issuer, nil, nil, nil)
+	ts := httptest.NewServer(brokerSrv.MCPGatewayWith("test", d))
+	t.Cleanup(ts.Close)
+
+	initR := mcpRequest(t, ts.URL, "alice-token", "", initializeRequest(1))
+	if initR.HTTPStatus != http.StatusOK {
+		t.Fatalf("initialize: status = %d", initR.HTTPStatus)
+	}
+	sessionID := initR.Headers[mcpSessionHeader]
+
+	resp := mcpRequest(t, ts.URL, "alice-token", sessionID, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "mark_publish",
+			"arguments": map[string]any{
+				"url":              "mark://team-a/journal/2026-05-21.md",
+				"body":             "## entry via gateway\n",
+				"expected_version": float64(0),
+			},
+		},
+	})
+	if resp.HTTPStatus != http.StatusOK {
+		t.Fatalf("tools/call: status = %d, body = %s", resp.HTTPStatus, resp.RawBody)
+	}
+	if resp.Error != nil {
+		t.Fatalf("tools/call JSON-RPC error: %+v", resp.Error)
+	}
+	isErr, _ := resp.Result["isError"].(bool)
+	if isErr {
+		t.Fatalf("tools/call isError = true: %+v", resp.Result)
+	}
+	contents, _ := resp.Result["content"].([]any)
+	if len(contents) == 0 {
+		t.Fatalf("content empty")
+	}
+	first, _ := contents[0].(map[string]any)
+	text, _ := first["text"].(string)
+	for _, want := range []string{"status: ok", "version: 1", "modified: 2026-05-21T11:00:00Z"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("end-to-end text missing %q\nfull:\n%s", want, text)
+		}
+	}
+}

--- a/tools/demarkus-broker/internal/broker/mcp_tools_write_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_write_test.go
@@ -531,6 +531,9 @@ func TestMCPGatewayMarkPublishEndToEnd(t *testing.T) {
 		t.Fatalf("initialize: status = %d", initR.HTTPStatus)
 	}
 	sessionID := initR.Headers[mcpSessionHeader]
+	if sessionID == "" {
+		t.Fatalf("initialize response missing %s header — session negotiation regressed", mcpSessionHeader)
+	}
 
 	resp := mcpRequest(t, ts.URL, "alice-token", sessionID, map[string]any{
 		"jsonrpc": "2.0",

--- a/tools/demarkus-broker/internal/broker/mcp_tools_write_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_write_test.go
@@ -247,6 +247,32 @@ func TestHandleMarkPublishTransportErrorFailsLoud(t *testing.T) {
 	}
 }
 
+func TestFakeDispatcherSnapshotsMetaOnCapture(t *testing.T) {
+	// PR #147 review (CodeRabbit): the fakeDispatcher used to
+	// store the caller-supplied meta map by reference. A
+	// post-call mutation of that map would silently change the
+	// historical writeCall record. The fake now snapshots; pin
+	// the property so a future refactor that drops cloneMeta
+	// fails this test instead of producing flaky assertions.
+	d := &fakeDispatcher{}
+	meta := map[string]string{"agent": "alice@example.com"}
+	if _, err := d.Publish("team-a", "/foo.md", "hello", "token", 0, meta); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	// Caller mutates AFTER the call returns — simulating a
+	// handler reusing one map across multiple dispatcher calls,
+	// or a future code path that builds meta lazily.
+	meta["agent"] = "mallory@evil.example"
+	meta["injected"] = "should-not-appear"
+
+	if got := d.publishCalls[0].meta["agent"]; got != "alice@example.com" {
+		t.Errorf("recorded meta[agent] = %q, want alice@example.com (mutation after Publish leaked into history)", got)
+	}
+	if _, ok := d.publishCalls[0].meta["injected"]; ok {
+		t.Error("recorded meta inherited a key added after Publish — snapshot broken")
+	}
+}
+
 // TestHandleMarkAppendHappyPath drives an append with an
 // explicit expected_version. Same byte-for-byte forwarding
 // invariant as publish.

--- a/tools/demarkus-broker/internal/broker/world_pool.go
+++ b/tools/demarkus-broker/internal/broker/world_pool.go
@@ -16,12 +16,17 @@ import (
 //
 // Surface kept narrow on purpose: handlers do not see fetch.Client
 // or QUIC concepts; they hand the dispatcher a worldName + path +
-// token and consume the resulting fetch.Result. Slice 3 will add
-// Publish/Append/Archive methods; the read-only verbs are Slice 2.
+// token (+ body / expectedVersion / meta for the write verbs) and
+// consume the resulting fetch.Result. Slice 2 added the three read
+// verbs; Slice 3 adds the three write verbs. The 7 federation
+// tools land in Slices 4–5.
 type worldDispatcher interface {
 	Fetch(worldName, path, token string) (fetch.Result, error)
 	List(worldName, path, token string) (fetch.Result, error)
 	Versions(worldName, path, token string) (fetch.Result, error)
+	Publish(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
+	Append(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
+	Archive(worldName, path, token string) (fetch.Result, error)
 }
 
 // errWorldNotFound surfaces when a tool call targets a worldName
@@ -121,6 +126,43 @@ func (p *worldPool) Versions(worldName, path, token string) (fetch.Result, error
 		return fetch.Result{}, err
 	}
 	return c.Versions(host, path, token)
+}
+
+// Publish dispatches a PUBLISH against worldName. Byte-for-byte
+// proxy: the broker forwards body and metadata verbatim, then
+// hands the world's response back without transformation.
+// expectedVersion follows fetch.Client.Publish's semantics:
+// <0 unconditional, 0 create-only, >0 update-only.
+func (p *worldPool) Publish(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error) {
+	c, host, err := p.clientFor(worldName)
+	if err != nil {
+		return fetch.Result{}, err
+	}
+	return c.Publish(host, path, body, token, expectedVersion, meta)
+}
+
+// Append dispatches an APPEND against worldName. The world
+// enforces the expectedVersion >= 1 invariant; the dispatcher
+// stays as a thin proxy so the world's protocol-level error
+// envelopes (`bad-request` on missing version) flow through
+// unchanged.
+func (p *worldPool) Append(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error) {
+	c, host, err := p.clientFor(worldName)
+	if err != nil {
+		return fetch.Result{}, err
+	}
+	return c.Append(host, path, body, token, expectedVersion, meta)
+}
+
+// Archive dispatches an ARCHIVE against worldName. The demarkus
+// protocol's destructive verb is ARCHIVE (not DELETE) — the
+// world keeps version history and flips status to `archived`.
+func (p *worldPool) Archive(worldName, path, token string) (fetch.Result, error) {
+	c, host, err := p.clientFor(worldName)
+	if err != nil {
+		return fetch.Result{}, err
+	}
+	return c.Archive(host, path, token)
 }
 
 // Close closes every per-world fetch.Client, releasing pooled


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added write tools: mark_publish, mark_append, and mark_archive — create, append to, and archive marks with version handling and formatted responses.

* **Refactor**
  * Streamlined dispatch/auth/retry flow so read and write operations behave consistently; append can auto-resolve versions when omitted.

* **Tests**
  * Extensive tests covering write handlers: validation, conflict and transport cases, retry/auth propagation, metadata snapshotting, and end-to-end call paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->