### PR TITLE
feat(broker):  Implement RFC 7591 Dynamic Client Registration endpoint

### DIFF
--- a/tools/demarkus-broker/internal/broker/discovery.go
+++ b/tools/demarkus-broker/internal/broker/discovery.go
@@ -264,6 +264,13 @@ func applyDiscoveryOverrides(raw []byte, brokerURL string) ([]byte, error) {
 	doc["device_authorization_endpoint"] = brokerURL + "/device/authorize"
 	doc["token_endpoint"] = brokerURL + "/device/token"
 	doc["jwks_uri"] = brokerURL + "/.well-known/jwks.json"
+	// RFC 7591 dynamic client registration endpoint. Advertised so MCP
+	// clients (which require DCR per the MCP authorization spec)
+	// don't reject the broker with "Incompatible auth server: does
+	// not support dynamic client registration" before they ever
+	// reach the device-flow surface. See register.go for the
+	// rubber-stamp semantics and the rationale.
+	doc["registration_endpoint"] = brokerURL + "/register"
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetIndent("", "  ")

--- a/tools/demarkus-broker/internal/broker/discovery_test.go
+++ b/tools/demarkus-broker/internal/broker/discovery_test.go
@@ -153,6 +153,11 @@ func TestDiscoveryOverridesBrokerEndpoints(t *testing.T) {
 		// fetching the broker's JWKS gets the broker's signing key,
 		// matching the issuer the discovery doc advertises.
 		{"jwks_uri", "https://broker.example.com/.well-known/jwks.json"},
+		// registration_endpoint added so MCP clients that require RFC
+		// 7591 dynamic client registration don't reject the broker with
+		// "Incompatible auth server" before reaching the device-flow
+		// surface. See register.go for the rubber-stamp rationale.
+		{"registration_endpoint", "https://broker.example.com/register"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.field, func(t *testing.T) {

--- a/tools/demarkus-broker/internal/broker/register.go
+++ b/tools/demarkus-broker/internal/broker/register.go
@@ -1,0 +1,148 @@
+package broker
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// maxRegisterBodySize bounds how much JSON the broker will buffer from
+// a /register request. RFC 7591 client metadata is typically small (a
+// few hundred bytes — redirect_uris, client_name, grant_types). 64 KiB
+// stops a misbehaving or hostile client from forcing the broker to
+// allocate unbounded memory while still admitting any realistic
+// registration payload.
+const maxRegisterBodySize = 64 << 10
+
+// clientIDByteLen is the entropy budget for the issued client_id. 16
+// bytes (128 bits) is the IETF's secure-random recommendation for
+// opaque identifiers — collision-resistant against any realistic
+// caller volume and short enough that the base64url-encoded form fits
+// inside a single log line. The broker does not persist these, so the
+// only constraint is that two concurrent /register calls never
+// collide.
+const clientIDByteLen = 16
+
+// registerHandler implements RFC 7591 Dynamic Client Registration.
+//
+// Why this exists: MCP clients (the model-context-protocol SDK that
+// Claude Code uses to talk to the broker's /mcp gateway) refuse to
+// proceed against an authorization server whose discovery doc omits
+// `registration_endpoint` — the SDK is built to RFC 7591 + MCP-auth-
+// spec assumptions and short-circuits with "Incompatible auth server"
+// when the field is missing. Surfacing /register makes the broker a
+// well-formed MCP authorization server.
+//
+// What this is NOT: a client database. The broker has no read of
+// `client_id` anywhere on the device-flow path — device.go:108 accepts
+// any non-empty value, no lookup, no policy. Real access control lives
+// at the id_token verification + per-world `Allow` list. So /register
+// rubber-stamps any caller: mints a random `client_id`, echoes the
+// request metadata, returns. No persistence, no validation beyond
+// shape. If the broker ever grows client_id-level enforcement
+// (per-client audit, registered redirect_uri checks, rate buckets keyed
+// on client_id), THAT is the moment to add storage and replace this
+// handler — adding it speculatively now would be vestigial state.
+//
+// Per RFC 7591:
+//   - §3.1 request is a JSON object with client metadata
+//   - §3.2.1 success response is 201 Created with the same JSON object
+//     augmented with `client_id` (required) and `client_id_issued_at`
+//     (recommended)
+//   - §3.2.2 error response is 400 Bad Request with
+//     `error: invalid_client_metadata` (we only surface this for
+//     malformed JSON; everything else is accepted)
+//
+// Authentication: none. The endpoint is anonymous-open (RFC 7591 §2 —
+// "open registration"). The broker's IP rate limiter (ipRateLimit
+// middleware in server.go) caps the per-IP /register rate so a single
+// host can't flood the endpoint; cluster-wide rate limiting is a
+// future enhancement if the open posture turns out to be exploitable
+// at scale.
+func (s *Server) register(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxRegisterBodySize+1))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":             "invalid_client_metadata",
+			"error_description": "could not read request body",
+		})
+		return
+	}
+	if len(body) > maxRegisterBodySize {
+		writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{
+			"error":             "invalid_client_metadata",
+			"error_description": "request body exceeds size limit",
+		})
+		return
+	}
+	// Decode into a generic map so unknown RFC 7591 + RFC 7592 fields
+	// (software_id, software_version, jwks, contacts, …) round-trip
+	// through without us tracking each one. RFC 7591 §3.1 lets the
+	// metadata object itself be empty (`{}`); we extend that to empty
+	// bodies as a permissive convenience — semantically equivalent and
+	// strictly easier on clients that forget the trailing braces.
+	doc := map[string]any{}
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &doc); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{
+				"error":             "invalid_client_metadata",
+				"error_description": "request body is not valid JSON",
+			})
+			return
+		}
+	}
+	clientID, err := newClientID()
+	if err != nil {
+		// crypto/rand failure is a process-level condition (entropy
+		// pool exhausted on a misconfigured kernel); surface 500 so
+		// the operator notices rather than papering over with a
+		// degraded id.
+		s.log.ErrorContext(r.Context(), "broker: register: client_id generation failed", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	// Broker-issued fields win over any caller-supplied client_id /
+	// client_id_issued_at in the request body. token_endpoint_auth_method
+	// is pinned to "none" because the broker's device-flow path is
+	// PKCE-only (no client_secret); echoing back the caller's value
+	// would let a misconfigured client think it needs a secret it
+	// will never get.
+	//
+	// grant_types is force-pinned to device_code for the same reason
+	// the broker pins token_endpoint_auth_method: it's the only grant
+	// type the token endpoint actually accepts. Echoing the caller's
+	// requested grant_types (e.g. ["authorization_code"]) would
+	// silently rubber-stamp a registration whose downstream auth
+	// dance is guaranteed to fail at /device/token. RFC 7591 §3.2.2
+	// further says the AS MUST respond with invalid_client_metadata
+	// when it does not allow a requested grant type; here we
+	// normalize rather than reject to keep the spec-following
+	// authorization_code-first MCP clients moving — they get a clear
+	// signal in the response about what the broker actually supports.
+	doc["client_id"] = clientID
+	doc["client_id_issued_at"] = s.clock().Unix()
+	doc["token_endpoint_auth_method"] = "none"
+	doc["grant_types"] = []string{"urn:ietf:params:oauth:grant-type:device_code"}
+	// Cache-Control: no-store mirrors the OAuth token-endpoint
+	// posture from RFC 6749 §5.1 — the response carries a freshly
+	// minted credential-shaped identifier and should never be cached
+	// by intermediaries. RFC 7591 doesn't mandate it, but
+	// credential-issuing endpoint hygiene says set it anyway.
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusCreated, doc)
+}
+
+// newClientID returns a fresh base64url-encoded random client_id. The
+// encoding choice matches the rest of the broker's token surface
+// (device_code, user_code are also base64url-ish) so logs stay
+// uniform. Unpadded because RFC 7591 treats client_id as an opaque
+// string and operators reading logs benefit from the shorter form.
+func newClientID() (string, error) {
+	buf := make([]byte, clientIDByteLen)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}

