### PR TITLE
fix(broker): drop dead defaultToken.operations/expiresAfter knobs

### DIFF
--- a/deploy/helm/demarkus-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-config.yaml
@@ -145,8 +145,6 @@ stringData:
           emails: {{ default (list) (get $allow "emails") | toJson }}
         defaultToken:
           paths: {{ .defaultToken.paths | toJson }}
-          operations: {{ .defaultToken.operations | toJson }}
-          expiresAfter: {{ .defaultToken.expiresAfter | quote }}
 {{- end }}
     sweeper:
       disabled: {{ .Values.sweeper.disabled }}

--- a/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
@@ -129,8 +129,6 @@ tests:
           tokensSecret: team-a-tokens
           defaultToken:
             paths: ["/team-a/*"]
-            operations: ["read"]
-            expiresAfter: 24h
     asserts:
       - matchRegex:
           path: stringData["config.yaml"]
@@ -145,8 +143,6 @@ tests:
           tokensSecret: team-a-tokens
           defaultToken:
             paths: ["/team-a/*"]
-            operations: ["read"]
-            expiresAfter: 24h
     asserts:
       - matchRegex:
           path: stringData["config.yaml"]
@@ -162,8 +158,6 @@ tests:
           publicURL: "mark://team-a.cluster.local:6309"
           defaultToken:
             paths: ["/team-a/*"]
-            operations: ["read"]
-            expiresAfter: 24h
     asserts:
       - matchRegex:
           path: stringData["config.yaml"]

--- a/deploy/helm/demarkus-broker/values.yaml
+++ b/deploy/helm/demarkus-broker/values.yaml
@@ -247,19 +247,11 @@ worlds: []
   #     # otherwise leave at /** so writers can publish anywhere
   #     # under the world.
   #     paths: ["/**"]
-  #     # Operations is ignored by the broker — the write token is
-  #     # always minted with hardcoded ["publish"] regardless of
-  #     # what's set here (see worldWriteTokenStore.Provision in
-  #     # tools/demarkus-broker/internal/broker/world_write_tokens.go
-  #     # for why). The chart still requires the field set so the
-  #     # config-validation surface stays stable across upgrades;
-  #     # values other than ["publish"] are silently ignored.
-  #     operations: ["publish"]
-  #     # ExpiresAfter is no longer consulted by the broker: the
-  #     # per-world write token is long-lived (no expiry) by design,
-  #     # and reads use no token. Kept for config-surface stability;
-  #     # the value is ignored, same as operations above.
-  #     expiresAfter: 24h
+  #     # paths is the only knob. The write token's operations are
+  #     # always ["publish"] (hardcoded in worldWriteTokenStore.Provision
+  #     # so an open-reads regression can't slip in via config) and the
+  #     # token never expires, so there is no operations/expiresAfter
+  #     # field to set.
 
 # Periodic expiry + drift sweeper. Leader-elected via
 # coordination.k8s.io/Lease so multi-replica deployments enforce

--- a/tools/demarkus-broker/internal/broker/authz_test.go
+++ b/tools/demarkus-broker/internal/broker/authz_test.go
@@ -43,9 +43,7 @@ func testConfig() *Config {
 				TokensSecret: "team-a-tokens",
 				Allow:        AllowConfig{Domains: []string{"example.com"}},
 				DefaultToken: TokenScope{
-					Paths:        []string{"/team-a/*"},
-					Operations:   []string{"read", "publish"},
-					ExpiresAfter: 24 * time.Hour,
+					Paths: []string{"/team-a/*"},
 				},
 			},
 		},

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -257,9 +257,8 @@ type WorldConfig struct {
 	// identity (back-compat with pre-Slice-C configs that had only
 	// AllowDomains and left it empty).
 	Allow AllowConfig `yaml:"allow"`
-	// DefaultToken describes the capabilities of every token minted for
-	// this world. Slice B treats DefaultToken as the only scope; per-call
-	// narrowing is a Slice C feature.
+	// DefaultToken carries the path scope applied to the broker's
+	// long-lived write token for this world.
 	DefaultToken TokenScope `yaml:"defaultToken"`
 }
 
@@ -387,24 +386,17 @@ type RateLimitRouteConfig struct {
 	Burst int `yaml:"burst"`
 }
 
