### PR TITLE
feat(broker):  Add MCP gateway support to demarkus-broker Helm chart

### DIFF
--- a/deploy/helm/demarkus-broker/Chart.yaml
+++ b/deploy/helm/demarkus-broker/Chart.yaml
@@ -7,8 +7,8 @@ description: |
   Multi-replica HA, leader-elected expiry/drift sweeper, per-subject and
   per-IP rate limiting.
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 keywords:
   - demarkus
   - mark-protocol

--- a/deploy/helm/demarkus-broker/README.md
+++ b/deploy/helm/demarkus-broker/README.md
@@ -22,9 +22,28 @@ Secrets and tracking ownership in a broker-namespace issuances Secret.
   filesystem, all capabilities dropped, seccomp RuntimeDefault.
 - Optional `Ingress` (default `ingressClassName: nginx`) with optional
   cert-manager-managed TLS Certificate.
+- **MCP gateway** (always-on, listens on `:8081` by default) exposing
+  the 13-tool demarkus surface to plugin-style agents over JSON-RPC
+  over Streamable HTTP. Identity is the company SSO `id_token` bearer;
+  world access-tokens are minted lazily per-session and never
+  persisted. See [MCP gateway](#mcp-gateway).
 - TopologySpreadConstraints to keep replicas off the same node.
 
 ## Endpoint surface
+
+The broker exposes two distinct HTTP listeners on the pod, fronted by
+the same Ingress controller through different hostnames:
+
+| Listener | Default port | Default Ingress host | Purpose |
+| --- | --- | --- | --- |
+| Management API | `:8080` (`server.port`) | `ingress.host` | OIDC login + device flow + token management + `/me/install` (see table below). |
+| MCP gateway | `:8081` (`server.mcp.addr`) | `ingress.mcp.host` (optional) | 13-tool demarkus surface over JSON-RPC/Streamable HTTP for plugin agents. See [MCP gateway](#mcp-gateway). |
+
+The two listeners share auth (`compositeVerifier`), rate-limit
+buckets (per-canonical-email), and the `Issuer` machinery — only the
+wire shape (JSON-RPC vs REST) differs.
+
+## Management API endpoint surface
 
 | Method | Path | Auth | Notes |
 | --- | --- | --- | --- |
@@ -89,6 +108,190 @@ Notes:
   Broker-signed tokens come from the device-flow refresh grant; IdP-
   signed tokens come from the device-flow completion. The broker's
   composite verifier dispatches by `kid`.
+
+## MCP gateway
+
+The MCP gateway is the broker's HTTPS-fronted JSON-RPC surface for
+plugin-style agents (Claude Code, IDE integrations, anything
+speaking the Model Context Protocol). One MCP server entry on the
+client connects the agent to every world the operator has
+configured under `worlds[]` — no per-world client setup. The
+gateway translates HTTPS/JSON-RPC at the org boundary into QUIC/Mark
+Protocol inside the cluster, so corporate networks that block UDP
+reach the universe over standard `:443`.
+
+### Always-on
+
+The gateway is part of the binary, not a feature flag. Every broker
+listens on `server.mcp.addr` (default `:8081`); the chart's Service
+exposes the port as `mcp`; the NetworkPolicy admits ingress on it.
+Existing deployments upgrading the chart pick up the listener
+silently — no `mcp.enabled` knob to set. To keep the listener
+cluster-internal, leave `ingress.mcp.host` blank; the port is still
+admitted from the ingress-controller namespace by the
+NetworkPolicy but no external rule routes traffic to it.
+
+### Hostname topology
+
+The MCP gateway routes through a SEPARATE hostname from the
+management API. The chart's `ingress.yaml` adds a second rule + TLS
+block to the same Ingress resource when `ingress.mcp.host` is set,
+backed by the Service's `mcp` port.
+
+```yaml
+ingress:
+  enabled: true
+  host: broker.acme.com          # management API
+  tls:
+    certManager:
+      enabled: true              # cert-manager mints broker.acme.com TLS
+  mcp:
+    host: mcp.broker.acme.com    # MCP gateway
+    tls:
+      certManager:
+        enabled: true            # cert-manager mints mcp.broker.acme.com TLS
+```
+
+Splitting the hosts avoids `.well-known/*` path collisions: the
+management API serves `/.well-known/openid-configuration` and
+`/.well-known/jwks.json` for OIDC discovery, while the MCP gateway
+serves `/.well-known/oauth-protected-resource` (RFC 9728) and
+`/.well-known/oauth-authorization-server` (RFC 8414) for OAuth
+metadata. Two hostnames, two TLS contexts, no path-routing
+fragility, and operators rotate certs on either side independently.
+
+### TLS termination
+
+Two supported modes. **Pick one per surface.**
+
+| Mode | Operator action | Where TLS terminates |
+| --- | --- | --- |
+| **Ingress-terminated** (recommended) | Configure `ingress.mcp.tls.{existingSecret,certManager}` as above. Leave `server.mcp.tls.existingSecretRef.name` blank. | At the Ingress controller. Broker speaks plain HTTP inside the cluster. Matches the management API's posture. |
+| **Broker-terminated** | Provision a `kubernetes.io/tls` Secret in the broker's namespace and set `server.mcp.tls.existingSecretRef.name=<secret>`. | At the broker pod. Chart mounts the Secret read-only at `/etc/demarkus-broker/tls/mcp/` and points `MCPConfig.TLS.{CertFile,KeyFile}` at the projected `tls.crt` / `tls.key`. Use when the topology bypasses the Ingress or requires mTLS broker→Ingress. |
+
+There is intentionally no in-line PEM mode (`brokerSigningKey`-style
+cleartext) for the MCP listener: a TLS private key in helm release
+history is never acceptable, even for dev. Use `existingSecretRef`
+or terminate at the Ingress.
+
+### Plugin-side flow
+
+The next slice ships a `/knowledge-join` slash command in the
+`demarkus-memory` Claude Code plugin. Operators direct users to:
+
+```
+/knowledge-join https://mcp.broker.acme.com
+```
+
+The plugin validates the broker URL by fetching
+`/.well-known/oauth-protected-resource`, derives a per-org slug from
+the hostname, and runs `claude mcp add --transport http {slug}
+{url}/mcp`. The Claude Code OAuth device flow handles the first-time
+identity exchange against the broker's existing
+`/device/authorize` + `/device/token` endpoints (universe-onboarding
+PR3+PR4). After that the plugin sees all 13 demarkus tools as one
+MCP server.
+
+### OAuth flow shape
+
+The gateway implements MCP's [authorization
+spec](https://modelcontextprotocol.io/specification/2024-11-05/basic/authorization)
+using the broker's existing OIDC machinery:
+
+- `GET /.well-known/oauth-protected-resource` (RFC 9728) — declares
+  the resource server and points clients at the authorization-server
+  metadata.
+- `GET /.well-known/oauth-authorization-server` (RFC 8414) —
+  authorization-server metadata. Aliases the broker's existing OIDC
+  Discovery handler (`/.well-known/openid-configuration` on the
+  management API) so the broker advertises itself as both the MCP
+  resource server AND the authorization server. The actual IdP
+  (Google, Okta, Entra) is one hop deeper, handled by the broker's
+  existing PR3 device-flow + PR4 refresh-grant code.
+- `POST /mcp` — single JSON-RPC endpoint. Unauthenticated requests
+  receive `401 + WWW-Authenticate: Bearer
+  resource_metadata="...oauth-protected-resource"` per RFC 6750 +
+  RFC 9728, so a fresh client knows where to start the auth flow.
+- All authenticated tool calls present `Authorization: Bearer
+  <id_token>`. The broker validates via the existing PR4
+  `compositeVerifier` (accepts both broker-signed and IdP-signed
+  tokens), extracts `email` + `email_verified`, **rejects unverified
+  emails** (matches `Issuer.ErrEmailUnverified`), and canonicalizes
+  the email (trim + lowercase) as the session-cache key.
+
+### Rate-limit behavior
+
+The gateway's rate limiter is the same per-canonical-email bucket
+the management API's `/tokens` family uses. A single user calling
+both the MCP gateway and the management API shares one bucket — an
+abusive identity cannot multiply its effective rate by fanning out
+across surfaces. Defaults from `rateLimit.tokens`: 10/min per
+email, burst 5. The 401 + 429 envelope shape is the same on either
+listener.
+
+### Ephemeral graph store
+
+**The broker's graph store (used by `mark_backlinks`, `mark_graph`,
+`mark_graph_export`, `mark_graph_publish`) lives in process memory
+and does NOT survive broker pod restarts.** A rolling chart upgrade,
+node drain, or pod eviction drops every cached graph. The first
+user to call a graph-store tool after restart triggers a fresh
+crawl via `mark_graph` (or whatever federation tool needs the
+data); the broker re-populates and continues. Operators planning
+maintenance windows should expect a few seconds of cold-start
+latency on the first graph-tool call after a bounce, and document
+the re-crawl as expected behavior for end users.
+
+This is a deliberate trade-off: a stateless broker pod is restart-
+resilient, multi-replica-safe, and matches the gateway's framing as
+a wire-shape adapter rather than a persistent protocol surface. A
+bucket-store-backed persistent graph is on the radar for the
+post-broker design window (see `/thoughts.md` § "On Bucket Stores")
+but is not part of the chart today.
+
+### Session cache + first-mint propagation
+
+The broker caches per-email world access-tokens in memory. Defaults
+sized for an enterprise universe: 10k unique users × 5 worlds × ~200
+bytes/token ≈ 10MB at saturation. Tune `server.mcp.maxSessions` and
+`server.mcp.sessionMaxIdle` if your population is materially larger
+or your idle profile differs.
+
+The `firstMintMax*` / `firstMintInitialBackoff` / `firstMintMaxBackoff`
+knobs govern a broker-side retry loop that absorbs the kubelet →
+world-Secret projection lag. When the broker lazily mints a new
+world token, the world's projected `tokens.toml` volume may not
+refresh before the next tool call, and the world will 401. The
+retry loop re-dispatches with exponential backoff (default 6
+attempts, 250ms → 8s) only on `unauthorized` responses for
+just-minted tokens; genuine permission denials and cache-hit 401s
+take separate paths. Defaults sit well under the typical kubelet
+sync period; tune up only for slow-kubelet clusters.
+
+### Operator reference: 13-tool surface
+
+See `tools/demarkus-broker/MCP-API.md` in the repo for the full
+tool reference (names, JSON schemas, semantics).
+
+### Upgrade notes
+
+Pre-gateway deployments upgrading this chart pick up the MCP
+listener silently:
+
+- Deployment grows a `mcp` containerPort on `:8081`.
+- Service grows a `mcp` port routing to the named containerPort.
+- NetworkPolicy admits ingress on the MCP port from the same
+  ingress-controller namespace already configured for the
+  management API.
+- The rendered `config.yaml` carries the MCP block; existing
+  deployments without operator overrides get the chart defaults.
+- No new RBAC: the broker SA already has the perms it needs (the
+  issuances Secret + world tokens Secrets that lazy-mint touches).
+- Worlds[] entries get an `internalAddress: ""` field. Empty string
+  preserves the default `<name>.<namespace>.svc.cluster.local:6309`
+  Service-DNS resolution the gateway uses for tool dispatch.
+- External exposure requires setting `ingress.mcp.host` (and TLS).
+  Without it, the listener stays cluster-internal.
 
 ## Quick install (development)
 

--- a/deploy/helm/demarkus-broker/templates/_helpers.tpl
+++ b/deploy/helm/demarkus-broker/templates/_helpers.tpl
@@ -106,7 +106,20 @@ on bind.
 {{- if not $port -}}
 {{- fail (printf "server.mcp.addr %q has no parseable port suffix" $addr) -}}
 {{- end -}}
-{{- $port | int -}}
+{{- /* Sprig's `int` is a best-effort cast that silently coerces
+       non-numeric strings to 0 (`{{ "abc" | int }}` → 0). Letting
+       a typo in server.mcp.addr (e.g. `:abc`, `localhost`, missing
+       colon) sail through would render containerPort: 0 and crash
+       the pod with no breadcrumb. Validate the suffix is purely
+       digits and within the legal port range BEFORE casting. */ -}}
+{{- if not (regexMatch "^[0-9]+$" $port) -}}
+{{- fail (printf "server.mcp.addr %q has a non-numeric port suffix %q" $addr $port) -}}
+{{- end -}}
+{{- $portInt := $port | int -}}
+{{- if or (lt $portInt 1) (gt $portInt 65535) -}}
+{{- fail (printf "server.mcp.addr %q port %d is outside the legal 1..65535 range" $addr $portInt) -}}
+{{- end -}}
+{{- $portInt -}}
 {{- end -}}
 
 {{/*

--- a/deploy/helm/demarkus-broker/templates/_helpers.tpl
+++ b/deploy/helm/demarkus-broker/templates/_helpers.tpl
@@ -71,6 +71,45 @@ Names for the chart-managed Secrets.
 {{- end -}}
 
 {{/*
+Chart-managed mount path for the MCP gateway's TLS Secret. Single
+source of truth for secret-config.yaml (renders certFile/keyFile into
+the broker's config.yaml) and deployment.yaml (mounts the Secret
+volume here). Not operator-facing — operators only choose the
+kubernetes.io/tls Secret name; the chart owns the in-pod path.
+
+kubernetes.io/tls Secrets always project `tls.crt` + `tls.key`, so
+the rendered paths are fixed and the chart never needs to surface
+key-name knobs.
+*/}}
+{{- define "demarkus-broker.mcpTLSMountPath" -}}
+/etc/demarkus-broker/tls/mcp
+{{- end -}}
+
+{{/*
+Extract the numeric port from server.mcp.addr (a `host:port` listen
+string like `:8081`). Used by deployment.yaml (containerPort),
+service.yaml (port + targetPort numbering), and networkpolicy.yaml
+(ingress port). Single source of truth keeps the four manifests in
+sync no matter how an operator overrides server.mcp.addr.
+
+Returns the port as an integer. Fails template render with a clear
+message if the addr lacks a parseable port suffix — better than
+silently rendering containerPort: 0 and producing a pod that crashes
+on bind.
+*/}}
+{{- define "demarkus-broker.mcpPort" -}}
+{{- $addr := .Values.server.mcp.addr -}}
+{{- if not $addr -}}
+{{- fail "server.mcp.addr is required (e.g. \":8081\")" -}}
+{{- end -}}
+{{- $port := splitList ":" $addr | last -}}
+{{- if not $port -}}
+{{- fail (printf "server.mcp.addr %q has no parseable port suffix" $addr) -}}
+{{- end -}}
+{{- $port | int -}}
+{{- end -}}
+
+{{/*
 Cookie key resolution. Order of precedence:
   1. .Values.server.cookieKey (operator-supplied literal)
   2. Existing config Secret (preserves the key across helm upgrades)

--- a/deploy/helm/demarkus-broker/templates/certificate.yaml
+++ b/deploy/helm/demarkus-broker/templates/certificate.yaml
@@ -30,3 +30,27 @@ spec:
     kind: {{ .Values.ingress.tls.certManager.issuerRef.kind }}
     name: {{ .Values.ingress.tls.certManager.issuerRef.name }}
 {{- end }}
+{{- if and .Values.ingress.enabled .Values.ingress.mcp.host .Values.ingress.mcp.tls.certManager.enabled }}
+---
+{{- /* Parallel Certificate for the MCP host. Independent secretName,
+       independent issuerRef — two surfaces, two certs, rotation on
+       either side cannot disturb the other. */ -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "demarkus-broker.fullname" . }}-mcp-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "demarkus-broker.labels" . | nindent 4 }}
+  {{- with .Values.ingress.mcp.tls.certManager.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  secretName: {{ include "demarkus-broker.fullname" . }}-mcp-tls
+  dnsNames:
+    - {{ .Values.ingress.mcp.host | quote }}
+  issuerRef:
+    kind: {{ .Values.ingress.mcp.tls.certManager.issuerRef.kind }}
+    name: {{ .Values.ingress.mcp.tls.certManager.issuerRef.name }}
+{{- end }}

--- a/deploy/helm/demarkus-broker/templates/deployment.yaml
+++ b/deploy/helm/demarkus-broker/templates/deployment.yaml
@@ -85,6 +85,15 @@ spec:
             - name: http
               protocol: TCP
               containerPort: {{ .Values.server.port }}
+            {{- /* MCP gateway listener (knowledge-system layer; plan:
+                   Broker MCP Gateway). Always rendered — the listener
+                   is part of the binary, not a feature flag. The port
+                   is extracted from server.mcp.addr so a single knob
+                   keeps containerPort, Service, NetworkPolicy, and
+                   the rendered config in sync. */}}
+            - name: mcp
+              protocol: TCP
+              containerPort: {{ include "demarkus-broker.mcpPort" . }}
           {{- if .Values.probes.enabled }}
           livenessProbe:
             httpGet:
@@ -109,6 +118,18 @@ spec:
               readOnly: true
             - name: tmp
               mountPath: /tmp
+            {{- /* MCP TLS Secret mount. Only present when the
+                   operator pinned an existingSecretRef — the chart's
+                   only TLS mode for the MCP listener (cleartext PEMs
+                   in helm release history are out of scope). Mount
+                   path is chart-managed so secret-config.yaml can
+                   render the absolute certFile/keyFile values into
+                   the broker's config.yaml without a separate knob. */}}
+            {{- if .Values.server.mcp.tls.existingSecretRef.name }}
+            - name: mcp-tls
+              mountPath: {{ include "demarkus-broker.mcpTLSMountPath" . | quote }}
+              readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -120,6 +141,22 @@ spec:
                 path: config.yaml
         - name: tmp
           emptyDir: {}
+        {{- if .Values.server.mcp.tls.existingSecretRef.name }}
+        - name: mcp-tls
+          secret:
+            secretName: {{ .Values.server.mcp.tls.existingSecretRef.name | quote }}
+            {{- /* kubernetes.io/tls Secrets always carry tls.crt +
+                   tls.key data keys. The chart projects those two
+                   keys explicitly so a misconfigured Secret (e.g. a
+                   generic Opaque Secret with the wrong data keys)
+                   fails pod startup with a clear "missing key"
+                   error rather than mounting an empty directory. */}}
+            items:
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+        {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- range $constraint := . }}

--- a/deploy/helm/demarkus-broker/templates/ingress.yaml
+++ b/deploy/helm/demarkus-broker/templates/ingress.yaml
@@ -24,6 +24,16 @@
 {{- $mgmtTLSSecret = printf "%s-tls" (include "demarkus-broker.fullname" .) -}}
 {{- end -}}
 {{- $mcpHost := .Values.ingress.mcp.host -}}
+{{- /* The MCP gateway routes through a SEPARATE hostname from the
+       management API; collocating them on the same host would mean
+       two Ingress rules backing different Service ports for the
+       same hostname (controller-dependent precedence, undefined
+       across implementations) AND would reintroduce the very
+       /.well-known/* collision the split-host topology exists to
+       avoid. Fail render rather than ship an ambiguous Ingress. */ -}}
+{{- if and $mcpHost (eq $mcpHost .Values.ingress.host) -}}
+{{- fail "ingress.mcp.host must differ from ingress.host (split-hostname topology — see README § MCP gateway)" -}}
+{{- end -}}
 {{- $mcpTLSSecret := "" -}}
 {{- if $mcpHost -}}
 {{- if .Values.ingress.mcp.tls.existingSecret -}}

--- a/deploy/helm/demarkus-broker/templates/ingress.yaml
+++ b/deploy/helm/demarkus-broker/templates/ingress.yaml
@@ -10,11 +10,27 @@
 {{- if and .Values.ingress.tls.existingSecret .Values.ingress.tls.certManager.enabled }}
 {{- fail "ingress.tls.existingSecret and ingress.tls.certManager.enabled are mutually exclusive; set exactly one" }}
 {{- end }}
-{{- $tlsSecret := "" -}}
+{{- /* Same mutual-exclusion guard for the MCP host's TLS modes.
+       Independent from the management host's TLS — operators rotate
+       certs on each surface independently, which is the point of
+       splitting the hosts in the first place. */ -}}
+{{- if and .Values.ingress.mcp.tls.existingSecret .Values.ingress.mcp.tls.certManager.enabled }}
+{{- fail "ingress.mcp.tls.existingSecret and ingress.mcp.tls.certManager.enabled are mutually exclusive; set exactly one" }}
+{{- end }}
+{{- $mgmtTLSSecret := "" -}}
 {{- if .Values.ingress.tls.existingSecret -}}
-{{- $tlsSecret = .Values.ingress.tls.existingSecret -}}
+{{- $mgmtTLSSecret = .Values.ingress.tls.existingSecret -}}
 {{- else if .Values.ingress.tls.certManager.enabled -}}
-{{- $tlsSecret = printf "%s-tls" (include "demarkus-broker.fullname" .) -}}
+{{- $mgmtTLSSecret = printf "%s-tls" (include "demarkus-broker.fullname" .) -}}
+{{- end -}}
+{{- $mcpHost := .Values.ingress.mcp.host -}}
+{{- $mcpTLSSecret := "" -}}
+{{- if $mcpHost -}}
+{{- if .Values.ingress.mcp.tls.existingSecret -}}
+{{- $mcpTLSSecret = .Values.ingress.mcp.tls.existingSecret -}}
+{{- else if .Values.ingress.mcp.tls.certManager.enabled -}}
+{{- $mcpTLSSecret = printf "%s-mcp-tls" (include "demarkus-broker.fullname" .) -}}
+{{- end -}}
 {{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -29,11 +45,18 @@ metadata:
   {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.className | quote }}
-  {{- if $tlsSecret }}
+  {{- if or $mgmtTLSSecret $mcpTLSSecret }}
   tls:
+    {{- if $mgmtTLSSecret }}
     - hosts:
         - {{ .Values.ingress.host | quote }}
-      secretName: {{ $tlsSecret }}
+      secretName: {{ $mgmtTLSSecret }}
+    {{- end }}
+    {{- if and $mcpHost $mcpTLSSecret }}
+    - hosts:
+        - {{ $mcpHost | quote }}
+      secretName: {{ $mcpTLSSecret }}
+    {{- end }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host | quote }}
@@ -46,4 +69,23 @@ spec:
                 name: {{ include "demarkus-broker.fullname" . }}
                 port:
                   number: {{ .Values.server.port }}
+    {{- /* MCP gateway routed via a SEPARATE hostname rather than
+           path-mixed on the management host. Avoids `.well-known/*`
+           collisions between the management API's OIDC discovery
+           and the MCP listener's OAuth metadata endpoints. The
+           backend Service port is the MCP port resolved from
+           server.mcp.addr by the mcpPort helper so the four
+           manifests stay in lockstep. */}}
+    {{- if $mcpHost }}
+    - host: {{ $mcpHost | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "demarkus-broker.fullname" . }}
+                port:
+                  number: {{ include "demarkus-broker.mcpPort" . }}
+    {{- end }}
 {{- end }}

--- a/deploy/helm/demarkus-broker/templates/networkpolicy.yaml
+++ b/deploy/helm/demarkus-broker/templates/networkpolicy.yaml
@@ -34,6 +34,14 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.server.port }}
+        {{- /* MCP gateway port admitted from the same ingress-
+               controller namespace. Same trust topology as the
+               management API — the gateway is fronted by the same
+               Ingress controller (different hostname, different
+               Service port) so it does not warrant a separate
+               from-block. */}}
+        - protocol: TCP
+          port: {{ include "demarkus-broker.mcpPort" . }}
   egress:
     # DNS — UDP + TCP to kube-system (CoreDNS / kube-dns).
     - to:

