### PR TITLE
feat(plugin): self-document to soul + lookup recall, bump security pins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,8 +9,8 @@
     {
       "name": "demarkus-memory",
       "source": "./plugins/claude-code",
-      "description": "Zero-config local memory for Claude Code. Spawns a local demarkus-server and wires MCP tools for fetch/publish/append/graph over your own versioned markdown store.",
-      "version": "0.1.1",
+      "description": "Zero-config local memory for Claude Code. Spawns a local demarkus-server and wires MCP tools for fetch/publish/append/graph/lookup over your own versioned markdown store, and self-documents sessions to it.",
+      "version": "0.3.0",
       "category": "memory",
       "tags": ["memory", "demarkus", "mark-protocol", "local-first"],
       "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/claude-code"

--- a/.gitignore
+++ b/.gitignore
@@ -36,12 +36,19 @@ tools/bin/
 # compile binaries here before invoking `docker build`).
 dist/
 
-# Stray binaries (built without -o flag)
+# Stray binaries (built without -o flag). Client/server sources live under
+# cmd/, so these names only ever match a stray binary. Tools sources do NOT:
+# each tools/<name>/ is a main package, and `go build` run inside it drops a
+# matching binary there. Anchor to the binary path so we ignore that stray
+# build artifact without matching the source directory (an unanchored
+# `tools/<name>` would silently ignore new source files in the package).
 client/demarkus
 client/demarkus-tui
 client/demarkus-mcp
 server/demarkus-server
-tools/demarkus-token
+tools/demarkus-token/demarkus-token
+tools/demarkus-publish/demarkus-publish
+tools/demarkus-broker/demarkus-broker
 
 # OS files
 .DS_Store

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "demarkus-memory",
-  "version": "0.2.0",
-  "description": "Local, versioned memory for Claude Code via demarkus. Zero-config install: spawns a local demarkus-server, auto-generates a token, wires MCP tools for fetch/publish/append/graph.",
+  "version": "0.3.0",
+  "description": "Local, versioned memory for Claude Code via demarkus. Zero-config install: spawns a local demarkus-server, auto-generates a token, wires MCP tools for fetch/publish/append/graph/lookup, and injects standing guidance so sessions self-document to the soul and recall via lookup.",
   "author": {
     "name": "latebit",
     "url": "https://github.com/latebit-io"

--- a/plugins/claude-code/commands/knowledge-join.md
+++ b/plugins/claude-code/commands/knowledge-join.md
@@ -2,7 +2,7 @@
 description: Join an organizational demarkus knowledge system (broker-fronted universe) — validates the broker URL, registers it as a Claude Code MCP server, and points you at the device-flow auth on first tool call.
 ---
 
-Connect this Claude Code installation to an organizational demarkus knowledge system. The user supplies the public URL of the org's demarkus-broker MCP gateway; this command validates the URL, derives a short server slug from the hostname, and registers it with `claude mcp add` so the broker's 13-tool surface appears as a single MCP server.
+Connect this Claude Code installation to an organizational demarkus knowledge system. The user supplies the public URL of the org's demarkus-broker MCP gateway; this command validates the URL, derives a short server slug from the hostname, and registers it with `claude mcp add` so the broker's 14-tool surface appears as a single MCP server.
 
 This is the broker-fronted counterpart to `/soul-init` (which configures a personal, direct-QUIC soul). A Claude Code installation can have both — different commands, different MCP server entries, different auth modes.
 

--- a/plugins/claude-code/commands/soul-journal.md
+++ b/plugins/claude-code/commands/soul-journal.md
@@ -13,7 +13,12 @@ Append the following entry to today's journal file for the current project. One 
 
 3. **Check existence.** Call `mark_fetch` on the target path:
 
-   - If the result is `not-found`: the file does not exist yet. Create it with `mark_publish` (`expected_version: 0`) containing:
+   - If the result is `not-found`: the file does not exist yet. Create it with `mark_publish` (`expected_version: 0`). **Set a `metadata` object so the entry is findable via `mark_lookup`** — you are responsible for choosing these, the server does not infer them:
+
+     - `tags`: comma-separated subjects. Always include `journal` and the project slug, then add the concrete topics in the entry (e.g. `auth`, `release`, `bugfix`, `lookup`). Derive them from the entry text — don't stop at `journal`.
+     - `importance`: a float 0–1 reflecting how much this entry matters for later recall. Routine daily notes ~0.3–0.5; a real decision or milestone higher. Use 0.4 when unsure.
+
+     Body:
 
      ```
      # <Project> journal — <YYYY-MM-DD>
@@ -31,6 +36,8 @@ Append the following entry to today's journal file for the current project. One 
      ```
 
      Leave `expected_version` unset so the tool auto-resolves it. Always prefix the entry body with a leading blank line so it separates visually from the previous entry.
+
+     `mark_append` cannot carry metadata, so today's creation-time `tags`/`importance` stand. If this new entry introduces a materially new subject worth finding later, fetch the file and re-publish it (`mark_publish`, full current body, correct `expected_version`) with `tags` extended to cover it. Skip this for routine same-topic appends — don't republish gratuitously.
 
 4. **Confirm.** Tell the user the full path you wrote to so they can find it.
 

--- a/plugins/claude-code/context/session-guidance.md
+++ b/plugins/claude-code/context/session-guidance.md
@@ -1,0 +1,30 @@
+# demarkus-memory — persistent project memory is available
+
+You have a local, versioned memory store (the "soul") wired through the `demarkus-memory` MCP tools. Treat it like project memory you'd get from a CLAUDE.md: consult it before you start, and record what matters as you go — without waiting to be asked.
+
+**Project slug:** basename of `CLAUDE_PROJECT_DIR`, lowercased, spaces → hyphens. Everything for a project lives under `/<slug>/`.
+
+## Recall first (proactively)
+
+Before answering "what do I know about / did we decide / have we seen X" — and at the start of substantive work — check the soul instead of relying on the current context alone:
+
+- `mark_lookup` with `url=/<slug>/` and a subject `query` is the **card catalog**: it returns an importance-ranked table of matching docs (path, importance, title, tags), not bodies. Start here, then `mark_fetch` the rows worth reading. It only finds what was tagged or titled, so use it alongside — not instead of — `mark_fetch /<slug>/index.md`.
+- `mark_backlinks` / `mark_graph` surface related documents across the link graph.
+- If nothing relevant comes back, say so plainly — never fabricate memory.
+
+## Record as you go (proactively)
+
+When something is worth persisting, write it without being prompted:
+
+- **Decision** → an ADR at `/<slug>/adr/<NNNN>-<title>.md`
+- **Pattern / convention learned** → `/<slug>/patterns.md`
+- **Significant progress or end of a working session** → append to `/<slug>/journal/<YYYY-MM-DD>.md`
+- **Architecture / roadmap / task changes** → the matching file under `/<slug>/`
+
+**Always set `metadata` on `mark_publish`:** `tags` (comma-separated subjects) and, sparingly, `importance` (0–1, for genuinely central docs). An untagged document is invisible to `mark_lookup` later — tagging on write is what makes recall work.
+
+## Restraint
+
+- Don't journal trivia, ephemeral chat, or things derivable from the repo and git history. Capture the non-obvious: why a decision was made, a pattern, a gotcha.
+- Don't save secrets, credentials, or anything the user hasn't authorized.
+- The `soul-memory` skill has the full file-routing rules; `/soul-context` primes a session, `/soul-journal` appends a dated entry, `/soul-status` diagnoses the server.

--- a/plugins/claude-code/context/session-guidance.md
+++ b/plugins/claude-code/context/session-guidance.md
@@ -21,7 +21,11 @@ When something is worth persisting, write it without being prompted:
 - **Significant progress or end of a working session** → append to `/<slug>/journal/<YYYY-MM-DD>.md`
 - **Architecture / roadmap / task changes** → the matching file under `/<slug>/`
 
-**Always set `metadata` on `mark_publish`:** `tags` (comma-separated subjects) and, sparingly, `importance` (0–1, for genuinely central docs). An untagged document is invisible to `mark_lookup` later — tagging on write is what makes recall work.
+**You tag and rank — the server infers nothing.** On every `mark_publish`, set a `metadata` object:
+- `tags`: comma-separated subjects describing the doc. Derive them from the content. An untagged document is invisible to `mark_lookup`, so this is not optional — it's what makes the write recallable.
+- `importance`: a float 0–1 you choose deliberately. Reserve high values (≥0.8) for genuinely central docs (index hubs, architecture, key decisions); routine notes sit lower. It floats matches in lookup ranking; it never surfaces an unmatched doc, so it's a prior, not an override.
+
+`mark_append` can't carry metadata — tags/importance are fixed at the doc's last `mark_publish`. When an append adds a materially new subject, re-publish the doc with extended `tags` so the catalog stays accurate.
 
 ## Restraint
 

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -9,12 +9,20 @@
 #     taken. The user can rerun /soul-init at any time to reconfigure
 #     (e.g. to adopt an existing demarkus-server they were already running).
 #
+# Finally, emit a SessionStart additionalContext payload so every session knows
+# the soul exists and self-documents to it (recall via mark_lookup, record
+# decisions/patterns/journal proactively). If the server isn't reachable, the
+# payload leads with a warning so the agent surfaces it instead of silently
+# failing memory calls. All setup logging goes to stderr; stdout carries only
+# the JSON payload Claude Code parses.
+#
 # No core-code changes. Pure composition of existing CLI surface.
 
 set -euo pipefail
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPTS_DIR="${HOOK_DIR}/../scripts"
+GUIDANCE_FILE="${HOOK_DIR}/../context/session-guidance.md"
 # shellcheck source=../scripts/lib.sh
 . "${SCRIPTS_DIR}/lib.sh"
 
@@ -28,33 +36,61 @@ seed_index() {
   log "seeded ${target}"
 }
 
-main() {
-  if ! load_config; then
-    log "no plugin config — running default setup"
-    "${SCRIPTS_DIR}/setup.sh" default
-    load_config || die "setup.sh completed but ${PLUGIN_CONFIG} is missing or invalid"
+# emit_context — print the SessionStart additionalContext JSON to stdout.
+# Leads with the health warning (if any) so the agent relays it, then the
+# standing self-documentation guidance. Skips the guidance body gracefully if
+# the file is somehow missing, still surfacing any warning.
+emit_context() {
+  local warning="$1"
+  local payload=""
+  [[ -n "${warning}" ]] && payload="⚠️ ${warning}"$'\n\n'
+  if [[ -f "${GUIDANCE_FILE}" ]]; then
+    payload="${payload}$(cat "${GUIDANCE_FILE}")"
   fi
+  [[ -z "${payload}" ]] && return 0
+  printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}\n' \
+    "$(printf '%s' "${payload}" | json_escape)"
+}
 
-  ensure_binaries
+main() {
+  local warning=""
 
-  case "${MODE}" in
-    default|isolated)
-      ensure_managed_server "${SOUL_DIR}" "${PORT}"
-      ;;
-    reuse)
-      # User-managed server; verify it's still up but don't try to start it.
-      if [[ -z "$(pid_of_server_at_root "${SOUL_DIR}")" ]]; then
-        warn "configured to reuse server at ${SOUL_DIR} but none is running; run /soul-init to reconfigure"
-      fi
-      ;;
-    *)
-      die "unknown MODE in ${PLUGIN_CONFIG}: ${MODE}"
-      ;;
-  esac
+  # Run all setup with stdout folded into stderr: stdout must carry only the
+  # JSON payload emitted at the very end, regardless of what setup.sh or the
+  # binary downloader print.
+  {
+    if ! load_config; then
+      log "no plugin config — running default setup"
+      "${SCRIPTS_DIR}/setup.sh" default
+      load_config || die "setup.sh completed but ${PLUGIN_CONFIG} is missing or invalid"
+    fi
 
-  seed_index
+    ensure_binaries
 
-  log "ready (mode=${MODE}, soul=${SOUL_DIR}, port=${PORT})"
+    case "${MODE}" in
+      default|isolated)
+        ensure_managed_server "${SOUL_DIR}" "${PORT}"
+        ;;
+      reuse)
+        # User-managed server; verify it's still up but don't try to start it.
+        if [[ -z "$(pid_of_server_at_root "${SOUL_DIR}")" ]]; then
+          warn "configured to reuse server at ${SOUL_DIR} but none is running; run /soul-init to reconfigure"
+        fi
+        ;;
+      *)
+        die "unknown MODE in ${PLUGIN_CONFIG}: ${MODE}"
+        ;;
+    esac
+
+    seed_index
+
+    # Best-effort health check; never abort the hook over it.
+    warning="$(server_health_warning || true)"
+
+    log "ready (mode=${MODE}, soul=${SOUL_DIR}, port=${PORT})"
+  } 1>&2
+
+  emit_context "${warning}"
 }
 
 main "$@"

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -66,7 +66,12 @@ server_health_warning() {
   case "${MODE:-}" in
     default|isolated)
       local pid_file="${SOUL_DIR}/.pid"