-// TokenScope is the capability bundle every token minted for a given
-// world carries. Paths + Operations are written verbatim into the server-
-// readable tokens.toml; ExpiresAfter is the lifetime applied to each
-// minted token.
+// TokenScope is the path scope of the broker's long-lived write token
+// for a world. The operations are always ["publish"] (hardcoded in
+// worldWriteTokenStore.Provision so an open-reads regression can't slip
+// in via config) and the token never expires, so the only operator
+// knob is the path glob list written into the world's tokens.toml.
 type TokenScope struct {
-	// Paths is the list of glob patterns the token is allowed to access,
-	// e.g. ["/team-a/*"]. Empty means no path restriction (server-side
-	// default: deny). Validation: at least one entry is required to
-	// avoid accidentally issuing zero-scope tokens.
+	// Paths is the list of glob patterns the write token is allowed to
+	// access, e.g. ["/team-a/*"]. Empty means no path restriction
+	// (server-side default: deny). Validation: at least one entry is
+	// required to avoid accidentally issuing a zero-scope token.
 	Paths []string `yaml:"paths"`
-	// Operations is the set of capabilities granted, e.g.
-	// ["read", "publish"]. At least one entry is required.
-	Operations []string `yaml:"operations"`
-	// ExpiresAfter is the lifetime of minted tokens. Zero is rejected
-	// during validation — short-lived tokens are the primary identity-
-	// lifecycle mechanism (see plan §6.2 revocation), so accidentally
-	// issuing non-expiring tokens would silently break that property.
-	ExpiresAfter time.Duration `yaml:"expiresAfter"`
 }
 
 // LoadConfig reads, parses, and validates a broker config file. Validation
