### PR TITLE
feat(kind): drive auth-code + PKCE flow end-to-end in --with-mcp-smoke

### DIFF
--- a/deploy/kind/up.sh
+++ b/deploy/kind/up.sh
@@ -634,7 +634,7 @@ HTTP=$($CURL -o /tmp/tok.json -w "%{http_code}" -X POST "$BROKER/device/token" \
   --data-urlencode "code_verifier=$VERIFIER")
 [ "$HTTP" = "200" ] || { echo "FAIL: authorization_code exchange did not 200 (got $HTTP)"; cat /tmp/tok.json; exit 1; }
 grep -q "\"token_type\":\"Bearer\"" /tmp/tok.json || { echo "FAIL: token_type Bearer missing from token response"; exit 1; }
-grep -q "\"access_token\":\"..*\"" /tmp/tok.json || { echo "FAIL: access_token missing/empty in token response"; exit 1; }
+grep -Eq "\"access_token\":\"[^\"]+\"" /tmp/tok.json || { echo "FAIL: access_token missing/empty in token response"; cat /tmp/tok.json; exit 1; }
 echo "OK: authorization_code + verifier exchange minted a Bearer token"
 
 # 6. REPLAY — the code is one-shot; re-presenting it with the correct

--- a/deploy/kind/up.sh
+++ b/deploy/kind/up.sh
@@ -19,6 +19,13 @@
 # anything to the host. Stage 4 also runs an ephemeral curl pod that drives
 # /auth/login -> /authorize -> /auth/callback and asserts the broker's
 # mint response references both worlds.
+#
+# --with-mcp-smoke (layered on Stage 2) additionally drives the RFC 6749
+# authorization_code + PKCE flow end-to-end from a curl pod:
+# /oauth/authorize -> mock IdP -> /auth/callback -> loopback redirect with a
+# broker-minted code -> /device/token exchange, with negative (wrong
+# verifier -> invalid_grant) and replay (one-shot code) assertions. This is
+# the OAuth surface Claude Code's MCP SDK uses via /knowledge-join.
 
 set -euo pipefail
 
@@ -73,10 +80,13 @@ usage: up.sh [--with-broker] [--with-argo] [--with-mcp-smoke]
   --with-mcp-smoke  rebuild the broker image from this checkout,
                     sideload it into kind, install the LOCAL broker
                     chart (deploy/helm/demarkus-broker) with that image,
-                    and run smoke checks against the MCP gateway
-                    listener (\${BROKER_RELEASE}-...:8081). Requires
-                    --with-broker; not compatible with --with-argo
-                    (Stage 4 expects the published chart artifact).
+                    run smoke checks against the MCP gateway listener
+                    (\${BROKER_RELEASE}-...:8081), then drive the RFC 6749
+                    authorization_code + PKCE flow end-to-end against the
+                    broker's :8080 OAuth surface (the surface behind
+                    /knowledge-join). Requires --with-broker; not
+                    compatible with --with-argo (Stage 4 expects the
+                    published chart artifact).
 
   Combine --with-broker + --with-argo for Stage 4: Argo-managed worlds
   + broker wired across them. up.sh then drives a full OIDC mint flow
@@ -435,9 +445,17 @@ if [[ "$WITH_BROKER" == "true" ]]; then
     kind load docker-image "$MCP_SMOKE_IMAGE_REGISTRY/demarkus-broker:$MCP_SMOKE_IMAGE_TAG" --name "$CLUSTER"
 
     echo "--- installing LOCAL demarkus-broker chart from $REPO_ROOT/deploy/helm/demarkus-broker"
+    # server.insecureCookies=true is set here (not in values-broker.yaml) so
+    # only the --with-mcp-smoke install drops the Secure attribute on the
+    # OIDC state cookie. The auth-code smoke below drives /oauth/authorize ->
+    # /auth/callback over plain HTTP inside the curl pod; a Secure cookie
+    # would not replay on the callback leg and the flow would fail at state
+    # validation. The plain Stage 2 install (values-broker.yaml) stays
+    # untouched because it never drives a login flow.
     helm upgrade --install "$BROKER_RELEASE" "$REPO_ROOT/deploy/helm/demarkus-broker" \
       --namespace "$NAMESPACE" --create-namespace \
       --values "$BROKER_VALUES_FILE" \