-      if [[ ! -f "${pid_file}" ]] || ! kill -0 "$(cat "${pid_file}" 2>/dev/null)" 2>/dev/null; then
+      local pid=""
+      [[ -f "${pid_file}" ]] && pid="$(cat "${pid_file}" 2>/dev/null || true)"
+      # Validate the recorded PID is a bare positive integer before probing —
+      # an empty, partial, or option-like .pid (e.g. "-1") would otherwise make
+      # kill -0 misread it and report a dead server as alive.
+      if [[ -z "${pid}" || ! "${pid}" =~ ^[0-9]+$ ]] || ! kill -0 "${pid}" 2>/dev/null; then
         echo "the demarkus-memory server is not running (no live process for ${SOUL_DIR}). Memory tools (mark_fetch/mark_publish/mark_lookup/...) will fail until it restarts — run /soul-init to restart, or /soul-status to diagnose."
       fi
       ;;

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -25,11 +25,11 @@ readonly DEFAULT_PORT=6310             # plugin's first-choice port for its own 
 readonly ISOLATED_PORT_START=16310
 readonly ISOLATED_PORT_END=16509
 
-readonly SERVER_VERSION="0.17.10"
-readonly CLIENT_VERSION="0.12.36"
+readonly SERVER_VERSION="0.17.13"
+readonly CLIENT_VERSION="0.12.38"
 # demarkus-token moved from the server archive to its own tools/ release
 # in §6.7.A. Pin separately so a tools-only release can be picked up.