--- a/deploy/helm/demarkus-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-config.yaml
@@ -43,6 +43,22 @@ it contains both the OIDC client secret and the cookie HMAC key.
 {{- if and .Values.oidc.existingSigningKeyRef.name (not .Values.oidc.existingSigningKeyRef.key) -}}
 {{- fail "oidc.existingSigningKeyRef.key is required when oidc.existingSigningKeyRef.name is set" -}}
 {{- end -}}
+{{- /* MCP gateway TLS validation. The chart's only TLS mode is
+       existingSecretRef pointing at a kubernetes.io/tls Secret;
+       in-line cert/key cleartext is deliberately not supported (a
+       private-key PEM in helm release history is never acceptable
+       even for dev). Skipping TLS entirely (existingSecretRef.name
+       blank) is the recommended path because the Ingress terminates
+       TLS at the edge. */ -}}
+{{- /* server.port is an int, server.mcp.addr is a host:port string.
+       Catch the misconfig where an operator points both listeners
+       at the same port (would collide at bind() inside the broker
+       pod, surfacing as a CrashLoop with no breadcrumb in the
+       chart-render output). */ -}}
+{{- $mgmtAddr := printf ":%d" (int .Values.server.port) -}}
+{{- if and .Values.server.mcp.addr (eq .Values.server.mcp.addr $mgmtAddr) -}}
+{{- fail "server.mcp.addr must differ from server.port (management API and MCP gateway bind distinct listeners)" -}}
+{{- end -}}
 {{- $cookieKey := include "demarkus-broker.resolveCookieKey" . -}}
 apiVersion: v1
 kind: Secret