+      --set "server.insecureCookies=true" \
       --set "image.repository=$MCP_SMOKE_IMAGE_REGISTRY/demarkus-broker" \
       --set "image.tag=$MCP_SMOKE_IMAGE_TAG" \
       --set "image.pullPolicy=IfNotPresent" \
@@ -463,15 +481,14 @@ if [[ "$WITH_BROKER" == "true" ]]; then
   fi
 
   if [[ "$WITH_MCP_SMOKE" == "true" ]]; then
-    # MCP gateway smoke checks. We deliberately do NOT drive a full
-    # initialize/tools/call flow here — that requires an id_token bearer
-    # obtained via the device-flow exchange + a mint round trip, which
-    # is the natural test surface for Slice 8's /knowledge-join slash
-    # command. These three checks prove the chart's MCP listener is:
+    # MCP gateway smoke checks. These three prove the chart's MCP listener is:
     #   1. bound (port 8081 reachable through the Service)
     #   2. serving RFC 9728 OAuth metadata (well-known endpoint)
     #   3. enforcing auth on /mcp (401 + WWW-Authenticate challenge)
-    # That is the smallest evidence that Slice 7's chart wiring works.
+    # That is the smallest evidence that Slice 7's chart wiring works. The
+    # auth-code + PKCE flow that backs /knowledge-join is then driven
+    # end-to-end against the broker's :8080 OAuth surface in a second pod
+    # below (broker-auth-code-grant plan, PR3).
     echo "--- driving MCP gateway smoke checks from an ephemeral curl pod"
     BROKER_MCP_URL="http://$BROKER_RELEASE-demarkus-broker.$NAMESPACE.svc.cluster.local:8081"
     kubectl run -n "$NAMESPACE" mcp-smoke --rm -i --restart=Never \