-readonly TOOLS_VERSION="0.1.16"
+readonly TOOLS_VERSION="0.1.28"
 
 # Sentinel file recording the SERVER/CLIENT versions of the binaries currently
 # installed at PLUGIN_BIN_DIR. ensure_binaries compares this against the
@@ -40,6 +40,43 @@ readonly PLUGIN_VERSION_FILE="${PLUGIN_BIN_DIR}/.versions"
 log()  { echo "[demarkus-memory] $*" >&2; }
 warn() { echo "[demarkus-memory] warning: $*" >&2; }
 die()  { echo "[demarkus-memory] error: $*" >&2; exit 1; }
+
+# json_escape — reads stdin and emits it as a single JSON string literal
+# (quotes included). Pure awk so it works without jq on stock macOS/Linux.
+# Escapes backslash, double-quote, and tab; strips CR; turns each input line
+# into a \n-terminated chunk. Sufficient for our markdown context payloads
+# (printable ASCII + newlines); not a general-purpose UTF-8 control encoder.
+json_escape() {
+  awk '
+    BEGIN { ORS=""; print "\"" }
+    { gsub(/\\/, "\\\\"); gsub(/"/, "\\\""); gsub(/\t/, "\\t"); gsub(/\r/, ""); print $0 "\\n" }
+    END { print "\"" }
+  '
+}
+
+# server_health_warning — echoes a one-line human warning when the configured
+# memory server does not appear to be up, empty when it looks healthy. Relies
+# on load_config having set SOUL_DIR/PORT/MODE. Best-effort and probe-only (no
+# QUIC round-trip): for managed modes it trusts the .pid liveness that
+# ensure_managed_server maintains; for reuse it scans for the adopted process.
+# Deliberately avoids the port_is_free check as a health signal — that probe
+# degrades to permissive without lsof/ss and would emit false "not listening"
+# warnings on a perfectly healthy server.
+server_health_warning() {
+  case "${MODE:-}" in
+    default|isolated)
+      local pid_file="${SOUL_DIR}/.pid"
+      if [[ ! -f "${pid_file}" ]] || ! kill -0 "$(cat "${pid_file}" 2>/dev/null)" 2>/dev/null; then
+        echo "the demarkus-memory server is not running (no live process for ${SOUL_DIR}). Memory tools (mark_fetch/mark_publish/mark_lookup/...) will fail until it restarts — run /soul-init to restart, or /soul-status to diagnose."
+      fi
+      ;;
+    reuse)
+      if [[ -z "$(pid_of_server_at_root "${SOUL_DIR}" 2>/dev/null)" ]]; then
+        echo "demarkus-memory is configured to reuse a server rooted at ${SOUL_DIR}, but none is running. Memory tools will fail until it is started — start that server or run /soul-init to reconfigure."
+      fi
+      ;;
+  esac
+}
 
 # load_config — sources the config file, sets SOUL_DIR, PORT, MODE.
 # Returns 1 if config missing; dies on malformed config.

