### PR TITLE
fix(broker):  Implement RFC 6749 authorization-code grant flow

### DIFF
--- a/tools/demarkus-broker/internal/broker/auth_code_store.go
+++ b/tools/demarkus-broker/internal/broker/auth_code_store.go
@@ -1,0 +1,331 @@
+package broker
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// authCodeIDBytes is the raw entropy of the opaque internal id that
+// links a pending /oauth/authorize request to the eventual
+// /auth/callback resolution. 32 bytes = 64 hex chars; the id rides
+// inside the signed State cookie, never on the wire as a URL
+// parameter, so length is not a UX concern.
+const authCodeIDBytes = 32
+
+// authCodeBytes is the raw entropy of the authorization code we hand
+// the MCP client through the redirect_uri query. 32 bytes encoded as
+// base64url-no-pad keeps the URL short while preserving 256 bits of
+// entropy — well past brute-force inside the 60-second redemption
+// window.
+const authCodeBytes = 32
+
+// defaultPendingAuthCodeTTL is the lifetime of a pending grant from
+// /oauth/authorize until /auth/callback resolves it. Ten minutes
+// covers the worst case of a user fumbling through a corporate IdP
+// (MFA prompt, password reset interstitial, etc.) while keeping
+// abandoned grants from accumulating.
+const defaultPendingAuthCodeTTL = 10 * time.Minute
+
+// defaultAuthCodeTTL is the lifetime of an issued authorization code
+// from /auth/callback's redirect until /token redeems it. OAuth 2.1
+// §4.1.2 advises ≤ 60 seconds; we use the tight bound because the
+// only legitimate consumer is a localhost callback handler that
+// turns around and posts to /token immediately.
+const defaultAuthCodeTTL = 60 * time.Second
+
+// errAuthCodePendingNotFound is returned by LookupPending and Bind
+// when the supplied authCodeID is unknown or its pending entry
+// expired. The callback handler maps it to a redirect with
+// `error=invalid_request` per RFC 6749 §4.1.2.1 (the original
+// authorize request is no longer valid).
+var errAuthCodePendingNotFound = errors.New("auth code pending entry not found")
+
+// errAuthCodeNotFound is returned by Redeem when the code is unknown,
+// already redeemed, or expired. The /token handler maps it to
+// `invalid_grant` per RFC 6749 §5.2; we deliberately collapse
+// "unknown", "redeemed", and "expired" into one sentinel so the
+// surface does not leak which axis failed.
+var errAuthCodeNotFound = errors.New("auth code not found")
+
+// errAuthCodeClientMismatch is returned when the client_id presented
+// at /token does not match the one captured at /oauth/authorize. RFC
+// 6749 §4.1.3 requires this binding; the /token handler maps it to
+// `invalid_grant` (same surface as errAuthCodeNotFound to avoid
+// leaking which check failed).
+var errAuthCodeClientMismatch = errors.New("auth code client_id mismatch")
+
+// errAuthCodeRedirectMismatch is returned when the redirect_uri
+// presented at /token does not byte-for-byte match the one captured
+// at /oauth/authorize. RFC 6749 §4.1.3 binding; mapped to
+// `invalid_grant` at the HTTP layer.
+var errAuthCodeRedirectMismatch = errors.New("auth code redirect_uri mismatch")
+
+// errAuthCodePKCEFailed is returned when SHA-256(code_verifier) does
+// not match the stored code_challenge. RFC 7636 §4.6 binding; the
+// /token handler maps to `invalid_grant`. Comparison is
+// constant-time to avoid a timing oracle on the challenge value.
+var errAuthCodePKCEFailed = errors.New("auth code PKCE verification failed")
+
+// AuthCodeRequest is the subset of /oauth/authorize parameters the
+// store retains across the IdP round-trip. The handler validates
+// shape (response_type, code_challenge_method, loopback redirect)
+// before constructing the request; this struct is the cleaned form
+// the store remembers.
+//
+// ClientState is the OAuth `state` parameter the MCP client supplied
+// — the broker passes it through verbatim on the redirect to the
+// client's redirect_uri so the client can defend against its own
+// callback CSRF. Distinct from the broker's signed State cookie,
+// which protects the broker ↔ IdP leg.
+type AuthCodeRequest struct {
+	ClientID            string
+	RedirectURI         string
+	ClientState         string
+	Scope               string
+	CodeChallenge       string
+	CodeChallengeMethod string
+}
+
+// PendingAuthCode is what LookupPending returns: the original
+// /oauth/authorize request plus the absolute expiry the callback
+// handler enforces. Returned by value so callers cannot mutate the
+// store's copy outside the mutex.
+type PendingAuthCode struct {
+	AuthCodeRequest
+	ExpiresAt time.Time
+}
+
+// authCodeEntry is the post-callback state — the issued code's
+// binding to the IdP exchange result plus the original request's
+// PKCE + client/redirect for re-check at /token. Owned by the store
+// mutex; never returned by pointer.
+type authCodeEntry struct {
+	ClientID            string
+	RedirectURI         string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	Exchange            ExchangeResult
+	ExpiresAt           time.Time
+}
+
+// authCodeStore is the in-memory state for all in-flight
+// authorization-code grants on this broker replica. Same
+// single-broker invariant as deviceStore: process memory only,
+// dropped on restart. Acceptable because the pending TTL is short
+// (10m) and the issued-code TTL is shorter still (60s); the
+// redirect-flow window comfortably fits inside a pod restart's
+// readiness gate.
+type authCodeStore struct {
+	mu sync.Mutex
+
+	pending map[string]*PendingAuthCode // authCodeID → pending request
+	codes   map[string]*authCodeEntry   // issued code → bound entry
+
+	clock      func() time.Time
+	pendingTTL time.Duration
+	codeTTL    time.Duration
+}
+
+// newAuthCodeStore builds a fresh in-memory store. pendingTTL is the
+// /oauth/authorize → /auth/callback window; codeTTL is the
+// /auth/callback → /token window. clock is injected so tests can
+// drive expiry deterministically.
+func newAuthCodeStore(clock func() time.Time, pendingTTL, codeTTL time.Duration) *authCodeStore {
+	if clock == nil {
+		clock = time.Now
+	}
+	if pendingTTL <= 0 {
+		pendingTTL = defaultPendingAuthCodeTTL
+	}
+	if codeTTL <= 0 {
+		codeTTL = defaultAuthCodeTTL
+	}
+	return &authCodeStore{
+		pending:    make(map[string]*PendingAuthCode),
+		codes:      make(map[string]*authCodeEntry),
+		clock:      clock,
+		pendingTTL: pendingTTL,
+		codeTTL:    codeTTL,
+	}
+}
+
+// Begin records a new pending /oauth/authorize grant and returns the
+// opaque internal id the handler pins inside the signed State cookie.
+// The id never leaves the broker — it is not the authorization code
+// the client eventually sees — so its sole job is to link the
+// callback back to the original request. Takes a pointer to
+// AuthCodeRequest to avoid copying the ~100-byte struct through the
+// call site; the store dereferences into its own copy under the lock.
+func (s *authCodeStore) Begin(req *AuthCodeRequest) (string, error) {
+	id, err := newAuthCodeID()
+	if err != nil {
+		return "", fmt.Errorf("auth code id: %w", err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pending[id] = &PendingAuthCode{
+		AuthCodeRequest: *req,
+		ExpiresAt:       s.clock().Add(s.pendingTTL),
+	}
+	return id, nil
+}
+
+// LookupPending returns a copy of the pending grant for the supplied
+// id, or false when the id is unknown or expired. Unlike Bind it
+// does not mutate the store — callbacks can peek (e.g. for logging)
+// without consuming the entry.
+func (s *authCodeStore) LookupPending(id string) (PendingAuthCode, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.pending[id]
+	if !ok {
+		return PendingAuthCode{}, false
+	}
+	if s.clock().After(p.ExpiresAt) {
+		return PendingAuthCode{}, false
+	}
+	return *p, true
+}
+
+// Bind transitions a pending grant into an issued authorization code.
+// On success it returns the freshly-minted code plus a copy of the
+// pending request so the callback handler can build the redirect URL
+// (it needs the client's redirect_uri + client_state). The pending
+// entry is removed atomically — a second Bind on the same id returns
+// errAuthCodePendingNotFound.
+//
+// Takes a pointer to ExchangeResult to avoid copying ~120 bytes
+// through the call site; same pattern as deviceStore.Bind.
+//
+// On expired pending: errAuthCodePendingNotFound (the entry is also
+// dropped so a follow-up sweep does not have to re-find it).
+func (s *authCodeStore) Bind(id string, exchange *ExchangeResult) (string, PendingAuthCode, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.pending[id]
+	if !ok {
+		return "", PendingAuthCode{}, errAuthCodePendingNotFound
+	}
+	now := s.clock()
+	if now.After(p.ExpiresAt) {
+		delete(s.pending, id)
+		return "", PendingAuthCode{}, errAuthCodePendingNotFound
+	}
+	code, err := newAuthCode()
+	if err != nil {
+		return "", PendingAuthCode{}, fmt.Errorf("auth code: %w", err)
+	}
+	s.codes[code] = &authCodeEntry{
+		ClientID:            p.ClientID,
+		RedirectURI:         p.RedirectURI,
+		CodeChallenge:       p.CodeChallenge,
+		CodeChallengeMethod: p.CodeChallengeMethod,
+		Exchange:            *exchange,
+		ExpiresAt:           now.Add(s.codeTTL),
+	}
+	out := *p
+	delete(s.pending, id)
+	return code, out, nil
+}
+
+// Redeem consumes an issued authorization code. The handler at /token
+// drives this from a `grant_type=authorization_code` request: code +
+// client_id + redirect_uri + code_verifier. On success the entry is
+// removed (one-shot — a replay returns errAuthCodeNotFound) and the
+// stored IdP exchange result is returned for token minting.
+//
+// Validation order is deliberate: existence + expiry → client_id →
+// redirect_uri → PKCE. Each axis maps to a distinct sentinel so
+// internal logs name the failure without the handler having to
+// rebuild the reason from context — handler still maps every error
+// to `invalid_grant` on the wire.
+func (s *authCodeStore) Redeem(code, clientID, redirectURI, codeVerifier string) (ExchangeResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.codes[code]
+	if !ok {
+		return ExchangeResult{}, errAuthCodeNotFound
+	}
+	if s.clock().After(entry.ExpiresAt) {
+		delete(s.codes, code)
+		return ExchangeResult{}, errAuthCodeNotFound
+	}
+	if subtle.ConstantTimeCompare([]byte(entry.ClientID), []byte(clientID)) != 1 {
+		return ExchangeResult{}, errAuthCodeClientMismatch
+	}
+	if subtle.ConstantTimeCompare([]byte(entry.RedirectURI), []byte(redirectURI)) != 1 {
+		return ExchangeResult{}, errAuthCodeRedirectMismatch
+	}
+	if !verifyPKCE(entry.CodeChallenge, entry.CodeChallengeMethod, codeVerifier) {
+		return ExchangeResult{}, errAuthCodePKCEFailed
+	}
+	out := entry.Exchange
+	delete(s.codes, code)
+	return out, nil
+}
+
+// Sweep evicts expired pending and issued entries. Called by the
+// janitor; safe to call concurrently with all other store methods.
+// Expired-but-not-yet-redeemed codes are already rejected by Redeem
+// (the lazy expiry check above) — Sweep just keeps the map from
+// growing unboundedly under abandoned flows.
+func (s *authCodeStore) Sweep() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.clock()
+	for id, p := range s.pending {
+		if now.After(p.ExpiresAt) {
+			delete(s.pending, id)
+		}
+	}
+	for code, entry := range s.codes {
+		if now.After(entry.ExpiresAt) {
+			delete(s.codes, code)
+		}
+	}
+}
+
+// verifyPKCE returns true iff method+verifier matches the stored
+// challenge. The broker accepts S256 only — `plain` is excluded by
+// the /oauth/authorize handler before Begin is called, so a
+// non-S256 method here is a programming error and we return false
+// rather than try to handle it (defense-in-depth — a future
+// refactor that accidentally lets `plain` through would still fail
+// closed at Redeem time).
+func verifyPKCE(challenge, method, verifier string) bool {
+	if method != "S256" {
+		return false
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	computed := base64.RawURLEncoding.EncodeToString(sum[:])
+	return subtle.ConstantTimeCompare([]byte(challenge), []byte(computed)) == 1
+}
+
+// newAuthCodeID returns a fresh opaque internal id from crypto/rand.
+// Hex-encoded for symmetry with newDeviceCode — the id never appears
+// in a URL, so encoding choice is cosmetic.
+func newAuthCodeID() (string, error) {
+	buf := make([]byte, authCodeIDBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// newAuthCode returns a fresh authorization code from crypto/rand.
+// base64url-no-pad keeps the redirect URL short; the code is opaque
+// to every caller so encoding choice is internal.
+func newAuthCode() (string, error) {
+	buf := make([]byte, authCodeBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}

--- a/tools/demarkus-broker/internal/broker/auth_code_store.go
+++ b/tools/demarkus-broker/internal/broker/auth_code_store.go
@@ -246,6 +246,19 @@ func (s *authCodeStore) Bind(id string, exchange *ExchangeResult) (string, Pendi
 // internal logs name the failure without the handler having to
 // rebuild the reason from context — handler still maps every error
 // to `invalid_grant` on the wire.
+//
+// Consumption semantics: only successful redemption and expiry
+// delete the code. errAuthCodeClientMismatch /
+// errAuthCodeRedirectMismatch / errAuthCodePKCEFailed leave the
+// entry in place so a transient client misconfig — wrong client_id
+// passed in a retry, race between two callback ports, momentarily
+// wrong code_verifier — does not burn the user's flow inside the
+// 60-second window. The 256-bit code entropy and the PKCE binding
+// keep brute-force probes infeasible in that window. The "transient
+// client misconfig" subtest pins this contract. The HTTP handler in
+// oauth_authorize.go is the right place to emit a structured
+// debug log on validation failure (request context lives there,
+// not in the store).
 func (s *authCodeStore) Redeem(code, clientID, redirectURI, codeVerifier string) (ExchangeResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/tools/demarkus-broker/internal/broker/auth_code_store_test.go
+++ b/tools/demarkus-broker/internal/broker/auth_code_store_test.go
@@ -267,7 +267,7 @@ func TestAuthCodeStoreRedeem(t *testing.T) {
 		}
 	})
 
-	t.Run("client_id mismatch is rejected", func(t *testing.T) {
+	t.Run("transient client misconfig: client_id mismatch is rejected and preserves code", func(t *testing.T) {
 		store, _ := newTestAuthCodeStore(t)
 		req := newTestAuthCodeRequest()
 		id, err := store.Begin(req)

--- a/tools/demarkus-broker/internal/broker/auth_code_store_test.go
+++ b/tools/demarkus-broker/internal/broker/auth_code_store_test.go
@@ -1,0 +1,488 @@
+package broker
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	testPendingAuthCodeTTL = 10 * time.Minute
+	testAuthCodeTTL        = 60 * time.Second
+)
+
+func newTestAuthCodeStore(t *testing.T) (*authCodeStore, *fakeClock) {
+	t.Helper()
+	c := &fakeClock{now: time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)}
+	return newAuthCodeStore(c.Now, testPendingAuthCodeTTL, testAuthCodeTTL), c
+}
+
+// pkce returns a verifier/challenge pair for tests. The verifier is
+// the input to /token; the challenge is what the broker stored at
+// /oauth/authorize. Mirrors RFC 7636 §4.2 + §4.6.
+func pkce(verifier string) (codeVerifier, codeChallenge string) {
+	sum := sha256.Sum256([]byte(verifier))
+	return verifier, base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func newTestAuthCodeRequest() *AuthCodeRequest {
+	_, challenge := pkce("test-verifier-must-be-43-to-128-chars-long-1234")
+	return &AuthCodeRequest{
+		ClientID:            "client-abc",
+		RedirectURI:         "http://127.0.0.1:55408/callback",
+		ClientState:         "client-state-nonce",
+		Scope:               "openid email profile",
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: "S256",
+	}
+}
+
+func TestAuthCodeStoreBegin(t *testing.T) {
+	t.Run("returns distinct ids and stores the request verbatim", func(t *testing.T) {
+		store, clock := newTestAuthCodeStore(t)
+		req := newTestAuthCodeRequest()
+
+		id1, err := store.Begin(req)
+		if err != nil {
+			t.Fatalf("Begin: %v", err)
+		}
+		id2, err := store.Begin(req)
+		if err != nil {
+			t.Fatalf("Begin: %v", err)
+		}
+		if id1 == "" || id2 == "" {
+			t.Fatal("empty id")
+		}
+		if id1 == id2 {
+			t.Fatal("duplicate ids across Begins")
+		}
+
+		p, ok := store.LookupPending(id1)
+		if !ok {
+			t.Fatal("LookupPending returned false for fresh id")
+		}
+		if p.ClientID != req.ClientID || p.RedirectURI != req.RedirectURI ||
+			p.ClientState != req.ClientState || p.Scope != req.Scope ||
+			p.CodeChallenge != req.CodeChallenge ||
+			p.CodeChallengeMethod != req.CodeChallengeMethod {
+			t.Fatalf("pending request fields mutated: got %+v want %+v", p.AuthCodeRequest, req)
+		}
+		if got, want := p.ExpiresAt, clock.Now().Add(testPendingAuthCodeTTL); !got.Equal(want) {
+			t.Fatalf("expiresAt: got %v want %v", got, want)
+		}
+	})
+
+	t.Run("ids are unique across many Begins", func(t *testing.T) {
+		store, _ := newTestAuthCodeStore(t)
+		req := newTestAuthCodeRequest()
+		seen := make(map[string]bool)
+		for range 50 {
+			id, err := store.Begin(req)
+			if err != nil {
+				t.Fatalf("Begin: %v", err)
+			}
+			if seen[id] {
+				t.Fatalf("duplicate id: %q", id)
+			}
+			seen[id] = true
+		}
+	})
+}
+
+func TestAuthCodeStoreLookupPending(t *testing.T) {
+	t.Run("unknown id returns false", func(t *testing.T) {
+		store, _ := newTestAuthCodeStore(t)
+		if _, ok := store.LookupPending("never-issued"); ok {
+			t.Fatal("expected miss on unknown id")
+		}
+	})
+
+	t.Run("expired pending returns false", func(t *testing.T) {
+		store, clock := newTestAuthCodeStore(t)
+		id, err := store.Begin(newTestAuthCodeRequest())
+		if err != nil {
+			t.Fatalf("Begin: %v", err)
+		}
+		clock.Advance(testPendingAuthCodeTTL + time.Second)
+		if _, ok := store.LookupPending(id); ok {
+			t.Fatal("expected miss after TTL")
+		}
+	})
+}
+
+func TestAuthCodeStoreBind(t *testing.T) {
+	t.Run("issues a code, removes the pending entry, returns the request", func(t *testing.T) {
+		store, clock := newTestAuthCodeStore(t)
+		req := newTestAuthCodeRequest()
+		id, err := store.Begin(req)
+		if err != nil {
+			t.Fatalf("Begin: %v", err)
+		}
+		exchange := ExchangeResult{
+			Claims:      Claims{Subject: "sub-1", Email: "alice@example.com", EmailVerified: true},
+			RawIDToken:  "id-token-raw",
+			AccessToken: "access-token-raw",
+			Expiry:      clock.Now().Add(1 * time.Hour),
+		}
+
+		code, pending, err := store.Bind(id, &exchange)
+		if err != nil {
+			t.Fatalf("Bind: %v", err)
+		}
+		if code == "" {
+			t.Fatal("empty code")
+		}
+		if pending.ClientID != req.ClientID || pending.ClientState != req.ClientState ||
+			pending.RedirectURI != req.RedirectURI {
+			t.Fatalf("pending mirror mismatch: got %+v want %+v", pending.AuthCodeRequest, req)
+		}
+
+		if _, ok := store.LookupPending(id); ok {
+			t.Fatal("pending entry survived Bind")
+		}
+	})
+
+	t.Run("unknown id returns not-found", func(t *testing.T) {
+		store, _ := newTestAuthCodeStore(t)
+		if _, _, err := store.Bind("nonexistent", &ExchangeResult{}); !errors.Is(err, errAuthCodePendingNotFound) {
+			t.Fatalf("err: got %v want errAuthCodePendingNotFound", err)
+		}
+	})
+
+	t.Run("rebind on the same id is rejected", func(t *testing.T) {
+		store, _ := newTestAuthCodeStore(t)
+		id, err := store.Begin(newTestAuthCodeRequest())
+		if err != nil {
+			t.Fatalf("Begin: %v", err)
+		}
+		if _, _, err := store.Bind(id, &ExchangeResult{RawIDToken: "first"}); err != nil {
+			t.Fatalf("first Bind: %v", err)
+		}
+		_, _, err = store.Bind(id, &ExchangeResult{RawIDToken: "second"})
+		if !errors.Is(err, errAuthCodePendingNotFound) {
+			t.Fatalf("second Bind: got %v want errAuthCodePendingNotFound", err)
+		}
+	})
+
+	t.Run("expired pending is rejected", func(t *testing.T) {
+		store, clock := newTestAuthCodeStore(t)
+		id, err := store.Begin(newTestAuthCodeRequest())
+		if err != nil {
+			t.Fatalf("Begin: %v", err)
+		}
+		clock.Advance(testPendingAuthCodeTTL + time.Second)
+		if _, _, err := store.Bind(id, &ExchangeResult{}); !errors.Is(err, errAuthCodePendingNotFound) {
+			t.Fatalf("got %v want errAuthCodePendingNotFound", err)
+		}
+		// Pending entry is also dropped so the next sweep is a no-op.
+		if _, ok := store.LookupPending(id); ok {
+			t.Fatal("expired pending entry should have been removed at Bind time")
+		}
+	})
+
+	t.Run("codes are unique across many Binds", func(t *testing.T) {
+		store, _ := newTestAuthCodeStore(t)
+		seen := make(map[string]bool)
+		for range 50 {
+			id, err := store.Begin(newTestAuthCodeRequest())
+			if err != nil {
+				t.Fatalf("Begin: %v", err)
+			}
+			code, _, err := store.Bind(id, &ExchangeResult{})
+			if err != nil {
+				t.Fatalf("Bind: %v", err)
+			}
+			if seen[code] {
+				t.Fatalf("duplicate code: %q", code)
+			}
+			seen[code] = true
+		}
+	})
+}
+
+func TestAuthCodeStoreRedeem(t *testing.T) {
+	verifier, _ := pkce("test-verifier-must-be-43-to-128-chars-long-1234")
+
+	t.Run("returns the bound exchange on success and is one-shot", func(t *testing.T) {
+		store, _ := newTestAuthCodeStore(t)
+		req := newTestAuthCodeRequest()
+		id, err := store.Begin(req)
+		if err != nil {
+			t.Fatalf("Begin: %v", err)
+		}
+		exchange := ExchangeResult{
+			Claims:      Claims{Subject: "sub-1", Email: "alice@example.com", EmailVerified: true},
+			RawIDToken:  "id-token-raw",
+			AccessToken: "access-token-raw",
+		}
+		code, _, err := store.Bind(id, &exchange)
+		if err != nil {
+			t.Fatalf("Bind: %v", err)
+		}
+
+		got, err := store.Redeem(code, req.ClientID, req.RedirectURI, verifier)
+		if err != nil {
+			t.Fatalf("Redeem: %v", err)
+		}
+		if got.RawIDToken != exchange.RawIDToken || got.AccessToken != exchange.AccessToken {
+			t.Fatalf("exchange forwarding mismatch: got %+v want %+v", got, exchange)
+		}
+
+		// Second Redeem fails — one-shot.
+		if _, err := store.Redeem(code, req.ClientID, req.RedirectURI, verifier); !errors.Is(err, errAuthCodeNotFound) {
+			t.Fatalf("replay: got %v want errAuthCodeNotFound", err)
+		}
+	})
+
+	t.Run("unknown code returns not-found", func(t *testing.T) {
+		store, _ := newTestAuthCodeStore(t)
+		req := newTestAuthCodeRequest()
+		if _, err := store.Redeem("never-issued", req.ClientID, req.RedirectURI, verifier); !errors.Is(err, errAuthCodeNotFound) {
+			t.Fatalf("got %v want errAuthCodeNotFound", err)
+		}
+	})
+
+	t.Run("expired code returns not-found and is removed", func(t *testing.T) {
+		store, clock := newTestAuthCodeStore(t)
+		req := newTestAuthCodeRequest()
+		id, err := store.Begin(req)
+		if err != nil {
+			t.Fatalf("Begin: %v", err)
+		}
+		code, _, err := store.Bind(id, &ExchangeResult{})
+		if err != nil {
+			t.Fatalf("Bind: %v", err)
+		}
+		clock.Advance(testAuthCodeTTL + time.Second)
+		if _, err := store.Redeem(code, req.ClientID, req.RedirectURI, verifier); !errors.Is(err, errAuthCodeNotFound) {
+			t.Fatalf("expired Redeem: got %v want errAuthCodeNotFound", err)
+		}
+		// Re-Redeem after expiry-driven delete still returns not-found.
+		if _, err := store.Redeem(code, req.ClientID, req.RedirectURI, verifier); !errors.Is(err, errAuthCodeNotFound) {
+			t.Fatalf("post-delete Redeem: got %v want errAuthCodeNotFound", err)
+		}
+	})
+
+	t.Run("client_id mismatch is rejected", func(t *testing.T) {
+		store, _ := newTestAuthCodeStore(t)
+		req := newTestAuthCodeRequest()
+		id, err := store.Begin(req)
+		if err != nil {
+			t.Fatalf("Begin: %v", err)
+		}
+		code, _, err := store.Bind(id, &ExchangeResult{})
+		if err != nil {
+			t.Fatalf("Bind: %v", err)
+		}
+		if _, err := store.Redeem(code, "wrong-client", req.RedirectURI, verifier); !errors.Is(err, errAuthCodeClientMismatch) {
+			t.Fatalf("got %v want errAuthCodeClientMismatch", err)
+		}
+		// Failed Redeem must NOT consume the entry — the legitimate
+		// client could still come in. (Whether to invalidate here is
+		// a tradeoff; we choose to keep the code alive so a transient
+		// client misconfig doesn't burn the user's flow.)
+		if _, err := store.Redeem(code, req.ClientID, req.RedirectURI, verifier); err != nil {
+			t.Fatalf("legitimate Redeem after mismatch failed: %v", err)
+		}
+	})
+
+	t.Run("redirect_uri mismatch is rejected", func(t *testing.T) {
+		store, _ := newTestAuthCodeStore(t)
+		req := newTestAuthCodeRequest()
+		id, err := store.Begin(req)
+		if err != nil {
+			t.Fatalf("Begin: %v", err)
+		}
+		code, _, err := store.Bind(id, &ExchangeResult{})
+		if err != nil {
+			t.Fatalf("Bind: %v", err)
+		}
+		if _, err := store.Redeem(code, req.ClientID, "http://127.0.0.1:99999/other", verifier); !errors.Is(err, errAuthCodeRedirectMismatch) {
+			t.Fatalf("got %v want errAuthCodeRedirectMismatch", err)
+		}
+	})
+
+	t.Run("pkce verifier mismatch is rejected", func(t *testing.T) {
+		store, _ := newTestAuthCodeStore(t)
+		req := newTestAuthCodeRequest()
+		id, err := store.Begin(req)
+		if err != nil {
+			t.Fatalf("Begin: %v", err)
+		}
+		code, _, err := store.Bind(id, &ExchangeResult{})
+		if err != nil {
+			t.Fatalf("Bind: %v", err)
+		}
+		if _, err := store.Redeem(code, req.ClientID, req.RedirectURI, "wrong-verifier"); !errors.Is(err, errAuthCodePKCEFailed) {
+			t.Fatalf("got %v want errAuthCodePKCEFailed", err)
+		}
+	})
+
+	t.Run("non-S256 stored method always fails verification", func(t *testing.T) {
+		// Defense-in-depth: the /oauth/authorize handler rejects
+		// method != S256 before Begin. If a future refactor lets a
+		// `plain` request through, Redeem must still fail closed.
+		store, _ := newTestAuthCodeStore(t)
+		req := newTestAuthCodeRequest()
+		req.CodeChallengeMethod = "plain"
+		req.CodeChallenge = "any-plain-value"
+		id, err := store.Begin(req)
+		if err != nil {
+			t.Fatalf("Begin: %v", err)
+		}
+		code, _, err := store.Bind(id, &ExchangeResult{})
+		if err != nil {
+			t.Fatalf("Bind: %v", err)
+		}
+		if _, err := store.Redeem(code, req.ClientID, req.RedirectURI, "any-plain-value"); !errors.Is(err, errAuthCodePKCEFailed) {
+			t.Fatalf("got %v want errAuthCodePKCEFailed", err)
+		}
+	})
+}
+
+func TestAuthCodeStoreSweep(t *testing.T) {
+	store, clock := newTestAuthCodeStore(t)
+
+	// Two pending grants, one issued code.
+	idLive, err := store.Begin(newTestAuthCodeRequest())
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	idExpired, err := store.Begin(newTestAuthCodeRequest())
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	idBindable, err := store.Begin(newTestAuthCodeRequest())
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	codeExpired, _, err := store.Bind(idBindable, &ExchangeResult{})
+	if err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+
+	// Pre-expiry sweep: no-op.
+	store.Sweep()
+	if _, ok := store.LookupPending(idLive); !ok {
+		t.Fatal("live pending evicted prematurely")
+	}
+	if _, ok := store.LookupPending(idExpired); !ok {
+		t.Fatal("about-to-expire pending evicted prematurely")
+	}
+
+	// Advance past the code TTL but inside the pending TTL.
+	clock.Advance(testAuthCodeTTL + time.Second)
+	store.Sweep()
+	if _, ok := store.LookupPending(idLive); !ok {
+		t.Fatal("live pending evicted by code-TTL sweep")
+	}
+	// Issued code must be gone.
+	verifier, _ := pkce("test-verifier-must-be-43-to-128-chars-long-1234")
+	if _, err := store.Redeem(codeExpired, "client-abc", "http://127.0.0.1:55408/callback", verifier); !errors.Is(err, errAuthCodeNotFound) {
+		t.Fatalf("expired code survived sweep: %v", err)
+	}
+
+	// Advance past the pending TTL.
+	clock.Advance(testPendingAuthCodeTTL + time.Second)
+	store.Sweep()
+	if _, ok := store.LookupPending(idLive); ok {
+		t.Fatal("expired pending survived sweep")
+	}
+	if _, ok := store.LookupPending(idExpired); ok {
+		t.Fatal("expired pending survived sweep")
+	}
+}
+
+func TestAuthCodeStoreConcurrentRedeemOneWinner(t *testing.T) {
+	// Two Redeem calls race on the same code; exactly one must win.
+	store, _ := newTestAuthCodeStore(t)
+	req := newTestAuthCodeRequest()
+	id, err := store.Begin(req)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	code, _, err := store.Bind(id, &ExchangeResult{RawIDToken: "id-token"})
+	if err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	verifier, _ := pkce("test-verifier-must-be-43-to-128-chars-long-1234")
+
+	var wg sync.WaitGroup
+	results := make(chan error, 2)
+	for range 2 {
+		wg.Go(func() {
+			_, err := store.Redeem(code, req.ClientID, req.RedirectURI, verifier)
+			results <- err
+		})
+	}
+	wg.Wait()
+	close(results)
+
+	var success, notFound int
+	for err := range results {
+		switch {
+		case err == nil:
+			success++
+		case errors.Is(err, errAuthCodeNotFound):
+			notFound++
+		default:
+			t.Fatalf("unexpected err: %v", err)
+		}
+	}
+	if success != 1 || notFound != 1 {
+		t.Fatalf("expected 1 success + 1 not-found, got success=%d not-found=%d", success, notFound)
+	}
+}
+
+func TestVerifyPKCE(t *testing.T) {
+	verifier := "test-verifier-must-be-43-to-128-chars-long-1234"
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	tests := []struct {
+		name      string
+		challenge string
+		method    string
+		verifier  string
+		want      bool
+	}{
+		{"happy path S256", challenge, "S256", verifier, true},
+		{"wrong verifier", challenge, "S256", "wrong", false},
+		{"non-S256 method", challenge, "plain", verifier, false},
+		{"empty method", challenge, "", verifier, false},
+		{"empty challenge", "", "S256", verifier, false},
+		{"empty verifier", challenge, "S256", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := verifyPKCE(tt.challenge, tt.method, tt.verifier); got != tt.want {
+				t.Fatalf("got %v want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewAuthCodeAndID(t *testing.T) {
+	t.Run("auth code id is hex of expected length", func(t *testing.T) {
+		id, err := newAuthCodeID()
+		if err != nil {
+			t.Fatalf("newAuthCodeID: %v", err)
+		}
+		if len(id) != authCodeIDBytes*2 {
+			t.Fatalf("len: got %d want %d", len(id), authCodeIDBytes*2)
+		}
+	})
+	t.Run("auth code is base64url no padding", func(t *testing.T) {
+		code, err := newAuthCode()
+		if err != nil {
+			t.Fatalf("newAuthCode: %v", err)
+		}
+		if strings.ContainsAny(code, "=+/") {
+			t.Fatalf("expected base64url-no-pad, got %q", code)
+		}
+	})
+}

--- a/tools/demarkus-broker/internal/broker/device.go
+++ b/tools/demarkus-broker/internal/broker/device.go
@@ -434,13 +434,20 @@ func (s *Server) deviceCallback(w http.ResponseWriter, r *http.Request, deviceCo
 	s.renderDeviceDone(w, r)
 }
 
-// RunDeviceJanitor sweeps the deviceStore on a fixed cadence until ctx
-// is canceled. Sweep cadence is half the configured device-code TTL so
-// terminal entries are evicted within one TTL window after resolution.
-// Unlike the Sweeper, this janitor needs no leader election: the store
-// is per-replica in-memory state (plan §"Single broker only for now"),
-// so each replica sweeps its own store. Multi-replica deployments are
-// out of scope until the device store grows a shared backing store.
+// RunDeviceJanitor sweeps the deviceStore and the authCodeStore on a
+// fixed cadence until ctx is canceled. Sweep cadence is half the
+// configured device-code TTL so terminal device-flow entries are
+// evicted within one TTL window after resolution; the same tick
+// also sweeps the auth-code store, whose own TTLs (10m pending,
+// 60s code) are correctly enforced lazily by LookupPending/Redeem
+// regardless of sweep timing — the sweep is only a memory-cleanup
+// concern for abandoned grants.
+//
+// Unlike the Sweeper, this janitor needs no leader election: the
+// stores are per-replica in-memory state (plan §"Single broker only
+// for now"), so each replica sweeps its own. Multi-replica
+// deployments are out of scope until either store grows a shared
+// backing store.
 func (s *Server) RunDeviceJanitor(ctx context.Context) {
 	ttl := s.cfg.Server.DeviceCodeTTL
 	if ttl <= 0 {
@@ -455,6 +462,9 @@ func (s *Server) RunDeviceJanitor(ctx context.Context) {
 			return
 		case <-t.C:
 			s.deviceStore.Sweep()
+			if s.authCodeStore != nil {
+				s.authCodeStore.Sweep()
+			}
 		}
 	}
 }

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -37,6 +37,14 @@ type Server struct {
 	// HTTP surface; the store owns the state machine.
 	deviceStore *deviceStore
 
+	// authCodeStore holds in-flight RFC 6749 authorization-code grants
+	// for MCP clients that do not pivot to device flow (Claude Code's
+	// MCP SDK as of 2026-05). Same single-broker invariant as
+	// deviceStore — process-memory only, dropped on restart. The
+	// handlers in oauth_authorize.go own the HTTP surface; the store
+	// owns the pending → code → exchange state machine.
+	authCodeStore *authCodeStore
+
 	// RefreshStore owns the Secret-backed map of sha256(refresh_token)
 	// → record. Wired by NewServer with the configured (or defaulted)
 	// broker-namespace Secret. Survives broker restarts unlike
@@ -146,6 +154,7 @@ func NewServer(cfg *Config, signer *Signer, verifier Verifier, issuer *Issuer, d
 		log:               log,
 		clock:             clock,
 		deviceStore:       newDeviceStore(clock, deviceTTL, pollInterval),
+		authCodeStore:     newAuthCodeStore(clock, defaultPendingAuthCodeTTL, defaultAuthCodeTTL),
 		refreshStore:      NewRefreshStore(cfg, issuer.k8s),
 		trustForwardedFor: cfg.RateLimit.TrustForwardedFor,
 	}

--- a/tools/demarkus-broker/internal/broker/session.go
+++ b/tools/demarkus-broker/internal/broker/session.go
@@ -25,10 +25,23 @@ import (
 // mid-flow, then later did a normal browser login) would silently
 // route /auth/callback through the device branch and bind the
 // wrong grant. Empty means a regular browser code-flow callback.
+//
+// AuthCodeID is the analogous field for the OAuth authorization-code
+// grant the broker offers to MCP clients (Claude Code etc.) that do
+// not pivot to device flow. It opaquely identifies the pending
+// /oauth/authorize request the callback must resume; same dispatch
+// rationale as DeviceCode — keep the callback branch driven by a
+// tamper-evident value, not by an ambient cookie. DeviceCode and
+// AuthCodeID are mutually exclusive in practice (a single /auth/login
+// is driven by one entry-point), but encoded independently so the
+// callback handler's branch order — DeviceCode first, then
+// AuthCodeID — stays unambiguous if a future entry-point ever sets
+// both.
 type State struct {
 	Nonce      string    `json:"n"`
 	ExpiresAt  time.Time `json:"e"`
 	DeviceCode string    `json:"d,omitempty"`
+	AuthCodeID string    `json:"a,omitempty"`
 }
 
 // Signer encodes and verifies State values into the signed cookie format

--- a/tools/demarkus-broker/internal/broker/session_test.go
+++ b/tools/demarkus-broker/internal/broker/session_test.go
@@ -41,6 +41,30 @@ func TestSignerRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSignerRoundTripCarriesDispatchFields(t *testing.T) {
+	s := newTestSigner(t)
+	state := State{
+		Nonce:      "abc",
+		ExpiresAt:  time.Now().Add(5 * time.Minute),
+		DeviceCode: "device-code-opaque",
+		AuthCodeID: "auth-code-id-opaque",
+	}
+	token, err := s.Sign(state)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	got, err := s.Verify(token)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if got.DeviceCode != state.DeviceCode {
+		t.Errorf("DeviceCode = %q, want %q", got.DeviceCode, state.DeviceCode)
+	}
+	if got.AuthCodeID != state.AuthCodeID {
+		t.Errorf("AuthCodeID = %q, want %q", got.AuthCodeID, state.AuthCodeID)
+	}
+}
+
 func TestSignerRejectsTampering(t *testing.T) {
 	s := newTestSigner(t)
 	state := State{Nonce: "abc", ExpiresAt: time.Now().Add(5 * time.Minute)}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authorization-code lifecycle to the broker (create, pin, bind, redeem, expire)
  * Session state now includes an authorization-code identifier for OAuth flows

* **Tests**
  * Comprehensive tests covering the full auth-code lifecycle, PKCE validation, expiry/sweep behavior, and concurrent redemption
  * Session signing/verifying tests extended to include auth-code fields

* **Maintenance**
  * Background janitor now also cleans expired authorization-code entries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->