### PR TITLE
fix(helm/server): render volumeMode to avoid immutable PVC drift

### DIFF
--- a/deploy/helm/demarkus-server/templates/statefulset.yaml
+++ b/deploy/helm/demarkus-server/templates/statefulset.yaml
@@ -144,6 +144,15 @@ spec:
       spec:
         accessModes:
           - {{ .Values.storage.accessMode }}
+        # Render volumeMode explicitly. Kubernetes defaults a PVC's volumeMode
+        # to Filesystem server-side, so omitting it here makes the rendered
+        # manifest (volumeMode absent) drift from the live PVC (Filesystem).
+        # volumeClaimTemplates is immutable, so under a GitOps tool using
+        # ServerSideApply (e.g. ArgoCD) that drift turns every subsequent sync
+        # that must re-apply the StatefulSet — like an image bump — into a
+        # rejected "forbidden update to immutable field" loop. Emitting the
+        # value the cluster will default to keeps render == live.
+        volumeMode: {{ .Values.storage.volumeMode }}
         resources:
           requests:
             storage: {{ .Values.storage.size }}

--- a/deploy/helm/demarkus-server/templates/statefulset.yaml
+++ b/deploy/helm/demarkus-server/templates/statefulset.yaml
@@ -151,8 +151,11 @@ spec:
         # ServerSideApply (e.g. ArgoCD) that drift turns every subsequent sync
         # that must re-apply the StatefulSet — like an image bump — into a
         # rejected "forbidden update to immutable field" loop. Emitting the
-        # value the cluster will default to keeps render == live.
-        volumeMode: {{ .Values.storage.volumeMode }}
+        # value the cluster will default to keeps render == live. Default it
+        # so an empty override (""/null) can't render a blank field — that
+        # would let Kubernetes re-default it server-side and silently
+        # reintroduce the very drift this block exists to prevent.
+        volumeMode: {{ .Values.storage.volumeMode | default "Filesystem" }}
         resources:
           requests:
             storage: {{ .Values.storage.size }}

--- a/deploy/helm/demarkus-server/tests/statefulset_test.yaml
+++ b/deploy/helm/demarkus-server/tests/statefulset_test.yaml
@@ -180,3 +180,19 @@ tests:
       - equal:
           path: spec.volumeClaimTemplates[0].spec.storageClassName
           value: premium-rwo
+
+  - it: volumeClaimTemplates sets volumeMode to match the k8s default (no drift)
+    template: statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.volumeMode
+          value: Filesystem
+
+  - it: volumeMode is overridable
+    template: statefulset.yaml
+    set:
+      storage.volumeMode: Block
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.volumeMode
+          value: Block

--- a/deploy/helm/demarkus-server/tests/statefulset_test.yaml
+++ b/deploy/helm/demarkus-server/tests/statefulset_test.yaml
@@ -196,3 +196,12 @@ tests:
       - equal:
           path: spec.volumeClaimTemplates[0].spec.volumeMode
           value: Block
+
+  - it: empty volumeMode override still renders Filesystem (no silent drift)
+    template: statefulset.yaml
+    set:
+      storage.volumeMode: ""
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.volumeMode
+          value: Filesystem

--- a/deploy/helm/demarkus-server/values.yaml
+++ b/deploy/helm/demarkus-server/values.yaml
@@ -49,6 +49,11 @@ storage:
   className: ""        # cluster-default if empty
   size: 5Gi
   accessMode: ReadWriteOnce
+  # Match the value Kubernetes defaults onto the PVC so the rendered
+  # volumeClaimTemplates equals the live one — avoids immutable-field drift
+  # that wedges GitOps re-applies (e.g. ArgoCD on an image bump). Override to
+  # Block only for raw-block volumes.
+  volumeMode: Filesystem
 
 # TLS — server speaks QUIC, so TLS is mandatory. Three modes:
 #   1. existingSecret: reference a pre-existing tls Secret (cert-manager, etc.)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment stability improved by making storage volume mode explicit and defaulting to filesystem, with an override option.
  * Clarified configuration comments for storage volume mode to aid deploy-time clarity.

* **Tests**
  * Added automated tests validating default, overridden, and empty-value behaviors for storage volume mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->