### PR TITLE
feat(server): hot-reload tokens.toml on file change

### DIFF
--- a/server/cmd/demarkus-server/main.go
+++ b/server/cmd/demarkus-server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/latebit/demarkus/protocol/store"
 	"github.com/latebit/demarkus/server/internal/auth"
 	"github.com/latebit/demarkus/server/internal/config"
+	"github.com/latebit/demarkus/server/internal/configwatch"
 	"github.com/latebit/demarkus/server/internal/handler"
 	"github.com/latebit/demarkus/server/internal/logging"
 	"github.com/latebit/demarkus/server/internal/ratelimit"
@@ -117,6 +118,7 @@ func main() {
 			os.Exit(1)
 		}
 		logger.Info("auth: loaded tokens", "path", cfg.TokensFile)
+		startTokenFileWatcher(cfg.TokensFile, logger)
 	} else {
 		logger.Info("auth: no tokens file configured, writes disabled")
 	}
@@ -252,6 +254,22 @@ func loadTokenStore(path string) error {
 	currentTokenStore = ts
 	tokenMu.Unlock()
 	return nil
+}
+
+// startTokenFileWatcher reloads the token store when the tokens file changes
+// on disk. SIGHUP already covers operator-driven reloads; this complements it
+// for environments where the file is rewritten in place without a signal.
+func startTokenFileWatcher(path string, logger *slog.Logger) {
+	w := &configwatch.Watcher{
+		Target: path,
+		Reload: func() error { return loadTokenStore(path) },
+		Logger: logger,
+	}
+	go func() {
+		if err := w.Run(context.Background()); err != nil {
+			logger.Warn("auth: token file watcher exited", "error", err)
+		}
+	}()
 }
 
 // loadTLS returns a TLS config based on the server configuration.

--- a/server/go.mod
+++ b/server/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	golang.org/x/crypto v0.41.0 // indirect
 	golang.org/x/net v0.43.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/server/internal/configwatch/watcher.go
+++ b/server/internal/configwatch/watcher.go
@@ -57,7 +57,11 @@ func (w *Watcher) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("configwatch: create watcher: %w", err)
 	}
-	defer func() { _ = fw.Close() }()
+	defer func() {
+		if err := fw.Close(); err != nil {
+			w.Logger.Warn("configwatch: close watcher failed", "target", w.Target, "error", err)
+		}
+	}()
 
 	if err := fw.Add(dir); err != nil {
 		return fmt.Errorf("configwatch: watch %s: %w", dir, err)

--- a/server/internal/configwatch/watcher.go
+++ b/server/internal/configwatch/watcher.go
@@ -1,0 +1,117 @@
+// Package configwatch invokes a reload callback when a watched file changes
+// on disk. It watches the file's parent directory so it tolerates atomic
+// rename swaps and symlink retargets, where the target inode changes under a
+// stable path. Events are coalesced through a debounce window so a burst of
+// writes triggers one reload.
+package configwatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// defaultDebounce coalesces rapid-fire events from editors writing through a
+// temp file or directory swaps that fan out into multiple kernel events.
+const defaultDebounce = 150 * time.Millisecond
+
+// retryDelay covers a brief window when a directory swap can leave a path
+// momentarily unresolvable before the new contents are linked in.
+const retryDelay = 75 * time.Millisecond
+
+// Watcher invokes Reload whenever the directory holding Target sees any
+// change, after coalescing events through Debounce.
+type Watcher struct {
+	Target   string
+	Reload   func() error
+	Debounce time.Duration
+	Logger   *slog.Logger
+}
+
+// Run blocks until ctx is canceled. It is intended to run in its own
+// goroutine. Reload errors are logged and do not terminate the loop; only a
+// failure to set up the underlying watcher returns an error.
+func (w *Watcher) Run(ctx context.Context) error {
+	if w.Target == "" {
+		return errors.New("configwatch: target is empty")
+	}
+	if w.Reload == nil {
+		return errors.New("configwatch: reload callback is nil")
+	}
+	if w.Logger == nil {
+		return errors.New("configwatch: logger is nil")
+	}
+	debounce := w.Debounce
+	if debounce <= 0 {
+		debounce = defaultDebounce
+	}
+
+	dir := filepath.Dir(w.Target)
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("configwatch: create watcher: %w", err)
+	}
+	defer func() { _ = fw.Close() }()
+
+	if err := fw.Add(dir); err != nil {
+		return fmt.Errorf("configwatch: watch %s: %w", dir, err)
+	}
+
+	w.Logger.Info("configwatch: watching", "target", w.Target, "dir", dir, "debounce", debounce)
+
+	timer := time.NewTimer(debounce)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	armed := false
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err, ok := <-fw.Errors:
+			if !ok {
+				return nil
+			}
+			w.Logger.Warn("configwatch: error", "target", w.Target, "error", err)
+		case _, ok := <-fw.Events:
+			if !ok {
+				return nil
+			}
+			if armed && !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(debounce)
+			armed = true
+		case <-timer.C:
+			armed = false
+			if err := reloadWithRetry(w.Reload); err != nil {
+				w.Logger.Warn("configwatch: reload failed", "target", w.Target, "error", err)
+			} else {
+				w.Logger.Info("configwatch: reloaded", "target", w.Target)
+			}
+		}
+	}
+}
+
+// reloadWithRetry calls reload and retries once on a transient ErrNotExist,
+// which can briefly surface when a directory swap removes the old path before
+// the new one resolves.
+func reloadWithRetry(reload func() error) error {
+	err := reload()
+	if err == nil || !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	time.Sleep(retryDelay)
+	return reload()
+}

