### PR TITLE
fix(broker-chart): split create rules from resourceNames-restricted ones

### DIFF
--- a/deploy/helm/demarkus-broker/Chart.yaml
+++ b/deploy/helm/demarkus-broker/Chart.yaml
@@ -7,8 +7,8 @@ description: |
   Multi-replica HA, leader-elected expiry/drift sweeper, per-subject and
   per-IP rate limiting.
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.3.1
+appVersion: "0.3.1"
 keywords:
   - demarkus
   - mark-protocol

--- a/deploy/helm/demarkus-broker/templates/rbac-broker-ns.yaml
+++ b/deploy/helm/demarkus-broker/templates/rbac-broker-ns.yaml
@@ -1,34 +1,34 @@
 {{- if .Values.rbac.create }}
 {{- /* Broker-namespace RBAC: the broker SA's access to its own state.
 
-   - coordination.k8s.io/leases: the sweeper's leader-election Lease. Both
-     get/update are scoped to the configured lease name; create is in the
-     same rule because Helm install needs to seed the Lease on first
-     leadership acquisition. The k8s RBAC "create cannot be restricted by
-     resourceName" caveat means create effectively allows any Lease in
-     this namespace — acceptable scope since the namespace is broker-owned.
+   K8s RBAC has a hard limitation that shapes the structure below:
+   `resourceNames` does not apply to `create` requests (the name of
+   the new object isn't known at authorization time, so the rule
+   simply does not match). A single rule that lists `create`
+   alongside `get`/`update` AND uses `resourceNames` will silently
+   deny create. Each create-capable surface therefore needs a
+   separate, name-unrestricted rule. The cost is that create is
+   namespace-wide for that resource type — acceptable here because
+   the namespace is broker-owned, and the rest of the SA's surface
+   (get/update) is still tightly scoped by resourceNames.
+
+   - coordination.k8s.io/leases: the sweeper's leader-election Lease.
+     get/update pinned to the configured lease name; create gets
+     its own rule (namespace-wide).
 
    - secrets (issuances + refresh-tokens): chart-seeded at install
      time (secret-issuances.yaml + secret-refresh-tokens.yaml), so
-     the broker only needs get/update — not create. The
+     the broker only needs get/update — never create. The
      resource-policy: keep annotation on both means helm upgrade
      never re-templates them, so the broker SA's update verb is
      the only path that mutates them after install.
 
    - secrets (per-world write-token): the broker provisions these
-     lazily on the first write to each configured world (one
-     Secret per worlds[] entry). The chart does NOT seed them — if
-     it did, the broker would have to read+verify each one at
-     startup, and at-rest token rotation would race chart upgrades.
-     Lazy provisioning instead, which is why this rule must include
-     create. Names are pinned per world via resourceNames so a
-     compromised broker SA cannot read or update any other Secret
-     in the broker namespace. The same k8s RBAC "create cannot be
-     restricted by resourceName" caveat documented for leases above
-     applies here too: create effectively allows any Secret in
-     this namespace at the API level — acceptable scope since the
-     namespace is broker-owned, but worth knowing when threat-
-     modeling. */ -}}
+     lazily on the first write to each configured world. get/update
+     pinned per-world; create gets its own rule (namespace-wide).
+     Names are pinned per world via resourceNames so a compromised
+     broker SA cannot read or update any other Secret in the broker
+     namespace. */ -}}
 {{- $brokerNs := include "demarkus-broker.brokerNamespace" . -}}
 {{- $name := include "demarkus-broker.fullname" . -}}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -42,7 +42,10 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     resourceNames: [{{ .Values.sweeper.leaseName | quote }}]
