### PR TITLE
feat(plugin):  Add /knowledge-join command to Claude Code plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,15 @@ on:
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
+    # dorny/paths-filter@v3 calls the Pulls.listFiles GitHub API on
+    # pull_request events to compute the diff. The default GITHUB_TOKEN
+    # in this repo lacks pull-requests scope (Settings → Actions →
+    # Workflow permissions is set to restricted), so the action errors
+    # with "Bad credentials". Grant the two scopes the action needs at
+    # the job level — narrowest blast radius, no effect on other jobs.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       protocol: ${{ steps.filter.outputs.protocol }}
       server: ${{ steps.filter.outputs.server }}

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-memory",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Local, versioned memory for Claude Code via demarkus. Zero-config install: spawns a local demarkus-server, auto-generates a token, wires MCP tools for fetch/publish/append/graph.",
   "author": {
     "name": "latebit",

--- a/plugins/claude-code/commands/knowledge-join.md
+++ b/plugins/claude-code/commands/knowledge-join.md
@@ -10,7 +10,7 @@ This is the broker-fronted counterpart to `/soul-init` (which configures a perso
 
 The user invokes this command with the broker URL:
 
-```
+```bash
 /knowledge-join https://mcp.broker.acme.com
 ```
 
@@ -20,7 +20,7 @@ If the user invokes without an argument, ask them for the URL before running any
 
 1. **Validate + derive slug.** Run the helper script:
 
-   ```
+   ```bash
    bash "${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-join.sh" <broker-url>
    ```
 
@@ -43,7 +43,7 @@ If the user invokes without an argument, ask them for the URL before running any
 
 3. **Register the MCP server.** Run:
 
-   ```
+   ```bash
    claude mcp add --transport http <slug> <mcp-url>
    ```
 

--- a/plugins/claude-code/commands/knowledge-join.md
+++ b/plugins/claude-code/commands/knowledge-join.md
@@ -1,0 +1,65 @@
+---
+description: Join an organizational demarkus knowledge system (broker-fronted universe) — validates the broker URL, registers it as a Claude Code MCP server, and points you at the device-flow auth on first tool call.
+---
+
+Connect this Claude Code installation to an organizational demarkus knowledge system. The user supplies the public URL of the org's demarkus-broker MCP gateway; this command validates the URL, derives a short server slug from the hostname, and registers it with `claude mcp add` so the broker's 13-tool surface appears as a single MCP server.
+
+This is the broker-fronted counterpart to `/soul-init` (which configures a personal, direct-QUIC soul). A Claude Code installation can have both — different commands, different MCP server entries, different auth modes.
+
+## Argument
+
+The user invokes this command with the broker URL:
+
+```
+/knowledge-join https://mcp.broker.acme.com
+```
+
+If the user invokes without an argument, ask them for the URL before running anything. Do NOT guess a URL.
+
+## Steps
+
+1. **Validate + derive slug.** Run the helper script:
+
+   ```
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-join.sh" <broker-url>
+   ```
+
+   The script does HTTPS validation, fetches the broker's `/.well-known/oauth-protected-resource` (RFC 9728) to confirm it speaks the MCP gateway, and derives a slug from the broker hostname. Output is line-oriented `key=value`.
+
+2. **Read the script output.**
+
+   - If the first line is `OK`, parse the following lines:
+     - `url=...`   — canonicalized broker URL (no trailing slash)
+     - `slug=...`  — short identifier for the MCP server entry
+     - `mcp-url=...` — the `${url}/mcp` endpoint Claude Code will connect to
+
+     Continue to step 3.
+
+   - If the first line is `FAIL: <message>`, do NOT run `claude mcp add`. Show the user the message verbatim and one suggested next step based on the error:
+     - "broker URL must use https://" → ask the user to confirm the URL. If they're testing against a local broker, suggest port-forwarding + opening an issue rather than enabling the env-var escape hatch (which is test-only).
+     - "broker unreachable" → ask the user to confirm the URL is reachable from their network (DNS, VPN, corporate proxy).
+     - "broker has no /.well-known/oauth-protected-resource (HTTP 404)" → suggest they verify the URL points at the MCP host (typically `mcp.broker.<org>.com`), not the management API host.
+     - any other `FAIL` → surface the message as-is.
+
+3. **Register the MCP server.** Run:
+
+   ```
+   claude mcp add --transport http <slug> <mcp-url>
+   ```
+
+   Claude Code performs the OAuth device flow against the broker on the first tool call — there is no token to capture or paste here.
+
+4. **Confirm success.** Tell the user, in plain language:
+
+   > Added knowledge system **<slug>** at <url>. Claude Code will prompt you to complete the OAuth device flow against the broker the next time it talks to that MCP server. After that, the org's full demarkus tool surface (mark_fetch, mark_publish, mark_graph, etc.) is available against worlds the broker exposes (URL form: `mark://<worldName>/<path>`).
+
+   Mention that they can list joined knowledge systems with `claude mcp list` and remove this one with `claude mcp remove <slug>`.
+
+## Don't
+
+- Don't proceed past step 1 if the script emits `FAIL`. Surface the error and stop. The slug-and-URL output is only valid after `OK`.
+- Don't try to obtain or store any tokens locally. The plugin's `~/.demarkus/plugin-memory.token` is for the LOCAL soul (`/soul-init`); knowledge-system auth is handled entirely by Claude Code's MCP OAuth machinery against the broker.
+- Don't run `/knowledge-join` automatically — only when the user invokes it.
+- Don't conflate this command with `/soul-init`. They configure different things:
+  - `/soul-init`: personal, direct-QUIC, local demarkus-server, plugin-managed token.
+  - `/knowledge-join`: organizational, HTTPS-fronted broker, OAuth-managed token via Claude Code.

--- a/plugins/claude-code/scripts/knowledge-join.sh
+++ b/plugins/claude-code/scripts/knowledge-join.sh
@@ -42,9 +42,16 @@ URL="$1"
 # a local http:// mock without round-tripping through TLS plumbing. The
 # env var is deliberately long + namespaced so accidental shell exports
 # don't enable it.
+#
+# Per RFC 3986, scheme matching is case-insensitive — `HTTPS://...` and
+# `Https://...` are valid. Bash 3.2 (macOS stock) lacks `${URL,,}`
+# lower-casing, so use bracketed character classes for each scheme byte
+# instead. Surgical (only these two patterns get the treatment) rather
+# than `shopt -s nocasematch` which would silently affect every later
+# case statement in the script.
 case "${URL}" in
-  https://*) ;;
-  http://*)
+  [Hh][Tt][Tt][Pp][Ss]://*) ;;
+  [Hh][Tt][Tt][Pp]://*)
     if [[ "${DEMARKUS_KNOWLEDGE_JOIN_ALLOW_HTTP:-}" != "1" ]]; then
       fail "broker URL must use https:// (got: ${URL})"
     fi
@@ -57,6 +64,13 @@ esac
 # Strip trailing slashes so the joined /mcp URL is well-formed regardless
 # of how the user pasted the URL.
 URL="${URL%/}"
+
+# Normalize the scheme portion to lowercase. Case-insensitive scheme
+# validation above accepts `HTTPS://`, but everything downstream
+# (`claude mcp list`, broker logs, the emitted url=... line) reads
+# cleaner with `https://`. The scheme is guaranteed to be present at
+# this point — the case-validation block rejected anything else.
+URL="$(printf '%s' "${URL%%://*}" | tr '[:upper:]' '[:lower:]')://${URL#*://}"
 
 command -v curl >/dev/null 2>&1 || fail "curl is required"
 
@@ -103,8 +117,11 @@ esac
 # heuristic produces a wrong slug for a deployment, the user can rename
 # the MCP server entry via `claude mcp` after the fact — we are not
 # trying to be clever here.
-HOST="${URL#http://}"
-HOST="${HOST#https://}"
+# Strip everything up to and including `://` so the scheme drops out
+# regardless of case. Cheaper than two case-insensitive prefix patterns
+# and the case-validation step above already guaranteed a scheme is
+# present, so the # match here is always non-empty.
+HOST="${URL#*://}"
 HOST="${HOST%%/*}"
 HOST="${HOST%%:*}"          # strip :port if present
 SLUG_RAW="${HOST%%.*}"      # first DNS label

--- a/plugins/claude-code/scripts/knowledge-join.sh
+++ b/plugins/claude-code/scripts/knowledge-join.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# /knowledge-join script half. Validates a demarkus-broker URL and emits
+# the values the slash command needs to wire `claude mcp add`. The
+# command-side prompt parses our key=value output; do not change the
+# output shape without updating commands/knowledge-join.md.
+#
+# Usage: knowledge-join.sh <broker-url>
+# Output (stdout, on success):
+#   OK
+#   url=<canonicalized broker URL, no trailing slash>
+#   slug=<lowercase-sanitized first DNS label of the host>
+#   mcp-url=<url>/mcp
+# Output (stdout, on failure):
+#   FAIL: <one-line operator-readable message>
+# Exit codes: 0 on success, non-zero on validation/network failure. The
+# slash command treats any non-OK output as "do not run claude mcp add."
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# shellcheck source=./lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+# fail emits the operator-readable error on stdout (so the slash command
+# can show it verbatim) AND on stderr (so a human running the script
+# directly sees it), then exits non-zero. Two surfaces, one message.
+fail() {
+  local msg="$1"
+  echo "FAIL: ${msg}"
+  echo "[demarkus-memory] error: ${msg}" >&2
+  exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+  fail "usage: knowledge-join.sh <broker-url>"
+fi
+
+URL="$1"
+
+# Scheme validation. https:// is required for any real deployment;
+# the test harness flips DEMARKUS_KNOWLEDGE_JOIN_ALLOW_HTTP=1 to drive
+# a local http:// mock without round-tripping through TLS plumbing. The
+# env var is deliberately long + namespaced so accidental shell exports
+# don't enable it.
+case "${URL}" in
+  https://*) ;;
+  http://*)
+    if [[ "${DEMARKUS_KNOWLEDGE_JOIN_ALLOW_HTTP:-}" != "1" ]]; then
+      fail "broker URL must use https:// (got: ${URL})"
+    fi
+    ;;
+  *)
+    fail "broker URL must start with https:// (got: ${URL})"
+    ;;
+esac
+
+# Strip trailing slashes so the joined /mcp URL is well-formed regardless
+# of how the user pasted the URL.
+URL="${URL%/}"
+
+command -v curl >/dev/null 2>&1 || fail "curl is required"
+
+# RFC 9728 OAuth-protected-resource metadata is the natural validation
+# surface — Slice 7 of the gateway plan stood it up specifically as the
+# "is this a Slice-7+ broker" signal. A HEAD is enough; we don't need
+# the body, just the status code. --max-time bounds the worst-case wait
+# on a hung TLS handshake; --connect-timeout bounds DNS + TCP setup.
+META_URL="${URL}/.well-known/oauth-protected-resource"
+# curl writes "000" to stdout via -w on connection-level failure (DNS,
+# TCP refused, TLS handshake error) AND returns a non-zero exit. Using
+# `|| echo "000"` would concatenate "000" + "000" → "000000" on the
+# failure path. Suppress the OR and fall back via parameter expansion
+# for the rare case where curl produced no output at all (e.g. SIGKILL).
+http_code=$(curl -sS -o /dev/null -w "%{http_code}" \
+              --max-time 15 --connect-timeout 5 \
+              -I "${META_URL}" 2>/dev/null) || true
+http_code="${http_code:-000}"
+
+case "${http_code}" in
+  200)
+    : # validated
+    ;;
+  000)
+    fail "broker unreachable at ${META_URL} (DNS / TCP / TLS failure — check the URL and network)"
+    ;;
+  401|403)
+    fail "broker rejected metadata fetch with HTTP ${http_code} (metadata endpoint should be public — confirm this is a Slice 7+ demarkus-broker)"
+    ;;
+  404)
+    fail "broker has no /.well-known/oauth-protected-resource (HTTP 404) — this is not a Slice 7+ demarkus-broker, or the URL points at the management API instead of the MCP host"
+    ;;
+  *)
+    fail "broker metadata fetch returned HTTP ${http_code} (expected 200)"
+    ;;
+esac
+
+# Derive the slug from the first DNS label of the host. Examples:
+#   https://mcp.broker.acme.com    → acme
+#   https://broker.acme.com        → broker  (note: the FIRST label, not "acme")
+#   https://acme-broker.example    → acme-broker
+# The "first label" rule is naive but matches typical enterprise URL
+# shapes (broker is the first-label subdomain of the org). If the
+# heuristic produces a wrong slug for a deployment, the user can rename
+# the MCP server entry via `claude mcp` after the fact — we are not
+# trying to be clever here.
+HOST="${URL#http://}"
+HOST="${HOST#https://}"
+HOST="${HOST%%/*}"
+HOST="${HOST%%:*}"          # strip :port if present
+SLUG_RAW="${HOST%%.*}"      # first DNS label
+
+# Sanitize: lowercase, replace non-[a-z0-9-] with -, collapse + trim
+# leading/trailing hyphens. The output is what shows up as the MCP
+# server name in `claude mcp list`, so it must satisfy whatever
+# claude-cli accepts (a conservative [a-z0-9-]+ keeps us safe).
+SLUG=$(printf '%s' "${SLUG_RAW}" \
+       | tr '[:upper:]' '[:lower:]' \
+       | tr -c 'a-z0-9-' '-' \
+       | tr -s '-' \
+       | sed 's/^-*//;s/-*$//')
+
+if [[ -z "${SLUG}" ]]; then
+  fail "could not derive a usable MCP server slug from URL ${URL} (host: ${HOST}) — rename manually with \`claude mcp\` after a fallback install"
+fi
+
+echo "OK"
+echo "url=${URL}"
+echo "slug=${SLUG}"
+echo "mcp-url=${URL}/mcp"

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -26,10 +26,10 @@ readonly ISOLATED_PORT_START=16310
 readonly ISOLATED_PORT_END=16509
 
 readonly SERVER_VERSION="0.17.10"
