### PR TITLE
fix(broker): OAUTH Dcr 

### DIFF
--- a/tools/demarkus-broker/internal/broker/discovery.go
+++ b/tools/demarkus-broker/internal/broker/discovery.go
@@ -271,6 +271,31 @@ func applyDiscoveryOverrides(raw []byte, brokerURL string) ([]byte, error) {
 	// reach the device-flow surface. See register.go for the
 	// rubber-stamp semantics and the rationale.
 	doc["registration_endpoint"] = brokerURL + "/register"
+	// authorization_endpoint redirected to the broker's stub handler.
+	// The IdP's upstream value (e.g. accounts.google.com/o/oauth2/v2/auth)
+	// MUST NOT pass through: an MCP client following the spec's
+	// authorization_code-first preference would ship its DCR-minted
+	// client_id straight to the IdP, which has never heard of it →
+	// confusing `invalid_client` 401 surfaced at the wrong layer. The
+	// stub at /oauth/authorize returns RFC 6749 `unsupported_response_type`
+	// JSON pointing the client at device_authorization_endpoint. Paired
+	// with the grant_types_supported override below, this signals
+	// "device_code only" to a well-behaved MCP client. See
+	// oauth_authorize.go for the probe rationale — if Claude Code's SDK
+	// doesn't fall back, the broker needs a real authorization_code
+	// grant implementation.
+	doc["authorization_endpoint"] = brokerURL + "/oauth/authorize"
+	// grant_types_supported overridden so MCP clients reading the
+	// discovery doc see exactly what the broker's token endpoint
+	// actually accepts. The IdP's upstream list typically includes
+	// authorization_code, which the broker does NOT support yet —
+	// advertising it would invite clients to attempt a flow that
+	// will fail at /device/token with unsupported_grant_type. Dropping
+	// it here puts the spec-driven negotiation on the right footing.
+	doc["grant_types_supported"] = []string{
+		"urn:ietf:params:oauth:grant-type:device_code",
+		"refresh_token",
+	}
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetIndent("", "  ")

--- a/tools/demarkus-broker/internal/broker/discovery_test.go
+++ b/tools/demarkus-broker/internal/broker/discovery_test.go
@@ -158,6 +158,12 @@ func TestDiscoveryOverridesBrokerEndpoints(t *testing.T) {
 		// "Incompatible auth server" before reaching the device-flow
 		// surface. See register.go for the rubber-stamp rationale.
 		{"registration_endpoint", "https://broker.example.com/register"},
+		// authorization_endpoint redirected to the broker's stub handler
+		// so an MCP client following the spec's authorization_code-first
+		// preference does NOT ship its DCR-minted client_id to the
+		// upstream IdP (which has never heard of it → confusing
+		// invalid_client from the IdP). See oauth_authorize.go.
+		{"authorization_endpoint", "https://broker.example.com/oauth/authorize"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.field, func(t *testing.T) {
@@ -171,11 +177,15 @@ func TestDiscoveryOverridesBrokerEndpoints(t *testing.T) {
 
 func TestDiscoveryProxiesUnOverriddenFields(t *testing.T) {
 	// Round-trips fields the broker does NOT take over:
-	// userinfo_endpoint, authorization_endpoint, plus IdP-specific
-	// metadata arrays. Tests both presence and exact value so a
-	// regression that silently drops or rewrites these surfaces here.
+	// userinfo_endpoint plus IdP-specific metadata arrays. Tests both
+	// presence and exact value so a regression that silently drops or
+	// rewrites these surfaces here.
+	//
 	// jwks_uri WAS in this list pre-PR4 but moved to the override
-	// set when the broker started signing id_tokens.
+	// set when the broker started signing id_tokens. authorization_endpoint
+	// WAS in this list pre-DCR-followup but moved to the override set
+	// to stop MCP clients from shipping their DCR-minted client_id at
+	// the upstream IdP.
 	idp := newFakeDiscoveryIdP(t)
 	d, _ := newTestDiscovery(t, idp, time.Minute)
 	doc := serveAndDecode(t, d)
@@ -184,7 +194,6 @@ func TestDiscoveryProxiesUnOverriddenFields(t *testing.T) {
 		want  any
 	}{
 		{"userinfo_endpoint", "https://idp.example.com/userinfo"},
-		{"authorization_endpoint", "https://idp.example.com/authorize"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.field, func(t *testing.T) {
@@ -200,6 +209,31 @@ func TestDiscoveryProxiesUnOverriddenFields(t *testing.T) {
 	}
 	if got, ok := doc["code_challenge_methods_supported"].([]any); !ok || len(got) != 1 || got[0] != "S256" {
 		t.Errorf("code_challenge_methods_supported = %v, want [S256]", doc["code_challenge_methods_supported"])
+	}
+}
+
+// TestDiscoveryOverridesGrantTypesSupported asserts the broker advertises
+// only the grant types its /device/token endpoint actually accepts.
+// Upstream IdPs typically advertise authorization_code; passing that
+// through would invite MCP clients to attempt a flow that fails at
+// /device/token with unsupported_grant_type — the exact wrong-layer
+// confusion the authorization_endpoint stub avoids on the front side.
+func TestDiscoveryOverridesGrantTypesSupported(t *testing.T) {
+	idp := newFakeDiscoveryIdP(t)
+	d, _ := newTestDiscovery(t, idp, time.Minute)
+	doc := serveAndDecode(t, d)
+	got, ok := doc["grant_types_supported"].([]any)
+	if !ok {
+		t.Fatalf("grant_types_supported = %v (type %T), want []string", doc["grant_types_supported"], doc["grant_types_supported"])
+	}
+	want := []string{"urn:ietf:params:oauth:grant-type:device_code", "refresh_token"}
+	if len(got) != len(want) {
+		t.Fatalf("grant_types_supported length = %d, want %d (got=%v)", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("grant_types_supported[%d] = %v, want %q", i, got[i], w)
+		}
 	}
 }
 

--- a/tools/demarkus-broker/internal/broker/oauth_authorize.go
+++ b/tools/demarkus-broker/internal/broker/oauth_authorize.go
@@ -1,0 +1,45 @@
+package broker
+
+import (
+	"net/http"
+)
+
+// oauthAuthorize is a stub authorization endpoint that always rejects
+// with `unsupported_response_type`. It exists for one reason: MCP
+// clients that follow the spec's authorization_code-first preference
+// MUST be able to fetch SOME `authorization_endpoint` from the broker's
+// discovery doc and get a clear "not supported here" signal — otherwise
+// the field defaults to the upstream IdP (e.g. accounts.google.com)
+// which the broker's DCR-minted client_id was never registered with,
+// surfacing as a confusing `invalid_client` from the IdP itself.
+//
+// Returning a JSON 400 with a standard OAuth error code lets a
+// well-behaved MCP client either surface the error to the user or
+// (better) consult `grant_types_supported` in the same discovery doc
+// and pivot to the device_code grant.
+//
+// Probe semantics: this handler ships paired with the
+// `authorization_endpoint` + `grant_types_supported` discovery overrides
+// in applyDiscoveryOverrides. If Claude Code's MCP SDK pivots to
+// device flow on its own, this stub stays as-is. If the SDK insists on
+// authorization_code, the broker needs a real OAuth authorization-code
+// grant (handler that mediates between the MCP client and the upstream
+// IdP via /auth/callback); at that point this file becomes the real
+// authorize handler instead of a polite rejection.
+//
+// Authentication: none. The endpoint is anonymous-public — same posture
+// as the upstream IdP's authorization endpoint would be. IP rate
+// limiter (server.go) caps per-IP churn.
+//
+// HTTP method: GET and POST both accepted per RFC 6749 §3.1 ("The
+// authorization server MUST support the use of the HTTP GET method
+// [...] and MAY support the use of the HTTP POST method as well").
+// Routing them at the same handler keeps the rejection uniform —
+// neither shape is valid here.
+func (s *Server) oauthAuthorize(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusBadRequest, map[string]string{
+		"error":             "unsupported_response_type",
+		"error_description": "this broker does not support the authorization_code grant; clients should consult grant_types_supported in the discovery document and use the device_code grant via device_authorization_endpoint",
+	})
+}

--- a/tools/demarkus-broker/internal/broker/oauth_authorize_test.go
+++ b/tools/demarkus-broker/internal/broker/oauth_authorize_test.go
@@ -1,0 +1,114 @@
+package broker
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// TestOAuthAuthorizeAlwaysRejects covers the contract: any request shape
+// — GET with query params, POST with form body, bare GET — gets the same
+// 400 unsupported_response_type response. The stub is intentionally
+// uniform; there is no "valid" request shape until the broker grows a
+// real authorization_code grant.
+func TestOAuthAuthorizeAlwaysRejects(t *testing.T) {
+	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{
+			name:   "GET with full authorize query string",
+			method: http.MethodGet,
+			path:   "/oauth/authorize?response_type=code&client_id=abc&redirect_uri=http%3A%2F%2Flocalhost%3A1234%2Fcallback&code_challenge=xyz&code_challenge_method=S256&state=s1",
+		},
+		{
+			name:   "GET bare",
+			method: http.MethodGet,
+			path:   "/oauth/authorize",
+		},
+		{
+			name:   "POST form-encoded",
+			method: http.MethodPost,
+			path:   "/oauth/authorize",
+			body:   "response_type=code&client_id=abc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var resp *http.Response
+			var err error
+			if tt.method == http.MethodGet {
+				resp, err = testClient(srv).Get(srv.URL + tt.path)
+			} else {
+				resp, err = testClient(srv).Post(srv.URL+tt.path, "application/x-www-form-urlencoded", strings.NewReader(tt.body))
+			}
+			if err != nil {
+				t.Fatalf("%s %s: %v", tt.method, tt.path, err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusBadRequest {
+				rb, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want 400; body=%s", resp.StatusCode, rb)
+			}
+			if got := resp.Header.Get("Content-Type"); got != "application/json" {
+				t.Errorf("Content-Type = %q, want application/json", got)
+			}
+			if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+				t.Errorf("Cache-Control = %q, want \"no-store\"", got)
+			}
+			var doc map[string]string
+			if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if doc["error"] != "unsupported_response_type" {
+				t.Errorf("error = %q, want \"unsupported_response_type\"", doc["error"])
+			}
+			if !strings.Contains(doc["error_description"], "device_authorization_endpoint") {
+				t.Errorf("error_description = %q, want it to mention device_authorization_endpoint", doc["error_description"])
+			}
+		})
+	}
+}
+
+// TestOAuthAuthorizeIgnoresQueryParams confirms the stub does not echo
+// caller-supplied state, redirect_uri, or client_id back in the
+// response. Echoing those without validation would create XSS / open
+// redirect / response-injection surface; the stub stays pure-JSON and
+// declines to look at any input until a real handler replaces it.
+func TestOAuthAuthorizeIgnoresQueryParams(t *testing.T) {
+	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+
+	q := url.Values{
+		"client_id":             {"<script>alert(1)</script>"},
+		"state":                 {"injected\nheader: evil"},
+		"redirect_uri":          {"https://attacker.example/steal"},
+		"code_challenge":        {"x"},
+		"code_challenge_method": {"S256"},
+	}
+	resp, err := testClient(srv).Get(srv.URL + "/oauth/authorize?" + q.Encode())
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	for _, needle := range []string{"<script>", "attacker.example", "injected"} {
+		if strings.Contains(string(body), needle) {
+			t.Errorf("response body echoes untrusted query param %q; body=%s", needle, body)
+		}
+	}
+	if resp.Header.Get("Location") != "" {
+		t.Error("stub set Location header; should not redirect to caller-supplied redirect_uri")
+	}
+}

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -230,6 +230,13 @@ func (s *Server) Routes() http.Handler {
 	// it gates the device-flow POSTs. See register.go for the full
 	// rationale.
 	mux.Handle("POST /register", s.ipRateLimit(http.HandlerFunc(s.register)))
+	// /oauth/authorize stub. The discovery doc advertises this URL as
+	// `authorization_endpoint` to keep MCP clients from defaulting back
+	// to the upstream IdP's authorize URL (where the broker's DCR-minted
+	// client_id is unknown). GET + POST both routed at the same handler
+	// per RFC 6749 §3.1. See oauth_authorize.go for the probe rationale.
+	mux.Handle("GET /oauth/authorize", s.ipRateLimit(http.HandlerFunc(s.oauthAuthorize)))
+	mux.Handle("POST /oauth/authorize", s.ipRateLimit(http.HandlerFunc(s.oauthAuthorize)))
 	// RFC 7009 token revocation. Unauthenticated (possession of
 	// the token IS the authz signal) under the IP limiter for
 	// defense-in-depth. PR4 only operates on refresh tokens; the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OAuth authorization endpoint that rejects authorization code flows and directs clients to use the device code grant instead.
  * Updated discovery document to explicitly advertise only supported grant types (device_code and refresh_token).

* **Tests**
  * Added tests for authorization endpoint behavior and grant type discovery overrides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->