--- a/tools/demarkus-broker/internal/broker/register_test.go
+++ b/tools/demarkus-broker/internal/broker/register_test.go
@@ -1,0 +1,232 @@
+package broker
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// postJSON is a tiny helper specific to /register: every test in this
+// file POSTs a JSON body and decodes a JSON response, so wrap the
+// boilerplate once instead of in each subtest. Uses testClient(srv)
+// rather than http.DefaultClient because newTestServer mounts the
+// broker behind an httptest TLS server with a self-signed cert.
+func postJSON(t *testing.T, srv *httptest.Server, body []byte) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/register", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := testClient(srv).Do(req)
+	if err != nil {
+		t.Fatalf("POST /register: %v", err)
+	}
+	return resp
+}
+
+func TestRegister(t *testing.T) {
+	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "full RFC 7591 metadata",
+			body: `{"client_name":"Claude Code","redirect_uris":["http://localhost:1234/callback"],"grant_types":["urn:ietf:params:oauth:grant-type:device_code"]}`,
+		},
+		{
+			name: "minimal metadata",
+			body: `{"client_name":"test"}`,
+		},
+		{
+			name: "empty object",
+			body: `{}`,
+		},
+		{
+			name: "empty body",
+			body: ``,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := postJSON(t, srv, []byte(tt.body))
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusCreated {
+				rb, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want 201; body=%s", resp.StatusCode, rb)
+			}
+			var got map[string]any
+			if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			clientID, ok := got["client_id"].(string)
+			if !ok || clientID == "" {
+				t.Errorf("client_id missing or wrong type: %v", got["client_id"])
+			}
+			if _, ok := got["client_id_issued_at"].(float64); !ok {
+				t.Errorf("client_id_issued_at missing or wrong type: %v", got["client_id_issued_at"])
+			}
+			if got["token_endpoint_auth_method"] != "none" {
+				t.Errorf("token_endpoint_auth_method = %v, want \"none\"", got["token_endpoint_auth_method"])
+			}
+			grants, _ := got["grant_types"].([]any)
+			if len(grants) != 1 || grants[0] != "urn:ietf:params:oauth:grant-type:device_code" {
+				t.Errorf("grant_types = %v, want [\"urn:ietf:params:oauth:grant-type:device_code\"]", got["grant_types"])
+			}
+			if cc := resp.Header.Get("Cache-Control"); cc != "no-store" {
+				t.Errorf("Cache-Control = %q, want \"no-store\"", cc)
+			}
+		})
+	}
+}
+
+// TestRegisterEchoesRequestMetadata confirms that unknown RFC 7591 +
+// RFC 7592 fields (software_id, contacts, etc.) round-trip through the
+// rubber-stamp handler unchanged. Clients that submit these fields
+// expect to see them echoed in the registration response per RFC
+// 7591 §3.2.1 — otherwise they may treat the registration as silently
+// rejected.
+func TestRegisterEchoesRequestMetadata(t *testing.T) {
+	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+
+	body := `{
+      "client_name": "Claude Code",
+      "redirect_uris": ["http://localhost:1234/callback"],
+      "software_id": "anthropic-cli",
+      "contacts": ["alice@example.com"]
+    }`
+	resp := postJSON(t, srv, []byte(body))
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", resp.StatusCode)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["client_name"] != "Claude Code" {
+		t.Errorf("client_name = %v, want \"Claude Code\"", got["client_name"])
+	}
+	if got["software_id"] != "anthropic-cli" {
+		t.Errorf("software_id = %v, want \"anthropic-cli\"", got["software_id"])
+	}
+	redirects, _ := got["redirect_uris"].([]any)
+	if len(redirects) != 1 || redirects[0] != "http://localhost:1234/callback" {
+		t.Errorf("redirect_uris = %v, want [\"http://localhost:1234/callback\"]", got["redirect_uris"])
+	}
+}
+
+// TestRegisterBrokerFieldsOverrideRequest covers the case where a
+// caller submits a `client_id`, `token_endpoint_auth_method`, or
+// `grant_types` in the request body (by mistake or trying to claim a
+// specific id / unsupported grant). The broker MUST mint its own
+// client_id, pin token_endpoint_auth_method to "none", and pin
+// grant_types to device_code — otherwise a caller could trick
+// downstream consumers into accepting a chosen identifier or believing
+// the broker supports authorization_code.
+func TestRegisterBrokerFieldsOverrideRequest(t *testing.T) {
+	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+
+	body := `{
+      "client_id": "evil-pinned-id",
+      "token_endpoint_auth_method": "client_secret_basic",
+      "grant_types": ["authorization_code", "refresh_token"]
+    }`
+	resp := postJSON(t, srv, []byte(body))
+	defer func() { _ = resp.Body.Close() }()
+
+	var got map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["client_id"] == "evil-pinned-id" {
+		t.Error("broker honored caller-supplied client_id; should mint its own")
+	}
+	if got["token_endpoint_auth_method"] != "none" {
+		t.Errorf("token_endpoint_auth_method = %v, want \"none\"", got["token_endpoint_auth_method"])
+	}
+	grants, _ := got["grant_types"].([]any)
+	if len(grants) != 1 || grants[0] != "urn:ietf:params:oauth:grant-type:device_code" {
+		t.Errorf("grant_types = %v, want force-pinned to device_code only", got["grant_types"])
+	}
+}
+
+// TestRegisterDistinctIDs confirms that two registrations against the
+// same server return distinct client_ids. The broker mints fresh
+// random ids per call (no persistence, no dedup), so collisions would
+// indicate a broken CSPRNG path — worth catching before it reaches
+// production.
+func TestRegisterDistinctIDs(t *testing.T) {
+	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+
+	ids := make(map[string]bool)
+	for range 5 {
+		resp := postJSON(t, srv, []byte(`{}`))
+		var got map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		_ = resp.Body.Close()
+		id, _ := got["client_id"].(string)
+		if id == "" {
+			t.Fatal("client_id empty")
+		}
+		if ids[id] {
+			t.Errorf("duplicate client_id minted: %s", id)
+		}
+		ids[id] = true
+	}
+}
+
+func TestRegisterRejectsInvalidJSON(t *testing.T) {
+	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+
+	resp := postJSON(t, srv, []byte(`{not valid json`))
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	var got map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&got)
+	if got["error"] != "invalid_client_metadata" {
+		t.Errorf("error = %v, want \"invalid_client_metadata\"", got["error"])
+	}
+}
+
+func TestRegisterRejectsOversizedBody(t *testing.T) {
+	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+
+	// One byte past the limit triggers the 413 path.
+	body := []byte(`{"x":"` + strings.Repeat("a", maxRegisterBodySize) + `"}`)
+	resp := postJSON(t, srv, body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413", resp.StatusCode)
+	}
+}
+
+func TestRegisterRejectsGET(t *testing.T) {
+	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+
+	resp, err := testClient(srv).Get(srv.URL + "/register")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", resp.StatusCode)
+	}
+}

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -222,6 +222,14 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("GET /device", s.deviceFormGet)
 	mux.Handle("POST /device", s.ipRateLimit(http.HandlerFunc(s.deviceFormPost)))
 	mux.Handle("POST /device/token", s.ipRateLimit(http.HandlerFunc(s.deviceToken)))
+	// RFC 7591 dynamic client registration. Open (unauthenticated) per
+	// the spec's §2 open-registration mode; rubber-stamps any caller
+	// because the broker's actual access control lives at the
+	// id_token verification + per-world Allow list, not the client_id
+	// layer. IP rate limiter caps per-IP /register churn the same way
+	// it gates the device-flow POSTs. See register.go for the full
+	// rationale.
+	mux.Handle("POST /register", s.ipRateLimit(http.HandlerFunc(s.register)))
 	// RFC 7009 token revocation. Unauthenticated (possession of
 	// the token IS the authz signal) under the IP limiter for
 	// defense-in-depth. PR4 only operates on refresh tokens; the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Dynamic Client Registration support. Clients can now register via POST `/register` endpoint to obtain a unique client ID.
  * The OIDC discovery document now advertises the registration endpoint.

* **Tests**
  * Added comprehensive test coverage for the registration endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->