### PR TITLE
feat(broker): wire authorization_code grant handlers + discovery

### DIFF
--- a/tools/demarkus-broker/internal/broker/device.go
+++ b/tools/demarkus-broker/internal/broker/device.go
@@ -31,6 +31,11 @@ const deviceGrantType = "urn:ietf:params:oauth:grant-type:device_code"
 // the dispatch must reject typos rather than silently fall through.
 const refreshGrantType = "refresh_token"
 
+// authCodeGrantType is the RFC 6749 §4.1.3 grant_type identifier the
+// /device/token handler dispatches on for the authorization-code
+// exchange. Same single-source-of-truth rationale as the other two.
+const authCodeGrantType = "authorization_code"
+
 //go:embed templates/device_form.html templates/device_done.html
 var deviceTemplatesFS embed.FS
 
@@ -211,6 +216,8 @@ func (s *Server) deviceToken(w http.ResponseWriter, r *http.Request) {
 		s.deviceTokenDeviceFlow(w, r)
 	case refreshGrantType:
 		s.deviceTokenRefresh(w, r)
+	case authCodeGrantType:
+		s.deviceTokenAuthCode(w, r)
 	default:
 		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "unsupported_grant_type"})
 	}
@@ -311,6 +318,95 @@ func (s *Server) deviceTokenRefresh(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.log.ErrorContext(r.Context(), "broker: refresh sign id_token failed",
 			"err", err, "subject", hashSubject(record.Claims.Subject))
+		writeJSON(w, http.StatusInternalServerError, deviceTokenError{Error: "server_error"})
+		return
+	}
+	expiresIn := max(int(s.cfg.Server.IDTokenTTL.Seconds()), 0)
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	writeJSON(w, http.StatusOK, deviceTokenSuccess{
+		AccessToken:  idToken,
+		IDToken:      idToken,
+		RefreshToken: rawRefresh,
+		TokenType:    "Bearer",
+		ExpiresIn:    expiresIn,
+	})
+}
+
+// deviceTokenAuthCode handles RFC 6749 §4.1.3 authorization-code
+// exchange. Dispatched from deviceToken on grant_type=
+// authorization_code. Validates the supplied code against the
+// authCodeStore (existence, expiry, client_id binding, redirect_uri
+// binding, PKCE S256 verifier), mints a fresh broker refresh_token
+// + broker-signed id_token, and returns the standard OAuth2 token
+// response.
+//
+// access_token == id_token: same convention deviceTokenRefresh
+// uses (see its doc above) — the broker is the relying party for
+// its own bearer tokens, the compositeVerifier accepts either
+// field, and empty access_token would force every client to learn
+// a per-broker quirk.
+//
+// Error mapping:
+//   - Missing required form params → invalid_request
+//   - authCodeStore.Redeem error (unknown code, mismatch, PKCE) →
+//     invalid_grant. We deliberately collapse the store's distinct
+//     sentinels into one wire code so the response surface does
+//     not leak which axis failed (operator logs name the failure
+//     for in-the-room diagnosis).
+//   - Signing key not wired (operator misconfig) → server_error
+//   - Refresh-token issuance failure → server_error
+//   - id_token signing failure (programming error) → server_error
+//
+// The auth code is consumed by Redeem only on validation success;
+// transient client errors (wrong client_id, wrong redirect_uri,
+// wrong code_verifier) preserve the code for legitimate retry
+// inside the 60-second window. See authCodeStore.Redeem's
+// "Consumption semantics" note for the contract.
+func (s *Server) deviceTokenAuthCode(w http.ResponseWriter, r *http.Request) {
+	if s.idTokenSigner == nil {
+		s.log.ErrorContext(r.Context(), "broker: auth_code grant requested but id_token signer not wired")
+		writeJSON(w, http.StatusInternalServerError, deviceTokenError{Error: "server_error"})
+		return
+	}
+	code := r.PostFormValue("code")
+	clientID := r.PostFormValue("client_id")
+	redirectURI := r.PostFormValue("redirect_uri")
+	codeVerifier := r.PostFormValue("code_verifier")
+	if code == "" || clientID == "" || redirectURI == "" || codeVerifier == "" {
+		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "invalid_request"})
+		return
+	}
+
+	exchange, err := s.authCodeStore.Redeem(code, clientID, redirectURI, codeVerifier)
+	if err != nil {
+		// Log the specific axis at debug so an operator can tell
+		// apart wrong-verifier (client bug) from unknown-code
+		// (replay or storage churn); the wire response stays
+		// invalid_grant uniformly.
+		s.log.DebugContext(r.Context(), "broker: auth code redeem failed", "err", err)
+		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "invalid_grant"})
+		return
+	}
+
+	rawRefresh, err := s.refreshStore.Issue(r.Context(), exchange.Claims, s.cfg.Server.RefreshTokenTTL)
+	if err != nil {
+		// Code is already consumed by Redeem (one-shot). The user
+		// has to retry from /oauth/authorize; that's acceptable
+		// because the failure mode is a backend write to Secrets,
+		// rare in practice and resolved without user action by the
+		// time they retry.
+		s.log.ErrorContext(r.Context(), "broker: auth code refresh mint failed",
+			"err", err, "subject", hashSubject(exchange.Claims.Subject))
+		writeJSON(w, http.StatusInternalServerError, deviceTokenError{Error: "server_error"})
+		return
+	}
+
+	now := s.clock()
+	idToken, err := s.idTokenSigner.Sign(exchange.Claims, s.cfg.Server.PublicURL, s.cfg.Server.IDTokenTTL, now)
+	if err != nil {
+		s.log.ErrorContext(r.Context(), "broker: auth code sign id_token failed",
+			"err", err, "subject", hashSubject(exchange.Claims.Subject))
 		writeJSON(w, http.StatusInternalServerError, deviceTokenError{Error: "server_error"})
 		return
 	}