@@ -66,6 +82,23 @@ stringData:
       idTokenTTL: {{ .Values.server.idTokenTTL | quote }}
       publicURL: {{ required "server.publicURL is required" .Values.server.publicURL | quote }}
       insecureCookies: {{ .Values.server.insecureCookies }}
+      {{- /* MCP gateway block. Always rendered — gateway is always
+             on (plan v4 Non-Negotiable). TLS certFile/keyFile are
+             only emitted when an existingSecretRef pins them to the
+             chart-managed mount path; absence means the broker
+             listens plain HTTP and the Ingress terminates TLS. */}}
+      mcp:
+        addr: {{ .Values.server.mcp.addr | quote }}
+        {{- with .Values.server.mcp.tls.existingSecretRef.name }}
+        tls:
+          certFile: {{ printf "%s/tls.crt" (include "demarkus-broker.mcpTLSMountPath" $) | quote }}
+          keyFile: {{ printf "%s/tls.key" (include "demarkus-broker.mcpTLSMountPath" $) | quote }}
+        {{- end }}
+        sessionMaxIdle: {{ .Values.server.mcp.sessionMaxIdle | quote }}
+        maxSessions: {{ .Values.server.mcp.maxSessions }}
+        firstMintMaxAttempts: {{ .Values.server.mcp.firstMintMaxAttempts }}
+        firstMintInitialBackoff: {{ .Values.server.mcp.firstMintInitialBackoff | quote }}
+        firstMintMaxBackoff: {{ .Values.server.mcp.firstMintMaxBackoff | quote }}
     oidc:
       issuer: {{ required "oidc.issuer is required" .Values.oidc.issuer | quote }}
       clientID: {{ required "oidc.clientID is required" .Values.oidc.clientID | quote }}
@@ -99,6 +132,14 @@ stringData:
                and the operator can grep for the field. Blank string means
                "skip in /me/install" — enforced by the broker, not here. */}}
         publicURL: {{ default "" .publicURL | quote }}
+        {{- /* internalAddress overrides the default Service-DNS
+               resolution the MCP gateway uses to route tool calls
+               keyed by worldName. Optional: blank string means
+               "use the <name>.<namespace>.svc.cluster.local:6309
+               convention" — enforced broker-side, not here.
+               Rendered explicitly so the YAML shape stays stable
+               across set/unset. */}}
+        internalAddress: {{ default "" .internalAddress | quote }}
         allow:
           domains: {{ default (list) (get $allow "domains") | toJson }}
           groups: {{ default (list) (get $allow "groups") | toJson }}

--- a/deploy/helm/demarkus-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-config.yaml
@@ -50,13 +50,15 @@ it contains both the OIDC client secret and the cookie HMAC key.
        even for dev). Skipping TLS entirely (existingSecretRef.name
        blank) is the recommended path because the Ingress terminates
        TLS at the edge. */ -}}