-readonly CLIENT_VERSION="0.12.33"
+readonly CLIENT_VERSION="0.12.36"
 # demarkus-token moved from the server archive to its own tools/ release
 # in §6.7.A. Pin separately so a tools-only release can be picked up.
-readonly TOOLS_VERSION="0.1.10"
+readonly TOOLS_VERSION="0.1.16"
 
 # Sentinel file recording the SERVER/CLIENT versions of the binaries currently
 # installed at PLUGIN_BIN_DIR. ensure_binaries compares this against the

--- a/plugins/claude-code/tests/knowledge-join_test.sh
+++ b/plugins/claude-code/tests/knowledge-join_test.sh
@@ -205,27 +205,37 @@ test_trailing_slash_stripped_from_url() {
 # metadata path. We override HOST via a synthetic URL whose host portion
 # we control.
 
+test_uppercase_scheme_accepted_and_normalized() {
+  local broker
+  broker=$(start_mock 200) || return 1
+  local port="${broker##*:}"
+  local out
+  # User pastes the URL with an uppercase scheme. RFC 3986 says scheme
+  # is case-insensitive; the script must accept it AND normalize the
+  # emitted url= / mcp-url= back to lowercase so `claude mcp list`
+  # output stays clean.
+  out=$(DEMARKUS_KNOWLEDGE_JOIN_ALLOW_HTTP=1 bash "${KJ}" "HTTP://127.0.0.1:${port}" 2>&1) \
+    || { echo "script failed on uppercase scheme: ${out}"; return 1; }
+  grep -q "^url=http://127.0.0.1:${port}\$" <<<"${out}" \
+    || { echo "scheme not normalized in url=: ${out}"; return 1; }
+  grep -q "^mcp-url=http://127.0.0.1:${port}/mcp\$" <<<"${out}" \
+    || { echo "scheme not normalized in mcp-url=: ${out}"; return 1; }
+}
+
 test_slug_first_label_lowercased() {
   local broker
   broker=$(start_mock 200) || return 1
   local port="${broker##*:}"
-  # Use a hostname alias that resolves to 127.0.0.1 via /etc/hosts? No —
-  # instead, drive the script with an http URL whose host portion we
-  # craft. curl won't resolve `mcp.broker.example` to anything, so the
-  # mock can't serve it. We tested the happy path above; here we only
-  # care that slug derivation honors lowercasing on a real-DNS hostname.
-  # Repurpose the loopback: 127.0.0.1's first label IS already lowercase
-  # numeric. Cover lowercasing via an env-injected URL that points at
-  # the same mock via 'localhost' (also valid loopback alias, lowercase
-  # already). So lowercasing per se is covered by tr 'A-Z' 'a-z' on the
-  # source string — direct unit-test the script with an UPPERCASE host
-  # piece via a Host header trick? Simpler: just trust the tr; the
-  # interesting behaviors to pin in tests are slug-character-sanitization
-  # and the trim. We skip explicit upper→lower (a one-liner tr).
-  out=$(DEMARKUS_KNOWLEDGE_JOIN_ALLOW_HTTP=1 bash "${KJ}" "http://localhost:${port}" 2>&1) \
+  local out
+  # Drive the script with an UPPERCASE host (curl accepts case-insensitive
+  # hostnames for loopback, RFC 3986 §3.2.2). The slug derivation pipeline
+  # tr's [:upper:] → [:lower:] before character-class sanitization; this
+  # test pins that the lowercasing actually fires by passing LOCALHOST and
+  # asserting the emitted slug is the all-lowercase `localhost`.
+  out=$(DEMARKUS_KNOWLEDGE_JOIN_ALLOW_HTTP=1 bash "${KJ}" "http://LOCALHOST:${port}" 2>&1) \
     || { echo "script failed: ${out}"; return 1; }
   grep -q '^slug=localhost$' <<<"${out}" \
-    || { echo "slug derivation wrong: ${out}"; return 1; }
+    || { echo "slug not lowercased: ${out}"; return 1; }
 }
 
 test_slug_port_stripped_before_first_label_extraction() {

--- a/plugins/claude-code/tests/knowledge-join_test.sh
+++ b/plugins/claude-code/tests/knowledge-join_test.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# Shell-level tests for scripts/knowledge-join.sh.
+#
+# Each test_* function returns 0 on pass and non-zero on fail. The runner
+# at the bottom executes every test_* in lexical order, prints PASS/FAIL,
+# and exits non-zero if any test failed.
+#
+# We mock the broker side with a tiny python3 HTTPServer that answers
+# /.well-known/oauth-protected-resource with the status code requested
+# via the SERVER_PATH env var. The script's HTTPS-required gate is
+# bypassed via DEMARKUS_KNOWLEDGE_JOIN_ALLOW_HTTP=1 — the test-only
+# escape hatch documented in knowledge-join.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+PLUGIN_DIR="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+KJ="${PLUGIN_DIR}/scripts/knowledge-join.sh"
+
+[[ -x "${KJ}" ]] || { echo "knowledge-join.sh not executable at ${KJ}"; exit 2; }
+command -v python3 >/dev/null 2>&1 || { echo "python3 required for mock broker"; exit 2; }
+command -v curl    >/dev/null 2>&1 || { echo "curl required"; exit 2; }
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+# Tracks the most-recently-started mock broker so the suite trap can
+# always reap it even if a test exits mid-flight.
+MOCK_PID=""
+
+cleanup_mock() {
+  if [[ -n "${MOCK_PID}" ]] && kill -0 "${MOCK_PID}" 2>/dev/null; then
+    kill "${MOCK_PID}" 2>/dev/null || true
+    wait "${MOCK_PID}" 2>/dev/null || true
+  fi
+  MOCK_PID=""
+}
+trap cleanup_mock EXIT
+
+# start_mock STATUS — spawn a python HTTP server on a random free port
+# that answers any GET/HEAD with STATUS. Echoes the URL the script can
+# point at; sets MOCK_PID for cleanup. Fails the test if the server
+# doesn't come up within ~2s.
+start_mock() {
+  local status="$1"
+  cleanup_mock
+
+  local port
+  # Bind to port 0 to get an OS-assigned free port, then close. There is
+  # a microscopic reuse race between this and the python server binding,
+  # but in CI / local test runs the window is too small to matter; if a
+  # real conflict happens, curl will fail and the test fails loudly.
+  port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+
+  # Detach stdout+stderr so the python child does not keep the caller's
+  # `out=$(...)` command-substitution alive. Background processes inherit
+  # the parent's file descriptors; without this redirect, `$()` waits
+  # indefinitely for the python's stdout to close — which only happens
+  # when we kill it, but `$()` has already captured the test function's
+  # output by then. Hard-to-spot deadlock; the redirect is the fix.
+  python3 - "${port}" "${status}" >/dev/null 2>&1 <<'PY' &
+import http.server, sys
+port, status = int(sys.argv[1]), int(sys.argv[2])
+class H(http.server.BaseHTTPRequestHandler):
+    def _respond(self):
+        self.send_response(status)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+    do_HEAD = do_GET = lambda s: s._respond()
+    def log_message(self, *a): pass
+http.server.HTTPServer(("127.0.0.1", port), H).serve_forever()
+PY
+  MOCK_PID=$!
+
+  # Wait for the server to start serving. Cap at ~2s. -s (not -sS) so
+  # warmup connection-refused errors don't leak into test output before
+  # the python listener is ready.
+  local i
+  for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+    if curl -s --max-time 1 -o /dev/null "http://127.0.0.1:${port}/"; then
+      echo "http://127.0.0.1:${port}"
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "mock broker on port ${port} never came up" >&2
+  return 1
+}
+
+# run_test NAME — invokes the function named test_${NAME}; prints
+# colored PASS/FAIL with a short reason on failure.
+run_test() {
+  local name="$1"
+  local out rc
+  out=$( "test_${name}" 2>&1 )
+  rc=$?
+  cleanup_mock
+  if (( rc == 0 )); then
+    echo "PASS  ${name}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  ${name}"
+    # Indent the captured output so failure context is visible without
+    # drowning out the pass line.
+    printf '%s\n' "${out}" | sed 's/^/      /'
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("${name}")
+  fi
+}
+
+# ----- test functions ---------------------------------------------------
+
+test_happy_path_emits_ok_with_kv_lines() {
+  local broker
+  broker=$(start_mock 200) || return 1
+
+  local out
+  out=$(DEMARKUS_KNOWLEDGE_JOIN_ALLOW_HTTP=1 bash "${KJ}" "${broker}" 2>&1) || {
+    echo "script exit non-zero: ${out}"; return 1; }
+
+  grep -q '^OK$'              <<<"${out}" || { echo "missing OK line: ${out}"; return 1; }
+  grep -q "^url=${broker}\$"  <<<"${out}" || { echo "missing/wrong url= line: ${out}"; return 1; }
+  # Script takes the FIRST DNS label of the host; first label of
+  # 127.0.0.1 is "127" (not the full mangled "127-0-0-1"). The
+  # heuristic optimizes for typical enterprise broker hostnames like
+  # mcp.broker.acme.com → "mcp", not for IP literals.
+  grep -q '^slug=127$'        <<<"${out}" || { echo "missing/wrong slug= line: ${out}"; return 1; }
+  grep -q "^mcp-url=${broker}/mcp\$" <<<"${out}" || { echo "missing/wrong mcp-url= line: ${out}"; return 1; }
+}
+
+test_http_without_escape_hatch_fails_fast() {
+  # No mock needed — script rejects before touching the network.
+  local out rc
+  out=$(bash "${KJ}" "http://broker.example.com" 2>&1); rc=$?
+  (( rc != 0 )) || { echo "expected non-zero exit; got 0"; return 1; }
+  grep -q '^FAIL: broker URL must use https://' <<<"${out}" \
+    || { echo "wrong FAIL message: ${out}"; return 1; }
+}
+
+test_missing_scheme_fails_fast() {
+  local out rc
+  out=$(bash "${KJ}" "broker.example.com" 2>&1); rc=$?
+  (( rc != 0 )) || { echo "expected non-zero exit; got 0"; return 1; }
+  grep -q '^FAIL: broker URL must start with https://' <<<"${out}" \
+    || { echo "wrong FAIL message: ${out}"; return 1; }
+}
+
+test_missing_arg_fails_with_usage() {
+  local out rc
+  out=$(bash "${KJ}" 2>&1); rc=$?
+  (( rc != 0 )) || { echo "expected non-zero exit; got 0"; return 1; }
+  grep -q '^FAIL: usage:' <<<"${out}" \
+    || { echo "wrong FAIL message: ${out}"; return 1; }
+}
+
+test_broker_404_metadata_surfaces_typed_error() {
+  local broker
+  broker=$(start_mock 404) || return 1
+  local out rc
+  out=$(DEMARKUS_KNOWLEDGE_JOIN_ALLOW_HTTP=1 bash "${KJ}" "${broker}" 2>&1); rc=$?
+  (( rc != 0 )) || { echo "expected non-zero exit; got 0; out=${out}"; return 1; }
+  grep -q 'HTTP 404' <<<"${out}" \
+    || { echo "missing HTTP 404 in FAIL message: ${out}"; return 1; }
+  grep -q 'Slice 7' <<<"${out}" \
+    || { echo "missing Slice 7 hint in FAIL message: ${out}"; return 1; }
+}
+
+test_broker_500_metadata_surfaces_unexpected_code() {
+  local broker
+  broker=$(start_mock 500) || return 1
+  local out rc
+  out=$(DEMARKUS_KNOWLEDGE_JOIN_ALLOW_HTTP=1 bash "${KJ}" "${broker}" 2>&1); rc=$?
+  (( rc != 0 )) || { echo "expected non-zero exit; got 0; out=${out}"; return 1; }
+  grep -q 'HTTP 500' <<<"${out}" \
+    || { echo "missing HTTP 500 in FAIL message: ${out}"; return 1; }
+}
+
+test_broker_unreachable_surfaces_typed_error() {
+  # 127.0.0.1:1 — reserved port, nothing should be listening. The script
+  # treats curl exit as code 000 and emits the unreachable-network msg.
+  local out rc
+  out=$(DEMARKUS_KNOWLEDGE_JOIN_ALLOW_HTTP=1 bash "${KJ}" "http://127.0.0.1:1" 2>&1); rc=$?
+  (( rc != 0 )) || { echo "expected non-zero exit; got 0; out=${out}"; return 1; }
+  grep -q 'broker unreachable' <<<"${out}" \
+    || { echo "missing 'broker unreachable' in FAIL message: ${out}"; return 1; }
+}
+
+test_trailing_slash_stripped_from_url() {
+  local broker
+  broker=$(start_mock 200) || return 1
+  local out
+  out=$(DEMARKUS_KNOWLEDGE_JOIN_ALLOW_HTTP=1 bash "${KJ}" "${broker}/" 2>&1) \
+    || { echo "script exit non-zero: ${out}"; return 1; }
+  # Both url= and mcp-url= should reflect the stripped form.
+  grep -q "^url=${broker}\$"  <<<"${out}" \
+    || { echo "trailing slash not stripped from url=: ${out}"; return 1; }
+  grep -q "^mcp-url=${broker}/mcp\$" <<<"${out}" \
+    || { echo "mcp-url malformed: ${out}"; return 1; }
+}
+
+# Slug derivation tests use the standalone slug helper inlined into the
+# script. Easier to assert via stdout inspection on a wide variety of
+# input URLs against a single mock — the mock just has to 200 the
+# metadata path. We override HOST via a synthetic URL whose host portion
+# we control.
+
+test_slug_first_label_lowercased() {
+  local broker
+  broker=$(start_mock 200) || return 1
+  local port="${broker##*:}"
+  # Use a hostname alias that resolves to 127.0.0.1 via /etc/hosts? No —
+  # instead, drive the script with an http URL whose host portion we
+  # craft. curl won't resolve `mcp.broker.example` to anything, so the
+  # mock can't serve it. We tested the happy path above; here we only
+  # care that slug derivation honors lowercasing on a real-DNS hostname.
+  # Repurpose the loopback: 127.0.0.1's first label IS already lowercase
+  # numeric. Cover lowercasing via an env-injected URL that points at
+  # the same mock via 'localhost' (also valid loopback alias, lowercase
+  # already). So lowercasing per se is covered by tr 'A-Z' 'a-z' on the
+  # source string — direct unit-test the script with an UPPERCASE host
+  # piece via a Host header trick? Simpler: just trust the tr; the
+  # interesting behaviors to pin in tests are slug-character-sanitization
+  # and the trim. We skip explicit upper→lower (a one-liner tr).
+  out=$(DEMARKUS_KNOWLEDGE_JOIN_ALLOW_HTTP=1 bash "${KJ}" "http://localhost:${port}" 2>&1) \
+    || { echo "script failed: ${out}"; return 1; }
+  grep -q '^slug=localhost$' <<<"${out}" \
+    || { echo "slug derivation wrong: ${out}"; return 1; }
+}
+
+test_slug_port_stripped_before_first_label_extraction() {
+  local broker
+  broker=$(start_mock 200) || return 1
+  local port="${broker##*:}"
+  local out
+  out=$(DEMARKUS_KNOWLEDGE_JOIN_ALLOW_HTTP=1 bash "${KJ}" "http://127.0.0.1:${port}" 2>&1) \
+    || { echo "script failed: ${out}"; return 1; }
+  # First label of "127.0.0.1" is "127"; presence of slug=127 implies
+  # the :port suffix was correctly stripped before the first-label
+  # extraction (otherwise the dot/colon mix would corrupt the result).
+  grep -q '^slug=127$' <<<"${out}" \
+    || { echo "slug or port handling wrong: ${out}"; return 1; }
+  # Also pin that mcp-url has no port-doubling and lands on /mcp.
+  grep -q "^mcp-url=http://127.0.0.1:${port}/mcp\$" <<<"${out}" \
+    || { echo "mcp-url malformed: ${out}"; return 1; }
+}
+
+# ----- runner -----------------------------------------------------------
+
+# Discover test_* functions in declaration order.
+TESTS=$(declare -F | awk '$3 ~ /^test_/ { print $3 }')
+
+echo "=== knowledge-join shell tests ==="
+for t in ${TESTS}; do
+  run_test "${t#test_}"
+done
+
+echo
+echo "${PASS} passed, ${FAIL} failed"
+if (( FAIL > 0 )); then
+  echo "failing tests:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - ${n}"; done
+  exit 1
+fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a /knowledge-join command to connect Claude Code to external brokered knowledge systems, including an interactive validation flow.

* **Documentation**
  * Added user-facing docs explaining command usage, validation steps, success/failure messages, and explicit “don’t” guidance.

* **Tests**
  * Added automated tests covering validation, URL normalization, slug derivation, and error handling.

* **Chores**
  * Bumped plugin version to 0.2.0, updated pinned client/tool releases, and tightened CI workflow permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->