--- a/plugins/claude-code/skills/soul-memory/SKILL.md
+++ b/plugins/claude-code/skills/soul-memory/SKILL.md
@@ -56,7 +56,9 @@ Write intents — route to the right file for the content type:
 - **Roadmap item** → fetch and update `/<project>/roadmap.md`.
 - **Cross-project or global note** → if it does not fit a project, ask the user where it belongs. Do not create ad-hoc top-level files.
 
-**On every `mark_publish`, set `metadata`:** `tags` (comma-separated subjects — the primary match target for `mark_lookup`) and, sparingly, `importance` (0–1, default 0.5; reserve high values for genuinely central docs like index hubs and architecture). An untagged document can only be found by words in its title, so tagging on write is what makes later recall work. Reserved keys are rejected; any other metadata key is stored opaquely and reachable through lookup's `filter` axis.
+**On every `mark_publish`, set `metadata`:** `tags` (comma-separated subjects — the primary match target for `mark_lookup`) and, sparingly, `importance` (0–1, default 0.5; reserve high values for genuinely central docs like index hubs and architecture). An untagged document can only be found by words in its title, so tagging on write is what makes later recall work. The server does not infer either field — you choose them. Reserved keys are rejected; any other metadata key is stored opaquely and reachable through lookup's `filter` axis.
+
+`mark_append` carries no metadata, so a doc's `tags`/`importance` are whatever its last `mark_publish` set. When an append introduces a materially new subject, re-publish the doc (full body, correct `expected_version`) with extended `tags` rather than letting the catalog drift.
 
 Always reference what you saved by full path so the user can find it again.
 

