### PR TITLE
feat(broker): add worldDialer.insecureSkipVerify

### DIFF
--- a/deploy/helm/demarkus-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-config.yaml
@@ -164,3 +164,5 @@ stringData:
         perMinute: {{ .Values.rateLimit.login.perMinute }}
         burst: {{ .Values.rateLimit.login.burst }}
       trustForwardedFor: {{ .Values.rateLimit.trustForwardedFor }}
+    worldDialer:
+      insecureSkipVerify: {{ .Values.worldDialer.insecureSkipVerify }}

--- a/deploy/helm/demarkus-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-config.yaml
@@ -164,5 +164,6 @@ stringData:
         perMinute: {{ .Values.rateLimit.login.perMinute }}
         burst: {{ .Values.rateLimit.login.burst }}
       trustForwardedFor: {{ .Values.rateLimit.trustForwardedFor }}
+    {{- $worldDialer := .Values.worldDialer | default (dict) }}
     worldDialer:
-      insecureSkipVerify: {{ .Values.worldDialer.insecureSkipVerify }}
+      insecureSkipVerify: {{ default false $worldDialer.insecureSkipVerify }}

--- a/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
@@ -271,3 +271,29 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "oidc.existingSigningKeyRef.key is required when oidc.existingSigningKeyRef.name is set"
+
+  - it: worldDialer.insecureSkipVerify defaults to false (production-correct)
+    set:
+      oidc.clientSecret: shh
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'worldDialer:\s*\n\s*insecureSkipVerify: false'
+
+  - it: worldDialer.insecureSkipVerify=true override flows through to rendered config
+    set:
+      oidc.clientSecret: shh
+      worldDialer.insecureSkipVerify: true
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'worldDialer:\s*\n\s*insecureSkipVerify: true'
+
+  - it: worldDialer=null override renders safely with default false (nil-pointer guard)
+    set:
+      oidc.clientSecret: shh
+      worldDialer: ~
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'worldDialer:\s*\n\s*insecureSkipVerify: false'

--- a/deploy/helm/demarkus-broker/values.yaml
+++ b/deploy/helm/demarkus-broker/values.yaml
@@ -295,6 +295,23 @@ rateLimit:
     burst: 5
   trustForwardedFor: true
 