-{{- /* server.port is an int, server.mcp.addr is a host:port string.
-       Catch the misconfig where an operator points both listeners
-       at the same port (would collide at bind() inside the broker
+{{- /* Catch the misconfig where an operator points both listeners
+       at the same port — would collide at bind() inside the broker
        pod, surfacing as a CrashLoop with no breadcrumb in the
-       chart-render output). */ -}}
-{{- $mgmtAddr := printf ":%d" (int .Values.server.port) -}}
-{{- if and .Values.server.mcp.addr (eq .Values.server.mcp.addr $mgmtAddr) -}}
+       chart-render output. Compare the parsed port NUMBERS rather
+       than raw strings so equivalent forms like `0.0.0.0:8080`,
+       `:8080`, and `127.0.0.1:8080` all collapse to one collision
+       signal against management's `server.port`. */ -}}
+{{- $mcpPort := include "demarkus-broker.mcpPort" . | int -}}
+{{- if eq $mcpPort (int .Values.server.port) -}}
 {{- fail "server.mcp.addr must differ from server.port (management API and MCP gateway bind distinct listeners)" -}}
 {{- end -}}
 {{- $cookieKey := include "demarkus-broker.resolveCookieKey" . -}}

--- a/deploy/helm/demarkus-broker/templates/service.yaml
+++ b/deploy/helm/demarkus-broker/templates/service.yaml
@@ -15,5 +15,13 @@ spec:
       protocol: TCP
       port: {{ .Values.server.port }}
       targetPort: http