-    verbs: ["get", "create", "update"]
+    verbs: ["get", "update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
   - apiGroups: [""]
     resources: ["secrets"]
     resourceNames:
@@ -56,7 +59,10 @@ rules:
       {{- range .Values.worlds }}
       - {{ include "demarkus-broker.writeTokenSecretName" (dict "worldName" .name) | quote }}
       {{- end }}
-    verbs: ["get", "create", "update"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/helm/demarkus-broker/tests/deployment_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/latebit-io/demarkus-broker:0.3.0
+          value: ghcr.io/latebit-io/demarkus-broker:0.3.1
       - notExists:
           path: spec.template.spec.containers[0].command
 

--- a/deploy/helm/demarkus-broker/tests/rbac_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/rbac_test.yaml
@@ -34,7 +34,7 @@ tests:
           path: metadata.namespace
           value: broker-ns
 
-  - it: broker-ns Role leases rule pinned to get/create/update on the configured leaseName
+  - it: broker-ns Role leases get/update rule pinned to the configured leaseName
     template: rbac-broker-ns.yaml
     documentIndex: 0
     asserts:
@@ -49,37 +49,63 @@ tests:
           value: ["demarkus-broker-sweeper"]
       - equal:
           path: rules[0].verbs
-          value: ["get", "create", "update"]
+          value: ["get", "update"]
+      - notContains:
+          path: rules[0].verbs
+          content: create
+      - notContains:
+          path: rules[0].verbs
+          content: delete
+
+  - it: broker-ns Role leases create rule is namespace-wide (resourceNames is unsupported for create)
+    template: rbac-broker-ns.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: rules[1].apiGroups
+          value: ["coordination.k8s.io"]
+      - equal:
+          path: rules[1].resources
+          value: ["leases"]
+      - equal:
+          path: rules[1].verbs
+          value: ["create"]
+      - notExists:
+          # Critical: resourceNames MUST NOT be set on a create
+          # rule. k8s evaluates the rule as "does not match" when
+          # both are present, silently denying create. The Lease
+          # bootstrap depends on this rule landing un-restricted.
+          path: rules[1].resourceNames
 
   - it: broker-ns Role secrets rule pinned to get/update on issuances + refresh-tokens Secrets
     template: rbac-broker-ns.yaml
     documentIndex: 0
     asserts:
       - equal:
-          path: rules[1].apiGroups
+          path: rules[2].apiGroups
           value: [""]
       - equal:
-          path: rules[1].resources
+          path: rules[2].resources
           value: ["secrets"]
       - equal:
-          path: rules[1].resourceNames
+          path: rules[2].resourceNames
           value:
             - "RELEASE-NAME-demarkus-broker-issuances"
             - "RELEASE-NAME-demarkus-broker-refresh-tokens"
       - equal:
-          path: rules[1].verbs
+          path: rules[2].verbs
           value: ["get", "update"]
       - notContains:
-          path: rules[1].verbs
+          path: rules[2].verbs
           content: create
       - notContains:
-          path: rules[1].verbs
+          path: rules[2].verbs
           content: delete
       - notContains:
-          path: rules[1].verbs
+          path: rules[2].verbs
           content: list
 
-  - it: broker-ns Role per-world write-token rule grants get/create/update on each configured world's write-token Secret
+  - it: broker-ns Role per-world write-token rule pins get/update to each configured world's Secret
     template: rbac-broker-ns.yaml
     documentIndex: 0
     set:
@@ -102,36 +128,66 @@ tests:
             expiresAfter: 24h
     asserts:
       - equal:
-          path: rules[2].apiGroups
+          path: rules[3].apiGroups
           value: [""]
       - equal:
-          path: rules[2].resources
+          path: rules[3].resources
           value: ["secrets"]
       - equal:
-          path: rules[2].resourceNames
+          path: rules[3].resourceNames
           value:
             - "demarkus-broker-write-token-team-a"
             - "demarkus-broker-write-token-team-b"
       - equal:
-          path: rules[2].verbs
-          value: ["get", "create", "update"]
+          path: rules[3].verbs
+          value: ["get", "update"]
       - notContains:
-          path: rules[2].verbs
+          path: rules[3].verbs
+          content: create
+      - notContains:
+          path: rules[3].verbs
           content: delete
-      - notContains:
-          path: rules[2].verbs
-          content: list
 
-  - it: broker-ns Role omits the write-token rule entirely when worlds[] is empty
+  - it: broker-ns Role secrets create rule is namespace-wide (resourceNames is unsupported for create)
+    template: rbac-broker-ns.yaml
+    documentIndex: 0
+    set:
+      worlds:
+        - name: team-a
+          namespace: team-a
+          tokensSecret: team-a-tokens
+          allow: {}
+          defaultToken:
+            paths: ["/team-a/*"]
+            operations: ["publish"]
+            expiresAfter: 24h
+    asserts:
+      - equal:
+          path: rules[4].apiGroups
+          value: [""]
+      - equal:
+          path: rules[4].resources
+          value: ["secrets"]
+      - equal:
+          path: rules[4].verbs
+          value: ["create"]
+      - notExists:
+          # Same hard k8s RBAC constraint as the leases create rule:
+          # resourceNames on a create rule silently denies create.
+          # The per-world write-token bootstrap depends on this
+          # rule landing un-restricted.
+          path: rules[4].resourceNames
+
+  - it: broker-ns Role omits both worlds rules entirely when worlds[] is empty
     template: rbac-broker-ns.yaml
     documentIndex: 0
     set:
       worlds: []
     asserts:
-      # Only the leases rule + the issuances/refresh-tokens rule
-      # render; no rules[2] is emitted when there are no worlds.
+      # Only the two leases rules + the chart-seeded-secrets rule
+      # render; no rules[3] or [4] are emitted without worlds.
       - notExists:
-          path: rules[2]
+          path: rules[3]
 
   - it: per-world template emits 2 Roles + 2 RoleBindings for two worlds
     template: rbac-worlds.yaml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Released patch version 0.3.1 with operational improvements
- Refined Kubernetes cluster access control configuration to enhance security posture
- Updated permission policies to enforce principle of least privilege for broker namespace operations
- Enhanced test coverage for validating access control, security configurations, and container image deployment
- Updated deployment tests and RBAC test suite to reflect latest release version

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->