@@ -510,6 +527,129 @@ echo "$HDR" | grep -qi "^WWW-Authenticate: Bearer" || { echo "FAIL: 401 response
 echo "OK: POST /mcp 401 + WWW-Authenticate"
 '
     echo "--- MCP gateway smoke checks passed"
+
+    # Auth-code + PKCE end-to-end (broker-auth-code-grant plan, PR3).
+    # The three checks above prove the gateway demands a bearer; this
+    # proves the broker can actually MINT one via the RFC 6749
+    # authorization_code grant that Claude Code's MCP SDK drives — the
+    # exact surface that was a stub (`unsupported_response_type`) before
+    # PRs #155/#156. PKCE is S256-only; we compute the verifier +
+    # challenge on the host (openssl is already a harness requirement)
+    # and pass them into the pod, because the curlimages/curl pod has no
+    # guaranteed openssl for the base64url(sha256(verifier)) derivation.
+    AUTHCODE_CLIENT_ID="mcp-smoke-client"
+    # Loopback redirect per RFC 8252 — the broker refuses anything else.
+    # The port is arbitrary: nothing ever connects to it, we only parse
+    # the broker's 302 Location to recover the authorization code.
+    AUTHCODE_REDIRECT_URI="http://127.0.0.1:33000/callback"
+    AUTHCODE_CLIENT_STATE="$(openssl rand -hex 16)"
+    AUTHCODE_VERIFIER="$(openssl rand -hex 32)"
+    AUTHCODE_CHALLENGE="$(printf '%s' "$AUTHCODE_VERIFIER" \
+      | openssl dgst -sha256 -binary | openssl base64 -A | tr '+/' '-_' | tr -d '=')"
+
+    echo "--- driving auth-code + PKCE flow from an ephemeral curl pod"
+    BROKER_OAUTH_URL="http://$BROKER_RELEASE-demarkus-broker.$NAMESPACE.svc.cluster.local:8080"
+    kubectl run -n "$NAMESPACE" authcode-smoke --rm -i --restart=Never \
+      --image="$MINT_CURL_IMAGE" --command -- sh -c '
+set -eu
+BROKER='"$BROKER_OAUTH_URL"'
+CLIENT_ID='"$AUTHCODE_CLIENT_ID"'
+REDIRECT_URI='"$AUTHCODE_REDIRECT_URI"'
+CLIENT_STATE='"$AUTHCODE_CLIENT_STATE"'
+VERIFIER='"$AUTHCODE_VERIFIER"'
+CHALLENGE='"$AUTHCODE_CHALLENGE"'
+CURL="curl -sS --connect-timeout 5 --max-time 15"
+
+# 0. Wait for the broker OAuth Service to answer (Endpoints can lag
+#    helm --wait by a beat or two on a fresh pod).
+for attempt in $(seq 1 15); do
+  if $CURL -o /dev/null "$BROKER/healthz"; then break; fi
+  sleep 2
+done
+$CURL -f -o /dev/null "$BROKER/healthz" || { echo "FAIL: broker OAuth surface unreachable"; exit 1; }
+
+# 1. GET /oauth/authorize with PKCE S256. curl -G --data-urlencode
+#    encodes each query param (redirect_uri has reserved chars). The
+#    broker validates loopback redirect_uri + S256 challenge, sets the
+#    signed state cookie (Secure dropped via insecureCookies above), and
+#    302s to the mock IdP.
+$CURL -G -c /tmp/cookies -D /tmp/authz.h -o /dev/null \
+  --data-urlencode "response_type=code" \
+  --data-urlencode "client_id=$CLIENT_ID" \
+  --data-urlencode "redirect_uri=$REDIRECT_URI" \
+  --data-urlencode "code_challenge=$CHALLENGE" \
+  --data-urlencode "code_challenge_method=S256" \
+  --data-urlencode "state=$CLIENT_STATE" \
+  "$BROKER/oauth/authorize"
+IDP=$(awk "/^[Ll]ocation:/{print \$2}" /tmp/authz.h | tr -d "\r")
+[ -n "$IDP" ] || { echo "FAIL: no Location from /oauth/authorize"; cat /tmp/authz.h; exit 1; }
+
+# 2. Mock IdP /authorize (interactiveLogin=false) auto-approves and 302s
+#    back to the broker redirectURL with code+state.
+$CURL -D /tmp/idp.h -o /dev/null "$IDP"
+CB=$(awk "/^[Ll]ocation:/{print \$2}" /tmp/idp.h | tr -d "\r")
+[ -n "$CB" ] || { echo "FAIL: no Location from IdP /authorize"; cat /tmp/idp.h; exit 1; }
+IDP_CODE=$(printf "%s" "$CB" | sed -n "s/.*[?&]code=\([^&]*\).*/\1/p")
+IDP_STATE=$(printf "%s" "$CB" | sed -n "s/.*[?&]state=\([^&]*\).*/\1/p")
+[ -n "$IDP_CODE" ] && [ -n "$IDP_STATE" ] || { echo "FAIL: bad IdP callback URL: $CB"; exit 1; }
+
+# 3. Broker /auth/callback, replaying the state cookie (re-targeted at the
+#    in-cluster Service, not the literal localhost the IdP echoed). The
+#    AuthCodeID in the signed state routes this to authCodeCallback, which
+#    exchanges the IdP code, mints a broker authorization code, and 302s to
+#    OUR loopback redirect_uri with code+state+iss.
+$CURL -b /tmp/cookies -D /tmp/cb.h -o /dev/null "$BROKER/auth/callback?code=$IDP_CODE&state=$IDP_STATE"
+RU=$(awk "/^[Ll]ocation:/{print \$2}" /tmp/cb.h | tr -d "\r")
+[ -n "$RU" ] || { echo "FAIL: no Location from /auth/callback"; cat /tmp/cb.h; exit 1; }
+case "$RU" in
+  *"error="*) echo "FAIL: auth-code callback returned an OAuth error: $RU"; exit 1 ;;
+esac
+AUTH_CODE=$(printf "%s" "$RU" | sed -n "s/.*[?&]code=\([^&]*\).*/\1/p")
+RET_STATE=$(printf "%s" "$RU" | sed -n "s/.*[?&]state=\([^&]*\).*/\1/p")
+[ -n "$AUTH_CODE" ] || { echo "FAIL: no broker authorization code in redirect: $RU"; exit 1; }
+[ "$RET_STATE" = "$CLIENT_STATE" ] || { echo "FAIL: state mismatch (CSRF guard): got [$RET_STATE] want [$CLIENT_STATE]"; exit 1; }
+echo "$RU" | grep -q "iss=" || { echo "FAIL: success redirect missing iss (RFC 9207)"; exit 1; }
+echo "OK: /oauth/authorize -> broker authorization code issued (state echoed, iss present)"
+
+# 4. NEGATIVE — a WRONG code_verifier must be rejected, proving the PKCE
+#    challenge is actually checked. Redeem preserves the one-shot code on a
+#    verifier mismatch, so the positive exchange in step 5 still succeeds.
+HTTP=$($CURL -o /tmp/neg.json -w "%{http_code}" -X POST "$BROKER/device/token" \
+  --data-urlencode "grant_type=authorization_code" \
+  --data-urlencode "code=$AUTH_CODE" \
+  --data-urlencode "client_id=$CLIENT_ID" \
+  --data-urlencode "redirect_uri=$REDIRECT_URI" \
+  --data-urlencode "code_verifier=wrong-$VERIFIER")
+[ "$HTTP" = "400" ] || { echo "FAIL: wrong code_verifier did not 400 (got $HTTP)"; cat /tmp/neg.json; exit 1; }
+grep -q "invalid_grant" /tmp/neg.json || { echo "FAIL: wrong code_verifier not invalid_grant"; cat /tmp/neg.json; exit 1; }
+echo "OK: wrong code_verifier rejected with invalid_grant (PKCE enforced)"
+
+# 5. POSITIVE — the correct verifier mints a Bearer token. Assert response
+#    shape only; the raw token material never lands in CI logs.
+HTTP=$($CURL -o /tmp/tok.json -w "%{http_code}" -X POST "$BROKER/device/token" \
+  --data-urlencode "grant_type=authorization_code" \
+  --data-urlencode "code=$AUTH_CODE" \
+  --data-urlencode "client_id=$CLIENT_ID" \
+  --data-urlencode "redirect_uri=$REDIRECT_URI" \
+  --data-urlencode "code_verifier=$VERIFIER")
+[ "$HTTP" = "200" ] || { echo "FAIL: authorization_code exchange did not 200 (got $HTTP)"; cat /tmp/tok.json; exit 1; }
+grep -q "\"token_type\":\"Bearer\"" /tmp/tok.json || { echo "FAIL: token_type Bearer missing from token response"; exit 1; }
+grep -q "\"access_token\":\"..*\"" /tmp/tok.json || { echo "FAIL: access_token missing/empty in token response"; exit 1; }
+echo "OK: authorization_code + verifier exchange minted a Bearer token"
+
+# 6. REPLAY — the code is one-shot; re-presenting it with the correct
+#    verifier must now fail.
+HTTP=$($CURL -o /tmp/replay.json -w "%{http_code}" -X POST "$BROKER/device/token" \
+  --data-urlencode "grant_type=authorization_code" \
+  --data-urlencode "code=$AUTH_CODE" \
+  --data-urlencode "client_id=$CLIENT_ID" \
+  --data-urlencode "redirect_uri=$REDIRECT_URI" \
+  --data-urlencode "code_verifier=$VERIFIER")
+[ "$HTTP" = "400" ] || { echo "FAIL: consumed code replay did not 400 (got $HTTP)"; cat /tmp/replay.json; exit 1; }
+echo "OK: authorization code is one-shot (replay rejected)"
+echo "OK: auth-code + PKCE flow end-to-end"
+'
+    echo "--- auth-code + PKCE flow passed"
   fi
 
   cat <<EOF


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local end-to-end OAuth 2.0 authorization code + PKCE smoke-test option that runs an ephemeral test flow against the broker.
  * Expanded validations: verifies successful token issuance, rejects invalid exchanges, and ensures one-time-use (replay prevention); help text for the option was clarified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->