+    {{- /* MCP gateway port. Always rendered alongside `http` — the
+           listener is always on. `targetPort: mcp` resolves to the
+           deployment's named containerPort so renumbering
+           server.mcp.addr never desyncs the Service from the pod. */}}
+    - name: mcp
+      protocol: TCP
+      port: {{ include "demarkus-broker.mcpPort" . }}
+      targetPort: mcp
   selector:
     {{- include "demarkus-broker.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/demarkus-broker/tests/deployment_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/latebit-io/demarkus-broker:0.1.0
+          value: ghcr.io/latebit-io/demarkus-broker:0.2.0
       - notExists:
           path: spec.template.spec.containers[0].command
 

--- a/deploy/helm/demarkus-broker/tests/mcp_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/mcp_test.yaml
@@ -227,6 +227,30 @@ tests:
       - failedTemplate:
           errorMessage: "server.mcp.addr must differ from server.port (management API and MCP gateway bind distinct listeners)"
 
+  - it: fail-render when server.mcp.addr binds same port via 0.0.0.0 form (numeric compare, not string)
+    template: secret-config.yaml
+    set:
+      server.mcp.addr: "0.0.0.0:8080"
+    asserts:
+      - failedTemplate:
+          errorMessage: "server.mcp.addr must differ from server.port (management API and MCP gateway bind distinct listeners)"
+
+  - it: fail-render when server.mcp.addr has a non-numeric port suffix
+    template: service.yaml
+    set:
+      server.mcp.addr: ":abc"
+    asserts:
+      - failedTemplate:
+          errorMessage: 'server.mcp.addr ":abc" has a non-numeric port suffix "abc"'
+
+  - it: fail-render when server.mcp.addr port is out of legal range
+    template: service.yaml
+    set:
+      server.mcp.addr: ":99999"
+    asserts:
+      - failedTemplate:
+          errorMessage: 'server.mcp.addr ":99999" port 99999 is outside the legal 1..65535 range'
+
   # Ingress.mcp host topology: separate hostname, separate TLS Secret.
 
   - it: Ingress with no ingress.mcp.host has only the management rule
@@ -309,6 +333,16 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ingress.mcp.tls.existingSecret and ingress.mcp.tls.certManager.enabled are mutually exclusive; set exactly one"
+
+  - it: fail-render when ingress.mcp.host equals ingress.host (collocated hosts forbidden)
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.host: broker.example.com
+      ingress.mcp.host: broker.example.com
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.mcp.host must differ from ingress.host (split-hostname topology — see README § MCP gateway)"
 
   - it: parallel cert-manager Certificates emit when both hosts configured
     template: certificate.yaml

--- a/deploy/helm/demarkus-broker/tests/mcp_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/mcp_test.yaml
@@ -1,0 +1,365 @@
+suite: mcp gateway
+templates:
+  - deployment.yaml
+  - service.yaml
+  - networkpolicy.yaml
+  - ingress.yaml
+  - certificate.yaml
+  - secret-config.yaml
+release:
+  namespace: broker-ns
+set:
+  oidc.issuer: https://accounts.example.com
+  oidc.clientID: broker-app
+  oidc.clientSecret: shh
+  oidc.redirectURL: https://broker.example.com/auth/callback
+  oidc.brokerSigningKey: "test-pem-placeholder"
+  server.publicURL: https://broker.example.com
+tests:
+  # Deployment: always-on MCP containerPort + optional TLS volume.
+
+  - it: deployment exposes `mcp` containerPort derived from server.mcp.addr (default :8081)
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: mcp
+            protocol: TCP
+            containerPort: 8081
+
+  - it: server.mcp.addr override flows through to the MCP containerPort
+    template: deployment.yaml
+    set:
+      server.mcp.addr: ":9443"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: mcp
+            protocol: TCP
+            containerPort: 9443
+
+  - it: MCP TLS volume absent by default (no existingSecretRef.name)
+    template: deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          any: true
+          content:
+            name: mcp-tls
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          any: true
+          content:
+            name: mcp-tls
+            mountPath: /etc/demarkus-broker/tls/mcp
+            readOnly: true
+
+  - it: MCP TLS volume + mount projected when existingSecretRef.name set
+    template: deployment.yaml
+    set:
+      server.mcp.tls.existingSecretRef.name: my-mcp-tls
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: mcp-tls
+            mountPath: /etc/demarkus-broker/tls/mcp
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: mcp-tls
+            secret:
+              secretName: my-mcp-tls
+              items:
+                - key: tls.crt
+                  path: tls.crt
+                - key: tls.key
+                  path: tls.key
+
+  # Service: always-on mcp port aligned to the deployment's named containerPort.
+
+  - it: Service exposes `http` and `mcp` named ports, both default
+    template: service.yaml
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            protocol: TCP
+            port: 8080
+            targetPort: http
+      - contains:
+          path: spec.ports
+          content:
+            name: mcp
+            protocol: TCP
+            port: 8081
+            targetPort: mcp
+
+  - it: server.mcp.addr override flows through the Service port too
+    template: service.yaml
+    set:
+      server.mcp.addr: ":9443"
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: mcp
+            protocol: TCP
+            port: 9443
+            targetPort: mcp
+
+  # NetworkPolicy: ingress admits both ports from the same ingress namespace.
+
+  - it: NetworkPolicy admits MCP port alongside management API port
+    template: networkpolicy.yaml
+    asserts:
+      - contains:
+          path: spec.ingress[0].ports
+          content:
+            protocol: TCP
+            port: 8080
+      - contains:
+          path: spec.ingress[0].ports
+          content:
+            protocol: TCP
+            port: 8081
+
+  # Secret-config: the rendered config.yaml carries the MCP block.
+
+  - it: config.yaml renders the mcp block with defaults
+    template: secret-config.yaml
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'mcp:\s*\n\s*addr: ":8081"\s*\n\s*sessionMaxIdle: "1h"\s*\n\s*maxSessions: 10000\s*\n\s*firstMintMaxAttempts: 6\s*\n\s*firstMintInitialBackoff: "250ms"\s*\n\s*firstMintMaxBackoff: "8s"'
+
+  - it: config.yaml omits mcp.tls block when no existingSecretRef set
+    template: secret-config.yaml
+    asserts:
+      - notMatchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'certFile:'
+      - notMatchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'keyFile:'
+
+  - it: config.yaml emits mcp.tls cert/key paths when existingSecretRef set
+    template: secret-config.yaml
+    set:
+      server.mcp.tls.existingSecretRef.name: my-mcp-tls
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'tls:\s*\n\s*certFile: "/etc/demarkus-broker/tls/mcp/tls.crt"\s*\n\s*keyFile: "/etc/demarkus-broker/tls/mcp/tls.key"'
+
+  - it: mcp.sessionMaxIdle override flows through
+    template: secret-config.yaml
+    set:
+      server.mcp.sessionMaxIdle: 30m
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'sessionMaxIdle: "30m"'
+
+  - it: mcp.firstMint* knobs all override into the rendered config
+    template: secret-config.yaml
+    set:
+      server.mcp.firstMintMaxAttempts: 3
+      server.mcp.firstMintInitialBackoff: 100ms
+      server.mcp.firstMintMaxBackoff: 1s
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'firstMintMaxAttempts: 3'
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'firstMintInitialBackoff: "100ms"'
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'firstMintMaxBackoff: "1s"'
+
+  # worlds[].internalAddress: stable shape, override flows through.
+
+  - it: world without internalAddress renders an empty internalAddress field
+    template: secret-config.yaml
+    set:
+      worlds:
+        - name: team-a
+          namespace: team-a
+          tokensSecret: team-a-tokens
+          defaultToken:
+            paths: ["/team-a/*"]
+            operations: ["read"]
+            expiresAfter: 24h
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'internalAddress: ""'
+
+  - it: world internalAddress override flows through
+    template: secret-config.yaml
+    set:
+      worlds:
+        - name: team-a
+          namespace: team-a
+          tokensSecret: team-a-tokens
+          internalAddress: "team-a-mark.team-a:6309"
+          defaultToken:
+            paths: ["/team-a/*"]
+            operations: ["read"]
+            expiresAfter: 24h
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'internalAddress: "team-a-mark.team-a:6309"'
+
+  # Fail-fast guards.
+
+  - it: fail-render when server.mcp.addr collides with server.port
+    template: secret-config.yaml
+    set:
+      server.mcp.addr: ":8080"
+    asserts:
+      - failedTemplate:
+          errorMessage: "server.mcp.addr must differ from server.port (management API and MCP gateway bind distinct listeners)"
+
+  # Ingress.mcp host topology: separate hostname, separate TLS Secret.
+
+  - it: Ingress with no ingress.mcp.host has only the management rule
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.host: broker.example.com
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: broker.example.com
+      - notExists:
+          path: spec.rules[1]
+
+  - it: Ingress with ingress.mcp.host adds a second rule routing to the mcp Service port
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.host: broker.example.com
+      ingress.mcp.host: mcp.broker.example.com
+    asserts:
+      - equal:
+          path: spec.rules[1].host
+          value: mcp.broker.example.com
+      - equal:
+          path: spec.rules[1].http.paths[0].path
+          value: /
+      - equal:
+          path: spec.rules[1].http.paths[0].pathType
+          value: Prefix
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service.port.number
+          value: 8081
+
+  - it: ingress.mcp.host with existingSecret adds a parallel TLS block
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.host: broker.example.com
+      ingress.tls.existingSecret: mgmt-tls
+      ingress.mcp.host: mcp.broker.example.com
+      ingress.mcp.tls.existingSecret: mcp-tls
+    asserts:
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: broker.example.com
+      - equal:
+          path: spec.tls[0].secretName
+          value: mgmt-tls
+      - equal:
+          path: spec.tls[1].hosts[0]
+          value: mcp.broker.example.com
+      - equal:
+          path: spec.tls[1].secretName
+          value: mcp-tls
+
+  - it: ingress.mcp.host with certManager points TLS at the chart-generated Secret
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.host: broker.example.com
+      ingress.mcp.host: mcp.broker.example.com
+      ingress.mcp.tls.certManager.enabled: true
+    asserts:
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: mcp.broker.example.com
+      - equal:
+          path: spec.tls[0].secretName
+          value: RELEASE-NAME-demarkus-broker-mcp-tls
+
+  - it: fail-render when both ingress.mcp.tls.existingSecret and certManager.enabled set
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.host: broker.example.com
+      ingress.mcp.host: mcp.broker.example.com
+      ingress.mcp.tls.existingSecret: mcp-tls
+      ingress.mcp.tls.certManager.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.mcp.tls.existingSecret and ingress.mcp.tls.certManager.enabled are mutually exclusive; set exactly one"
+
+  - it: parallel cert-manager Certificates emit when both hosts configured
+    template: certificate.yaml
+    set:
+      ingress.enabled: true
+      ingress.host: broker.example.com
+      ingress.tls.certManager.enabled: true
+      ingress.mcp.host: mcp.broker.example.com
+      ingress.mcp.tls.certManager.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: MCP-only cert-manager Certificate renders when only MCP cert-manager enabled
+    template: certificate.yaml
+    set:
+      ingress.enabled: true
+      ingress.host: broker.example.com
+      ingress.tls.existingSecret: mgmt-pre-provisioned
+      ingress.mcp.host: mcp.broker.example.com
+      ingress.mcp.tls.certManager.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-demarkus-broker-mcp-tls
+      - equal:
+          path: spec.secretName
+          value: RELEASE-NAME-demarkus-broker-mcp-tls
+      - equal:
+          path: spec.dnsNames[0]
+          value: mcp.broker.example.com
+      - equal:
+          path: spec.issuerRef.kind
+          value: ClusterIssuer
+      - equal:
+          path: spec.issuerRef.name
+          value: letsencrypt-prod
+
+  - it: no MCP Certificate when ingress.mcp.host blank even if certManager enabled
+    template: certificate.yaml
+    set:
+      ingress.enabled: true
+      ingress.host: broker.example.com
+      ingress.tls.certManager.enabled: true
+      ingress.mcp.tls.certManager.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-demarkus-broker-tls
+          documentIndex: 0

--- a/deploy/helm/demarkus-broker/values.yaml
+++ b/deploy/helm/demarkus-broker/values.yaml
@@ -125,8 +125,12 @@ server:
     #      deployment topology bypasses the Ingress entirely.
     #
     # The Secret must be a kubernetes.io/tls Secret (data keys
-    # `tls.crt` + `tls.key`). The chart fails template-render if
-    # existingSecretRef is set with the wrong shape.
+    # `tls.crt` + `tls.key`). The chart only references the Secret
+    # by NAME at render time; a wrong type (Opaque instead of
+    # kubernetes.io/tls) or missing data keys surface later as a
+    # `CreateContainerConfigError` when the kubelet tries to project
+    # the volume at pod startup. Verify the Secret shape out of band
+    # before pointing the chart at it.
     tls:
       existingSecretRef:
         # Name of the kubernetes.io/tls Secret in the release

--- a/deploy/helm/demarkus-broker/values.yaml
+++ b/deploy/helm/demarkus-broker/values.yaml
@@ -90,6 +90,81 @@ server:
   # chart lifecycle events never invalidate live refresh tokens.
   refreshTokensSecret: ""
 
+  # MCP gateway listener (knowledge-system layer; plan: Broker MCP
+  # Gateway). The gateway is ALWAYS ON — every broker is a
+  # knowledge-system gateway, there is no `enabled` knob. Operators
+  # tune the address, TLS, and session-cache behavior here. An
+  # existing pre-gateway deployment picks up the listener on :8081
+  # silently on chart upgrade: the listener binds, the Service grows
+  # a second `mcp` port, the NetworkPolicy admits traffic to it.
+  # Exposure beyond the cluster requires setting `ingress.mcp.host`
+  # (see the Ingress block below); leaving it unset keeps the
+  # listener cluster-internal.
+  #
+  # Sized for an enterprise universe: ~10k unique users × ~5 worlds
+  # at ~200 bytes per cached world-token ≈ 10MB of session-cache
+  # memory at saturation. Tune `maxSessions` if your population is
+  # materially larger or smaller.
+  mcp:
+    # Listen address inside the pod. Must differ from server.port so
+    # the management API and the MCP surface bind distinct listeners.
+    # The Service exposes both ports; the Ingress routes by hostname.
+    addr: ":8081"
+    # TLS termination at the broker for the MCP listener. Two modes:
+    #
+    #   1. existingSecretRef.name unset (default) — broker speaks
+    #      plain HTTP inside the cluster; the Ingress controller
+    #      terminates TLS at the edge. Matches the management API's
+    #      posture. Recommended for typical k8s deployments.
+    #
+    #   2. existingSecretRef.name set — chart mounts the named
+    #      kubernetes.io/tls Secret read-only at a chart-managed
+    #      path inside the broker pod and the rendered config
+    #      points the MCP listener at the cert+key files. Use this
+    #      when broker-to-Ingress mTLS is required, or when the
+    #      deployment topology bypasses the Ingress entirely.
+    #
+    # The Secret must be a kubernetes.io/tls Secret (data keys
+    # `tls.crt` + `tls.key`). The chart fails template-render if
+    # existingSecretRef is set with the wrong shape.
+    tls:
+      existingSecretRef:
+        # Name of the kubernetes.io/tls Secret in the release
+        # namespace. Empty disables broker-side TLS.
+        name: ""
+    # Per-email session idle timeout. A returning user past idle pays
+    # one lazy-mint round trip on their next call. Default 1h.
+    sessionMaxIdle: 1h
+    # LRU cap on cached email sessions. Eviction is lossless from
+    # the user's perspective — an evicted session is re-minted on
+    # the next call. Default 10000.
+    maxSessions: 10000
+    # World-token TTL is NOT a chart knob. Cached world tokens carry
+    # their natural expiry from Issuer.MintFiltered (the world's
+    # defaultToken.expiresAfter, plus refresh on id_token rotation).
+    # Plan OQ#5 (Broker MCP Gateway v5) pinned this: the broker
+    # respects the world's own TTL rather than overriding it
+    # broker-side. Tune per-world TTL via `worlds[].defaultToken.
+    # expiresAfter` instead.
+    #
+    # First-mint retry loop knobs. After a lazy mint, the world's
+    # projected-Secret-volume refresh has a kubelet-bounded
+    # propagation lag — a freshly-minted token can 401 at the
+    # world for up to ~kubeletSyncPeriod (default ~1 min). The
+    # retry loop runs only when dispatch produces `unauthorized`
+    # on a token the broker just minted (or just re-minted after
+    # a cache-hit 401), distinguishing the propagation race from a
+    # genuine permission denial.
+    #
+    # Defaults (6 attempts, 250ms → 8s exponential) sum to ~16s of
+    # waiting across attempts, well under the typical worst-case
+    # propagation window. Tune up for slow-kubelet clusters; tune
+    # down for development setups where retry latency masks
+    # genuine misconfiguration.
+    firstMintMaxAttempts: 6
+    firstMintInitialBackoff: 250ms
+    firstMintMaxBackoff: 8s
+
 oidc:
   # OIDC discovery URL (e.g. https://accounts.google.com).
   issuer: ""
@@ -165,6 +240,16 @@ worlds: []
   #   # VPN-reachable hostname or in-cluster Service when the user's
   #   # network can route to it; see docs/deployment/security-topology.md.
   #   publicURL: "mark://world-a.cluster.internal:6309"
+  #   # Cluster-internal address the MCP gateway uses to route
+  #   # `mark://{worldName}/{path}` tool calls to this world.
+  #   # Optional: when blank, the gateway resolves via the standard
+  #   # `<name>.<namespace>.svc.cluster.local:6309` Service-DNS
+  #   # convention (the demarkus-server chart's default keeps Service
+  #   # name == world name, so most deployments leave this blank).
+  #   # Override when the Service name diverges from the world's
+  #   # logical name. Host:port only — the `mark://` scheme is
+  #   # implicit.
+  #   # internalAddress: "team-a-mark.team-a:6309"
   #   allow:
   #     domains: ["nesto.ca"]
   #     groups: ["engineering"]
@@ -303,6 +388,44 @@ ingress:
         name: letsencrypt-prod
       # Annotations on the Certificate resource.
       annotations: {}
+
+  # MCP gateway exposure. The MCP listener (server.mcp.addr, default
+  # :8081) is a separate listener from the management API, so it
+  # routes through a distinct hostname rather than path-mixing on
+  # the primary host. Keeping the hostnames separate avoids
+  # `.well-known/*` collisions between the management API's OIDC
+  # discovery (`/.well-known/openid-configuration`,
+  # `/.well-known/jwks.json`) and the MCP listener's OAuth metadata
+  # (`/.well-known/oauth-protected-resource`,
+  # `/.well-known/oauth-authorization-server`).
+  #
+  # When `mcp.host` is set the chart adds a second rule + TLS block
+  # to the same Ingress resource, routing the MCP host to the
+  # Service's `mcp` port. Leave blank to keep the listener
+  # cluster-internal (still reachable from inside the cluster for
+  # in-cluster MCP clients or smoke tests). The MCP host requires
+  # the parent `ingress.enabled` to be true.
+  mcp:
+    # Public hostname the MCP gateway is reachable at, e.g.
+    # mcp.broker.example.com. Empty disables MCP ingress (listener
+    # stays cluster-internal). Independent of `ingress.host`.
+    host: ""
+    # TLS configuration for the MCP host. Same three-mode shape as
+    # the management host's `ingress.tls`:
+    #   1. existingSecret: pre-existing kubernetes.io/tls Secret.
+    #   2. certManager.enabled=true: chart provisions a Certificate.
+    #   3. neither set: Ingress has no TLS block for this host.
+    # The two TLS modes are mutually exclusive (render-time check).
+    # Use a different Secret/issuer than the management host so
+    # cert rotation on either side stays independent.
+    tls:
+      existingSecret: ""
+      certManager:
+        enabled: false
+        issuerRef:
+          kind: ClusterIssuer
+          name: letsencrypt-prod
+        annotations: {}
 
 service:
   type: ClusterIP

--- a/deploy/kind/up.sh
+++ b/deploy/kind/up.sh
@@ -28,7 +28,7 @@ RELEASE="${RELEASE:-world-default}"
 SERVER_CHART_VERSION="${SERVER_CHART_VERSION:-0.17.9}"
 SERVER_CHART="oci://ghcr.io/latebit-io/charts/demarkus-server"
 BROKER_RELEASE="${BROKER_RELEASE:-broker}"
-BROKER_CHART_VERSION="${BROKER_CHART_VERSION:-0.1.3}"
+BROKER_CHART_VERSION="${BROKER_CHART_VERSION:-0.1.15}"
 BROKER_CHART="oci://ghcr.io/latebit-io/charts/demarkus-broker"
 # Ephemeral curl pod image used by the Stage 4 mint smoke test. Pinned so
 # behavior is reproducible across hosts; busybox sh + curl is all we need.
@@ -57,21 +57,30 @@ APPLICATIONSET_MANIFEST="$REPO_ROOT/deploy/k8s/examples/applicationset.yaml"
 
 WITH_BROKER=false
 WITH_ARGO=false
+WITH_MCP_SMOKE=false
 for arg in "$@"; do
   case "$arg" in
-    --with-broker) WITH_BROKER=true ;;
-    --with-argo)   WITH_ARGO=true ;;
+    --with-broker)   WITH_BROKER=true ;;
+    --with-argo)     WITH_ARGO=true ;;
+    --with-mcp-smoke) WITH_MCP_SMOKE=true ;;
     -h|--help)
       cat <<EOF