@@ -521,10 +513,9 @@ func (c *Config) validate() error {
 	// SweeperConfig doc for why it's named "Disabled" rather than
 	// "Enabled". Interval and LeaseName get production-safe defaults
 	// when omitted; negative Interval is a config typo, and an
-	// interval longer than the typical 24h token lifetime would let
-	// expired tokens linger past their `defaultToken.expiresAfter`
-	// window — defeating the short-lived-tokens identity-lifecycle
-	// model (see plan §Revocation §3).
+	// over-long interval lets expired refresh tokens linger in the
+	// broker's refresh-tokens Secret well past their TTL before the
+	// sweeper retires them.
 	if c.Sweeper.Interval == 0 {
 		c.Sweeper.Interval = 5 * time.Minute
 	}
@@ -738,10 +729,6 @@ func validateWorld(i int, w *WorldConfig) error {
 		return fmt.Errorf("worlds[%d] (%s): tokensSecret is required", i, w.Name)
 	case len(w.DefaultToken.Paths) == 0:
 		return fmt.Errorf("worlds[%d] (%s): defaultToken.paths is required", i, w.Name)
-	case len(w.DefaultToken.Operations) == 0:
-		return fmt.Errorf("worlds[%d] (%s): defaultToken.operations is required", i, w.Name)
-	case w.DefaultToken.ExpiresAfter <= 0:
-		return fmt.Errorf("worlds[%d] (%s): defaultToken.expiresAfter must be > 0", i, w.Name)
 	}
 	// All three lists are lowercased+trimmed at load so authorizedWorlds
 	// can do plain string compares on every login. Group-name match is

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -38,8 +38,6 @@ worlds:
       domains: ["example.com"]
     defaultToken:
       paths: ["/team-a/*"]
-      operations: ["read", "publish"]
-      expiresAfter: 24h
 `
 
 // validConfig is the rendered template with a fresh signing-key
@@ -82,8 +80,6 @@ const validWorldBlock = `worlds:
       domains: ["example.com"]
     defaultToken:
       paths: ["/team-a/*"]
-      operations: ["read", "publish"]
-      expiresAfter: 24h
 `
 
 func writeConfig(t *testing.T, body string) string {
@@ -123,9 +119,6 @@ func TestLoadConfig(t *testing.T) {
 				if len(c.Worlds) != 1 || c.Worlds[0].Name != "team-a" {
 					t.Errorf("worlds = %+v", c.Worlds)
 				}
-				if c.Worlds[0].DefaultToken.ExpiresAfter != 24*time.Hour {
-					t.Errorf("expiresAfter = %v", c.Worlds[0].DefaultToken.ExpiresAfter)
-				}
 			},
 		},
 		{
@@ -145,18 +138,8 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			name:    "duplicate world name",
-			body:    validConfig + "  - name: team-a\n    namespace: team-a\n    tokensSecret: team-a-tokens\n    defaultToken:\n      paths: [\"/x\"]\n      operations: [\"read\"]\n      expiresAfter: 1h\n",
+			body:    validConfig + "  - name: team-a\n    namespace: team-a\n    tokensSecret: team-a-tokens\n    defaultToken:\n      paths: [\"/x\"]\n",
 			wantErr: `duplicate name "team-a"`,
-		},
-		{
-			name:    "missing defaultToken.operations",
-			body:    strings.Replace(validConfig, `operations: ["read", "publish"]`, `operations: []`, 1),
-			wantErr: "defaultToken.operations is required",
-		},
-		{
-			name:    "zero expiresAfter rejected",
-			body:    strings.Replace(validConfig, "expiresAfter: 24h", "expiresAfter: 0s", 1),
-			wantErr: "defaultToken.expiresAfter must be > 0",
 		},
 		{
 			name:    "negative stateTTL rejected",

--- a/tools/demarkus-broker/internal/broker/install_test.go
+++ b/tools/demarkus-broker/internal/broker/install_test.go
@@ -37,9 +37,7 @@ func installTestConfigTwoWorlds() *Config {
 		PublicURL:    "mark://team-b.cluster.local:6309",
 		Allow:        AllowConfig{Domains: []string{"example.com"}},
 		DefaultToken: TokenScope{
-			Paths:        []string{"/team-b/*"},
-			Operations:   []string{"read"},
-			ExpiresAfter: 12 * time.Hour,
+			Paths: []string{"/team-b/*"},
 		},
 	})
 	return cfg

--- a/tools/demarkus-broker/internal/broker/mcp_tools_federation_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_federation_test.go
@@ -277,9 +277,7 @@ func TestHandleMarkResolveContentHashMismatchSkipsCandidate(t *testing.T) {
 		TokensSecret: "team-b-tokens",
 		Allow:        AllowConfig{Domains: []string{"example.com"}},
 		DefaultToken: TokenScope{
-			Paths:        []string{"/*"},
-			Operations:   []string{"read"},
-			ExpiresAfter: cfg.Worlds[0].DefaultToken.ExpiresAfter,
+			Paths: []string{"/*"},
 		},
 	})
 	d := &fakeDispatcher{
@@ -387,9 +385,7 @@ func TestHandleMarkResolveAllCandidatesFailReportsLast(t *testing.T) {
 		TokensSecret: "team-b-tokens",
 		Allow:        AllowConfig{Domains: []string{"example.com"}},
 		DefaultToken: TokenScope{
-			Paths:        []string{"/*"},
-			Operations:   []string{"read"},
-			ExpiresAfter: cfg.Worlds[0].DefaultToken.ExpiresAfter,
+			Paths: []string{"/*"},
 		},
 	})
 	d := &fakeDispatcher{

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph_test.go
@@ -287,9 +287,7 @@ func TestHandleMarkIndexBoundsOnDirectoryCycle(t *testing.T) {
 		TokensSecret: "hub-tokens",
 		Allow:        AllowConfig{Domains: []string{"example.com"}},
 		DefaultToken: TokenScope{
-			Paths:        []string{"/*"},
-			Operations:   []string{"read", "publish"},
-			ExpiresAfter: cfg.Worlds[0].DefaultToken.ExpiresAfter,
+			Paths: []string{"/*"},
 		},
 	})
 	var listCalls atomic.Int32
@@ -467,9 +465,7 @@ func TestHandleMarkIndexHappyPath(t *testing.T) {
 		TokensSecret: "hub-tokens",
 		Allow:        AllowConfig{Domains: []string{"example.com"}},
 		DefaultToken: TokenScope{
-			Paths:        []string{"/*"},
-			Operations:   []string{"read", "publish"},
-			ExpiresAfter: cfg.Worlds[0].DefaultToken.ExpiresAfter,
+			Paths: []string{"/*"},
 		},
 	})
 	var publishCalled atomic.Bool
@@ -537,9 +533,7 @@ func TestHandleMarkIndexBlocksWhenTargetHasNoManifest(t *testing.T) {
 		TokensSecret: "hub-tokens",
 		Allow:        AllowConfig{Domains: []string{"example.com"}},
 		DefaultToken: TokenScope{
-			Paths:        []string{"/*"},
-			Operations:   []string{"read", "publish"},
-			ExpiresAfter: cfg.Worlds[0].DefaultToken.ExpiresAfter,
+			Paths: []string{"/*"},
 		},
 	})
 	d := &fakeDispatcher{
@@ -576,9 +570,7 @@ func TestHandleMarkIndexForceOverridesManifestBlock(t *testing.T) {
 		TokensSecret: "hub-tokens",
 		Allow:        AllowConfig{Domains: []string{"example.com"}},
 		DefaultToken: TokenScope{
-			Paths:        []string{"/*"},
-			Operations:   []string{"read", "publish"},
-			ExpiresAfter: cfg.Worlds[0].DefaultToken.ExpiresAfter,
+			Paths: []string{"/*"},
 		},
 	})
 	var publishCalled atomic.Bool
@@ -629,9 +621,7 @@ func TestHandleMarkIndexDryRunReturnsBodyWithoutPublishing(t *testing.T) {
 		TokensSecret: "hub-tokens",
 		Allow:        AllowConfig{Domains: []string{"example.com"}},
 		DefaultToken: TokenScope{
-			Paths:        []string{"/*"},
-			Operations:   []string{"read", "publish"},
-			ExpiresAfter: cfg.Worlds[0].DefaultToken.ExpiresAfter,
+			Paths: []string{"/*"},
 		},
 	})
 	var publishCalled atomic.Bool

--- a/tools/demarkus-broker/internal/broker/world_write_tokens.go
+++ b/tools/demarkus-broker/internal/broker/world_write_tokens.go
@@ -124,20 +124,19 @@ func (s *worldWriteTokenStore) Provision(ctx context.Context, worldName string) 
 			}
 			return existing, nil
 		}
-		// Operations is hardcoded — NOT sourced from
-		// world.DefaultToken.Operations — to keep the open-reads
-		// design impossible to regress via config. The server only
-		// recognizes "publish" for write verbs (PUBLISH / APPEND /
-		// ARCHIVE all call Authorize with "publish"), so anything
-		// else is dead weight. Critically, if "read" ever leaked
-		// into the operator's `operations:` list, the server's
-		// `RequiresReadAuth` would flip on for every path matched
-		// by this token (`/*` in the default config) and every
-		// open-bearer read would start returning unauthorized.
-		// One char of config drift would silently break the
-		// architectural invariant the entire broker simplification
-		// rests on. Path stays configurable — narrowing the write
-		// surface to e.g. /team-a/** is a legitimate operator knob.
+		// Operations is hardcoded to "publish" and deliberately is
+		// NOT a config knob (defaultToken carries paths only). The
+		// server recognizes "publish" for every write verb (PUBLISH /
+		// APPEND / ARCHIVE all call Authorize with "publish"), so
+		// nothing else is useful here. The deeper reason it isn't
+		// configurable: if "read" ever landed in this list, the
+		// server's `RequiresReadAuth` would flip on for every path
+		// this token matches (`/**` in the default config) and every
+		// open-bearer read would start returning unauthorized — one
+		// char of config drift silently breaking the open-reads
+		// invariant the whole broker simplification rests on. Path
+		// stays configurable (worlds[].defaultToken.paths) — narrowing
+		// the write surface to e.g. /team-a/** is a legitimate knob.
 		minted, mErr := token.Generate(label, world.DefaultToken.Paths, []string{"publish"})
 		if mErr != nil {
 			return nil, fmt.Errorf("generate write token: %w", mErr)

--- a/tools/demarkus-broker/internal/broker/world_write_tokens_test.go
+++ b/tools/demarkus-broker/internal/broker/world_write_tokens_test.go
@@ -125,7 +125,7 @@ func TestWorldWriteTokenStoreRewritesStaleWorldEntry(t *testing.T) {
 	stale := token.Entry{
 		Hash:       "sha256-" + strings.Repeat("d", 64), // deliberately not what Generate would produce
 		Paths:      cfg.Worlds[0].DefaultToken.Paths,
-		Operations: cfg.Worlds[0].DefaultToken.Operations,
+		Operations: []string{"publish"}, // broker hardcodes write-token ops to ["publish"]
 	}
 	staleBytes, err := token.AppendBytes(nil, label, &stale)
 	if err != nil {
@@ -170,18 +170,15 @@ func TestWorldWriteTokenStoreRewritesStaleWorldEntry(t *testing.T) {
 
 func TestWorldWriteTokenStoreProvisionIgnoresConfiguredOperations(t *testing.T) {
 	// Regression guard: the broker MUST hardcode the write-token
-	// operations to ["publish"] regardless of what the operator put
-	// in worlds[].defaultToken.operations. If "read" ever leaked
-	// through (e.g. via a well-intentioned "make it configurable"
-	// refactor), the server's RequiresReadAuth would flip on for
-	// every path matched by this token and the open-bearer read
-	// path that the entire broker simplification rests on would
+	// operations to ["publish"]. The operations knob was removed from
+	// worlds[].defaultToken entirely, so there is no operator config
+	// to honor; Provision must still emit exactly ["publish"]. If
+	// "read" ever leaked through (e.g. via a well-intentioned "make it
+	// configurable" refactor), the server's RequiresReadAuth would
+	// flip on for every path matched by this token and the open-bearer
+	// read path that the entire broker simplification rests on would
 	// silently start returning unauthorized.
 	cfg := testConfig()
-	// The classic foot-gun config: operator includes "read" thinking
-	// it grants read capability, not realizing it inverts the
-	// world's read-auth gate to require auth on /*.
-	cfg.Worlds[0].DefaultToken.Operations = []string{"read", "publish", "append", "archive"}
 
 	k8s := fake.NewSimpleClientset()
 	store := newWorldWriteTokenStore(cfg, k8s)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Simplified `defaultToken` configuration: only the `paths` field is now supported; the `operations` and `expiresAfter` fields are no longer configurable
  * Write tokens are now always long-lived with hardcoded `publish` operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/latebit-io/demarkus/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->