--- a/tools/demarkus-broker/internal/broker/device_test.go
+++ b/tools/demarkus-broker/internal/broker/device_test.go
@@ -508,8 +508,12 @@ func TestDeviceTokenStates(t *testing.T) {
 
 	t.Run("unsupported_grant_type", func(t *testing.T) {
 		srv, _ := newTestServer(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+		// `client_credentials` is genuinely unsupported by the broker
+		// (PR2 of broker-auth-code-grant added authorization_code as a
+		// recognized grant_type, so a placeholder there would no longer
+		// exercise the default branch).
 		resp, err := testClient(srv).PostForm(srv.URL+"/device/token", url.Values{
-			"grant_type":  {"authorization_code"},
+			"grant_type":  {"client_credentials"},
 			"device_code": {"x"},
 		})
 		if err != nil {

--- a/tools/demarkus-broker/internal/broker/discovery.go
+++ b/tools/demarkus-broker/internal/broker/discovery.go
@@ -271,31 +271,40 @@ func applyDiscoveryOverrides(raw []byte, brokerURL string) ([]byte, error) {
 	// reach the device-flow surface. See register.go for the
 	// rubber-stamp semantics and the rationale.
 	doc["registration_endpoint"] = brokerURL + "/register"
-	// authorization_endpoint redirected to the broker's stub handler.
+	// authorization_endpoint redirected to the broker's own handler.
 	// The IdP's upstream value (e.g. accounts.google.com/o/oauth2/v2/auth)
 	// MUST NOT pass through: an MCP client following the spec's
 	// authorization_code-first preference would ship its DCR-minted
 	// client_id straight to the IdP, which has never heard of it →
-	// confusing `invalid_client` 401 surfaced at the wrong layer. The
-	// stub at /oauth/authorize returns RFC 6749 `unsupported_response_type`
-	// JSON pointing the client at device_authorization_endpoint. Paired
-	// with the grant_types_supported override below, this signals
-	// "device_code only" to a well-behaved MCP client. See
-	// oauth_authorize.go for the probe rationale — if Claude Code's SDK
-	// doesn't fall back, the broker needs a real authorization_code
-	// grant implementation.
+	// confusing `invalid_client` 401 surfaced at the wrong layer.
+	// The broker IS the OAuth AS for the MCP client; the IdP only
+	// ever sees the broker as its OAuth client. See
+	// oauth_authorize.go for the handler.
 	doc["authorization_endpoint"] = brokerURL + "/oauth/authorize"
 	// grant_types_supported overridden so MCP clients reading the
 	// discovery doc see exactly what the broker's token endpoint
 	// actually accepts. The IdP's upstream list typically includes
-	// authorization_code, which the broker does NOT support yet —
-	// advertising it would invite clients to attempt a flow that
-	// will fail at /device/token with unsupported_grant_type. Dropping
-	// it here puts the spec-driven negotiation on the right footing.
+	// extras (client_credentials, password, etc.) that the broker
+	// does not support; dropping them here keeps the spec-driven
+	// negotiation honest. Order matches the broker's own dispatch
+	// preference: authorization_code is the MCP-SDK default and
+	// gets listed first.
 	doc["grant_types_supported"] = []string{
+		"authorization_code",
 		"urn:ietf:params:oauth:grant-type:device_code",
 		"refresh_token",
 	}
+	// response_types_supported declares the broker's authorize
+	// endpoint accepts only `code` — no implicit / hybrid. MCP SDKs
+	// that probe for OAuth 2.1 compliance check this list before
+	// they kick off /oauth/authorize.
+	doc["response_types_supported"] = []string{"code"}
+	// code_challenge_methods_supported declares S256-only PKCE.
+	// `plain` is excluded by policy (see oauth_authorize.go). The
+	// override replaces any upstream value verbatim so the broker's
+	// stricter posture is advertised honestly even when the IdP
+	// would have allowed `plain`.
+	doc["code_challenge_methods_supported"] = []string{"S256"}
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetIndent("", "  ")

--- a/tools/demarkus-broker/internal/broker/discovery_test.go
+++ b/tools/demarkus-broker/internal/broker/discovery_test.go
@@ -177,15 +177,18 @@ func TestDiscoveryOverridesBrokerEndpoints(t *testing.T) {
 
 func TestDiscoveryProxiesUnOverriddenFields(t *testing.T) {
 	// Round-trips fields the broker does NOT take over:
-	// userinfo_endpoint plus IdP-specific metadata arrays. Tests both
-	// presence and exact value so a regression that silently drops or
-	// rewrites these surfaces here.
+	// userinfo_endpoint and similar pass-through metadata.
 	//
 	// jwks_uri WAS in this list pre-PR4 but moved to the override
-	// set when the broker started signing id_tokens. authorization_endpoint
-	// WAS in this list pre-DCR-followup but moved to the override set
-	// to stop MCP clients from shipping their DCR-minted client_id at
-	// the upstream IdP.
+	// set when the broker started signing id_tokens.
+	// authorization_endpoint WAS in this list pre-DCR-followup but
+	// moved to the override set to stop MCP clients from shipping
+	// their DCR-minted client_id at the upstream IdP.
+	// response_types_supported + code_challenge_methods_supported
+	// moved to the override set with the auth-code grant rollout
+	// (PR2 of broker-auth-code-grant): the broker enforces a
+	// stricter S256-only / code-only posture than the IdP may
+	// advertise.
 	idp := newFakeDiscoveryIdP(t)
 	d, _ := newTestDiscovery(t, idp, time.Minute)
 	doc := serveAndDecode(t, d)
@@ -203,21 +206,50 @@ func TestDiscoveryProxiesUnOverriddenFields(t *testing.T) {
 			}
 		})
 	}
-	// Arrays should come through structurally intact.
-	if got, ok := doc["response_types_supported"].([]any); !ok || len(got) != 1 || got[0] != "code" {
-		t.Errorf("response_types_supported = %v, want [code]", doc["response_types_supported"])
+}
+
+// TestDiscoveryOverridesResponseTypesSupported asserts the broker
+// advertises `code` only — no implicit, no hybrid. MCP SDKs probing
+// for OAuth 2.1 compliance check this list before they POST to
+// /oauth/authorize, and the broker would reject anything else at
+// that handler regardless.
+func TestDiscoveryOverridesResponseTypesSupported(t *testing.T) {
+	idp := newFakeDiscoveryIdP(t)
+	d, _ := newTestDiscovery(t, idp, time.Minute)
+	doc := serveAndDecode(t, d)
+	got, ok := doc["response_types_supported"].([]any)
+	if !ok {
+		t.Fatalf("response_types_supported = %v, want []string", doc["response_types_supported"])
 	}
-	if got, ok := doc["code_challenge_methods_supported"].([]any); !ok || len(got) != 1 || got[0] != "S256" {
-		t.Errorf("code_challenge_methods_supported = %v, want [S256]", doc["code_challenge_methods_supported"])
+	if len(got) != 1 || got[0] != "code" {
+		t.Errorf("response_types_supported = %v, want [code]", got)
 	}
 }
 
-// TestDiscoveryOverridesGrantTypesSupported asserts the broker advertises
-// only the grant types its /device/token endpoint actually accepts.
-// Upstream IdPs typically advertise authorization_code; passing that
-// through would invite MCP clients to attempt a flow that fails at
-// /device/token with unsupported_grant_type — the exact wrong-layer
-// confusion the authorization_endpoint stub avoids on the front side.
+// TestDiscoveryOverridesCodeChallengeMethodsSupported asserts the
+// broker advertises S256-only. The IdP fixture happens to advertise
+// the same, but a customer IdP that allowed `plain` would otherwise
+// proxy that through and mislead the SDK; the override pins the
+// broker's stricter posture independent of upstream.
+func TestDiscoveryOverridesCodeChallengeMethodsSupported(t *testing.T) {
+	idp := newFakeDiscoveryIdP(t)
+	d, _ := newTestDiscovery(t, idp, time.Minute)
+	doc := serveAndDecode(t, d)
+	got, ok := doc["code_challenge_methods_supported"].([]any)
+	if !ok {
+		t.Fatalf("code_challenge_methods_supported = %v, want []string", doc["code_challenge_methods_supported"])
+	}
+	if len(got) != 1 || got[0] != "S256" {
+		t.Errorf("code_challenge_methods_supported = %v, want [S256]", got)
+	}
+}
+
+// TestDiscoveryOverridesGrantTypesSupported asserts the broker
+// advertises exactly the grant types its /device/token endpoint
+// accepts: authorization_code (PR2), device_code, refresh_token.
+// Order matches the broker's dispatch preference; MCP SDKs that
+// honor list order pick authorization_code first, which is the
+// happy path Claude Code drives.
 func TestDiscoveryOverridesGrantTypesSupported(t *testing.T) {
 	idp := newFakeDiscoveryIdP(t)
 	d, _ := newTestDiscovery(t, idp, time.Minute)
@@ -226,7 +258,7 @@ func TestDiscoveryOverridesGrantTypesSupported(t *testing.T) {
 	if !ok {
 		t.Fatalf("grant_types_supported = %v (type %T), want []string", doc["grant_types_supported"], doc["grant_types_supported"])
 	}
-	want := []string{"urn:ietf:params:oauth:grant-type:device_code", "refresh_token"}
+	want := []string{"authorization_code", "urn:ietf:params:oauth:grant-type:device_code", "refresh_token"}
 	if len(got) != len(want) {
 		t.Fatalf("grant_types_supported length = %d, want %d (got=%v)", len(got), len(want), got)
 	}

--- a/tools/demarkus-broker/internal/broker/oauth_authorize.go
+++ b/tools/demarkus-broker/internal/broker/oauth_authorize.go
@@ -2,44 +2,311 @@ package broker
 
 import (
 	"net/http"
+	"net/url"
+	"strings"
 )
 
-// oauthAuthorize is a stub authorization endpoint that always rejects
-// with `unsupported_response_type`. It exists for one reason: MCP
-// clients that follow the spec's authorization_code-first preference
-// MUST be able to fetch SOME `authorization_endpoint` from the broker's
-// discovery doc and get a clear "not supported here" signal — otherwise
-// the field defaults to the upstream IdP (e.g. accounts.google.com)
-// which the broker's DCR-minted client_id was never registered with,
-// surfacing as a confusing `invalid_client` from the IdP itself.
+// oauthAuthorize implements GET / POST /oauth/authorize — the RFC
+// 6749 §4.1.1 authorization endpoint, scoped to the
+// `response_type=code` + PKCE-S256 flow MCP clients drive against
+// the broker. The handler does not bounce to an IdP directly; the
+// broker is its own AS to the MCP client, and the IdP dance is
+// resumed by /auth/callback via the signed State cookie's
+// AuthCodeID field (mirroring the existing DeviceCode dispatch).
 //
-// Returning a JSON 400 with a standard OAuth error code lets a
-// well-behaved MCP client either surface the error to the user or
-// (better) consult `grant_types_supported` in the same discovery doc
-// and pivot to the device_code grant.
+// Two-phase validation matches RFC 6749 §4.1.2.1: errors that
+// happen BEFORE the redirect_uri is trusted (missing client_id,
+// non-loopback redirect_uri) surface as a JSON 400 directly to the
+// user agent. Errors AFTER trust is established (bad response_type,
+// missing PKCE, store failure) redirect to the client's
+// redirect_uri with `error=...&state=...` so the MCP SDK can surface
+// the failure programmatically.
 //
-// Probe semantics: this handler ships paired with the
-// `authorization_endpoint` + `grant_types_supported` discovery overrides
-// in applyDiscoveryOverrides. If Claude Code's MCP SDK pivots to
-// device flow on its own, this stub stays as-is. If the SDK insists on
-// authorization_code, the broker needs a real OAuth authorization-code
-// grant (handler that mediates between the MCP client and the upstream
-// IdP via /auth/callback); at that point this file becomes the real
-// authorize handler instead of a polite rejection.
+// PKCE is required: the broker accepts only `code_challenge_method=
+// S256` and rejects requests missing `code_challenge`. OAuth 2.1
+// guidance + the MCP authorization spec both require this; with no
+// legacy clients to placate, the broker fails closed.
 //
-// Authentication: none. The endpoint is anonymous-public — same posture
-// as the upstream IdP's authorization endpoint would be. IP rate
-// limiter (server.go) caps per-IP churn.
-//
-// HTTP method: GET and POST both accepted per RFC 6749 §3.1 ("The
-// authorization server MUST support the use of the HTTP GET method
-// [...] and MAY support the use of the HTTP POST method as well").
-// Routing them at the same handler keeps the rejection uniform —
-// neither shape is valid here.
-func (s *Server) oauthAuthorize(w http.ResponseWriter, _ *http.Request) {
+// Method handling: GET (per RFC 6749 §3.1) is the canonical entry;
+// POST is accepted on the same handler. r.URL.Query() covers both
+// because Go's net/http populates form values on POST too, but we
+// stick to query semantics so signed-state state cookie set here
+// doesn't depend on POST body parsing.
+func (s *Server) oauthAuthorize(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-store")
-	writeJSON(w, http.StatusBadRequest, map[string]string{
-		"error":             "unsupported_response_type",
-		"error_description": "this broker does not support the authorization_code grant; clients should consult grant_types_supported in the discovery document and use the device_code grant via device_authorization_endpoint",
+
+	if err := r.ParseForm(); err != nil {
+		writeAuthorizeJSONError(w, "invalid_request", "could not parse form")
+		return
+	}
+	params := r.Form
+
+	clientID := strings.TrimSpace(params.Get("client_id"))
+	if clientID == "" {
+		writeAuthorizeJSONError(w, "invalid_request", "client_id required")
+		return
+	}
+	redirectURI := strings.TrimSpace(params.Get("redirect_uri"))
+	if redirectURI == "" {
+		writeAuthorizeJSONError(w, "invalid_request", "redirect_uri required")
+		return
+	}
+	if !isLoopbackRedirectURI(redirectURI) {
+		// RFC 8252 §7.3: native apps MUST use loopback. Any other
+		// host is a configuration mistake or an attack; either way
+		// the broker refuses BEFORE the redirect is trusted, so the
+		// error stays on the broker's surface (no 302 to a hostile
+		// host).
+		writeAuthorizeJSONError(w, "invalid_request", "redirect_uri must be loopback (http://127.0.0.1:PORT or http://localhost:PORT)")
+		return
+	}
+
+	// redirect_uri is now trusted. All subsequent errors redirect.
+	clientState := params.Get("state")
+
+	responseType := strings.TrimSpace(params.Get("response_type"))
+	if responseType != "code" {
+		redirectAuthorizeError(w, r, redirectURI, clientState, "unsupported_response_type",
+			"only response_type=code is supported")
+		return
+	}
+	codeChallenge := strings.TrimSpace(params.Get("code_challenge"))
+	if codeChallenge == "" {
+		redirectAuthorizeError(w, r, redirectURI, clientState, "invalid_request",
+			"code_challenge required")
+		return
+	}
+	codeChallengeMethod := strings.TrimSpace(params.Get("code_challenge_method"))
+	if codeChallengeMethod == "" {
+		// RFC 7636 §4.3: omitted method defaults to `plain`, but the
+		// broker does not accept `plain`. Reject the omitted case
+		// explicitly so the SDK gets a helpful error code rather
+		// than the broker silently treating it as plain and then
+		// failing PKCE at the /token leg.
+		redirectAuthorizeError(w, r, redirectURI, clientState, "invalid_request",
+			"code_challenge_method required (only S256 is supported)")
+		return
+	}
+	if codeChallengeMethod != "S256" {
+		redirectAuthorizeError(w, r, redirectURI, clientState, "invalid_request",
+			"only code_challenge_method=S256 is supported")
+		return
+	}
+
+	authCodeID, err := s.authCodeStore.Begin(&AuthCodeRequest{
+		ClientID:            clientID,
+		RedirectURI:         redirectURI,
+		ClientState:         clientState,
+		Scope:               params.Get("scope"),
+		CodeChallenge:       codeChallenge,
+		CodeChallengeMethod: codeChallengeMethod,
 	})
+	if err != nil {
+		s.log.ErrorContext(r.Context(), "broker: auth code begin failed", "err", err)
+		redirectAuthorizeError(w, r, redirectURI, clientState, "server_error", "internal error")
+		return
+	}
+
+	nonce, err := NewNonce()
+	if err != nil {
+		s.log.ErrorContext(r.Context(), "broker: nonce", "err", err)
+		redirectAuthorizeError(w, r, redirectURI, clientState, "server_error", "internal error")
+		return
+	}
+	state := State{
+		Nonce:      nonce,
+		AuthCodeID: authCodeID,
+		ExpiresAt:  s.clock().Add(s.cfg.Server.StateTTL),
+	}
+	signed, err := s.signer.Sign(state)
+	if err != nil {
+		s.log.ErrorContext(r.Context(), "broker: sign state", "err", err)
+		redirectAuthorizeError(w, r, redirectURI, clientState, "server_error", "internal error")
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     stateCookieName,
+		Value:    signed,
+		Path:     "/auth/callback",
+		HttpOnly: true,
+		Secure:   !s.cfg.Server.InsecureCookies,
+		SameSite: http.SameSiteLaxMode,
+		Expires:  state.ExpiresAt,
+		MaxAge:   int(s.cfg.Server.StateTTL.Seconds()),
+	})
+	http.Redirect(w, r, s.verifier.AuthCodeURL(nonce), http.StatusFound)
+}
+
+// authCodeCallback resumes the auth-code flow after the IdP has
+// returned the user to /auth/callback. Dispatched from authCallback
+// when the verified State carries a non-empty AuthCodeID. State
+// validation (signature, nonce match, expiry, cookie clear) is
+// owned by the caller; this function is invoked only after those
+// gates pass.
+//
+// On success: Exchange the IdP code, Bind into the authCodeStore
+// (which mints the broker's authorization code), 302 back to the
+// client's redirect_uri with `code` + `state` + `iss` (RFC 9207
+// mix-up defense — cheap to ship even if Claude Code's SDK ignores
+// it).
+//
+// On IdP-side denial (?error=...): redirect to the client's
+// redirect_uri with the equivalent OAuth error code so the MCP SDK
+// surfaces a real failure rather than waiting for /token.
+//
+// On broker-side failure (LookupPending miss, Exchange error, Bind
+// error): redirect with `error=server_error` whenever the pending
+// entry is still recoverable (so we have a redirect_uri to send
+// the SDK to); render a generic error page only when the pending
+// entry is gone entirely.
+func (s *Server) authCodeCallback(w http.ResponseWriter, r *http.Request, authCodeID string) {
+	pending, ok := s.authCodeStore.LookupPending(authCodeID)
+	if !ok {
+		// No redirect_uri to send the client to — the pending entry
+		// has been swept or never existed. Surface the failure as a
+		// plain 400; the MCP SDK will see it as an aborted browser
+		// leg.
+		s.log.WarnContext(r.Context(), "broker: auth code callback — pending entry missing",
+			"authCodeID", authCodeID)
+		http.Error(w, "authorization session expired", http.StatusBadRequest)
+		return
+	}
+
+	if errParam := r.URL.Query().Get("error"); errParam != "" {
+		s.log.InfoContext(r.Context(), "broker: auth code callback denied by idp", "err", errParam)
+		// The IdP error code may not match the OAuth 2.0
+		// client-facing set; map to access_denied as the closest
+		// safe equivalent. Real failure detail stays in the log.
+		redirectAuthorizeError(w, r, pending.RedirectURI, pending.ClientState,
+			"access_denied", "identity provider denied the request")
+		return
+	}
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		s.log.WarnContext(r.Context(), "broker: auth code callback missing code param")
+		redirectAuthorizeError(w, r, pending.RedirectURI, pending.ClientState,
+			"server_error", "missing authorization code from identity provider")
+		return
+	}
+
+	exchange, err := s.verifier.Exchange(r.Context(), code)
+	if err != nil {
+		s.log.WarnContext(r.Context(), "broker: auth code callback oauth exchange failed", "err", err)
+		// Do NOT translate to access_denied — same rationale as
+		// deviceCallback. A transient IdP failure is not a user
+		// denial.
+		redirectAuthorizeError(w, r, pending.RedirectURI, pending.ClientState,
+			"server_error", "identity provider exchange failed")
+		return
+	}
+
+	authCode, _, err := s.authCodeStore.Bind(authCodeID, &exchange)
+	if err != nil {
+		s.log.WarnContext(r.Context(), "broker: auth code bind failed",
+			"err", err, "subject", hashSubject(exchange.Claims.Subject))
+		redirectAuthorizeError(w, r, pending.RedirectURI, pending.ClientState,
+			"server_error", "authorization session expired")
+		return
+	}
+
+	s.log.InfoContext(r.Context(), "broker: auth code bind succeeded",
+		"subject", hashSubject(exchange.Claims.Subject))
+
+	redirectAuthorizeSuccess(w, r, pending.RedirectURI, pending.ClientState, authCode, s.cfg.Server.PublicURL)
+}
+
+// writeAuthorizeJSONError emits a pre-redirect-trust error in the
+// OAuth 2.0 JSON-400 shape. Only invoked while redirect_uri is not
+// yet trusted (missing/malformed client_id, redirect_uri).
+func writeAuthorizeJSONError(w http.ResponseWriter, code, description string) {
+	writeJSON(w, http.StatusBadRequest, map[string]string{
+		"error":             code,
+		"error_description": description,
+	})
+}
+
+// redirectAuthorizeError 302s to the client's redirect_uri with
+// `error=<code>&error_description=<desc>&state=<client_state>` per
+// RFC 6749 §4.1.2.1. Caller MUST have validated that redirectURI
+// is a loopback URI (or otherwise trusted) before invoking — this
+// helper does not re-check.
+func redirectAuthorizeError(w http.ResponseWriter, r *http.Request, redirectURI, clientState, code, description string) {
+	u, err := url.Parse(redirectURI)
+	if err != nil {
+		// Unreachable in practice — caller validated. Falling back
+		// to a JSON 400 keeps the failure surfaced rather than
+		// generating a malformed Location header.
+		writeAuthorizeJSONError(w, "server_error", "invalid redirect_uri")
+		return
+	}
+	q := u.Query()
+	q.Set("error", code)
+	if description != "" {
+		q.Set("error_description", description)
+	}
+	if clientState != "" {
+		q.Set("state", clientState)
+	}
+	u.RawQuery = q.Encode()
+	http.Redirect(w, r, u.String(), http.StatusFound)
+}
+
+// redirectAuthorizeSuccess 302s to the client's redirect_uri with
+// `code=<authCode>&state=<client_state>&iss=<brokerURL>`. The `iss`
+// parameter (RFC 9207) lets a defensive SDK confirm the redirect
+// came from the broker it expected, defending against authorization-
+// response mix-up attacks. Cheap to emit even if a given SDK ignores
+// it.
+func redirectAuthorizeSuccess(w http.ResponseWriter, r *http.Request, redirectURI, clientState, authCode, brokerURL string) {
+	u, err := url.Parse(redirectURI)
+	if err != nil {
+		writeAuthorizeJSONError(w, "server_error", "invalid redirect_uri")
+		return
+	}
+	q := u.Query()
+	q.Set("code", authCode)
+	if clientState != "" {
+		q.Set("state", clientState)
+	}
+	if brokerURL != "" {
+		q.Set("iss", brokerURL)
+	}
+	u.RawQuery = q.Encode()
+	http.Redirect(w, r, u.String(), http.StatusFound)
+}
+
+// isLoopbackRedirectURI returns true iff raw parses as
+// http://127.0.0.1[:PORT][/path] or http://localhost[:PORT][/path]
+// or http://[::1][:PORT][/path]. RFC 8252 §7.3 requires native apps
+// use loopback; the broker refuses anything else outright.
+//
+// Implementation notes:
+//   - Scheme is http only (TLS is irrelevant on loopback, and HTTPS
+//     loopback redirects are not in the MCP SDK's repertoire).
+//   - Hostname (without port) is compared as the parsed Host so an
+//     attacker cannot smuggle a non-loopback target via userinfo
+//     (`http://localhost@evil.example/`) — net/url's Hostname()
+//     strips userinfo automatically.
+//   - Port is unrestricted (RFC 8252 §7.3 explicitly permits any
+//     port; native apps bind ephemeral ports).
+func isLoopbackRedirectURI(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "http" {
+		return false
+	}
+	if u.User != nil {
+		// Userinfo on a redirect URI has no legitimate use here and
+		// is a known SSRF / mix-up footgun. Reject outright.
+		return false
+	}
+	host := u.Hostname()
+	switch host {
+	case "127.0.0.1", "localhost", "::1":
+		return true
+	default:
+		return false
+	}
 }

--- a/tools/demarkus-broker/internal/broker/oauth_authorize_test.go
+++ b/tools/demarkus-broker/internal/broker/oauth_authorize_test.go
@@ -1,9 +1,13 @@
 package broker
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"strings"
 	"testing"
@@ -11,104 +15,675 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-// TestOAuthAuthorizeAlwaysRejects covers the contract: any request shape
-// — GET with query params, POST with form body, bare GET — gets the same
-// 400 unsupported_response_type response. The stub is intentionally
-// uniform; there is no "valid" request shape until the broker grows a
-// real authorization_code grant.
-func TestOAuthAuthorizeAlwaysRejects(t *testing.T) {
+// authorizeQuery returns a fully-populated /oauth/authorize query
+// string for a happy-path MCP client request. Tests can copy + tweak
+// individual fields to exercise each validation axis.
+func authorizeQuery() url.Values {
+	return url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"client-abc"},
+		"redirect_uri":          {"http://127.0.0.1:55408/callback"},
+		"code_challenge":        {"E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"}, // S256 of "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk" (RFC 7636 example)
+		"code_challenge_method": {"S256"},
+		"state":                 {"client-state-nonce"},
+		"scope":                 {"openid email profile"},
+	}
+}
+
+// jsonError300 decodes an OAuth-style error JSON 400 body.
+type jsonAuthError struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+func decodeJSONError(t *testing.T, body io.Reader) jsonAuthError {
+	t.Helper()
+	var doc jsonAuthError
+	if err := json.NewDecoder(body).Decode(&doc); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	return doc
+}
+
+func parseLocationQuery(t *testing.T, resp *http.Response) (loc *url.URL, q url.Values) {
+	t.Helper()
+	raw := resp.Header.Get("Location")
+	if raw == "" {
+		t.Fatalf("no Location header (status=%d)", resp.StatusCode)
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse Location %q: %v", raw, err)
+	}
+	q = u.Query()
+	return u, q
+}
+
+// TestOAuthAuthorizePreTrustErrorsReturnJSON locks the pre-redirect-
+// trust failure path: any error before redirect_uri is validated
+// surfaces as a JSON 400, never as a 302 (which could be exploited
+// to bounce the user to an attacker-controlled URL).
+func TestOAuthAuthorizePreTrustErrorsReturnJSON(t *testing.T) {
 	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+	client := testClient(srv)
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 
 	tests := []struct {
-		name   string
-		method string
-		path   string
-		body   string
+		name    string
+		mutate  func(url.Values)
+		wantErr string
 	}{
 		{
-			name:   "GET with full authorize query string",
-			method: http.MethodGet,
-			path:   "/oauth/authorize?response_type=code&client_id=abc&redirect_uri=http%3A%2F%2Flocalhost%3A1234%2Fcallback&code_challenge=xyz&code_challenge_method=S256&state=s1",
+			name:    "missing client_id",
+			mutate:  func(q url.Values) { q.Del("client_id") },
+			wantErr: "invalid_request",
 		},
 		{
-			name:   "GET bare",
-			method: http.MethodGet,
-			path:   "/oauth/authorize",
+			name:    "missing redirect_uri",
+			mutate:  func(q url.Values) { q.Del("redirect_uri") },
+			wantErr: "invalid_request",
 		},
 		{
-			name:   "POST form-encoded",
-			method: http.MethodPost,
-			path:   "/oauth/authorize",
-			body:   "response_type=code&client_id=abc",
+			name:    "non-loopback redirect_uri",
+			mutate:  func(q url.Values) { q.Set("redirect_uri", "https://attacker.example/steal") },
+			wantErr: "invalid_request",
+		},
+		{
+			name:    "https loopback rejected",
+			mutate:  func(q url.Values) { q.Set("redirect_uri", "https://127.0.0.1:1234/callback") },
+			wantErr: "invalid_request",
+		},
+		{
+			name:    "userinfo redirect_uri rejected",
+			mutate:  func(q url.Values) { q.Set("redirect_uri", "http://localhost@evil.example/") },
+			wantErr: "invalid_request",
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var resp *http.Response
-			var err error
-			if tt.method == http.MethodGet {
-				resp, err = testClient(srv).Get(srv.URL + tt.path)
-			} else {
-				resp, err = testClient(srv).Post(srv.URL+tt.path, "application/x-www-form-urlencoded", strings.NewReader(tt.body))
-			}
+			q := authorizeQuery()
+			tt.mutate(q)
+			resp, err := client.Get(srv.URL + "/oauth/authorize?" + q.Encode())
 			if err != nil {
-				t.Fatalf("%s %s: %v", tt.method, tt.path, err)
+				t.Fatalf("GET: %v", err)
 			}
 			defer func() { _ = resp.Body.Close() }()
-
 			if resp.StatusCode != http.StatusBadRequest {
-				rb, _ := io.ReadAll(resp.Body)
-				t.Fatalf("status = %d, want 400; body=%s", resp.StatusCode, rb)
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want 400; body=%s", resp.StatusCode, body)
 			}
-			if got := resp.Header.Get("Content-Type"); got != "application/json" {
-				t.Errorf("Content-Type = %q, want application/json", got)
+			if got := resp.Header.Get("Location"); got != "" {
+				t.Errorf("set Location header on pre-trust error: %q", got)
 			}
 			if got := resp.Header.Get("Cache-Control"); got != "no-store" {
-				t.Errorf("Cache-Control = %q, want \"no-store\"", got)
+				t.Errorf("Cache-Control = %q, want no-store", got)
 			}
-			var doc map[string]string
-			if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
-				t.Fatalf("decode: %v", err)
-			}
-			if doc["error"] != "unsupported_response_type" {
-				t.Errorf("error = %q, want \"unsupported_response_type\"", doc["error"])
-			}
-			if !strings.Contains(doc["error_description"], "device_authorization_endpoint") {
-				t.Errorf("error_description = %q, want it to mention device_authorization_endpoint", doc["error_description"])
+			doc := decodeJSONError(t, resp.Body)
+			if doc.Error != tt.wantErr {
+				t.Errorf("error = %q, want %q", doc.Error, tt.wantErr)
 			}
 		})
 	}
 }
 
-// TestOAuthAuthorizeIgnoresQueryParams confirms the stub does not echo
-// caller-supplied state, redirect_uri, or client_id back in the
-// response. Echoing those without validation would create XSS / open
-// redirect / response-injection surface; the stub stays pure-JSON and
-// declines to look at any input until a real handler replaces it.
-func TestOAuthAuthorizeIgnoresQueryParams(t *testing.T) {
+// TestOAuthAuthorizePostTrustErrorsRedirect locks the post-redirect-
+// trust failure path: after redirect_uri is validated as loopback,
+// every subsequent error must surface via a 302 to the client's
+// redirect_uri with error + state per RFC 6749 §4.1.2.1.
+func TestOAuthAuthorizePostTrustErrorsRedirect(t *testing.T) {
 	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+	client := testClient(srv)
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 
-	q := url.Values{
-		"client_id":             {"<script>alert(1)</script>"},
-		"state":                 {"injected\nheader: evil"},
-		"redirect_uri":          {"https://attacker.example/steal"},
-		"code_challenge":        {"x"},
-		"code_challenge_method": {"S256"},
+	tests := []struct {
+		name    string
+		mutate  func(url.Values)
+		wantErr string
+	}{
+		{
+			name:    "missing response_type",
+			mutate:  func(q url.Values) { q.Del("response_type") },
+			wantErr: "unsupported_response_type",
+		},
+		{
+			name:    "wrong response_type",
+			mutate:  func(q url.Values) { q.Set("response_type", "token") },
+			wantErr: "unsupported_response_type",
+		},
+		{
+			name:    "missing code_challenge",
+			mutate:  func(q url.Values) { q.Del("code_challenge") },
+			wantErr: "invalid_request",
+		},
+		{
+			name:    "missing code_challenge_method",
+			mutate:  func(q url.Values) { q.Del("code_challenge_method") },
+			wantErr: "invalid_request",
+		},
+		{
+			name:    "plain code_challenge_method rejected",
+			mutate:  func(q url.Values) { q.Set("code_challenge_method", "plain") },
+			wantErr: "invalid_request",
+		},
 	}
-	resp, err := testClient(srv).Get(srv.URL + "/oauth/authorize?" + q.Encode())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := authorizeQuery()
+			tt.mutate(q)
+			resp, err := client.Get(srv.URL + "/oauth/authorize?" + q.Encode())
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusFound {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want 302; body=%s", resp.StatusCode, body)
+			}
+			loc, lq := parseLocationQuery(t, resp)
+			if !strings.HasPrefix(loc.String(), "http://127.0.0.1:55408/callback") {
+				t.Errorf("redirected to %q, want loopback callback", loc.String())
+			}
+			if got := lq.Get("error"); got != tt.wantErr {
+				t.Errorf("error = %q, want %q", got, tt.wantErr)
+			}
+			if got := lq.Get("state"); got != "client-state-nonce" {
+				t.Errorf("state passthrough mismatch: got %q", got)
+			}
+		})
+	}
+}
+
+// TestOAuthAuthorizeHappyPathSetsStateCookieAndRedirectsToIdP locks
+// the canonical request: a valid /oauth/authorize 302s to the IdP's
+// AuthCodeURL with a fresh nonce, AND sets the signed broker state
+// cookie scoped to /auth/callback so the eventual callback can
+// reassemble dispatch.
+func TestOAuthAuthorizeHappyPathSetsStateCookieAndRedirectsToIdP(t *testing.T) {
+	verifier := &fakeVerifier{authURL: "https://idp.example.com/authorize"}
+	srv, _ := newTestServer(t, testConfig(), verifier, fake.NewSimpleClientset())
+	client := testClient(srv)
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	resp, err := client.Get(srv.URL + "/oauth/authorize?" + authorizeQuery().Encode())
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, _ := io.ReadAll(resp.Body)
-	for _, needle := range []string{"<script>", "attacker.example", "injected"} {
-		if strings.Contains(string(body), needle) {
-			t.Errorf("response body echoes untrusted query param %q; body=%s", needle, body)
+	if resp.StatusCode != http.StatusFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 302; body=%s", resp.StatusCode, body)
+	}
+	loc := resp.Header.Get("Location")
+	if !strings.HasPrefix(loc, "https://idp.example.com/authorize") {
+		t.Errorf("redirected to %q, want IdP authorize URL", loc)
+	}
+
+	var stateCookie *http.Cookie
+	for _, c := range resp.Cookies() {
+		if c.Name == stateCookieName {
+			stateCookie = c
+			break
 		}
 	}
-	if resp.Header.Get("Location") != "" {
-		t.Error("stub set Location header; should not redirect to caller-supplied redirect_uri")
+	if stateCookie == nil {
+		t.Fatal("state cookie not set on /oauth/authorize")
+	}
+	if !stateCookie.HttpOnly || !stateCookie.Secure {
+		t.Errorf("cookie attrs HttpOnly=%v Secure=%v", stateCookie.HttpOnly, stateCookie.Secure)
+	}
+	if stateCookie.Path != "/auth/callback" {
+		t.Errorf("cookie path = %q, want /auth/callback", stateCookie.Path)
+	}
+}
+
+// TestOAuthAuthorizeAcceptsLocalhostAndIPv6Loopback confirms the
+// loopback validator accepts the three forms RFC 8252 sanctions.
+func TestOAuthAuthorizeAcceptsLocalhostAndIPv6Loopback(t *testing.T) {
+	verifier := &fakeVerifier{authURL: "https://idp.example.com/authorize"}
+	srv, _ := newTestServer(t, testConfig(), verifier, fake.NewSimpleClientset())
+	client := testClient(srv)
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	tests := []struct {
+		name, redirectURI string
+	}{
+		{"127.0.0.1", "http://127.0.0.1:1234/callback"},
+		{"localhost", "http://localhost:1234/callback"},
+		{"::1", "http://[::1]:1234/callback"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := authorizeQuery()
+			q.Set("redirect_uri", tt.redirectURI)
+			resp, err := client.Get(srv.URL + "/oauth/authorize?" + q.Encode())
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusFound {
+				t.Fatalf("status = %d, want 302 for %q", resp.StatusCode, tt.redirectURI)
+			}
+			loc := resp.Header.Get("Location")
+			if !strings.HasPrefix(loc, "https://idp.example.com/authorize") {
+				t.Errorf("redirected to %q, want IdP authorize URL", loc)
+			}
+		})
+	}
+}
+
+// TestOAuthAuthorizeEndToEnd drives the full happy-path flow:
+// /oauth/authorize → simulated /auth/callback → MCP-client redirect
+// with code+state+iss. Uses a cookie jar so the state cookie set at
+// /oauth/authorize is replayed on /auth/callback through the same
+// path/scope rules the real browser would enforce.
+func TestOAuthAuthorizeEndToEnd(t *testing.T) {
+	verifier := &fakeVerifier{
+		authURL: "https://idp.example.com/authorize",
+		claims:  Claims{Subject: "google|123", Email: "alice@example.com", EmailVerified: true},
+	}
+	cfg := testConfig()
+	cfg.Server.PublicURL = "https://broker.example.com"
+	srv, _ := newTestServer(t, cfg, verifier, fake.NewSimpleClientset())
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	client := testClient(srv)
+	client.Jar = jar
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	authResp, err := client.Get(srv.URL + "/oauth/authorize?" + authorizeQuery().Encode())
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	_ = authResp.Body.Close()
+	if authResp.StatusCode != http.StatusFound {
+		t.Fatalf("authorize status = %d, want 302", authResp.StatusCode)
+	}
+	idpRedirect, err := url.Parse(authResp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse IdP redirect: %v", err)
+	}
+	nonce := idpRedirect.Query().Get("state")
+	if nonce == "" {
+		t.Fatal("missing IdP state nonce")
+	}
+
+	// Simulate the IdP coming back with a code. The jar replays the
+	// state cookie set on /oauth/authorize.
+	cbReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		srv.URL+"/auth/callback?code=idp-code-abc&state="+url.QueryEscape(nonce), http.NoBody)
+	cbResp, err := client.Do(cbReq)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	defer func() { _ = cbResp.Body.Close() }()
+	if cbResp.StatusCode != http.StatusFound {
+		body, _ := io.ReadAll(cbResp.Body)
+		t.Fatalf("callback status = %d, want 302; body=%s", cbResp.StatusCode, body)
+	}
+
+	clientRedirect, err := url.Parse(cbResp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse client redirect: %v", err)
+	}
+	if clientRedirect.Scheme != "http" || clientRedirect.Host != "127.0.0.1:55408" || clientRedirect.Path != "/callback" {
+		t.Errorf("client redirect = %q, want loopback callback", clientRedirect.String())
+	}
+	q := clientRedirect.Query()
+	if q.Get("code") == "" {
+		t.Error("missing code on client redirect")
+	}
+	if got := q.Get("state"); got != "client-state-nonce" {
+		t.Errorf("state passthrough mismatch: got %q", got)
+	}
+	if got := q.Get("iss"); got == "" {
+		t.Error("missing iss (RFC 9207 mix-up defense)")
+	}
+}
+
+// TestOAuthAuthorizeStaleStateCookieRoutesToAuthCodeBranch confirms
+// the dispatch order: a State cookie carrying AuthCodeID enters the
+// auth-code branch even if it also happened to carry DeviceCode (it
+// won't in practice — the two entry points each set only their own
+// field — but the dispatch order is the load-bearing invariant).
+//
+// Implementation: the test only exercises pure AuthCodeID since the
+// production code paths never set both simultaneously; including
+// the "both fields set" case would assert behavior outside the
+// reachable state space and risk codifying the wrong order.
+func TestOAuthAuthorizeStaleStateCookieRoutesToAuthCodeBranch(t *testing.T) {
+	verifier := &fakeVerifier{authURL: "https://idp.example.com/authorize"}
+	srv, _ := newTestServer(t, testConfig(), verifier, fake.NewSimpleClientset())
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	client := testClient(srv)
+	client.Jar = jar
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	resp, err := client.Get(srv.URL + "/oauth/authorize?" + authorizeQuery().Encode())
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	_ = resp.Body.Close()
+	loc, _ := url.Parse(resp.Header.Get("Location"))
+	if loc == nil {
+		t.Fatal("no Location after /oauth/authorize")
+	}
+	nonce := loc.Query().Get("state")
+
+	cbReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		srv.URL+"/auth/callback?code=x&state="+url.QueryEscape(nonce), http.NoBody)
+	cbResp, err := client.Do(cbReq)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	defer func() { _ = cbResp.Body.Close() }()
+	// Routes to authCodeCallback (302 back to client redirect),
+	// not authCallback's default mint-and-JSON path.
+	if cbResp.StatusCode != http.StatusFound {
+		body, _ := io.ReadAll(cbResp.Body)
+		t.Fatalf("callback status = %d, want 302 (auth-code dispatch); body=%s", cbResp.StatusCode, body)
+	}
+	if loc := cbResp.Header.Get("Location"); !strings.HasPrefix(loc, "http://127.0.0.1:55408/callback") {
+		t.Errorf("dispatched to non-auth-code branch: Location=%q", loc)
+	}
+}
+
+// TestDeviceTokenAuthCodeHappyPath drives the /token leg directly
+// against a pre-seeded authCodeStore entry. Avoids re-running the
+// full IdP dance — the end-to-end test above covers that — and
+// instead focuses on the token-mint surface.
+func TestDeviceTokenAuthCodeHappyPath(t *testing.T) {
+	verifier := &fakeVerifier{
+		claims: Claims{Subject: "google|123", Email: "alice@example.com", EmailVerified: true},
+	}
+	signer := newTestIDTokenSigner(t)
+	srv, broker := newTestServerWithSigner(t, testConfig(), verifier, fake.NewSimpleClientset(), signer)
+
+	// Seed the store directly so this test isolates the /token leg.
+	codeVerifier := "test-verifier-must-be-43-to-128-chars-long-1234"
+	sum := sha256.Sum256([]byte(codeVerifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+	id, err := broker.authCodeStore.Begin(&AuthCodeRequest{
+		ClientID:            "client-abc",
+		RedirectURI:         "http://127.0.0.1:55408/callback",
+		ClientState:         "client-state-nonce",
+		Scope:               "openid",
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: "S256",
+	})
+	if err != nil {
+		t.Fatalf("seed Begin: %v", err)
+	}
+	exchange := ExchangeResult{
+		Claims:      Claims{Subject: "google|123", Email: "alice@example.com", EmailVerified: true},
+		RawIDToken:  "idp-id-token-raw",
+		AccessToken: "idp-access-token-raw",
+	}
+	code, _, err := broker.authCodeStore.Bind(id, &exchange)
+	if err != nil {
+		t.Fatalf("seed Bind: %v", err)
+	}
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"client_id":     {"client-abc"},
+		"redirect_uri":  {"http://127.0.0.1:55408/callback"},
+		"code_verifier": {codeVerifier},
+	}
+	resp, err := testClient(srv).Post(srv.URL+"/device/token", "application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("POST /device/token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+	}
+	var doc deviceTokenSuccess
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if doc.AccessToken == "" {
+		t.Error("missing access_token")
+	}
+	if doc.IDToken == "" {
+		t.Error("missing id_token")
+	}
+	if doc.AccessToken != doc.IDToken {
+		t.Error("auth-code path should return access_token == id_token (broker convention)")
+	}
+	if doc.RefreshToken == "" {
+		t.Error("missing refresh_token")
+	}
+	if doc.TokenType != "Bearer" {
+		t.Errorf("token_type = %q, want Bearer", doc.TokenType)
+	}
+	if doc.ExpiresIn <= 0 {
+		t.Errorf("expires_in = %d, want > 0", doc.ExpiresIn)
+	}
+}
+
+// TestDeviceTokenAuthCodeErrorMapping locks the wire surface: every
+// store-side validation failure collapses to invalid_grant, while
+// missing required form params surface as invalid_request. Replay
+// of a successful redemption surfaces as invalid_grant.
+func TestDeviceTokenAuthCodeErrorMapping(t *testing.T) {
+	codeVerifier := "test-verifier-must-be-43-to-128-chars-long-1234"
+	sum := sha256.Sum256([]byte(codeVerifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	// Each subtest builds a fresh store-seeded code so the table can
+	// independently mutate the token request.
+	seed := func(t *testing.T) (client *http.Client, srvURL, code string) {
+		t.Helper()
+		signer := newTestIDTokenSigner(t)
+		srv, broker := newTestServerWithSigner(t, testConfig(), &fakeVerifier{
+			claims: Claims{Subject: "x", Email: "x@y", EmailVerified: true},
+		}, fake.NewSimpleClientset(), signer)
+		id, err := broker.authCodeStore.Begin(&AuthCodeRequest{
+			ClientID:            "client-abc",
+			RedirectURI:         "http://127.0.0.1:55408/callback",
+			CodeChallenge:       challenge,
+			CodeChallengeMethod: "S256",
+		})
+		if err != nil {
+			t.Fatalf("Begin: %v", err)
+		}
+		c, _, err := broker.authCodeStore.Bind(id, &ExchangeResult{
+			Claims: Claims{Subject: "x", Email: "x@y", EmailVerified: true},
+		})
+		if err != nil {
+			t.Fatalf("Bind: %v", err)
+		}
+		return testClient(srv), srv.URL, c
+	}
+
+	type errCase struct {
+		name     string
+		form     func(code string) url.Values
+		wantCode int
+		wantErr  string
+	}
+	cases := []errCase{
+		{
+			name: "missing code",
+			form: func(_ string) url.Values {
+				return url.Values{
+					"grant_type":    {"authorization_code"},
+					"client_id":     {"client-abc"},
+					"redirect_uri":  {"http://127.0.0.1:55408/callback"},
+					"code_verifier": {codeVerifier},
+				}
+			},
+			wantCode: http.StatusBadRequest,
+			wantErr:  "invalid_request",
+		},
+		{
+			name: "missing code_verifier",
+			form: func(code string) url.Values {
+				return url.Values{
+					"grant_type":   {"authorization_code"},
+					"code":         {code},
+					"client_id":    {"client-abc"},
+					"redirect_uri": {"http://127.0.0.1:55408/callback"},
+				}
+			},
+			wantCode: http.StatusBadRequest,
+			wantErr:  "invalid_request",
+		},
+		{
+			name: "unknown code",
+			form: func(_ string) url.Values {
+				return url.Values{
+					"grant_type":    {"authorization_code"},
+					"code":          {"never-issued"},
+					"client_id":     {"client-abc"},
+					"redirect_uri":  {"http://127.0.0.1:55408/callback"},
+					"code_verifier": {codeVerifier},
+				}
+			},
+			wantCode: http.StatusBadRequest,
+			wantErr:  "invalid_grant",
+		},
+		{
+			name: "wrong client_id",
+			form: func(code string) url.Values {
+				return url.Values{
+					"grant_type":    {"authorization_code"},
+					"code":          {code},
+					"client_id":     {"wrong-client"},
+					"redirect_uri":  {"http://127.0.0.1:55408/callback"},
+					"code_verifier": {codeVerifier},
+				}
+			},
+			wantCode: http.StatusBadRequest,
+			wantErr:  "invalid_grant",
+		},
+		{
+			name: "wrong redirect_uri",
+			form: func(code string) url.Values {
+				return url.Values{
+					"grant_type":    {"authorization_code"},
+					"code":          {code},
+					"client_id":     {"client-abc"},
+					"redirect_uri":  {"http://127.0.0.1:9999/other"},
+					"code_verifier": {codeVerifier},
+				}
+			},
+			wantCode: http.StatusBadRequest,
+			wantErr:  "invalid_grant",
+		},
+		{
+			name: "wrong code_verifier",
+			form: func(code string) url.Values {
+				return url.Values{
+					"grant_type":    {"authorization_code"},
+					"code":          {code},
+					"client_id":     {"client-abc"},
+					"redirect_uri":  {"http://127.0.0.1:55408/callback"},
+					"code_verifier": {"wrong-verifier"},
+				}
+			},
+			wantCode: http.StatusBadRequest,
+			wantErr:  "invalid_grant",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, srvURL, code := seed(t)
+			resp, err := client.Post(srvURL+"/device/token", "application/x-www-form-urlencoded",
+				strings.NewReader(tc.form(code).Encode()))
+			if err != nil {
+				t.Fatalf("POST: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != tc.wantCode {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want %d; body=%s", resp.StatusCode, tc.wantCode, body)
+			}
+			var doc deviceTokenError
+			if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if doc.Error != tc.wantErr {
+				t.Errorf("error = %q, want %q", doc.Error, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestDeviceTokenAuthCodeReplayFails confirms one-shot semantics:
+// a code that successfully redeems once returns invalid_grant on
+// the next try. The store's deletion-on-success path is the gate;
+// this test is the wire-level confirmation.
+func TestDeviceTokenAuthCodeReplayFails(t *testing.T) {
+	codeVerifier := "test-verifier-must-be-43-to-128-chars-long-1234"
+	sum := sha256.Sum256([]byte(codeVerifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	signer := newTestIDTokenSigner(t)
+	srv, broker := newTestServerWithSigner(t, testConfig(), &fakeVerifier{
+		claims: Claims{Subject: "x", Email: "x@y", EmailVerified: true},
+	}, fake.NewSimpleClientset(), signer)
+	id, err := broker.authCodeStore.Begin(&AuthCodeRequest{
+		ClientID:            "client-abc",
+		RedirectURI:         "http://127.0.0.1:55408/callback",
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: "S256",
+	})
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	code, _, err := broker.authCodeStore.Bind(id, &ExchangeResult{
+		Claims: Claims{Subject: "x", Email: "x@y", EmailVerified: true},
+	})
+	if err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"client_id":     {"client-abc"},
+		"redirect_uri":  {"http://127.0.0.1:55408/callback"},
+		"code_verifier": {codeVerifier},
+	}
+	client := testClient(srv)
+
+	first, err := client.Post(srv.URL+"/device/token", "application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("first POST: %v", err)
+	}
+	_ = first.Body.Close()
+	if first.StatusCode != http.StatusOK {
+		t.Fatalf("first status = %d, want 200", first.StatusCode)
+	}
+
+	second, err := client.Post(srv.URL+"/device/token", "application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("second POST: %v", err)
+	}
+	defer func() { _ = second.Body.Close() }()
+	if second.StatusCode != http.StatusBadRequest {
+		t.Fatalf("replay status = %d, want 400", second.StatusCode)
+	}
+	var doc deviceTokenError
+	if err := json.NewDecoder(second.Body).Decode(&doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if doc.Error != "invalid_grant" {
+		t.Errorf("replay error = %q, want invalid_grant", doc.Error)
 	}
 }

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -373,6 +373,15 @@ func (s *Server) authCallback(w http.ResponseWriter, r *http.Request) {
 		s.deviceCallback(w, r, state.DeviceCode)
 		return
 	}
+	// Auth-code dispatch (parallel to device-flow): the signed State
+	// carries AuthCodeID when /oauth/authorize set the cookie. The
+	// AuthCodeID was minted by authCodeStore.Begin and never left
+	// the broker (it lives only in the signed cookie), so a callback
+	// claiming a non-empty AuthCodeID is necessarily one we issued.
+	if state.AuthCodeID != "" {
+		s.authCodeCallback(w, r, state.AuthCodeID)
+		return
+	}
 
 	code := r.URL.Query().Get("code")
 	if code == "" {


### PR DESCRIPTION
## Summary

Second slice of the [broker authorization-code grant plan](https://soul.demarkus.io/plans/broker-auth-code-grant.md). PR #155 landed the in-memory store + \`State.AuthCodeID\` dispatch field; this PR connects them to the wire so Claude Code's MCP SDK can complete the auth-code flow against the broker.

- \`oauth_authorize.go\`: replace the \`unsupported_response_type\` stub with a real RFC 6749 §4.1.1 authorize handler. PKCE-S256 only, RFC 8252 loopback \`redirect_uri\` only (\`127.0.0.1\` / \`localhost\` / \`::1\`), two-phase validation (JSON 400 before \`redirect_uri\` is trusted; 302 with \`error\`+\`state\` after). Mints \`AuthCodeID\` via \`authCodeStore.Begin\`, pins it in the signed State cookie, and 302s to the IdP via \`verifier.AuthCodeURL\`.
- \`authCodeCallback\` resumes the flow after the IdP returns to \`/auth/callback\`. Exchanges, Binds, 302s to the client \`redirect_uri\` with \`code\`+\`state\`+\`iss\` (RFC 9207 mix-up defense).
- \`server.go\` \`authCallback\`: parallel \`AuthCodeID\` dispatch branch next to the existing \`DeviceCode\` one.
- \`device.go\` \`deviceToken\`: new \`authorization_code\` grant branch dispatching to \`deviceTokenAuthCode\`. Redeems via the store, mints a fresh broker refresh_token + broker-signed id_token, returns the standard OAuth2 token success body (\`access_token == id_token\` matching the refresh-grant convention).
- \`discovery.go\`: advertise \`authorization_code\` in \`grant_types_supported\` (first, ahead of device_code + refresh_token), \`response_types_supported=[code]\`, \`code_challenge_methods_supported=[S256]\`.

## Test plan

- [x] \`go test ./internal/broker/\` — all green
- [x] \`bash pre-commit.sh\` — clean (fmt, vet, lint across all four modules)
- [ ] Manual: deploy to \`broker.knowledge.demarkus.io\`, run \`/knowledge-join\` from Claude Code, confirm the original \`unsupported_response_type\` error is gone and an end-to-end token exchange succeeds. (Tracked separately; PR3 of the plan adds a kind-harness smoke + journal entry for this.)

## Next

PR3: in-process integration test driving the full \`/oauth/authorize\` → \`/auth/callback\` → \`/device/token\` happy path against a fake \`Verifier\` (already partially covered by \`TestOAuthAuthorizeEndToEnd\` in this PR; PR3 broadens to negative paths inside the same integration shape), plus kind-harness coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented OAuth 2.0 authorization code flow with PKCE support for enhanced security.
  * Updated service discovery to advertise authorization code grant type and supported challenge methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->