-usage: up.sh [--with-broker] [--with-argo]
+usage: up.sh [--with-broker] [--with-argo] [--with-mcp-smoke]
 
-  --with-broker    install mock-oauth2-server + demarkus-broker chart
-  --with-argo      install Argo CD + ApplicationSet templating two worlds
-                   (replaces the Stage 1 server install)
+  --with-broker     install mock-oauth2-server + demarkus-broker chart
+  --with-argo       install Argo CD + ApplicationSet templating two worlds
+                    (replaces the Stage 1 server install)
+  --with-mcp-smoke  rebuild the broker image from this checkout,
+                    sideload it into kind, install the LOCAL broker
+                    chart (deploy/helm/demarkus-broker) with that image,
+                    and run smoke checks against the MCP gateway
+                    listener (\${BROKER_RELEASE}-...:8081). Requires
+                    --with-broker; not compatible with --with-argo
+                    (Stage 4 expects the published chart artifact).
 
-  Combine both for Stage 4: Argo-managed worlds + broker wired across
-  them. up.sh then drives a full OIDC mint flow via curl and asserts
-  tokens land in BOTH world Secrets.
+  Combine --with-broker + --with-argo for Stage 4: Argo-managed worlds
+  + broker wired across them. up.sh then drives a full OIDC mint flow
+  via curl and asserts tokens land in BOTH world Secrets.
 
 env overrides:
   CLUSTER, NAMESPACE, RELEASE, SERVER_CHART_VERSION,
@@ -85,6 +94,22 @@ EOF
   esac
 done
 