--- a/server/internal/configwatch/watcher_test.go
+++ b/server/internal/configwatch/watcher_test.go
@@ -1,0 +1,274 @@
+package configwatch
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// waitForCount blocks until the counter reaches at least want or the deadline
+// passes. Returns the final value.
+func waitForCount(counter *atomic.Int32, want int32, deadline time.Duration) int32 {
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if counter.Load() >= want {
+			return counter.Load()
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return counter.Load()
+}
+
+func TestRunValidatesInputs(t *testing.T) {
+	tests := []struct {
+		name string
+		w    Watcher
+		want string
+	}{
+		{"empty target", Watcher{Reload: func() error { return nil }, Logger: discardLogger()}, "target is empty"},
+		{"nil reload", Watcher{Target: "/tmp/x", Logger: discardLogger()}, "reload callback is nil"},
+		{"nil logger", Watcher{Target: "/tmp/x", Reload: func() error { return nil }}, "logger is nil"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.w.Run(t.Context())
+			if err == nil || !contains(err.Error(), tt.want) {
+				t.Fatalf("Run() error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestInPlaceWriteTriggersReload(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "tokens.toml")
+	if err := os.WriteFile(target, []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls atomic.Int32
+	w := Watcher{
+		Target:   target,
+		Reload:   func() error { calls.Add(1); return nil },
+		Debounce: 20 * time.Millisecond,
+		Logger:   discardLogger(),
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { _ = w.Run(ctx) }()
+
+	time.Sleep(50 * time.Millisecond) // let watcher attach
+	if err := os.WriteFile(target, []byte("v2"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := waitForCount(&calls, 1, time.Second); got < 1 {
+		t.Fatalf("expected at least 1 reload call, got %d", got)
+	}
+}
+
+func TestAtomicRenameTriggersReload(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "tokens.toml")
+	if err := os.WriteFile(target, []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls atomic.Int32
+	w := Watcher{
+		Target:   target,
+		Reload:   func() error { calls.Add(1); return nil },
+		Debounce: 20 * time.Millisecond,
+		Logger:   discardLogger(),
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { _ = w.Run(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+	tmp := filepath.Join(dir, "tokens.toml.tmp")
+	if err := os.WriteFile(tmp, []byte("v2"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(tmp, target); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := waitForCount(&calls, 1, time.Second); got < 1 {
+		t.Fatalf("expected at least 1 reload call after atomic rename, got %d", got)
+	}
+}
+
+// TestSymlinkRetargetTriggersReload simulates the canonical mount-refresh
+// pattern: the target path is a symlink that points through a stable
+// indirection (here "current") into one of several content directories.
+// Swapping the indirection atomically retargets every leaf symlink at once,
+// the same way a process refreshing a mounted config tree does.
+func TestSymlinkRetargetTriggersReload(t *testing.T) {
+	dir := t.TempDir()
+
+	v1 := filepath.Join(dir, "v1")
+	v2 := filepath.Join(dir, "v2")
+	for _, d := range []string{v1, v2} {
+		if err := os.Mkdir(d, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(v1, "tokens.toml"), []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v2, "tokens.toml"), []byte("v2"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	current := filepath.Join(dir, "current")
+	if err := os.Symlink(v1, current); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(dir, "tokens.toml")
+	if err := os.Symlink(filepath.Join(current, "tokens.toml"), target); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls atomic.Int32
+	w := Watcher{
+		Target:   target,
+		Reload:   func() error { calls.Add(1); return nil },
+		Debounce: 20 * time.Millisecond,
+		Logger:   discardLogger(),
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { _ = w.Run(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+	// Atomic swap of the indirection: stage a new symlink and rename it over
+	// the old one. os.Rename replaces the destination atomically on POSIX.
+	staged := filepath.Join(dir, "current.new")
+	if err := os.Symlink(v2, staged); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(staged, current); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := waitForCount(&calls, 1, time.Second); got < 1 {
+		t.Fatalf("expected at least 1 reload call after symlink retarget, got %d", got)
+	}
+}
+
+func TestDebounceCoalescesBurst(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "tokens.toml")
+	if err := os.WriteFile(target, []byte("v0"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls atomic.Int32
+	w := Watcher{
+		Target:   target,
+		Reload:   func() error { calls.Add(1); return nil },
+		Debounce: 80 * time.Millisecond,
+		Logger:   discardLogger(),
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { _ = w.Run(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+	// Fire several writes well within the debounce window.
+	for i := range 10 {
+		if err := os.WriteFile(target, []byte{byte('a' + i)}, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Let the debounce window elapse and the reload fire.
+	time.Sleep(200 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 reload from coalesced burst, got %d", got)
+	}
+}
+
+func TestCtxCancelReturnsCleanly(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "tokens.toml")
+	if err := os.WriteFile(target, []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	w := Watcher{
+		Target:   target,
+		Reload:   func() error { return nil },
+		Debounce: 20 * time.Millisecond,
+		Logger:   discardLogger(),
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() returned error after ctx cancel: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run() did not return within 1s after ctx cancel")
+	}
+}
+
+func TestReloadWithRetryENOENT(t *testing.T) {
+	var calls atomic.Int32
+	reload := func() error {
+		n := calls.Add(1)
+		if n == 1 {
+			return os.ErrNotExist
+		}
+		return nil
+	}
+	if err := reloadWithRetry(reload); err != nil {
+		t.Fatalf("reloadWithRetry returned %v, want nil after retry", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("expected exactly 2 calls (initial + retry), got %d", got)
+	}
+}
+
+func TestReloadWithRetryNonTransientErrorPropagates(t *testing.T) {
+	sentinel := errors.New("parse error")
+	var calls atomic.Int32
+	reload := func() error {
+		calls.Add(1)
+		return sentinel
+	}
+	err := reloadWithRetry(reload)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("reloadWithRetry returned %v, want %v", err, sentinel)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 call (no retry for non-transient), got %d", got)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/configwatch/watcher_test.go
+++ b/server/internal/configwatch/watcher_test.go
@@ -16,6 +16,29 @@ func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
+// runInBackground starts w.Run on a goroutine and registers a cleanup that
+// cancels the context and asserts Run returned without error within 1s. This
+// keeps Run's error surfaced to the test rather than discarded by the
+// goroutine, and ensures the watcher goroutine is joined before the test
+// returns.
+func runInBackground(t *testing.T, w *Watcher) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("Run() returned error: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Errorf("Run() did not return within 1s after ctx cancel")
+		}
+	})
+}
+
 // waitForCount blocks until the counter reaches at least want or the deadline
 // passes. Returns the final value.
 func waitForCount(counter *atomic.Int32, want int32, deadline time.Duration) int32 {
@@ -63,9 +86,7 @@ func TestInPlaceWriteTriggersReload(t *testing.T) {
 		Debounce: 20 * time.Millisecond,
 		Logger:   discardLogger(),
 	}
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	go func() { _ = w.Run(ctx) }()
+	runInBackground(t, &w)
 
 	time.Sleep(50 * time.Millisecond) // let watcher attach
 	if err := os.WriteFile(target, []byte("v2"), 0o600); err != nil {
@@ -91,9 +112,7 @@ func TestAtomicRenameTriggersReload(t *testing.T) {
 		Debounce: 20 * time.Millisecond,
 		Logger:   discardLogger(),
 	}
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	go func() { _ = w.Run(ctx) }()
+	runInBackground(t, &w)
 
 	time.Sleep(50 * time.Millisecond)
 	tmp := filepath.Join(dir, "tokens.toml.tmp")
@@ -147,9 +166,7 @@ func TestSymlinkRetargetTriggersReload(t *testing.T) {
 		Debounce: 20 * time.Millisecond,
 		Logger:   discardLogger(),
 	}
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	go func() { _ = w.Run(ctx) }()
+	runInBackground(t, &w)
 
 	time.Sleep(50 * time.Millisecond)
 	// Atomic swap of the indirection: stage a new symlink and rename it over
@@ -181,9 +198,7 @@ func TestDebounceCoalescesBurst(t *testing.T) {
 		Debounce: 80 * time.Millisecond,
 		Logger:   discardLogger(),
 	}
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	go func() { _ = w.Run(ctx) }()
+	runInBackground(t, &w)
 
 	time.Sleep(50 * time.Millisecond)
 	// Fire several writes well within the debounce window.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token store now automatically monitors the configured tokens file and reloads whenever changes are detected on disk, so server restarts are no longer required after updating token files. Reloading is resilient to common filesystem update patterns and stops cleanly on shutdown.

* **Tests**
  * Added comprehensive tests for token-file monitoring covering varied change scenarios, debounce/coalescing behavior, retry-on-transient-missing-file, and graceful cancellation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->