--- a/plugins/claude-code/skills/soul-memory/SKILL.md
+++ b/plugins/claude-code/skills/soul-memory/SKILL.md
@@ -39,10 +39,10 @@ Each `/<project>/` subtree has a fixed layout:
 
 ## Tool routing
 
-Read intents → start with `mark_fetch`:
+Read intents → start with `mark_lookup` (the catalog), then `mark_fetch`:
 
-1. Fetch `/index.md` to see the project list
-2. Fetch `/<project>/` (directory listing) or a specific file under it
+1. `mark_lookup` with `url=/<project>/` (or `/` to span every project) and a subject `query` — returns an importance-ranked markdown table of matching docs (path, importance, title, tags), not bodies. This is a catalog lookup, not full-text search: it finds only what was tagged or titled. Narrow with the optional `filter` arg (`tag=`, `modified-after=`, `modified-before=`) and cap with `limit`.
+2. `mark_fetch` the rows worth reading. Also `mark_fetch /index.md` / `/<project>/index.md` directly — lookup won't surface untagged docs, so the index hub still anchors discovery.
 3. Use `mark_backlinks` or `mark_graph` to surface related documents across projects
 4. If nothing relevant is found, say so honestly rather than fabricating
 
@@ -55,6 +55,8 @@ Write intents — route to the right file for the content type:
 - **Task / todo** → fetch and update `/<project>/plan/tasks.md`.
 - **Roadmap item** → fetch and update `/<project>/roadmap.md`.
 - **Cross-project or global note** → if it does not fit a project, ask the user where it belongs. Do not create ad-hoc top-level files.
+
+**On every `mark_publish`, set `metadata`:** `tags` (comma-separated subjects — the primary match target for `mark_lookup`) and, sparingly, `importance` (0–1, default 0.5; reserve high values for genuinely central docs like index hubs and architecture). An untagged document can only be found by words in its title, so tagging on write is what makes later recall work. Reserved keys are rejected; any other metadata key is stored opaquely and reachable through lookup's `filter` axis.
 
 Always reference what you saved by full path so the user can find it again.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced MCP tool capabilities (added lookup/graph lookup and related behaviors)
  * Session output now includes contextual guidance for project memory when available

* **Documentation**
  * Added detailed session guidance for persistent project memory, metadata, and journaling best practices
  * Updated command docs to reflect expanded tool surface and lookup behavior

* **Chores**
  * Plugin version bumps (demarkus-memory and claude-code to 0.3.0)
  * Updated pinned server, client, and tools versions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->