+if [[ "$WITH_MCP_SMOKE" == "true" ]]; then
+  if [[ "$WITH_BROKER" != "true" ]]; then
+    echo "--with-mcp-smoke requires --with-broker" >&2
+    exit 2
+  fi
+  if [[ "$WITH_ARGO" == "true" ]]; then
+    # Stage 4 pulls the published broker chart from OCI and pins its
+    # version for reproducibility. Mixing in a local-chart/local-image
+    # build would invert that invariant. Run the MCP smoke against
+    # Stage 2 instead, then layer Argo on a separate harness invocation
+    # if both shapes are needed.
+    echo "--with-mcp-smoke is not compatible with --with-argo (Stage 4 pins the OCI chart)" >&2
+    exit 2
+  fi
+fi
+
 require() {
   command -v "$1" >/dev/null 2>&1 || {
     echo "missing required tool: $1" >&2
@@ -96,6 +121,10 @@ require kind
 require helm
 require kubectl
 require openssl
+if [[ "$WITH_MCP_SMOKE" == "true" ]]; then
+  require docker
+  require make
+fi
 
 # ensure_broker_signing_key generates a fresh ECDSA P-256 PEM and
 # applies it as a Kubernetes Secret named `broker-signing-key`
@@ -390,22 +419,97 @@ if [[ "$WITH_BROKER" == "true" ]]; then
 
   ensure_broker_signing_key "$NAMESPACE"
 
-  echo "--- installing demarkus-broker chart $BROKER_CHART_VERSION"
-  # helm install --wait blocks on the broker's readiness probe, which hits
-  # /readyz. /readyz only flips green after OIDC discovery + JWKS fetch
-  # against the mock issuer have completed, so a successful install here
-  # already proves discovery works end-to-end.
-  helm upgrade --install "$BROKER_RELEASE" "$BROKER_CHART" \
-    --version "$BROKER_CHART_VERSION" \
-    --namespace "$NAMESPACE" --create-namespace \
-    --values "$BROKER_VALUES_FILE" \
-    --wait --timeout 5m
+  if [[ "$WITH_MCP_SMOKE" == "true" ]]; then
+    # --with-mcp-smoke replaces the OCI broker install with a local-chart
+    # + locally-built-image install so the MCP smoke checks below actually
+    # exercise THIS BRANCH's chart wiring (server.mcp.*, the `mcp`
+    # Service port, the NetworkPolicy port admission). Image tag is
+    # ephemeral so subsequent --with-mcp-smoke runs always rebuild from
+    # the current checkout.
+    MCP_SMOKE_IMAGE_REGISTRY=demarkus-mcp-smoke
+    MCP_SMOKE_IMAGE_TAG="local-$(date +%s)"
+    echo "--- building demarkus-broker image $MCP_SMOKE_IMAGE_REGISTRY/demarkus-broker:$MCP_SMOKE_IMAGE_TAG"
+    ( cd "$REPO_ROOT" && \
+        make image-broker "IMAGE_REGISTRY=$MCP_SMOKE_IMAGE_REGISTRY" "TAG=$MCP_SMOKE_IMAGE_TAG" )
+    echo "--- sideloading image into kind cluster $CLUSTER"
+    kind load docker-image "$MCP_SMOKE_IMAGE_REGISTRY/demarkus-broker:$MCP_SMOKE_IMAGE_TAG" --name "$CLUSTER"
+
+    echo "--- installing LOCAL demarkus-broker chart from $REPO_ROOT/deploy/helm/demarkus-broker"
+    helm upgrade --install "$BROKER_RELEASE" "$REPO_ROOT/deploy/helm/demarkus-broker" \
+      --namespace "$NAMESPACE" --create-namespace \
+      --values "$BROKER_VALUES_FILE" \
+      --set "image.repository=$MCP_SMOKE_IMAGE_REGISTRY/demarkus-broker" \
+      --set "image.tag=$MCP_SMOKE_IMAGE_TAG" \
+      --set "image.pullPolicy=IfNotPresent" \
+      --wait --timeout 5m
+  else
+    echo "--- installing demarkus-broker chart $BROKER_CHART_VERSION"
+    # helm install --wait blocks on the broker's readiness probe, which hits
+    # /readyz. /readyz only flips green after OIDC discovery + JWKS fetch
+    # against the mock issuer have completed, so a successful install here
+    # already proves discovery works end-to-end.
+    helm upgrade --install "$BROKER_RELEASE" "$BROKER_CHART" \
+      --version "$BROKER_CHART_VERSION" \
+      --namespace "$NAMESPACE" --create-namespace \
+      --values "$BROKER_VALUES_FILE" \
+      --wait --timeout 5m
+  fi
 
   BROKER_POD_SELECTOR="app.kubernetes.io/instance=$BROKER_RELEASE,app.kubernetes.io/name=demarkus-broker"
   BROKER_POD=$(kubectl -n "$NAMESPACE" get pods -l "$BROKER_POD_SELECTOR" -o jsonpath='{.items[0].metadata.name}')
   if [[ -z "$BROKER_POD" ]]; then
     echo "no demarkus-broker pod found for selector: $BROKER_POD_SELECTOR" >&2
     exit 1
+  fi
+
+  if [[ "$WITH_MCP_SMOKE" == "true" ]]; then
+    # MCP gateway smoke checks. We deliberately do NOT drive a full
+    # initialize/tools/call flow here — that requires an id_token bearer
+    # obtained via the device-flow exchange + a mint round trip, which
+    # is the natural test surface for Slice 8's /knowledge-join slash
+    # command. These three checks prove the chart's MCP listener is:
+    #   1. bound (port 8081 reachable through the Service)
+    #   2. serving RFC 9728 OAuth metadata (well-known endpoint)
+    #   3. enforcing auth on /mcp (401 + WWW-Authenticate challenge)
+    # That is the smallest evidence that Slice 7's chart wiring works.
+    echo "--- driving MCP gateway smoke checks from an ephemeral curl pod"
+    BROKER_MCP_URL="http://$BROKER_RELEASE-demarkus-broker.$NAMESPACE.svc.cluster.local:8081"
+    kubectl run -n "$NAMESPACE" mcp-smoke --rm -i --restart=Never \
+      --image="$MINT_CURL_IMAGE" --command -- sh -c '
+set -eu
+BROKER_MCP='"$BROKER_MCP_URL"'
+CURL="curl -sS --connect-timeout 5 --max-time 15"
+
+# Wait for the MCP Service endpoint to be reachable. Service object
+# Endpoints can lag the Pod-Ready transition by a beat or two even
+# after helm --wait returns, so a curl on a fresh pod can race.
+for attempt in $(seq 1 15); do
+  HTTP=$($CURL -o /dev/null -w "%{http_code}" "$BROKER_MCP/.well-known/oauth-protected-resource" 2>/dev/null || echo "")
+  if [ "$HTTP" = "200" ]; then break; fi
+  sleep 2
+done
+
+# 1. RFC 9728 metadata endpoint. Returns the resource server
+#    identity + a pointer at the auth-server metadata. No auth.
+META=$($CURL "$BROKER_MCP/.well-known/oauth-protected-resource")
+echo "$META" | grep -q "resource" || { echo "FAIL: oauth-protected-resource missing resource field"; echo "$META"; exit 1; }
+echo "OK: /.well-known/oauth-protected-resource"
+
+# 2. RFC 8414 metadata endpoint. Auth-server metadata — aliases
+#    the broker OIDC Discovery handler. Plain GET, no auth.
+META=$($CURL "$BROKER_MCP/.well-known/oauth-authorization-server")
+echo "$META" | grep -q "issuer" || { echo "FAIL: oauth-authorization-server missing issuer field"; echo "$META"; exit 1; }
+echo "OK: /.well-known/oauth-authorization-server"
+
+# 3. /mcp without auth must 401 with a WWW-Authenticate challenge
+#    per RFC 6750 + RFC 9728 — point fresh clients at the metadata
+#    endpoint they need to bootstrap the auth flow.
+HDR=$($CURL -D - -o /dev/null -X POST "$BROKER_MCP/mcp" -H "Content-Type: application/json" -d "{}")
+echo "$HDR" | grep -qi "^HTTP/.* 401" || { echo "FAIL: POST /mcp without bearer did not 401"; echo "$HDR"; exit 1; }
+echo "$HDR" | grep -qi "^WWW-Authenticate: Bearer" || { echo "FAIL: 401 response missing WWW-Authenticate: Bearer"; echo "$HDR"; exit 1; }
+echo "OK: POST /mcp 401 + WWW-Authenticate"
+'
+    echo "--- MCP gateway smoke checks passed"
   fi
 
   cat <<EOF
@@ -419,12 +523,17 @@ broker release: $BROKER_RELEASE
 broker pod:     $BROKER_POD
 server svc:     $RELEASE-demarkus-server.$NAMESPACE.svc.cluster.local:6309 (UDP)
 broker svc:     $BROKER_RELEASE-demarkus-broker.$NAMESPACE.svc.cluster.local:8080 (HTTP)
+broker MCP svc: $BROKER_RELEASE-demarkus-broker.$NAMESPACE.svc.cluster.local:8081 (HTTP)
 mock OIDC:      mock-oauth2-server.$NAMESPACE.svc.cluster.local:8080/default
 
 probe the broker (from another shell):
   kubectl -n $NAMESPACE port-forward svc/$BROKER_RELEASE-demarkus-broker 8080:8080
   curl http://localhost:8080/healthz
   curl http://localhost:8080/readyz
+
+probe the MCP gateway:
+  kubectl -n $NAMESPACE port-forward svc/$BROKER_RELEASE-demarkus-broker 8081:8081
+  curl http://localhost:8081/.well-known/oauth-protected-resource
 
 server fetch from inside the cluster:
   kubectl -n $NAMESPACE exec -it $POD -- \\

--- a/tools/demarkus-broker/MCP-API.md
+++ b/tools/demarkus-broker/MCP-API.md
@@ -61,7 +61,7 @@ that the demarkus-server already manages.
 
 Every tool that addresses a world uses the URL shape:
 
-```
+```text
 mark://{worldName}/{path}
 ```
 
@@ -200,8 +200,10 @@ hub manifest unless `force: true`.
 
 ### Graph store (ephemeral)
 
-> **The broker's graph store is in-memory only and per-pod-lifetime.**
-> A broker restart drops every cached graph. Re-run `mark_graph` to
+> **The broker's graph store is in-memory only and pod-scoped.**
+> Any event that recycles the broker pod — Helm rollout, OOMKill,
+> node drain or eviction, kubelet restart — drops every cached
+> graph. Re-run `mark_graph` against the relevant worlds to
 > re-populate. This is a deliberate trade-off documented under
 > "Ephemeral graph store" in the chart README — bucket-store-backed
 > persistence is parked for the post-broker design window.

--- a/tools/demarkus-broker/MCP-API.md
+++ b/tools/demarkus-broker/MCP-API.md
@@ -1,0 +1,278 @@
+# Broker MCP API
+
+Operator + developer reference for the 13-tool MCP surface exposed by
+the demarkus-broker's `/mcp` endpoint. Mirrors the local
+`client/cmd/demarkus-mcp` stdio server byte-for-byte: a document
+fetched via the broker and the same document fetched direct-QUIC
+produce identical body bytes, version, modified timestamp, etag, and
+content-hash. The broker is a wire-shape adapter
+(HTTPS/JSON-RPC ↔ QUIC/Mark Protocol), not a content transformation
+layer.
+
+For deployment instructions, TLS, and Ingress topology, see
+`deploy/helm/demarkus-broker/README.md` § "MCP gateway".
+
+## Transport
+
+- **Protocol**: MCP over Streamable HTTP (the MCP spec's preferred
+  remote transport).
+- **Endpoint**: `POST /mcp` on the broker's MCP listener (default
+  `:8081`; typically fronted at `https://mcp.broker.<org>/mcp` by an
+  Ingress).
+- **Auth**: `Authorization: Bearer <id_token>` on every request.
+  The broker accepts both broker-signed id_tokens (from the
+  device-flow refresh grant, PR4) and IdP-signed id_tokens (from
+  the device-flow completion, PR3). Unverified-email tokens are
+  rejected at the gateway boundary.
+- **OAuth metadata**: standard discovery via RFC 9728
+  (`/.well-known/oauth-protected-resource`) and RFC 8414
+  (`/.well-known/oauth-authorization-server`). An unauthenticated
+  request to `/mcp` receives `401 + WWW-Authenticate: Bearer
+  resource_metadata="…oauth-protected-resource"` per RFC 6750 + RFC
+  9728, so a fresh client knows where to bootstrap.
+
+## Identity + session model
+
+The broker keys per-session state on the **canonical verified email**
+extracted from the bearer (`email` claim, trimmed + lowercased,
+`email_verified=true` required). This is the same identity dimension
+the broker's `/me/install`, `/tokens` list/revoke, `AllowConfig`, and
+audit logs already use — one identity per broker, no cross-surface
+drift.
+
+For each `(email, worldName)` pair, the broker lazy-mints a world
+access-token on first use via `Issuer.MintFiltered`, caches it in
+process memory, and re-uses it on subsequent calls. The cache:
+
+- Is per-pod, in-memory only. Broker restart drops it; the next tool
+  call re-mints.
+- Has bounded size (`server.mcp.maxSessions`, default 10000) with LRU
+  eviction.
+- Times out idle sessions (`server.mcp.sessionMaxIdle`, default 1h).
+- Coalesces concurrent first-call bursts on `(email, worldName)` via
+  singleflight, so a plugin reconnecting after a broker restart
+  triggers one mint per world, not N.
+
+Raw world tokens are NEVER persisted to disk by the broker. They live
+in memory; their hashes land in the per-world `tokens.toml` Secret
+that the demarkus-server already manages.
+
+## URL form
+
+Every tool that addresses a world uses the URL shape:
+
+```
+mark://{worldName}/{path}
+```
+
+`{worldName}` is the logical name from the broker's `worlds[]` config
+(typically the Kubernetes namespace / Service name). The broker
+resolves the name to a cluster-internal address using
+`worlds[].internalAddress` if set, otherwise the standard Service-DNS
+convention `<name>.<namespace>.svc.cluster.local:6309`. The agent
+never sees the internal address — it knows worlds only by name.
+
+Path traversal, query strings, and fragments are rejected by the
+gateway parser (strict shape, clear errors). The crawler used by
+`mark_graph` is lenient about `?query` and `#fragment` on outbound
+links it discovers in document bodies, because real-world markdown
+embeds them; that leniency is crawler-scoped only, never the parser
+for caller-supplied URLs.
+
+## Tools
+
+All 13 tools below have semantic parity with the local
+`client/cmd/demarkus-mcp` stdio server. The proxy-fidelity gate is a
+broker-side unit test that asserts the broker's `formatToolResult`
+matches the local server's `formatResult` byte-for-byte across
+representative `fetch.Result` cases.
+
+### Read
+
+#### `mark_fetch`
+
+Fetch a document. Returns `status` (`ok` | `not-found` | `archived` |
+`unauthorized`), `version`, `modified`, `etag`, `content-hash`, and
+the markdown `body`. Identical wire shape to direct-QUIC `FETCH`.
+
+| Param | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `url` | string | yes | `mark://{worldName}/{path}` |
+
+#### `mark_list`
+
+List documents and subdirectories under a path. Returns a directory
+listing as markdown.
+
+| Param | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `url` | string | yes | `mark://{worldName}/{path}` |
+
+#### `mark_versions`
+
+Version history of a document. Returns `total`, `current`, hash chain
+validation status, and a list of versions with timestamps.
+
+| Param | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `url` | string | yes | `mark://{worldName}/{path}` |
+
+### Write
+
+#### `mark_publish`
+
+Publish or update a document. Conflict-aware: on version mismatch,
+the default `on_conflict: "merge"` returns a structurally-merged
+candidate body (git-style conflict markers if both sides edited the
+same lines) for the agent to verify, then re-call with
+`expected_version` set to the candidate's `publish-at-version`. Pass
+`on_conflict: "fail"` for the raw conflict envelope with no merge
+attempt.
+
+| Param | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `url` | string | yes | `mark://{worldName}/{path}` |
+| `body` | string | yes | Markdown content. |
+| `expected_version` | number | yes | From a prior fetch. `0` to create a new document. |
+| `on_conflict` | string | no | `"merge"` (default) or `"fail"`. |
+
+#### `mark_append`
+
+Append content to the end of an existing document. The server
+concatenates after the existing body. `expected_version` is optional:
+when omitted or `0`, the broker calls VERSIONS internally to resolve
+the current version (one extra round trip, invisible to the agent).
+
+| Param | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `url` | string | yes | `mark://{worldName}/{path}` |
+| `body` | string | yes | Markdown to append. |
+| `expected_version` | number | no | Pass explicitly to skip the auto-resolve round trip. |
+
+#### `mark_archive`
+
+Archive a document. Archived documents return `archived` status on
+FETCH; version history is preserved.
+
+| Param | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `url` | string | yes | `mark://{worldName}/{path}` |
+
+### Federation reads
+
+#### `mark_discover`
+
+Fetch a world's agent manifest at `/.well-known/agent-manifest.md`.
+Returns `not-found` if no manifest is published.
+
+| Param | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `url` | string | yes | `mark://{worldName}/` (or any path on the world; the broker resolves to the manifest path). |
+
+#### `mark_resolve`
+
+Resolve content by its SHA-256 hash using a hub index document.
+Looks the hash up in the index, finds candidate servers, and fetches
+by hash. Skips candidates the broker has no `worlds[]` entry for and
+candidates whose mint fails with `ErrNotAuthorized` — both collapse to
+"this broker can't reach this candidate for me; try the next."
+
+| Param | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `hash` | string | yes | `sha256-` + 64 lowercase hex chars. |
+| `index` | string | yes | `mark://hub/index.md` or similar. |
+
+### Federation writes
+
+#### `mark_index`
+
+Crawl a source world, collect content hashes, and publish a hash
+index to a target world (typically a hub). Verifies the target has a
+hub manifest unless `force: true`.
+
+| Param | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `source` | string | yes | Source world URL to crawl. |
+| `target` | string | yes | Target URL where the index is published. |
+| `expected_version` | number | no | Conflict detection on the target. `0` to create new. |
+| `dry_run` | boolean | no | Return the index without publishing (default `false`). |
+| `force` | boolean | no | Publish even if target has no hub manifest (default `false`). |
+
+### Graph store (ephemeral)
+
+> **The broker's graph store is in-memory only and per-pod-lifetime.**
+> A broker restart drops every cached graph. Re-run `mark_graph` to
+> re-populate. This is a deliberate trade-off documented under
+> "Ephemeral graph store" in the chart README — bucket-store-backed
+> persistence is parked for the post-broker design window.
+
+#### `mark_backlinks`
+
+Look up which documents link to a given URL, using the broker's
+graph store. Returns results from previous `mark_graph` runs;
+returns an empty hint if no crawl has populated the relevant edges.
+
+| Param | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `url` | string | yes | `mark://{worldName}/{path}` |
+
+#### `mark_graph`
+
+Crawl outbound links from a document up to a depth and return the
+link graph. External (non-`mark://`) links are recorded but not
+followed. Results populate the broker's graph store for subsequent
+`mark_backlinks` / `mark_graph_export` / `mark_graph_publish` calls.
+
+| Param | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `url` | string | yes | `mark://{worldName}/{path}` |
+| `depth` | number | no | Default `2`, max `5`. |
+
+#### `mark_graph_export`
+
+Export the broker's graph store as a publishable markdown document
+containing `mark://` links. Crawling the exported document naturally
+re-discovers the topology. Returns an empty hint if the store is
+empty.
+
+(No parameters.)
+
+#### `mark_graph_publish`
+
+Export the broker's graph store and publish it to a world in one
+step. `mark_graph_export` + `mark_publish` combined.
+
+| Param | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `url` | string | yes | Target where the graph document is published. |
+| `expected_version` | number | yes | From a prior fetch. `0` to create new. |
+
+## Error envelope
+
+The broker returns errors via the MCP tool-error envelope (`isError:
+true` in the `CallToolResult`) for genuine tool failures: malformed
+URL, unknown world, transport failure to the world, exhausted
+first-mint retry budget. World-side `conflict`, `archived`, and
+`not-permitted` responses are forwarded **verbatim** with `isError:
+false` — they are first-class outcomes the agent acts on (re-fetch
+and retry; ask the operator for more scope), not gateway errors.
+
+A few non-obvious categories worth pinning:
+
+- **Unverified-email id_token** → `401` from `gatewayAuth` with the
+  standard RFC 6750 + RFC 9728 `WWW-Authenticate` challenge. Same
+  shape as a missing or expired bearer.
+- **World-side `unauthorized` after a fresh mint** → retried by the
+  broker with exponential backoff (`firstMint*` knobs) up to the
+  configured attempts. The Kubelet projects refreshed Secret
+  volumes on a sync cycle, so a just-minted token can briefly 401
+  at the world before propagation completes. The retry loop is
+  invisible to the agent.
+- **Cache-hit `unauthorized`** (a token the broker had cached that
+  the world now rejects: hand-revoked, sweeper-retired, etc.) →
+  cache entry invalidated immediately and one re-mint attempted
+  without backoff. Subsequent failures surface as the world's
+  `unauthorized` envelope.
+- **Cross-org candidate in `mark_resolve`** → the candidate is
+  skipped with a logged reason; if all candidates skip or fail, the
+  last failure surfaces in the tool response.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Always-on MCP gateway exposing 13 tools via Streamable HTTP (default :8081) with session identity and world-token minting.
  * Optional external MCP ingress with independent TLS/host and network/service exposure.

* **Documentation**
  * Comprehensive MCP API and gateway integration guide; expanded chart README and values reference.

* **Tests**
  * Added MCP-focused Helm chart test suite validating rendering and failure cases.

* **Chores**
  * Chart bumped to v0.2.0; local-kind smoke test support for MCP.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->