+# Knobs governing how the MCP gateway dials world servers over QUIC.
+# Single block at the top level (not per-world) — the dialer posture is
+# uniform across worlds.
+worldDialer:
+  # Disable QUIC TLS chain + hostname verification on the broker→world
+  # dial. Required today for in-cluster deployments where each world
+  # has a self-signed cert from cert-manager's `selfsigned` ClusterIssuer
+  # (no shared CA the broker can trust). QUIC still encrypts on the
+  # wire; the broker takes on faith that the address it dialed actually
+  # belongs to the world it expects — NetworkPolicy + cluster RBAC do
+  # the real isolation work in that topology.
+  #
+  # Flip back to false once a shared CA is wired (e.g., a cert-manager
+  # CA Issuer signing all world certs + a broker-side CA bundle config
+  # that loads it into the QUIC client's RootCAs).
+  insecureSkipVerify: false
+
 resources:
   requests:
     cpu: 100m

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -16,11 +16,40 @@ import (
 // is authorized to mint tokens for. The world Tokens Secrets live in each
 // world's namespace; the issuances Secret lives in the broker's namespace.
 type Config struct {
-	Server    ServerConfig    `yaml:"server"`
-	OIDC      OIDCConfig      `yaml:"oidc"`
-	Worlds    []WorldConfig   `yaml:"worlds"`
-	Sweeper   SweeperConfig   `yaml:"sweeper"`
-	RateLimit RateLimitConfig `yaml:"rateLimit"`
+	Server      ServerConfig      `yaml:"server"`
+	OIDC        OIDCConfig        `yaml:"oidc"`
+	Worlds      []WorldConfig     `yaml:"worlds"`
+	Sweeper     SweeperConfig     `yaml:"sweeper"`
+	RateLimit   RateLimitConfig   `yaml:"rateLimit"`
+	WorldDialer WorldDialerConfig `yaml:"worldDialer"`
+}
+
+// WorldDialerConfig holds knobs governing how the broker's MCP gateway
+// dials world servers over QUIC. Single block at the top level (rather
+// than per-world WorldConfig) because the dialer's posture is uniform
+// across worlds — the trust model is "all worlds the broker is
+// configured for are equally trusted." Per-world overrides would
+// invite a misconfiguration where one world's relaxed posture leaks
+// onto another via shared connection pooling.
+type WorldDialerConfig struct {
+	// InsecureSkipVerify disables the QUIC client's TLS chain +
+	// hostname verification when dialing worlds. Required today for
+	// in-cluster deployments where each world has a self-signed cert
+	// from cert-manager's `selfsigned` ClusterIssuer (no shared CA the
+	// broker can trust) — QUIC still encrypts on the wire, but the
+	// broker takes on faith that the address it dialed actually
+	// belongs to the world it expects. NetworkPolicy + cluster RBAC
+	// are doing the real isolation work in that topology.
+	//
+	// Production-correct value once a shared CA is wired (e.g.,
+	// cert-manager CA Issuer signing all world certs + a `caBundle`
+	// config that loads it into the broker's RootCAs): false. The
+	// flag stays as the operator escape hatch for environments where
+	// shared CA setup isn't feasible.
+	//
+	// Default false. Operators who want skip-verify must opt in
+	// explicitly so the verification posture is never silently relaxed.
+	InsecureSkipVerify bool `yaml:"insecureSkipVerify"`
 }
 
 // ServerConfig holds the broker's own runtime settings — listen address,

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -380,6 +380,24 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: "rateLimit.login.burst must be >= 1",
 		},
 		{
+			name: "worldDialer defaults to verify-strict",
+			body: validConfig,
+			validate: func(t *testing.T, c *Config) {
+				if c.WorldDialer.InsecureSkipVerify {
+					t.Error("worldDialer.insecureSkipVerify defaulted to true; want secure-by-default false")
+				}
+			},
+		},
+		{
+			name: "worldDialer.insecureSkipVerify honored",
+			body: validConfig + "worldDialer:\n  insecureSkipVerify: true\n",
+			validate: func(t *testing.T, c *Config) {
+				if !c.WorldDialer.InsecureSkipVerify {
+					t.Error("worldDialer.insecureSkipVerify=true not honored")
+				}
+			},
+		},
+		{
 			name:    "missing server.publicURL",
 			body:    strings.Replace(validConfig, `publicURL: "https://broker.example.com"`, `publicURL: ""`, 1),
 			wantErr: "server.publicURL is required",

--- a/tools/demarkus-broker/internal/broker/mcp_gateway.go
+++ b/tools/demarkus-broker/internal/broker/mcp_gateway.go
@@ -178,7 +178,15 @@ func (g *mcpGateway) Routes() http.Handler {
 // main.go calls (*Server).CloseMCPGateway during shutdown to drain
 // pooled QUIC connections. For test injection use MCPGatewayWith.
 func (s *Server) MCPGateway(version string) http.Handler {
-	pool := newWorldPool(s.cfg, fetch.Options{})
+	// WorldDialer.InsecureSkipVerify propagates into fetch.Options.Insecure
+	// so the QUIC client skips TLS chain + hostname verification on
+	// dial. Required today for in-cluster deployments using per-world
+	// self-signed certs (no shared CA the broker can trust); the flag
+	// stays opt-in so the secure-by-default posture is preserved.
+	// See WorldDialerConfig doc for the trust-model rationale.
+	pool := newWorldPool(s.cfg, fetch.Options{
+		Insecure: s.cfg.WorldDialer.InsecureSkipVerify,
+	})
 	s.mcpPool = pool
 	return newMCPGateway(s, version, pool).Routes()
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a world-dialer configuration to control TLS certificate verification for QUIC connections to world servers; defaults to strict verification.
  * Broker now respects this setting at runtime, enabling optional verification skipping for deployments with self-signed certificates.

* **Tests**
  * Added unit and template tests to verify default behavior, overrides, and safe handling of unset values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->