### PR TITLE
fix(ci): release workflow detects chart-only changes per module

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,15 @@ jobs:
             server:
               - 'server/**'
               - 'protocol/**'
+              - 'deploy/helm/demarkus-server/**'
             client:
               - 'client/**'
               - 'protocol/**'
+              - 'deploy/helm/demarkus-agent/**'
             tools:
               - 'tools/**'
               - 'protocol/**'
+              - 'deploy/helm/demarkus-broker/**'
 
   test-protocol:
     needs: detect-changes
@@ -136,7 +139,12 @@ jobs:
           tag_prefix: "server/v"
           major_pattern: "BREAKING CHANGE:"
           minor_pattern: "feat:"
-          change_path: "server/"
+          # Chart and image are released together at the same version,
+          # so a chart-only commit must bump the version too. Without
+          # the chart path here, fix(server-chart) commits would slip
+          # past the change-path gate, leave should_release=false, and
+          # silently never publish.
+          change_path: "server/ deploy/helm/demarkus-server/"
           bump_each_commit: false
           search_commit_body: true
       - name: Check if version changed
@@ -167,7 +175,9 @@ jobs:
           tag_prefix: "client/v"
           major_pattern: "BREAKING CHANGE:"
           minor_pattern: "feat:"
-          change_path: "client/"
+          # See server's change_path note: chart-only commits must
+          # bump the version so the chart actually publishes.
+          change_path: "client/ deploy/helm/demarkus-agent/"
           bump_each_commit: false
           search_commit_body: true
       - name: Check if version changed
@@ -198,7 +208,9 @@ jobs:
           tag_prefix: "tools/v"
           major_pattern: "BREAKING CHANGE:"
           minor_pattern: "feat:"
-          change_path: "tools/"
+          # See server's change_path note: chart-only commits must
+          # bump the version so the chart actually publishes.
+          change_path: "tools/ deploy/helm/demarkus-broker/"
           bump_each_commit: false
           search_commit_body: true
       - name: Check if version changed

--- a/deploy/helm/demarkus-broker/Chart.yaml
+++ b/deploy/helm/demarkus-broker/Chart.yaml
@@ -7,8 +7,16 @@ description: |
   Multi-replica HA, leader-elected expiry/drift sweeper, per-subject and
   per-IP rate limiting.
 type: application
-version: 0.3.1
-appVersion: "0.3.1"
+# version + appVersion are pinned 1:1 to the `tools/v<X>` git tag at
+# publish time — the release workflow renders the chart with
+# `helm package --version $VER --app-version $VER` where $VER is the
+# auto-bumped tools/ semver. The values committed below are only used
+# for local-render and unittest paths; the source-of-truth at publish
+# is the workflow. Keep this file's version in sync with the latest
+# tools/v* tag for predictable local renders, but don't expect a manual
+# bump here to actually publish a new chart on its own.
+version: 0.1.22
+appVersion: "0.1.22"
 keywords:
   - demarkus
   - mark-protocol

--- a/deploy/helm/demarkus-broker/tests/deployment_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/latebit-io/demarkus-broker:0.3.1
+          value: ghcr.io/latebit-io/demarkus-broker:0.1.22
       - notExists:
           path: spec.template.spec.containers[0].command
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow enhanced to detect and track Helm chart changes alongside component version bumps.
  * Helm chart version numbers updated for consistency with component releases.
  * Deployment tests updated to reflect current version references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->