### PR TITLE
feat(plugin): enforce tags on publish via warn/block/ask gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ From the demarkus-soul MCP server:
 
 ## demarkus-soul layout (flat — one project)
 
-```
+```text
 /index.md         — hub, links to every section
 /architecture.md  — system design, module boundaries, key decisions
 /patterns.md      — code patterns, build commands, conventions, workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,44 +1,55 @@
 # CLAUDE.md
 
-## demarkus-soul
+Project context — architecture, patterns, build commands, conventions, debugging
+notes, roadmap — lives on the **demarkus-soul** MCP server. Generic memory
+mechanics (recall, tagging, journaling, the project template) are handled by the
+demarkus-memory plugin; this file carries only what's specific to demarkus.
 
-All project context — architecture, patterns, build commands, conventions, debugging notes, and roadmap — lives on the demarkus-soul MCP server.
-No sycophancy — code or ideas. Critically review code before presenting: layering violations, missing edge cases, state desync, stale references, channel blocking, rune vs byte vs cell-width confusion, silent error paths, leaky abstractions, wrong architectural layer. Challenge ideas and proposals before agreeing: what's the downside? What breaks? What's the simpler alternative? Is this solving the right problem? Push back when something doesn't hold up — disagreement backed by reasoning is expected.
-Never silently swallow errors. Every error must be explicitly handled — logged or surfaced. No _ = fn() without a comment.
-After each implementation run tests and pre-commit.sh.
+## How I work
 
-### Required Preflight (Every Session)
+- No sycophancy — on code or ideas. Critically review before presenting: layering
+  violations, missing edge cases, state desync, stale references, channel blocking,
+  rune vs byte vs cell-width confusion, silent error paths, leaky abstractions,
+  wrong architectural layer.
+- Challenge ideas before agreeing: what's the downside? what breaks? what's the
+  simpler alternative? is this the right problem? Push back when something doesn't
+  hold up — disagreement backed by reasoning is expected.
+- Never silently swallow errors. Every error is explicitly handled — logged or
+  surfaced. No `_ = fn()` without a comment.
+- After each implementation, run tests and `bash pre-commit.sh`.
 
-1. `mark_fetch` `/index.md` — get the hub page
-2. `mark_fetch` `/patterns.md` — build commands, code style, workflow
-3. `mark_fetch` `/guidelines.md` — hard rules for code quality, must read before writing code
-4. Fetch other pages as needed: `/architecture.md`, `/debugging.md`, `/roadmap.md`
-5. If MCP is unavailable, stop and ask the developer before proceeding
+## Required preflight (every session, before writing code)
 
-### During Work
+From the demarkus-soul MCP server:
 
-- Update soul pages when learning something new
-- Use natural language; avoid overusing "-" within sentences. For bullet points, "-" is still preferred.
-- Use `mark_append` for journal entries and incremental notes
-- Always use `expected_version` from a prior fetch when publishing or appending
+1. `mark_fetch /index.md` — the hub
+2. `mark_fetch /patterns.md` — build commands, code style, workflow
+3. `mark_fetch /guidelines.md` — hard code-quality rules; read before writing code
+4. Fetch as needed: `/architecture.md`, `/debugging.md`, `/roadmap.md`
+5. If the MCP server is unavailable, stop and ask before proceeding.
 
-### End of Session
-
-- Add a journal entry to `/<project>/journal/<YYYY-MM-DD>.md` if something significant happened
-
-### Content Structure
+## demarkus-soul layout (flat — one project)
 
 ```
-/index.md          — Hub page, links to all sections
-/architecture.md   — System design, module boundaries, key decisions
-/patterns.md       — Code patterns, build commands, conventions, workflow
-/guidelines.md     — Hard rules for code quality, must read before writing code
-/debugging.md      — Lessons from bugs and investigations
-/roadmap.md        — What's done, what's next
-/<project>/journal/<YYYY-MM-DD>.md — Dated session notes, one file per day
-/thoughts.md       — Agent reflections and ideas
-/guide.md          — Setup instructions for demarkus-soul
+/index.md         — hub, links to every section
+/architecture.md  — system design, module boundaries, key decisions
+/patterns.md      — code patterns, build commands, conventions, workflow
+/guidelines.md    — hard code-quality rules
+/debugging.md     — lessons from bugs and investigations
+/roadmap.md       — what's done, what's next
+/thoughts.md      — reflections and ideas
+/journal/<YYYY-MM-DD>.md — dated session notes, one file per day
+/plans/<name>.md  — plan documents
 ```
-### Plans
- - Agents should never store the plans in their own vendor specific folder
- - The agent should always publish the plan to demarkus soul instead
+
+This is a single-project flat soul. The demarkus-memory plugin's per-project
+`/<slug>/` template does **not** apply here.
+
+## Plans
+
+Never store plans in a vendor-specific folder. Publish them to demarkus-soul
+(`/plans/<name>.md`).
+
+## Doc style
+
+Natural language in soul docs; avoid overusing "-" within sentences (bullet "- " is fine).

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -40,6 +40,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-journal-nudge.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -50,6 +50,16 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/recall-nudge.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -21,7 +21,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "mcp__.*demarkus-memory__mark_publish",
+        "matcher": "mcp__.*__mark_publish",
         "hooks": [
           {
             "type": "command",
@@ -32,7 +32,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "mcp__.*demarkus-memory__mark_publish",
+        "matcher": "mcp__.*__mark_publish",
         "hooks": [
           {
             "type": "command",

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "demarkus-memory",
-  "version": "0.3.0",
-  "description": "Local, versioned memory for Claude Code via demarkus. Zero-config install: spawns a local demarkus-server, auto-generates a token, wires MCP tools for fetch/publish/append/graph/lookup, and injects standing guidance so sessions self-document to the soul and recall via lookup.",
+  "version": "0.4.0",
+  "description": "Local, versioned memory for Claude Code via demarkus. Zero-config install: spawns a local demarkus-server, auto-generates a token, wires MCP tools for fetch/publish/append/graph/lookup, injects standing guidance so sessions self-document to the soul, and enforces a publish tag-gate so documents stay findable via lookup.",
   "author": {
     "name": "latebit",
     "url": "https://github.com/latebit-io"
@@ -15,6 +15,28 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "mcp__.*demarkus-memory__mark_publish",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/publish-gate.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "mcp__.*demarkus-memory__mark_publish",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/publish-gate.sh"
           }
         ]
       }

--- a/plugins/claude-code/commands/knowledge-join.md
+++ b/plugins/claude-code/commands/knowledge-join.md
@@ -49,7 +49,32 @@ If the user invokes without an argument, ask them for the URL before running any
 
    Claude Code performs the OAuth device flow against the broker on the first tool call — there is no token to capture or paste here.
 
-4. **Confirm success.** Tell the user, in plain language:
+4. **Record the system for the publish gate.** After `claude mcp add` succeeds, run:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/register-knowledge.sh" <slug>
+   ```
+
+   This records the slug so the publish tag-gate enforces tags on writes to this knowledge system, the same way it does for the local soul. (It does not gate unrelated demarkus servers the user may have configured.)
+
+5. **Adopt the system's conventions (`root` hub).** A knowledge system can publish org-wide conventions to its guaranteed `root` hub world. Once the OAuth flow is complete and you are doing real work against this system, fetch them and follow them:
+
+   - `mark_fetch mark://root/.well-known/demarkus/template.md` — the required per-world structure (same shape as the local `/project-template.md`). Follow it.
+   - `mark_fetch mark://root/.well-known/demarkus/policy.md` — strictness + required tags. Mirror the enforceable knobs to local files so the gate (which cannot reach the broker) can apply them:
+
+     - If it declares a `strictness:` line:
+       ```bash
+       printf '%s\n' "<warn|block|ask from policy.md>" > ~/.demarkus/plugin-memory.strictness.<slug>
+       ```
+     - If it declares a `require_tags:` line (the tag axes every doc must carry, e.g. `category`), mirror the axes so the gate presence-checks them:
+       ```bash
+       printf '%s\n' "<axes from policy.md, e.g. category>" > ~/.demarkus/plugin-memory.require-tags.<slug>
+       ```
+       Each axis is then satisfied by an `axis:value` tag (e.g. `category:project`).
+
+   If either document is `not-found`, the system simply hasn't declared that convention yet — skip silently. See `${CLAUDE_PLUGIN_ROOT}/examples/knowledge-system/` for the format an admin publishes.
+
+6. **Confirm success.** Tell the user, in plain language:
 
    > Added knowledge system **<slug>** at <url>. Claude Code will prompt you to complete the OAuth device flow against the broker the next time it talks to that MCP server. After that, the org's full demarkus tool surface (mark_fetch, mark_publish, mark_graph, etc.) is available against worlds the broker exposes (URL form: `mark://<worldName>/<path>`).
 

--- a/plugins/claude-code/commands/knowledge-join.md
+++ b/plugins/claude-code/commands/knowledge-join.md
@@ -55,21 +55,25 @@ If the user invokes without an argument, ask them for the URL before running any
    bash "${CLAUDE_PLUGIN_ROOT}/scripts/register-knowledge.sh" <slug>
    ```
 
-   This records the slug so the publish tag-gate enforces tags on writes to this knowledge system, the same way it does for the local soul. (It does not gate unrelated demarkus servers the user may have configured.)
+   Check the exit status. On success it records the slug so the publish tag-gate enforces tags on writes to this knowledge system, the same way it does for the local soul. (It does not gate unrelated demarkus servers the user may have configured.) **If the script fails (non-zero exit), surface its error to the user and stop here — do not report that the gate is covering this system, because it is not yet.**
 
 5. **Adopt the system's conventions (`root` hub).** A knowledge system can publish org-wide conventions to its guaranteed `root` hub world. Once the OAuth flow is complete and you are doing real work against this system, fetch them and follow them:
 
    - `mark_fetch mark://root/.well-known/demarkus/template.md` — the required per-world structure (same shape as the local `/project-template.md`). Follow it.
    - `mark_fetch mark://root/.well-known/demarkus/policy.md` — strictness + required tags. Mirror the enforceable knobs to local files so the gate (which cannot reach the broker) can apply them:
 
-     - If it declares a `strictness:` line:
+     - If it declares a `strictness:` line, write:
+
        ```bash
        printf '%s\n' "<warn|block|ask from policy.md>" > ~/.demarkus/plugin-memory.strictness.<slug>
        ```
+
      - If it declares a `require_tags:` line (the tag axes every doc must carry, e.g. `category`), mirror the axes so the gate presence-checks them:
+
        ```bash
        printf '%s\n' "<axes from policy.md, e.g. category>" > ~/.demarkus/plugin-memory.require-tags.<slug>
        ```
+
        Each axis is then satisfied by an `axis:value` tag (e.g. `category:project`).
 
    If either document is `not-found`, the system simply hasn't declared that convention yet — skip silently. See `${CLAUDE_PLUGIN_ROOT}/examples/knowledge-system/` for the format an admin publishes.

--- a/plugins/claude-code/commands/soul-context.md
+++ b/plugins/claude-code/commands/soul-context.md
@@ -12,7 +12,7 @@ Bring the current project's recent memory into the session so the agent and the 
 
 3. **Pull recent journal entries.** List `/<project>/journal/` via `mark_list`. Take today's entry plus the two most recent prior days (UTC `YYYY-MM-DD.md`). For each, `mark_fetch` and read in full. If today's file doesn't exist, just use the most recent two prior days.
 
-4. **Pull active work.** `mark_fetch /<project>/plan/tasks.md` if it exists. Skip silently if `not-found`.
+4. **Pull active work.** `mark_fetch /<project>/roadmap.md` if it exists (what's next / in flight). Skip silently if `not-found`.
 
 5. **Summarize for the user.** Render in this shape, plain text, no preamble:
 
@@ -20,7 +20,7 @@ Bring the current project's recent memory into the session so the agent and the 
    ## <Project> — recent context
 
    ### What's in flight
-   <one or two sentences pulled from tasks.md, or "No active task list">
+   <one or two sentences pulled from roadmap.md, or "No roadmap yet">
 
    ### Recent journal
    - <YYYY-MM-DD>: <one-line summary of that day's entry>

--- a/plugins/claude-code/commands/soul-context.md
+++ b/plugins/claude-code/commands/soul-context.md
@@ -1,5 +1,5 @@
 ---
-description: Restore session context from the current project's soul (recent journal, active tasks)
+description: Restore session context from the current project's soul (recent journal, active work)
 ---
 
 Bring the current project's recent memory into the session so the agent and the user can pick up where they left off. Read-only; does not modify the soul.
@@ -34,6 +34,6 @@ Bring the current project's recent memory into the session so the agent and the 
 
 ## Don't
 
-- Don't fabricate. If a section is empty (no tasks file, no recent journals), say so.
+- Don't fabricate. If a section is empty (no roadmap, no recent journals), say so.
 - Don't pull every doc in the project — this is a session primer, not a dump.
 - Don't write to the soul. This command is read-only.

--- a/plugins/claude-code/commands/soul-doctor.md
+++ b/plugins/claude-code/commands/soul-doctor.md
@@ -1,0 +1,67 @@
+---
+description: Audit the soul (or a project / knowledge-system world) for catalog hygiene — orphans, broken links, untagged docs, stale index entries, ADR gaps. Read-only.
+argument-hint: "[project-slug | mark://<world>/ | blank = whole local soul]"
+---
+
+Run a read-only health check over a demarkus knowledge base and report what's rotting. This **never writes** — it surfaces findings and suggests fixes; the user decides what to act on.
+
+## Scope
+
+Resolve the audit root from `$ARGUMENTS`:
+
+- **blank** → the whole local soul (`/`). Use the `demarkus-memory` MCP tools (`mark_graph` / `mark_list` / `mark_fetch` / `mark_backlinks`) with bare paths.
+- **a project slug** (e.g. `demarkus`) → scope to `/<slug>/`.
+- **a `mark://<world>/` URL** → a knowledge-system world. Use the broker MCP tools (`mcp__<slug>__*`) and `mark://` URLs.
+
+Anchor on the scope's hub: `/index.md`, `/<slug>/index.md`, or `mark://<world>/index.md`.
+
+## Gather (cheap — two calls)
+
+1. **Crawl the link graph.** `mark_graph` on the scope hub with `depth: 5`. Parse:
+   - **Nodes:** `[status] <url> "title" N links` — note any status that isn't `ok` (e.g. `archived`), and `(no title)`.
+   - **Edges:** `<from> -> <to>` — `mark://` targets are internal; `http(s)` targets are external.
+2. **Inventory.** `mark_list` the scope (recurse into subdirectories) for the full set of documents that actually exist.
+
+## Core checks (from the graph + inventory — no per-doc fetching)
+
+- **Broken links** — an edge whose `mark://` target does not exist. The inventory (`mark_list`) is the source of truth for existence — **not** the crawl: a target can be absent from the graph's Nodes simply because it sat beyond the crawl depth, which is *not* a broken link. So flag a target only when it's missing from the inventory, and confirm each suspect with a single `mark_fetch` (`not-found`) before reporting `source → missing-target`.
+- **Orphans** — an inventory document that is never the target of any `mark://` edge (no inbound links) and isn't the scope's root hub. It's unreachable except by knowing its path.
+- **Stale index entries** — broken links whose source is a hub/index doc (an index pointing at something gone).
+- **Missing hub** — a `/<project>/` subtree with documents but no `index.md`.
+- **Untitled docs** — nodes shown as `(no title)` (no H1 / declared title).
+- **ADR sequence** — for each `adr/` directory, list it and flag duplicate or gapped `NNNN` prefixes.
+
+## Deep checks (per-doc `mark_fetch` — run on a small scope, or when asked)
+
+These cost one fetch per document, so only run them for a single project / world or when the user asks for a thorough audit. **If you cap or sample, say so explicitly in the report — don't imply full coverage.**
+
+- **Untagged docs** — fetch and check the `tags` metadata is non-empty. An untagged doc is invisible to `mark_lookup`. (This is what the publish gate now prevents going forward; this finds pre-existing ones.)
+- **Duplicate content** — compare `content-hash` across fetched docs; identical hashes under different paths are duplicates.
+- **Knowledge-system taxonomy** (only for a `mark://<world>/` scope) — fetch `mark://root/.well-known/demarkus/policy.md`. For each required axis in its `require_tags:`, flag docs missing an `axis:value` tag; for documented taxonomy values, flag tags that use an out-of-vocabulary value. (The gate enforces axis *presence* going forward; this audits the advisory *values* and back-catalog.)
+
+## Report
+
+Render plainly, grouped by check, most actionable first. For each finding give the path and a one-line suggested fix. Lead with a one-line summary (`N docs, X findings`). Shape:
+
+```
+## <scope> — hygiene report  (<N> docs)
+
+### Broken links (<n>)
+- /<doc>.md → /<missing-target>.md  (fetch → not-found) — fix the link or restore the target
+
+### Orphans (<n>)
+- /plans/<name>.md — exists but no hub links to it; add it to the relevant index.md
+
+### Untagged (<n>)        [deep check — scanned <k>/<N> docs]
+- /<slug>/bar.md — no tags; re-publish with metadata.tags
+
+### ADR / index / titles / duplicates …
+```
+
+End with a short prioritized "what I'd fix first." If everything is clean, say so plainly.
+
+## Don't
+
+- Don't write to the soul or modify any document. This command is read-only. If the user then asks you to fix something (e.g. "add the orphans to the index"), do that as a separate, explicit step.
+- Don't fabricate. If `mark_graph` returns nothing (empty soul) or the scope hub is `not-found`, say so and stop.
+- Don't fetch every document by default — the core checks don't need it. Only run the deep checks on a bounded scope, and disclose the bound.

--- a/plugins/claude-code/commands/soul-doctor.md
+++ b/plugins/claude-code/commands/soul-doctor.md
@@ -37,7 +37,7 @@ These cost one fetch per document, so only run them for a single project / world
 
 - **Untagged docs** — fetch and check the `tags` metadata is non-empty. An untagged doc is invisible to `mark_lookup`. (This is what the publish gate now prevents going forward; this finds pre-existing ones.)
 - **Duplicate content** — compare `content-hash` across fetched docs; identical hashes under different paths are duplicates.
-- **Knowledge-system taxonomy** (only for a `mark://<world>/` scope) — fetch `mark://root/.well-known/demarkus/policy.md`. For each required axis in its `require_tags:`, flag docs missing an `axis:value` tag; for documented taxonomy values, flag tags that use an out-of-vocabulary value. (The gate enforces axis *presence* going forward; this audits the advisory *values* and back-catalog.)
+- **Knowledge-system taxonomy** (only for a `mark://<world>/` scope) — fetch the policy from **the same knowledge system the audited world belongs to**, via the same broker MCP server you're auditing through: `mark://root/.well-known/demarkus/policy.md` on that server (its `root` hub — not some other system's). If that policy is `not-found`, skip this check; the system hasn't declared a taxonomy. Otherwise, for each required axis in its `require_tags:`, flag docs missing an `axis:value` tag, and for documented taxonomy values flag tags that use an out-of-vocabulary value. (The gate enforces axis *presence* going forward; this audits the advisory *values* and the back-catalog.)
 
 ## Report
 

--- a/plugins/claude-code/context/session-guidance.md
+++ b/plugins/claude-code/context/session-guidance.md
@@ -25,6 +25,8 @@ When something is worth persisting, write it without being prompted:
 - `tags`: comma-separated subjects describing the doc. Derive them from the content. An untagged document is invisible to `mark_lookup`, so this is not optional — it's what makes the write recallable.
 - `importance`: a float 0–1 you choose deliberately. Reserve high values (≥0.8) for genuinely central docs (index hubs, architecture, key decisions); routine notes sit lower. It floats matches in lookup ranking; it never surfaces an unmatched doc, so it's a prior, not an override.
 
+This is **enforced** by a write-time gate, not just guidance: a `mark_publish` with no `metadata.tags` (or an `importance` outside [0,1]) trips the publish gate. By default it warns (a system-reminder asking you to re-publish with tags); stricter setups deny the call until you add them. Either way, set `tags` on the first try — don't make the gate ask twice.
+
 `mark_append` can't carry metadata — tags/importance are fixed at the doc's last `mark_publish`. When an append adds a materially new subject, re-publish the doc with extended `tags` so the catalog stays accurate.
 
 ## Restraint

--- a/plugins/claude-code/context/session-guidance.md
+++ b/plugins/claude-code/context/session-guidance.md
@@ -14,12 +14,15 @@ Before answering "what do I know about / did we decide / have we seen X" — and
 
 ## Record as you go (proactively)
 
-When something is worth persisting, write it without being prompted:
+When something is worth persisting, write it without being prompted. The full per-project layout lives in `/project-template.md` at the soul root (the canonical source); the common routes:
 
 - **Decision** → an ADR at `/<slug>/adr/<NNNN>-<title>.md`
+- **Lesson from a bug / a gotcha** → `/<slug>/debugging.md` (often the highest recall value)
 - **Pattern / convention learned** → `/<slug>/patterns.md`
-- **Significant progress or end of a working session** → append to `/<slug>/journal/<YYYY-MM-DD>.md`
-- **Architecture / roadmap / task changes** → the matching file under `/<slug>/`
+- **Progress / end of a working session** → today's `/<slug>/journal/<YYYY-MM-DD>.md`
+- **Architecture, roadmap, debt, plans, open questions** → the matching file under `/<slug>/` (see the template)
+
+Keep each project's `/<slug>/index.md` hub current — it's the discovery backstop for anything `mark_lookup` can't surface.
 
 **Tag every publish — it's the rule the harness enforces hardest.** On `mark_publish`, set a `metadata` object: `tags` (comma-separated subjects drawn from the content; an untagged doc is invisible to `mark_lookup`) and `importance` (a float 0–1 — reserve ≥0.8 for hubs, architecture, and key decisions; routine notes sit lower). A write-time gate catches a tagless publish (or `importance` outside [0,1]): it warns by default and re-states why at the moment it fires, or denies in stricter setups. So set `tags` on the first try rather than waiting to be told.
 

--- a/plugins/claude-code/context/session-guidance.md
+++ b/plugins/claude-code/context/session-guidance.md
@@ -26,7 +26,7 @@ Keep each project's `/<slug>/index.md` hub current — it's the discovery backst
 
 **Tag every publish — it's the rule the harness enforces hardest.** On `mark_publish`, set a `metadata` object: `tags` (comma-separated subjects drawn from the content; an untagged doc is invisible to `mark_lookup`) and `importance` (a float 0–1 — reserve ≥0.8 for hubs, architecture, and key decisions; routine notes sit lower). A write-time gate catches a tagless publish (or `importance` outside [0,1]): it warns by default and re-states why at the moment it fires, or denies in stricter setups. So set `tags` on the first try rather than waiting to be told.
 
-Two soft checks back you up: that publish gate, and a one-time session-end nudge if you changed files but recorded nothing here. Recalling before you answer and routing to the right file have **no** backstop at all — those are purely on you.
+Soft checks back you up at the moment they matter: the publish gate (tags), a session-end nudge to journal if you changed files but recorded nothing, and a recall nudge when you ask a "did we / what did we decide" question. They're reminders, not substitutes — routing to the right file is still purely on you, and you shouldn't wait to be nudged.
 
 `mark_append` can't carry metadata — tags/importance are fixed at the doc's last `mark_publish`. When an append adds a materially new subject, re-publish the doc with extended `tags` so the catalog stays accurate.
 

--- a/plugins/claude-code/context/session-guidance.md
+++ b/plugins/claude-code/context/session-guidance.md
@@ -21,11 +21,9 @@ When something is worth persisting, write it without being prompted:
 - **Significant progress or end of a working session** → append to `/<slug>/journal/<YYYY-MM-DD>.md`
 - **Architecture / roadmap / task changes** → the matching file under `/<slug>/`
 
-**You tag and rank — the server infers nothing.** On every `mark_publish`, set a `metadata` object:
-- `tags`: comma-separated subjects describing the doc. Derive them from the content. An untagged document is invisible to `mark_lookup`, so this is not optional — it's what makes the write recallable.
-- `importance`: a float 0–1 you choose deliberately. Reserve high values (≥0.8) for genuinely central docs (index hubs, architecture, key decisions); routine notes sit lower. It floats matches in lookup ranking; it never surfaces an unmatched doc, so it's a prior, not an override.
+**Tag every publish — it's the rule the harness enforces hardest.** On `mark_publish`, set a `metadata` object: `tags` (comma-separated subjects drawn from the content; an untagged doc is invisible to `mark_lookup`) and `importance` (a float 0–1 — reserve ≥0.8 for hubs, architecture, and key decisions; routine notes sit lower). A write-time gate catches a tagless publish (or `importance` outside [0,1]): it warns by default and re-states why at the moment it fires, or denies in stricter setups. So set `tags` on the first try rather than waiting to be told.
 
-This is **enforced** by a write-time gate, not just guidance: a `mark_publish` with no `metadata.tags` (or an `importance` outside [0,1]) trips the publish gate. By default it warns (a system-reminder asking you to re-publish with tags); stricter setups deny the call until you add them. Either way, set `tags` on the first try — don't make the gate ask twice.
+Two soft checks back you up: that publish gate, and a one-time session-end nudge if you changed files but recorded nothing here. Recalling before you answer and routing to the right file have **no** backstop at all — those are purely on you.
 
 `mark_append` can't carry metadata — tags/importance are fixed at the doc's last `mark_publish`. When an append adds a materially new subject, re-publish the doc with extended `tags` so the catalog stays accurate.
 

--- a/plugins/claude-code/examples/knowledge-system/README.md
+++ b/plugins/claude-code/examples/knowledge-system/README.md
@@ -1,0 +1,30 @@
+# Knowledge System Conventions
+
+Reference artifacts for an organizational demarkus knowledge system (a broker-fronted universe joined with `/knowledge-join`). These are **not** auto-installed — the plugin can't write to your broker. An admin publishes them to the system's `root` hub; joined agents read and follow them.
+
+## The `root` hub
+
+Every knowledge system has a guaranteed hub world named **`root`** that tracks things globally for the system. Org-wide conventions live there as ordinary versioned documents under a well-known prefix:
+
+```
+mark://root/.well-known/demarkus/policy.md     ← strictness + required tags (see policy.md here)
+mark://root/.well-known/demarkus/template.md   ← required per-world structure (the canonical layout)
+```
+
+`template.md` is the same layout the local soul seeds as `/project-template.md` — publish a copy of that to `root` (tailored as needed). `policy.md` is the example in this directory.
+
+## How a joined agent consumes them
+
+`/knowledge-join` registers the system so the publish tag-gate enforces on its writes (the same tag check as the local soul; tags travel in the tool call, so no broker access is needed for that). For the rest:
+
+1. On first substantive work against a knowledge system, the agent fetches `mark://root/.well-known/demarkus/policy.md` and `template.md` and follows them — structure conventions are advisory by necessity (only the agent, via its MCP OAuth session, can reach the broker; a hook cannot).
+2. The agent mirrors the policy's **enforced core** into local files the gate reads (`<slug>` is the MCP server name `/knowledge-join` registered, shown by `claude mcp list`):
+   ```
+   printf '%s\n' "block"      > ~/.demarkus/plugin-memory.strictness.<slug>     # from strictness:
+   printf '%s\n' "category"   > ~/.demarkus/plugin-memory.require-tags.<slug>   # from require_tags:
+   ```
+   The org declares these once on `root`; each agent mirrors them; the local gate enforces them. `strictness:` sets the severity; `require_tags:` are tag axes the gate presence-checks (each satisfied by an `axis:value` tag, e.g. `category:project`).
+
+## Why this shape
+
+A shared catalog with many writers needs consistency conventions more than a personal soul does, and the org should set the bar centrally rather than each member re-deriving it. Hosting the policy and template on `root` means a single edit propagates to everyone, with no plugin release and no per-user setup — the conventions travel through the same knowledge system they govern.

--- a/plugins/claude-code/examples/knowledge-system/README.md
+++ b/plugins/claude-code/examples/knowledge-system/README.md
@@ -6,7 +6,7 @@ Reference artifacts for an organizational demarkus knowledge system (a broker-fr
 
 Every knowledge system has a guaranteed hub world named **`root`** that tracks things globally for the system. Org-wide conventions live there as ordinary versioned documents under a well-known prefix:
 
-```
+```text
 mark://root/.well-known/demarkus/policy.md     ← strictness + required tags (see policy.md here)
 mark://root/.well-known/demarkus/template.md   ← required per-world structure (the canonical layout)
 ```
@@ -19,10 +19,12 @@ mark://root/.well-known/demarkus/template.md   ← required per-world structure 
 
 1. On first substantive work against a knowledge system, the agent fetches `mark://root/.well-known/demarkus/policy.md` and `template.md` and follows them — structure conventions are advisory by necessity (only the agent, via its MCP OAuth session, can reach the broker; a hook cannot).
 2. The agent mirrors the policy's **enforced core** into local files the gate reads (`<slug>` is the MCP server name `/knowledge-join` registered, shown by `claude mcp list`):
-   ```
+
+   ```bash
    printf '%s\n' "block"      > ~/.demarkus/plugin-memory.strictness.<slug>     # from strictness:
    printf '%s\n' "category"   > ~/.demarkus/plugin-memory.require-tags.<slug>   # from require_tags:
    ```
+
    The org declares these once on `root`; each agent mirrors them; the local gate enforces them. `strictness:` sets the severity; `require_tags:` are tag axes the gate presence-checks (each satisfied by an `axis:value` tag, e.g. `category:project`).
 
 ## Why this shape

--- a/plugins/claude-code/examples/knowledge-system/policy.md
+++ b/plugins/claude-code/examples/knowledge-system/policy.md
@@ -1,0 +1,43 @@
+# Knowledge System Policy
+
+policy_version: 1
+owner: <team / contact, e.g. platform-eng (#knowledge-base)>
+
+strictness: warn
+require_tags: category
+
+The write policy for this demarkus knowledge system. Joined agents (via the demarkus-memory Claude Code plugin's `/knowledge-join`) fetch this from `mark://root/.well-known/demarkus/policy.md` and follow it. Edit it here on `root` to change the policy for everyone — it is versioned like any demarkus document and propagates to each member on their next session.
+
+The two lines above are the **enforced core** — the agent mirrors them into the plugin's local gate (`strictness:` → severity, `require_tags:` → mandatory tag axes). Everything below is **convention** the agent follows; a future hygiene auditor can check it after the fact.
+
+## What to publish here
+
+This is a shared catalog, not a scratch pad. Publish when the content is useful to another team and ready to rely on.
+
+- Keep drafts and personal working notes in your own soul; promote to a world when ready.
+- Never publish secrets, credentials, tokens, or PII.
+- Prefer one well-tagged document over scattered fragments.
+
+## Required metadata on every publish
+
+Enforced by the plugin's publish gate, at the severity set by `strictness:` above:
+
+- `tags` — comma-separated subjects; never empty (an untagged doc is invisible to `mark_lookup`).
+- `importance` — float 0–1, chosen deliberately; reserve ≥0.8 for hubs, architecture, and key decisions.
+
+## Tag taxonomy
+
+Tag as `axis:value` so the catalog stays coherent. The axes named in `require_tags:` are mandatory — the gate checks each is present.
+
+- `category:` — the kind/area of the document, e.g. `category:project`, `category:ops`, `category:reference`, `category:test`. Keep the set small and stable.
+- As the catalog grows and more teams write, add axes (`team:`, `type:`, `status:`) and list them in `require_tags:` above to enforce them too.
+
+## Strictness levels
+
+- `warn` — a tagless / out-of-range / missing-axis publish is allowed but the agent is nudged to fix it.
+- `block` — denied until fixed. Recommended once the catalog has several active writers.
+- `ask` — escalated to the user.
+
+## Structure
+
+Each world follows `template.md` alongside this file — the canonical per-project layout (index hub, `architecture.md`, `patterns.md`, `guidelines.md`, `debugging.md`, `roadmap.md`, `debt.md`, `thoughts.md`, `adr/`, `plans/`, `journal/`).

--- a/plugins/claude-code/hooks/publish-gate.sh
+++ b/plugins/claude-code/hooks/publish-gate.sh
@@ -63,14 +63,14 @@ esac
 
 # Required tag axes (knowledge-system policy, mirrored locally). An axis is
 # satisfied by an "axis:value" token in the tags. Only checked when tags are
-# present (a tagless publish is already a violation below). Axes are simple
-# identifiers; a stray regex metachar in a policy just won't match → reported
-# missing, which is the safe direction.
+# present (a tagless publish is already a violation below). Axis matching is
+# literal (tags_have_axis), so a policy axis containing metacharacters can't
+# overmatch and falsely satisfy the check.
 missing_axes=""
 if [[ "${tags_ok}" == "1" ]]; then
   required_axes="$(configured_require_tags "${strict_slug}")"
   for axis in ${required_axes}; do
-    grep -qE "(^|,)[[:space:]]*${axis}:" <<<"${tags_value}" \
+    tags_have_axis "${tags_value}" "${axis}" \
       || missing_axes="${missing_axes:+${missing_axes} }${axis}"
   done
 fi

--- a/plugins/claude-code/hooks/publish-gate.sh
+++ b/plugins/claude-code/hooks/publish-gate.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Publish tag-gate for the demarkus-memory plugin.
+#
+# Wired in plugin.json on BOTH PreToolUse and PostToolUse for the plugin's own
+# mark_publish tool. One script, two events — it branches on hook_event_name:
+#
+#   STRICTNESS=warn  (default) → PostToolUse injects an additionalContext
+#                                system-reminder after a tagless publish,
+#                                nudging a re-publish with tags. Non-blocking.
+#   STRICTNESS=block           → PreToolUse denies a tagless publish.
+#   STRICTNESS=ask             → PreToolUse escalates to the user.
+#
+# The whole point: an untagged publish is invisible to mark_lookup forever, and
+# the server accepts it silently. This makes that failure loud at write time.
+#
+# Zero runtime dependencies: the payload is parsed with pure awk (see
+# publish_metadata_check in lib.sh) — no jq, no python, nothing that might not
+# be installed. FAIL OPEN: if parsing yields nothing usable the gate defers — it
+# must never block a legitimate publish over a parse hiccup. -e is deliberately
+# NOT set: this is control-flow code and a stray non-zero from a probe must not
+# abort into a misread hook exit code.
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="${HOOK_DIR}/../scripts"
+# shellcheck source=../scripts/lib.sh
+. "${SCRIPTS_DIR}/lib.sh"
+
+input="$(cat)"
+
+# Parse the payload (pure awk; always available). Defensive guard only: if awk
+# itself were somehow missing or errored, defer rather than block.
+parsed="$(printf '%s' "${input}" | publish_metadata_check)" || {
+  warn "publish gate: payload parse failed; deferring"
+  exit 0
+}
+
+event="$(sed -n '1p' <<<"${parsed}")"
+tool="$(sed -n '2p' <<<"${parsed}")"
+tags_ok="$(sed -n '3p' <<<"${parsed}")"
+imp_ok="$(sed -n '4p' <<<"${parsed}")"
+url="$(sed -n '5p' <<<"${parsed}")"
+
+# Defensive scope: the matcher already limits us to mark_publish, but a
+# misconfigured matcher must not let the gate act on unrelated tools.
+case "${tool}" in
+  *mark_publish) ;;
+  *) exit 0 ;;
+esac
+
+# Properly tagged + valid importance → nothing to enforce.
+[[ "${tags_ok}" == "1" && "${imp_ok}" == "1" ]] && exit 0
+
+target="${url:-the document}"
+problems=""
+[[ "${tags_ok}" != "1" ]] && problems="no metadata.tags (it will be invisible to mark_lookup)"
+if [[ "${imp_ok}" != "1" ]]; then
+  [[ -n "${problems}" ]] && problems="${problems}; "
+  problems="${problems}metadata.importance outside [0,1]"
+fi
+reason="demarkus publish to ${target} has ${problems}. Re-issue mark_publish with a metadata object: tags (comma-separated subjects derived from the content) and, if set, importance in [0,1]. Tags are what make this document findable via mark_lookup."
+
+strictness="$(configured_strictness)"
+
+emit_pre() {
+  local decision="$1" why="$2"
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"%s","permissionDecisionReason":%s}}\n' \
+    "${decision}" "$(printf '%s' "${why}" | json_escape)"
+}
+
+emit_post_context() {
+  local ctx="$1"
+  printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":%s}}\n' \
+    "$(printf '%s' "${ctx}" | json_escape)"
+}
+
+case "${event}" in
+  PreToolUse)
+    case "${strictness}" in
+      block) emit_pre "deny" "${reason}" ;;
+      ask)   emit_pre "ask"  "${reason}" ;;
+      *)     exit 0 ;;  # warn is enforced post-call
+    esac
+    ;;
+  PostToolUse)
+    case "${strictness}" in
+      warn) emit_post_context "⚠️ ${reason}" ;;
+      *)    exit 0 ;;  # block/ask already enforced before the call ran
+    esac
+    ;;
+  *)
+    exit 0
+    ;;
+esac

--- a/plugins/claude-code/hooks/publish-gate.sh
+++ b/plugins/claude-code/hooks/publish-gate.sh
@@ -69,10 +69,14 @@ esac
 missing_axes=""
 if [[ "${tags_ok}" == "1" ]]; then
   required_axes="$(configured_require_tags "${strict_slug}")"
+  # Split the space-separated axes with globbing off (an axis must never expand
+  # against the filesystem); tags_have_axis then matches each literally.
+  set -f
   for axis in ${required_axes}; do
     tags_have_axis "${tags_value}" "${axis}" \
       || missing_axes="${missing_axes:+${missing_axes} }${axis}"
   done
+  set +f
 fi
 
 # Properly tagged + valid importance + all required axes present → nothing to do.

--- a/plugins/claude-code/hooks/publish-gate.sh
+++ b/plugins/claude-code/hooks/publish-gate.sh
@@ -41,16 +41,42 @@ tool="$(sed -n '2p' <<<"${parsed}")"
 tags_ok="$(sed -n '3p' <<<"${parsed}")"
 imp_ok="$(sed -n '4p' <<<"${parsed}")"
 url="$(sed -n '5p' <<<"${parsed}")"
+tags_value="$(sed -n '6p' <<<"${parsed}")"
 
-# Defensive scope: the matcher already limits us to mark_publish, but a
-# misconfigured matcher must not let the gate act on unrelated tools.
+# Defensive scope: the matcher is broad (mcp__.*__mark_publish), so a stray
+# non-publish tool must not be acted on.
 case "${tool}" in
   *mark_publish) ;;
   *) exit 0 ;;
 esac
 
-# Properly tagged + valid importance → nothing to enforce.
-[[ "${tags_ok}" == "1" && "${imp_ok}" == "1" ]] && exit 0
+# Server scope: gate only the plugin's own soul and knowledge systems joined via
+# /knowledge-join — never an unrelated demarkus server the user configured. A
+# registered knowledge system carries its own (agent-mirrored) per-slug strictness.
+scope="$(publish_gate_scope "${tool}")"
+strict_slug=""
+case "${scope}" in
+  local) ;;                          # plugin soul → global strictness
+  ks:*)  strict_slug="${scope#ks:}" ;;
+  *)     exit 0 ;;                    # not a server the plugin manages
+esac
+
+# Required tag axes (knowledge-system policy, mirrored locally). An axis is
+# satisfied by an "axis:value" token in the tags. Only checked when tags are
+# present (a tagless publish is already a violation below). Axes are simple
+# identifiers; a stray regex metachar in a policy just won't match → reported
+# missing, which is the safe direction.
+missing_axes=""
+if [[ "${tags_ok}" == "1" ]]; then
+  required_axes="$(configured_require_tags "${strict_slug}")"
+  for axis in ${required_axes}; do
+    grep -qE "(^|,)[[:space:]]*${axis}:" <<<"${tags_value}" \
+      || missing_axes="${missing_axes:+${missing_axes} }${axis}"
+  done
+fi
+
+# Properly tagged + valid importance + all required axes present → nothing to do.
+[[ "${tags_ok}" == "1" && "${imp_ok}" == "1" && -z "${missing_axes}" ]] && exit 0
 
 target="${url:-the document}"
 problems=""
@@ -59,9 +85,13 @@ if [[ "${imp_ok}" != "1" ]]; then
   [[ -n "${problems}" ]] && problems="${problems}; "
   problems="${problems}metadata.importance outside [0,1]"
 fi
+if [[ -n "${missing_axes}" ]]; then
+  [[ -n "${problems}" ]] && problems="${problems}; "
+  problems="${problems}missing required tag axes for this knowledge system: ${missing_axes} (tag as \"axis:value\", e.g. ${missing_axes%% *}:<value>)"
+fi
 reason="demarkus publish to ${target} has ${problems}. Re-issue mark_publish with a metadata object: tags (comma-separated subjects derived from the content) and, if set, importance in [0,1]. Tags are what make this document findable via mark_lookup."
 
-strictness="$(configured_strictness)"
+strictness="$(configured_strictness "${strict_slug}")"
 
 emit_pre() {
   local decision="$1" why="$2"

--- a/plugins/claude-code/hooks/recall-nudge.sh
+++ b/plugins/claude-code/hooks/recall-nudge.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook for the demarkus-memory plugin.
+#
+# When the user's prompt reads like a RECALL question ("did we...", "what did we
+# decide", "last time", "do we have a note on..."), inject a discreet reminder to
+# consult the soul before answering. Recall is the one quality behavior with no
+# other backstop — the publish gate only fires on writes, and the SessionStart
+# "recall first" guidance decays as a session grows. This re-asserts it at the
+# exact moment a recall question is asked.
+#
+# Non-blocking: emits additionalContext, never decision:block — a nudge, not a
+# gate. The pattern is deliberately tight (multi-word, recall-specific) to keep
+# false positives low; a stray nudge costs only one discreet line. Pure grep/tr,
+# no deps. Fails open (no nudge) on anything unexpected. If it proves noisy in
+# practice, tighten the pattern or add a disable knob (deferred until there's
+# signal it's needed).
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="${HOOK_DIR}/../scripts"
+# shellcheck source=../scripts/lib.sh
+. "${SCRIPTS_DIR}/lib.sh"
+
+# No point nudging toward a memory store that isn't configured yet.
+[[ -f "${PLUGIN_CONFIG}" ]] || exit 0
+
+input="$(cat)"
+lc="$(printf '%s' "${input}" | tr '[:upper:]' '[:lower:]')"
+
+# Recall-intent patterns — multi-word and specific so ordinary questions don't
+# trip them. Matched against the lowercased payload; only the `prompt` field
+# carries prose, so the uuid/path/mode fields won't false-match these phrases.
+recall_re='\bdid we\b|\bhave we\b|\bhad we\b|\bwhat did we\b|\bwhy did we\b|\bhow did we\b|\bwhat( is| was|s)? our\b|\bdo we (have|know)\b|\bwe (decided|agreed|chose|discussed|already)\b|\blast time\b|\bpreviously\b|\brecall\b|\bis there (a |an |any )?(adr|decision|note|record)\b'
+
+printf '%s' "${lc}" | grep -qE "${recall_re}" || exit 0
+
+nudge="This reads like a recall question. Before answering from this conversation alone, check the soul first: mark_lookup the project for the subject (and mark_fetch the project /index.md), then answer from what's recorded — or say plainly if nothing is there."
+
+printf '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":%s}}\n' \
+  "$(printf '%s' "${nudge}" | json_escape)"

--- a/plugins/claude-code/hooks/session-journal-nudge.sh
+++ b/plugins/claude-code/hooks/session-journal-nudge.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Stop hook for the demarkus-memory plugin.
+#
+# Journaling a significant session is a quality behavior the gate can't backstop
+# (the publish gate only fires when you DO write). This nudges once, at session
+# end, when the session changed files but recorded nothing to any demarkus
+# memory store — so substantive work isn't silently lost to the next session.
+#
+# Stop hooks can only surface a message by blocking (decision:block forces one
+# more turn); there is no non-blocking context channel. So the nudge blocks
+# exactly once and hands the agent an explicit "if it's routine, just stop" out,
+# honoring the don't-journal-trivia restraint. Two independent loop guards:
+#   1. stop_hook_active == true  → already mid stop-cycle, never re-block.
+#   2. a per-session sentinel file → fire at most once per session_id, even if
+#      the block triggers another Stop after the agent journals.
+#
+# Zero runtime deps (pure awk/bash). Fails open: any missing/unreadable input
+# means no nudge — never wedge the session over a heuristic.
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="${HOOK_DIR}/../scripts"
+# shellcheck source=../scripts/lib.sh
+. "${SCRIPTS_DIR}/lib.sh"
+
+input="$(cat)"
+
+parsed="$(printf '%s' "${input}" | stop_hook_fields)" || exit 0
+sid="$(sed -n '1p' <<<"${parsed}")"
+tpath="$(sed -n '2p' <<<"${parsed}")"
+active="$(sed -n '3p' <<<"${parsed}")"
+
+# Loop guard 1: never block a stop that is itself the product of a prior block.
+[[ "${active}" == "true" ]] && exit 0
+
+# Without a session id we can't dedup safely — don't risk a loop; stay quiet.
+[[ -n "${sid}" ]] || exit 0
+
+# Loop guard 2: at most once per session. Sanitize the id for use in a filename.
+sentinel="${TMPDIR:-/tmp}/demarkus-memory-nudge-${sid//[^A-Za-z0-9_-]/_}"
+[[ -e "${sentinel}" ]] && exit 0
+
+# Need a readable transcript to judge what happened.
+[[ -n "${tpath}" && -r "${tpath}" ]] || exit 0
+
+# Did the session write to a demarkus memory store? Match the structured MCP
+# attribution field and the tool_use call name — both compact-serialized in the
+# transcript JSONL. Prose mentions of "mark_publish" won't match these shapes.
+soul_write=0
+if grep -qE '"attributionMcpTool":"mark_(publish|append)"|"name":"mcp__[^"]*mark_(publish|append)"' "${tpath}"; then
+  soul_write=1
+fi
+
+# Did the session do real work? File mutations are the low-false-positive signal
+# (a pure-chat/research session won't trip this).
+real_work=0
+if grep -qE '"name":"(Edit|Write|NotebookEdit)"' "${tpath}"; then
+  real_work=1
+fi
+
+if (( real_work == 1 && soul_write == 0 )); then
+  # Create the sentinel BEFORE blocking so the follow-up Stop won't re-nudge.
+  : > "${sentinel}" 2>/dev/null || true
+  reason="This session changed files but recorded nothing to the soul. If something here is worth remembering — a decision, a gotcha, a non-obvious why — capture it now with /soul-journal (or mark_append to today's journal under /<project>/journal/<YYYY-MM-DD>.md). If it's all routine, just say so and stop; you won't be nudged again this session."
+  printf '{"decision":"block","reason":%s}\n' "$(printf '%s' "${reason}" | json_escape)"
+  exit 0
+fi
+
+exit 0

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -26,14 +26,13 @@ GUIDANCE_FILE="${HOOK_DIR}/../context/session-guidance.md"
 # shellcheck source=../scripts/lib.sh
 . "${SCRIPTS_DIR}/lib.sh"
 
-seed_index() {
-  local seed_file="${HOOK_DIR}/../seed/index.md"
-  local target="${SOUL_DIR}/index.md"
-  [[ -d "${SOUL_DIR}" && -w "${SOUL_DIR}" ]] || return 0
-  [[ -f "${target}"    ]] && return 0
-  [[ -f "${seed_file}" ]] || return 0
-  cp "${seed_file}" "${target}"
-  log "seeded ${target}"
+# seed_souldocs — drop the bundled seed docs into an empty soul. seed_doc never
+# clobbers, so this is safe to run every session: it fills in only what's
+# missing (a fresh soul, or an existing one that predates a new seed doc).
+seed_souldocs() {
+  local seed_dir="${HOOK_DIR}/../seed"
+  seed_doc "${seed_dir}/index.md"            "${SOUL_DIR}/index.md"
+  seed_doc "${seed_dir}/project-template.md" "${SOUL_DIR}/project-template.md"
 }
 
 # emit_context — print the SessionStart additionalContext JSON to stdout.
@@ -82,7 +81,7 @@ main() {
         ;;
     esac
 
-    seed_index
+    seed_souldocs
 
     # Best-effort health check; never abort the hook over it.
     warning="$(server_health_warning || true)"

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -219,6 +219,58 @@ publish_metadata_check() {
   '
 }
 
+# stop_hook_fields — reads a Claude Code Stop hook payload (a flat JSON object)
+# on stdin and emits exactly three lines:
+#   1: session_id
+#   2: transcript_path
+#   3: stop_hook_active ("true"/"false"; "false" when absent)
+# Same pure-awk, string-boundary-aware approach as publish_metadata_check, but
+# the Stop payload is flat so it only captures top-level (depth 1) keys. No deps.
+stop_hook_fields() {
+  awk '
+    { data = data $0 "\n" }
+    END {
+      n = split(data, ch, "")
+      depth = 0; inStr = 0; esc = 0; buf = ""; curkey = ""
+      sid = ""; tpath = ""; active = "false"
+      for (i = 1; i <= n; i++) {
+        c = ch[i]
+        if (inStr) {
+          if (esc) { buf = buf c; esc = 0; continue }
+          if (c == "\\") { buf = buf c; esc = 1; continue }
+          if (c == "\"") { inStr = 0; onstr(buf); buf = ""; continue }
+          buf = buf c; continue
+        }
+        if (c == "\"") { inStr = 1; buf = ""; continue }
+        if (c == " " || c == "\t" || c == "\n" || c == "\r") continue
+        if (c == "{") { depth++; expect[depth] = "key"; continue }
+        if (c == "[") { depth++; expect[depth] = "val"; continue }
+        if (c == "}" || c == "]") { depth--; continue }
+        if (c == ":") { expect[depth] = "val"; continue }
+        if (c == ",") { expect[depth] = "key"; continue }
+        # scalar value (bool/number/null) — read to the next delimiter.
+        sv = c
+        while (i + 1 <= n) {
+          d = ch[i+1]
+          if (d == "," || d == "}" || d == "]" || d == " " || d == "\t" || d == "\n" || d == "\r") break
+          sv = sv d; i++
+        }
+        if (depth == 1 && curkey == "stop_hook_active") active = sv
+        expect[depth] = "key"
+      }
+      print sid; print tpath; print active
+    }
+    # At depth 1, a string is a key (records curkey) or the value for curkey.
+    function onstr(s) {
+      if (depth == 1 && expect[depth] == "key") { curkey = s; return }
+      if (depth == 1) {
+        if (curkey == "session_id") sid = s
+        else if (curkey == "transcript_path") tpath = s
+      }
+    }
+  '
+}
+
 # server_health_warning — echoes a one-line human warning when the configured
 # memory server does not appear to be up, empty when it looks healthy. Relies
 # on load_config having set SOUL_DIR/PORT/MODE. Best-effort and probe-only (no

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -48,6 +48,21 @@ log()  { echo "[demarkus-memory] $*" >&2; }
 warn() { echo "[demarkus-memory] warning: $*" >&2; }
 die()  { echo "[demarkus-memory] error: $*" >&2; exit 1; }
 
+# seed_doc SEED_FILE TARGET_FILE — copy SEED_FILE to TARGET_FILE if the target
+# is absent and its directory is writable. Best-effort: a no-op (return 0) when
+# the directory isn't writable, the seed is missing, or the target already
+# exists — it never clobbers existing content, so a user's customized doc
+# survives across sessions. Logs only on an actual copy.
+seed_doc() {
+  local seed_file="$1" target="$2"
+  local dir
+  dir="$(dirname "${target}")"
+  [[ -d "${dir}" && -w "${dir}" ]] || return 0
+  [[ -f "${target}" ]] && return 0
+  [[ -f "${seed_file}" ]] || return 0
+  cp "${seed_file}" "${target}" && log "seeded ${target}"
+}
+
 # json_escape — reads stdin and emits it as a single JSON string literal
 # (quotes included). Pure awk so it works without jq on stock macOS/Linux.
 # Escapes backslash, double-quote, and tab; strips CR; turns each input line

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -125,13 +125,71 @@ publish_metadata_check() {
         }
         recordValue(sv)
       }
-      tags_ok = (haveTags && trim(tags) != "") ? "1" : "0"
+      # Decode JSON string escapes BEFORE validating, otherwise {"tags":"\n"}
+      # is stored raw as backslash+n — non-empty — and a whitespace-only value
+      # slips past the emptiness check. The gate is a policy boundary, so the
+      # decoded value is what must be judged.
+      tags_d = json_unescape(tags)
+      imp_d = json_unescape(imp)
+      url_d = json_unescape(url)
+      tags_ok = (haveTags && trim(tags_d) != "") ? "1" : "0"
       if (!haveImp) imp_ok = "1"
-      else if (imp ~ /^-?[0-9]+(\.[0-9]+)?$/) { nimp = imp + 0; imp_ok = (nimp >= 0 && nimp <= 1) ? "1" : "0" }
+      else if (imp_d ~ /^-?[0-9]+(\.[0-9]+)?$/) { nimp = imp_d + 0; imp_ok = (nimp >= 0 && nimp <= 1) ? "1" : "0" }
       else imp_ok = "0"
-      print ev; print tool; print tags_ok; print imp_ok; print url
+      print ev; print tool; print tags_ok; print imp_ok; print url_d
     }
     function trim(s) { gsub(/^[ \t\r\n]+/, "", s); gsub(/[ \t\r\n]+$/, "", s); return s }
+    # json_unescape — decode JSON string escapes (\n \t \r \b \f \/ \" \\ and
+    # \uXXXX) to their actual characters. For \uXXXX, whitespace codepoints
+    # become a space and all other codepoints a non-space marker — enough to
+    # judge emptiness/numeric-ness correctly without full UTF-8 reconstruction.
+    function json_unescape(s,   out, i, n2, c, d, hex, code) {
+      out = ""; n2 = length(s); i = 1
+      while (i <= n2) {
+        c = substr(s, i, 1)
+        if (c == "\\" && i < n2) {
+          d = substr(s, i + 1, 1)
+          if (d == "n") { out = out "\n"; i += 2; continue }
+          if (d == "t") { out = out "\t"; i += 2; continue }
+          if (d == "r") { out = out "\r"; i += 2; continue }
+          if (d == "b") { out = out "\b"; i += 2; continue }
+          if (d == "f") { out = out "\f"; i += 2; continue }
+          if (d == "/") { out = out "/"; i += 2; continue }
+          if (d == "\"") { out = out "\""; i += 2; continue }
+          if (d == "\\") { out = out "\\"; i += 2; continue }
+          if (d == "u" && i + 5 <= n2) {
+            hex = substr(s, i + 2, 4)
+            if (hex ~ /^[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]$/) {
+              code = hexval(hex)
+              out = out (is_ws_code(code) ? " " : "x")
+              i += 6; continue
+            }
+          }
+          # Unknown/invalid escape: drop the backslash, keep the next char.
+          out = out d; i += 2; continue
+        }
+        out = out c; i++
+      }
+      return out
+    }
+    # hexval — parse a hex string to its integer value (no 0x literals; BSD awk).
+    function hexval(h,   v, i, c, dgt) {
+      v = 0
+      for (i = 1; i <= length(h); i++) {
+        c = tolower(substr(h, i, 1))
+        if (c >= "0" && c <= "9") dgt = c + 0
+        else if (c == "a") dgt = 10; else if (c == "b") dgt = 11
+        else if (c == "c") dgt = 12; else if (c == "d") dgt = 13
+        else if (c == "e") dgt = 14; else if (c == "f") dgt = 15
+        else dgt = 0
+        v = v * 16 + dgt
+      }
+      return v
+    }
+    # is_ws_code — true for ASCII + common Unicode whitespace codepoints.
+    function is_ws_code(code) {
+      return (code == 9 || code == 10 || code == 11 || code == 12 || code == 13 || code == 32 || code == 160 || (code >= 8192 && code <= 8202) || code == 8232 || code == 8233 || code == 8239 || code == 8287 || code == 12288)
+    }
     # Object-key path of the current position, e.g. /tool_input/metadata/tags.
     # Array levels contribute "/#" so an array can never alias an object path.
     function curpath(   p, d2) {

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -261,11 +261,15 @@ stop_hook_fields() {
       print sid; print tpath; print active
     }
     # At depth 1, a string is a key (records curkey) or the value for curkey.
+    # stop_hook_active is documented as a JSON boolean (handled on the scalar
+    # path), but accept a quoted "true"/"false" too — a loop guard should not
+    # silently fail on a nonconforming payload.
     function onstr(s) {
       if (depth == 1 && expect[depth] == "key") { curkey = s; return }
       if (depth == 1) {
         if (curkey == "session_id") sid = s
         else if (curkey == "transcript_path") tpath = s
+        else if (curkey == "stop_hook_active") active = s
       }
     }
   '

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -19,9 +19,22 @@ readonly TOKEN_LABEL="claude-code-plugin"
 # Strictness for the publish tag-gate (hooks/publish-gate.sh). One line:
 # warn | block | ask. Kept in its own file, orthogonal to PLUGIN_CONFIG, so
 # setup.sh rewrites of the conf never clobber a chosen strictness. Absent file
-# means the warn default. The knowledge-system courier (#7) will write
-# per-slug siblings (plugin-memory.strictness.<slug>); not used yet.
+# means the warn default. A joined knowledge system can carry its own severity
+# in a per-slug sibling (plugin-memory.strictness.<slug>), which the agent
+# mirrors from the system's published policy (see register-knowledge.sh / #7).
 readonly PLUGIN_STRICTNESS_FILE="${PLUGIN_HOME}/plugin-memory.strictness"
+
+# Registry of joined knowledge-system MCP server slugs (one per line), recorded
+# by /knowledge-join. The publish gate enforces tags on writes to a registered
+# system the same way it does for the local soul, but never on unrelated
+# demarkus servers the user happens to have configured (e.g. a personal soul).
+readonly PLUGIN_KNOWLEDGE_REGISTRY="${PLUGIN_HOME}/knowledge-systems"
+
+# Required tag axes a knowledge system declares in its policy (e.g. team, type).
+# A publish satisfies an axis when its tags include an "axis:value" token. The
+# agent mirrors the policy's require_tags into a per-slug sibling
+# (PLUGIN_REQUIRE_TAGS_FILE.<slug>); the gate then presence-checks each axis.
+readonly PLUGIN_REQUIRE_TAGS_FILE="${PLUGIN_HOME}/plugin-memory.require-tags"
 
 # Soul dirs that setup.sh may choose.
 readonly SHARED_SOUL_DIR="${PLUGIN_HOME}/soul"
@@ -76,18 +89,78 @@ json_escape() {
   '
 }
 
-# configured_strictness — echoes the publish tag-gate strictness: warn|block|ask.
-# Precedence: DEMARKUS_MEMORY_STRICTNESS env override, then PLUGIN_STRICTNESS_FILE,
-# then the warn default. Never dies. Any unrecognized value falls back to warn so
-# a corrupt file or typo can never silently escalate to block.
+# configured_strictness [SLUG] — echoes the publish tag-gate strictness:
+# warn|block|ask. Precedence: DEMARKUS_MEMORY_STRICTNESS env override, then a
+# per-slug file (PLUGIN_STRICTNESS_FILE.<slug>, when SLUG is given — a knowledge
+# system's mirrored policy), then the global PLUGIN_STRICTNESS_FILE, then the
+# warn default. Never dies. Any unrecognized value falls back to warn so a
+# corrupt file or typo can never silently escalate to block.
 configured_strictness() {
+  local slug="${1:-}"
   local s="${DEMARKUS_MEMORY_STRICTNESS:-}"
+  if [[ -z "${s}" && -n "${slug}" && -f "${PLUGIN_STRICTNESS_FILE}.${slug}" ]]; then
+    s="$(tr -d '[:space:]' < "${PLUGIN_STRICTNESS_FILE}.${slug}" 2>/dev/null || true)"
+  fi
   if [[ -z "${s}" && -f "${PLUGIN_STRICTNESS_FILE}" ]]; then
     s="$(tr -d '[:space:]' < "${PLUGIN_STRICTNESS_FILE}" 2>/dev/null || true)"
   fi
   case "${s}" in
     warn|block|ask) echo "${s}" ;;
     *)              echo "warn" ;;
+  esac
+}
+
+# configured_require_tags [SLUG] — echo the required tag axes (space-separated)
+# for this scope: a per-slug PLUGIN_REQUIRE_TAGS_FILE.<slug>, else the global
+# PLUGIN_REQUIRE_TAGS_FILE, else empty. The file may list axes comma- or
+# newline-separated; output is normalized to single spaces. Empty → no axis
+# requirement (the common case; only knowledge systems that declare it have one).
+configured_require_tags() {
+  local slug="${1:-}" raw=""
+  if [[ -n "${slug}" && -f "${PLUGIN_REQUIRE_TAGS_FILE}.${slug}" ]]; then
+    raw="$(cat "${PLUGIN_REQUIRE_TAGS_FILE}.${slug}" 2>/dev/null || true)"
+  elif [[ -f "${PLUGIN_REQUIRE_TAGS_FILE}" ]]; then
+    raw="$(cat "${PLUGIN_REQUIRE_TAGS_FILE}" 2>/dev/null || true)"
+  fi
+  printf '%s' "${raw}" | tr ',\r\n\t' '    ' | tr -s ' ' | sed 's/^ //;s/ $//'
+}
+
+# register_knowledge_system SLUG — append SLUG to the knowledge-system registry
+# if absent. Idempotent. Returns non-zero on empty input.
+register_knowledge_system() {
+  local slug="$1"
+  [[ -n "${slug}" ]] || return 1
+  mkdir -p "${PLUGIN_HOME}"
+  touch "${PLUGIN_KNOWLEDGE_REGISTRY}"
+  grep -qxF "${slug}" "${PLUGIN_KNOWLEDGE_REGISTRY}" 2>/dev/null && return 0
+  printf '%s\n' "${slug}" >> "${PLUGIN_KNOWLEDGE_REGISTRY}"
+}
+
+# is_registered_knowledge_system SLUG — true if SLUG is in the registry.
+is_registered_knowledge_system() {
+  local slug="$1"
+  [[ -n "${slug}" && -f "${PLUGIN_KNOWLEDGE_REGISTRY}" ]] || return 1
+  grep -qxF "${slug}" "${PLUGIN_KNOWLEDGE_REGISTRY}" 2>/dev/null
+}
+
+# publish_gate_scope TOOLNAME — classifies an MCP mark_publish tool by which
+# server it targets, echoing one of:
+#   local         — the plugin's own soul server (gate with global strictness)
+#   ks:<slug>      — a registered knowledge system (gate with per-slug strictness)
+#   (empty)        — a server the plugin does not manage (do not gate)
+# The server is the segment between the leading "mcp__" and the trailing
+# "__mark_publish"; for the local plugin server it contains "demarkus-memory".
+publish_gate_scope() {
+  local tool="$1" server
+  server="${tool#mcp__}"
+  server="${server%__mark_publish}"
+  case "${server}" in
+    *demarkus-memory*) echo "local" ;;
+    *)
+      if is_registered_knowledge_system "${server}"; then
+        echo "ks:${server}"
+      fi
+      ;;
   esac
 }
 
@@ -98,6 +171,8 @@ configured_strictness() {
 #   3: TAGS_OK  — "1" if tool_input.metadata.tags is a non-empty (trimmed) string, else "0"
 #   4: IMP_OK   — "1" if metadata.importance is absent OR a number in [0,1], else "0"
 #   5: url      — tool_input.url (or empty)
+#   6: tags     — the decoded tags string, internal whitespace flattened to one
+#                 line (for axis-presence checks; empty when tagless)
 #
 # Pure awk — NO jq, NO python, nothing outside coreutils. The plugin ships zero
 # runtime dependencies; awk is already the parser behind json_escape. A naive
@@ -156,7 +231,11 @@ publish_metadata_check() {
       if (!haveImp) imp_ok = "1"
       else if (imp_d ~ /^-?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?$/) { nimp = imp_d + 0; imp_ok = (nimp >= 0 && nimp <= 1) ? "1" : "0" }
       else imp_ok = "0"
-      print ev; print tool; print tags_ok; print imp_ok; print url_d
+      # Surface the decoded tags (flattened to one line) so the gate can
+      # presence-check required axes. Only for a genuine JSON-string value.
+      tags_emit = (tagsStr ? tags_d : "")
+      gsub(/[\n\r\t]/, " ", tags_emit)
+      print ev; print tool; print tags_ok; print imp_ok; print url_d; print tags_emit
     }
     function trim(s) { gsub(/^[ \t\r\n]+/, "", s); gsub(/[ \t\r\n]+$/, "", s); return s }
     # json_unescape — decode JSON string escapes (\n \t \r \b \f \/ \" \\ and

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -16,6 +16,13 @@ readonly PLUGIN_CONFIG="${PLUGIN_HOME}/plugin-memory.conf"
 readonly PLUGIN_TOKEN_FILE="${PLUGIN_HOME}/plugin-memory.token"
 readonly TOKEN_LABEL="claude-code-plugin"
 
+# Strictness for the publish tag-gate (hooks/publish-gate.sh). One line:
+# warn | block | ask. Kept in its own file, orthogonal to PLUGIN_CONFIG, so
+# setup.sh rewrites of the conf never clobber a chosen strictness. Absent file
+# means the warn default. The knowledge-system courier (#7) will write
+# per-slug siblings (plugin-memory.strictness.<slug>); not used yet.
+readonly PLUGIN_STRICTNESS_FILE="${PLUGIN_HOME}/plugin-memory.strictness"
+
 # Soul dirs that setup.sh may choose.
 readonly SHARED_SOUL_DIR="${PLUGIN_HOME}/soul"
 readonly ISOLATED_SOUL_DIR="${PLUGIN_HOME}/plugin-soul"
@@ -25,7 +32,7 @@ readonly DEFAULT_PORT=6310             # plugin's first-choice port for its own 
 readonly ISOLATED_PORT_START=16310
 readonly ISOLATED_PORT_END=16509
 
-readonly SERVER_VERSION="0.17.13"
+readonly SERVER_VERSION="0.17.14"
 readonly CLIENT_VERSION="0.12.38"
 # demarkus-token moved from the server archive to its own tools/ release
 # in §6.7.A. Pin separately so a tools-only release can be picked up.
@@ -51,6 +58,100 @@ json_escape() {
     BEGIN { ORS=""; print "\"" }
     { gsub(/\\/, "\\\\"); gsub(/"/, "\\\""); gsub(/\t/, "\\t"); gsub(/\r/, ""); print $0 "\\n" }
     END { print "\"" }
+  '
+}
+
+# configured_strictness — echoes the publish tag-gate strictness: warn|block|ask.
+# Precedence: DEMARKUS_MEMORY_STRICTNESS env override, then PLUGIN_STRICTNESS_FILE,
+# then the warn default. Never dies. Any unrecognized value falls back to warn so
+# a corrupt file or typo can never silently escalate to block.
+configured_strictness() {
+  local s="${DEMARKUS_MEMORY_STRICTNESS:-}"
+  if [[ -z "${s}" && -f "${PLUGIN_STRICTNESS_FILE}" ]]; then
+    s="$(tr -d '[:space:]' < "${PLUGIN_STRICTNESS_FILE}" 2>/dev/null || true)"
+  fi
+  case "${s}" in
+    warn|block|ask) echo "${s}" ;;
+    *)              echo "warn" ;;
+  esac
+}
+
+# publish_metadata_check — reads a Claude Code PreToolUse/PostToolUse hook
+# payload (the full JSON object) on stdin and emits exactly five lines:
+#   1: hook_event_name
+#   2: tool_name
+#   3: TAGS_OK  — "1" if tool_input.metadata.tags is a non-empty (trimmed) string, else "0"
+#   4: IMP_OK   — "1" if metadata.importance is absent OR a number in [0,1], else "0"
+#   5: url      — tool_input.url (or empty)
+#
+# Pure awk — NO jq, NO python, nothing outside coreutils. The plugin ships zero
+# runtime dependencies; awk is already the parser behind json_escape. A naive
+# grep for "tags" would false-match the arbitrary `body` value (which can
+# contain literal "tags": text and braces), so this is a real character-level
+# JSON scan: it tracks string boundaries (honoring backslash escapes, so a
+# quote inside `body` can't end the string early) and the object-key path, and
+# captures only values at the exact paths it cares about. MCP metadata values
+# arrive as strings, so importance is range-checked from its string form;
+# numeric form is handled too. Pure read — mutates nothing.
+publish_metadata_check() {
+  awk '
+    { data = data $0 "\n" }
+    END {
+      n = split(data, ch, "")
+      depth = 0; inStr = 0; esc = 0; buf = ""
+      ev = ""; tool = ""; url = ""
+      tags = ""; haveTags = 0; imp = ""; haveImp = 0
+      for (i = 1; i <= n; i++) {
+        c = ch[i]
+        if (inStr) {
+          if (esc) { buf = buf c; esc = 0; continue }
+          if (c == "\\") { buf = buf c; esc = 1; continue }
+          if (c == "\"") { inStr = 0; handleString(buf); buf = ""; continue }
+          buf = buf c; continue
+        }
+        if (c == "\"") { inStr = 1; buf = ""; continue }
+        if (c == " " || c == "\t" || c == "\n" || c == "\r") continue
+        if (c == "{") { depth++; ctype[depth] = "o"; expect[depth] = "key"; continue }
+        if (c == "[") { depth++; ctype[depth] = "a"; expect[depth] = "val"; continue }
+        if (c == "}" || c == "]") { depth--; continue }
+        if (c == ":") { expect[depth] = "val"; continue }
+        if (c == ",") { expect[depth] = (ctype[depth] == "o") ? "key" : "val"; continue }
+        # scalar value (number/true/false/null) — read to the next delimiter.
+        sv = c
+        while (i + 1 <= n) {
+          d = ch[i+1]
+          if (d == "," || d == "}" || d == "]" || d == " " || d == "\t" || d == "\n" || d == "\r") break
+          sv = sv d; i++
+        }
+        recordValue(sv)
+      }
+      tags_ok = (haveTags && trim(tags) != "") ? "1" : "0"
+      if (!haveImp) imp_ok = "1"
+      else if (imp ~ /^-?[0-9]+(\.[0-9]+)?$/) { nimp = imp + 0; imp_ok = (nimp >= 0 && nimp <= 1) ? "1" : "0" }
+      else imp_ok = "0"
+      print ev; print tool; print tags_ok; print imp_ok; print url
+    }
+    function trim(s) { gsub(/^[ \t\r\n]+/, "", s); gsub(/[ \t\r\n]+$/, "", s); return s }
+    # Object-key path of the current position, e.g. /tool_input/metadata/tags.
+    # Array levels contribute "/#" so an array can never alias an object path.
+    function curpath(   p, d2) {
+      p = ""
+      for (d2 = 1; d2 <= depth; d2++) p = p "/" ((ctype[d2] == "o") ? ckey[d2] : "#")
+      return p
+    }
+    # A completed string is a key (object, expecting a key) or a value.
+    function handleString(s) {
+      if (ctype[depth] == "o" && expect[depth] == "key") { ckey[depth] = s; return }
+      recordValue(s)
+    }
+    function recordValue(v,   p) {
+      p = curpath()
+      if (p == "/hook_event_name") ev = v
+      else if (p == "/tool_name") tool = v
+      else if (p == "/tool_input/url") url = v
+      else if (p == "/tool_input/metadata/tags") { tags = v; haveTags = 1 }
+      else if (p == "/tool_input/metadata/importance") { imp = v; haveImp = 1 }
+    }
   '
 }
 

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -100,7 +100,7 @@ publish_metadata_check() {
       n = split(data, ch, "")
       depth = 0; inStr = 0; esc = 0; buf = ""
       ev = ""; tool = ""; url = ""
-      tags = ""; haveTags = 0; imp = ""; haveImp = 0
+      tags = ""; haveTags = 0; tagsStr = 0; imp = ""; haveImp = 0
       for (i = 1; i <= n; i++) {
         c = ch[i]
         if (inStr) {
@@ -117,13 +117,14 @@ publish_metadata_check() {
         if (c == ":") { expect[depth] = "val"; continue }
         if (c == ",") { expect[depth] = (ctype[depth] == "o") ? "key" : "val"; continue }
         # scalar value (number/true/false/null) — read to the next delimiter.
+        # is_string=0: a non-string scalar must not satisfy the tags check.
         sv = c
         while (i + 1 <= n) {
           d = ch[i+1]
           if (d == "," || d == "}" || d == "]" || d == " " || d == "\t" || d == "\n" || d == "\r") break
           sv = sv d; i++
         }
-        recordValue(sv)
+        recordValue(sv, 0)
       }
       # Decode JSON string escapes BEFORE validating, otherwise {"tags":"\n"}
       # is stored raw as backslash+n — non-empty — and a whitespace-only value
@@ -132,9 +133,13 @@ publish_metadata_check() {
       tags_d = json_unescape(tags)
       imp_d = json_unescape(imp)
       url_d = json_unescape(url)
-      tags_ok = (haveTags && trim(tags_d) != "") ? "1" : "0"
+      # tags must be a JSON STRING (per the field contract) and non-empty after
+      # decode/trim — a bare false/null/0 scalar must not satisfy the gate.
+      tags_ok = (haveTags && tagsStr && trim(tags_d) != "") ? "1" : "0"
+      # importance: absent is fine; otherwise a JSON number in [0,1], including
+      # exponent form (e.g. 1e-1). MCP sends it as a string, raw number handled too.
       if (!haveImp) imp_ok = "1"
-      else if (imp_d ~ /^-?[0-9]+(\.[0-9]+)?$/) { nimp = imp_d + 0; imp_ok = (nimp >= 0 && nimp <= 1) ? "1" : "0" }
+      else if (imp_d ~ /^-?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?$/) { nimp = imp_d + 0; imp_ok = (nimp >= 0 && nimp <= 1) ? "1" : "0" }
       else imp_ok = "0"
       print ev; print tool; print tags_ok; print imp_ok; print url_d
     }
@@ -198,16 +203,17 @@ publish_metadata_check() {
       return p
     }
     # A completed string is a key (object, expecting a key) or a value.
+    # A value here is_string=1 so tags captured from a JSON string is honored.
     function handleString(s) {
       if (ctype[depth] == "o" && expect[depth] == "key") { ckey[depth] = s; return }
-      recordValue(s)
+      recordValue(s, 1)
     }
-    function recordValue(v,   p) {
+    function recordValue(v, is_string,   p) {
       p = curpath()
       if (p == "/hook_event_name") ev = v
       else if (p == "/tool_name") tool = v
       else if (p == "/tool_input/url") url = v
-      else if (p == "/tool_input/metadata/tags") { tags = v; haveTags = 1 }
+      else if (p == "/tool_input/metadata/tags") { tags = v; haveTags = 1; tagsStr = is_string }
       else if (p == "/tool_input/metadata/importance") { imp = v; haveImp = 1 }
     }
   '

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -73,7 +73,14 @@ seed_doc() {
   [[ -d "${dir}" && -w "${dir}" ]] || return 0
   [[ -f "${target}" ]] && return 0
   [[ -f "${seed_file}" ]] || return 0
-  cp "${seed_file}" "${target}" && log "seeded ${target}"
+  # Best-effort: a cp failure is surfaced (never silently swallowed) but does not
+  # propagate a non-zero status to a caller running under `set -e`.
+  if cp "${seed_file}" "${target}" 2>/dev/null; then
+    log "seeded ${target}"
+  else
+    warn "could not seed ${target} (cp failed); continuing"
+  fi
+  return 0
 }
 
 # json_escape — reads stdin and emits it as a single JSON string literal
@@ -123,6 +130,26 @@ configured_require_tags() {
     raw="$(cat "${PLUGIN_REQUIRE_TAGS_FILE}" 2>/dev/null || true)"
   fi
   printf '%s' "${raw}" | tr ',\r\n\t' '    ' | tr -s ' ' | sed 's/^ //;s/ $//'
+}
+
+# tags_have_axis TAGS AXIS — true if the comma-separated TAGS list contains a
+# token of the form "AXIS:value". AXIS is matched as a LITERAL prefix (the case
+# pattern quotes it), so an axis containing regex/glob metacharacters can't
+# overmatch — unlike a `grep -E` interpolation would.
+tags_have_axis() {
+  local tags="$1" axis="$2" tok
+  local oldifs="$IFS"
+  IFS=','
+  for tok in ${tags}; do
+    # trim surrounding whitespace from the token
+    tok="${tok#"${tok%%[![:space:]]*}"}"
+    tok="${tok%"${tok##*[![:space:]]}"}"
+    case "${tok}" in
+      "${axis}:"*) IFS="${oldifs}"; return 0 ;;
+    esac
+  done
+  IFS="${oldifs}"
+  return 1
 }
 
 # register_knowledge_system SLUG — append SLUG to the knowledge-system registry

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -137,19 +137,24 @@ configured_require_tags() {
 # pattern quotes it), so an axis containing regex/glob metacharacters can't
 # overmatch — unlike a `grep -E` interpolation would.
 tags_have_axis() {
-  local tags="$1" axis="$2" tok
-  local oldifs="$IFS"
+  local tags="$1" axis="$2" tok rc=1
+  local oldifs="$IFS" reglob=""
+  # Disable pathname expansion while splitting the unquoted list, so a tag with
+  # glob metacharacters (*, ?, []) can't expand against the filesystem and make
+  # matching nondeterministic. Restore -f only if we were the one to set it.
+  case "$-" in *f*) ;; *) reglob=1; set -f ;; esac
   IFS=','
   for tok in ${tags}; do
     # trim surrounding whitespace from the token
     tok="${tok#"${tok%%[![:space:]]*}"}"
     tok="${tok%"${tok##*[![:space:]]}"}"
     case "${tok}" in
-      "${axis}:"*) IFS="${oldifs}"; return 0 ;;
+      "${axis}:"*) rc=0; break ;;
     esac
   done
   IFS="${oldifs}"
-  return 1
+  [[ -n "${reglob}" ]] && set +f
+  return "${rc}"
 }
 
 # register_knowledge_system SLUG — append SLUG to the knowledge-system registry

--- a/plugins/claude-code/scripts/register-knowledge.sh
+++ b/plugins/claude-code/scripts/register-knowledge.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Record a joined knowledge-system MCP server slug so the publish tag-gate
+# enforces on writes to it (same as the local soul). Idempotent. Invoked by the
+# /knowledge-join command after `claude mcp add` succeeds.
+#
+# Usage: register-knowledge.sh <slug>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+[[ $# -eq 1 && -n "${1:-}" ]] || die "usage: register-knowledge.sh <slug>"
+
+register_knowledge_system "$1"
+log "registered knowledge system '${1}' for publish-gate enforcement"

--- a/plugins/claude-code/seed/index.md
+++ b/plugins/claude-code/seed/index.md
@@ -8,16 +8,9 @@ _No projects yet. Add a link below when the agent creates a project subtree._
 
 ## Per-Project Structure
 
-Each `/<project>/` subtree contains:
+Each `/<project>/` subtree follows the canonical layout defined in **[/project-template.md](/project-template.md)** — the single source of truth. In brief: a maintained `index.md` hub, plus `architecture.md`, `patterns.md`, `guidelines.md`, `debugging.md`, `roadmap.md`, `debt.md`, `thoughts.md`, an `adr/` directory (one ADR per decision), a `plans/` directory, and `journal/<YYYY-MM-DD>.md` dated notes.
 
-- `plan/tasks.md` — active work, priorities, what's in flight
-- `architecture.md` — system design, module boundaries, key decisions
-- `patterns.md` — code patterns, conventions, idioms
-- `roadmap.md` — what's done, what's next, what's deliberately not prioritized
-- `adr/` — Architecture Decision Records, one file per decision (e.g. `0001-auth-model.md`)
-- `journal/` — dated session notes, one file per day (`YYYY-MM-DD.md`), appended as the day progresses
-
-The agent keeps this layout consistent across projects so `/soul`, `/soul-journal`, and the memory skill know where to look.
+The agent keeps this layout consistent across projects so `/soul`, `/soul-journal`, and the memory skill always know where to look. See `/project-template.md` for the full descriptions and conventions.
 
 ## Technical
 

--- a/plugins/claude-code/seed/project-template.md
+++ b/plugins/claude-code/seed/project-template.md
@@ -1,0 +1,29 @@
+# Per-Project Memory Template
+
+The canonical layout for a project's memory, lifted from the structure the demarkus-soul knowledge base evolved in practice. Every project lives under `/<project>/` — the slug is the basename of `CLAUDE_PROJECT_DIR`, lowercased, spaces → hyphens.
+
+**This document is the single source of truth for the layout.** The `soul-memory` skill, the SessionStart guidance, and `/index.md` defer to it — keep the structure here, not duplicated across three places.
+
+## Layout
+
+- `/<project>/index.md` — the project hub. Links to every doc below; the discovery backstop for anything `mark_lookup` can't surface (an untagged doc is invisible to the catalog, but the hub still points at it). Keep it current as you add docs.
+- `/<project>/architecture.md` — system design, module boundaries, key decisions.
+- `/<project>/patterns.md` — code patterns, conventions, idioms used in the project.
+- `/<project>/guidelines.md` — hard rules for code quality; read before writing code.
+- `/<project>/debugging.md` — lessons from bugs and investigations. Often the highest recall value: the non-obvious gotcha you'd otherwise rediscover the hard way.
+- `/<project>/roadmap.md` — what's done, what's next, what's deliberately not prioritized.
+- `/<project>/debt.md` — technical debt and improvement opportunities.
+- `/<project>/thoughts.md` — open questions, reflections, ideas not yet decided.
+- `/<project>/adr/<NNNN>-<slug>.md` — Architecture Decision Records, one per decision, zero-padded 4-digit sequence. Body: `# <NNNN>. <Title>`, then `## Status`, `## Context`, `## Decision`, `## Consequences`.
+- `/<project>/plans/<name>.md` — plan documents. Carry the lifecycle in the text (active / completed / archived) and link them from `index.md`.
+- `/<project>/journal/<YYYY-MM-DD>.md` — dated session notes, one file per day, appended as the day progresses.
+
+## Conventions
+
+- **Tag every doc on publish** (`metadata.tags` + `importance`) — the publish gate enforces it. The per-project `index.md` hub is the backstop for anything left untagged.
+- **No ad-hoc top-level files.** Everything for a project lives under `/<project>/`. If something doesn't fit a file above, put it in `thoughts.md` or ask where it belongs.
+- **Not every project needs every file.** Create a doc when there's something real to put in it. The common core is `index.md`, `journal/`, and whichever of architecture / patterns / decisions the work actually produces.
+
+## Customizing
+
+This file is seeded once and never overwritten. Edit `/project-template.md` to tailor the layout to how you work — the change persists, and the seed won't clobber it on the next session.

--- a/plugins/claude-code/skills/soul-memory/SKILL.md
+++ b/plugins/claude-code/skills/soul-memory/SKILL.md
@@ -28,13 +28,18 @@ Before reading or writing, resolve the project slug:
 
 ## Per-project structure
 
-Each `/<project>/` subtree has a fixed layout:
+The canonical layout lives in **`/project-template.md`** at the soul root (seeded on first session, user-customizable). Fetch it when in doubt — it is the single source of truth. In brief, each `/<project>/` subtree uses:
 
-- `/<project>/plan/tasks.md` — active work, priorities, what's in flight
+- `/<project>/index.md` — the project hub; links to every doc below and anchors discovery
 - `/<project>/architecture.md` — system design, module boundaries, key decisions
 - `/<project>/patterns.md` — code patterns, conventions, idioms
-- `/<project>/roadmap.md` — done, next, not prioritized
+- `/<project>/guidelines.md` — hard rules for code quality; read before writing code
+- `/<project>/debugging.md` — lessons from bugs and investigations
+- `/<project>/roadmap.md` — done, next, deliberately not prioritized
+- `/<project>/debt.md` — technical debt and improvement opportunities
+- `/<project>/thoughts.md` — open questions, reflections, ideas
 - `/<project>/adr/<NNNN>-<slug>.md` — Architecture Decision Records (one per decision, zero-padded 4-digit sequence)
+- `/<project>/plans/<name>.md` — plan documents (lifecycle carried in the text)
 - `/<project>/journal/<YYYY-MM-DD>.md` — dated session notes, one file per day
 
 ## Tool routing
@@ -51,10 +56,14 @@ Write intents — route to the right file for the content type:
 - **Fleeting observation / daily note** → append to today's `/<project>/journal/<YYYY-MM-DD>.md`. If the file does not exist yet, create it with `mark_publish` (`expected_version: 0`) and a header like `# <Project> journal — <YYYY-MM-DD>`, then append on subsequent calls. The `/soul-journal` command handles this automatically.
 - **Architecture decision** → create a new ADR at `/<project>/adr/<NNNN>-<slug>.md` with `mark_publish` (`expected_version: 0`). Pick the next sequence number by listing the `adr/` directory. Standard ADR template: `# <NNNN>. <Title>`, `## Status`, `## Context`, `## Decision`, `## Consequences`.
 - **Pattern / convention learned** → append to `/<project>/patterns.md`. Fetch first if updating an existing section; otherwise `mark_append` with `expected_version` unset.
+- **Hard rule for code quality** → `/<project>/guidelines.md`.
+- **Lesson from a bug / a gotcha** → `/<project>/debugging.md` (high recall value — capture the non-obvious why).
 - **Architecture change** → fetch `/<project>/architecture.md`, update the relevant section, publish with the correct `expected_version`.
-- **Task / todo** → fetch and update `/<project>/plan/tasks.md`.
-- **Roadmap item** → fetch and update `/<project>/roadmap.md`.
-- **Cross-project or global note** → if it does not fit a project, ask the user where it belongs. Do not create ad-hoc top-level files.
+- **What's next / done / not prioritized** → `/<project>/roadmap.md`.
+- **Technical debt** → `/<project>/debt.md`.
+- **Plan document** → `/<project>/plans/<name>.md` (carry active / completed / archived in the text).
+- **Open question / idea, not yet decided** → `/<project>/thoughts.md`.
+- **Cross-project or global note** → if it does not fit a project, ask the user where it belongs. Do not create ad-hoc top-level files (the soul root holds only `/index.md` and `/project-template.md`).
 
 **On every `mark_publish`, set `metadata`:** `tags` (comma-separated subjects — the primary match target for `mark_lookup`) and, sparingly, `importance` (0–1, default 0.5; reserve high values for genuinely central docs like index hubs and architecture). An untagged document can only be found by words in its title, so tagging on write is what makes later recall work. The server does not infer either field — you choose them. Reserved keys are rejected; any other metadata key is stored opaquely and reachable through lookup's `filter` axis.
 
@@ -64,11 +73,12 @@ Always reference what you saved by full path so the user can find it again.
 
 ## Creating a new project
 
-When the user wants to start memory for a project that does not exist in `/index.md` yet:
+When the user wants to start memory for a project that does not exist in `/index.md` yet (fetch `/project-template.md` first if you need the full layout):
 
 1. Confirm the slug (basename of `CLAUDE_PROJECT_DIR`, lowercased, spaces → hyphens)
-2. Create the first relevant file (e.g. today's journal entry, or `architecture.md` stub) with `mark_publish` `expected_version: 0`
-3. Fetch `/index.md`, add a bullet `- [<Project Name>](/<slug>/)` under the project list, and publish with the correct `expected_version`
+2. Create the project hub `/<slug>/index.md` with `mark_publish` `expected_version: 0` — a short page that will link to the project's docs as they appear. Don't pre-create empty stubs for every template file; add docs when there's something real to put in them.
+3. Create the first content doc (today's journal entry, or an `architecture.md` stub) and link it from `/<slug>/index.md`.
+4. Fetch `/index.md`, add a bullet `- [<Project Name>](/<slug>/)` under the project list, and publish with the correct `expected_version`
 
 ## Don't
 

--- a/plugins/claude-code/tests/knowledge-gate_test.sh
+++ b/plugins/claude-code/tests/knowledge-gate_test.sh
@@ -165,6 +165,22 @@ test_require_tags_warn_nudges_post() {
     || { echo "nudge should name the missing axis 'team': ${out}"; return 1; }
 }
 
+test_require_tags_axis_matched_literally() {
+  # An axis containing a regex metachar ('a.c') must be matched LITERALLY — a
+  # token 'abc:x' must NOT satisfy it (a grep -E interpolation would overmatch).
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  printf 'a.c\n' > "${home}/.demarkus/plugin-memory.require-tags.acme"
+  local deny tagged
+  deny="$(gate "${home}" block "$(payload 'mcp__acme__mark_publish' '{"tags":"abc:x"}')")"
+  tagged="$(gate "${home}" block "$(payload 'mcp__acme__mark_publish' '{"tags":"a.c:yes"}')")"
+  rm -rf "${home}"
+  grep -q '"permissionDecision":"deny"' <<<"${deny}" \
+    || { echo "axis 'a.c' must not be satisfied by 'abc:x' (literal match): ${deny}"; return 1; }
+  [[ -z "${tagged}" ]] \
+    || { echo "axis 'a.c' satisfied by literal 'a.c:yes' should defer: ${tagged}"; return 1; }
+}
+
 test_require_tags_isolation() {
   # acme requires team; beta requires nothing — a bare-tagged beta publish defers.
   local home; home="$(mktemp -d)"

--- a/plugins/claude-code/tests/knowledge-gate_test.sh
+++ b/plugins/claude-code/tests/knowledge-gate_test.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Shell-level tests for knowledge-system scoping of the publish gate (#7):
+# register-knowledge.sh, the registry, server scoping in publish-gate.sh, and
+# per-slug strictness. Each case runs with an isolated HOME so the registry and
+# strictness files (~/.demarkus/...) never touch the real environment.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+PLUGIN_DIR="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+GATE="${PLUGIN_DIR}/hooks/publish-gate.sh"
+REGISTER="${PLUGIN_DIR}/scripts/register-knowledge.sh"
+
+[[ -x "${GATE}" && -x "${REGISTER}" ]] || { echo "gate or register script not executable"; exit 2; }
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+run_test() {
+  local name="$1" out rc
+  out=$( "test_${name}" 2>&1 )
+  rc=$?
+  if (( rc == 0 )); then echo "PASS  ${name}"; PASS=$((PASS + 1))
+  else echo "FAIL  ${name}"; printf '%s\n' "${out}" | sed 's/^/      /'; FAIL=$((FAIL + 1)); FAILED_NAMES+=("${name}"); fi
+}
+
+# payload TOOL META — tagless if META=="none", else META is the metadata object.
+payload() {
+  local tool="$1" meta="$2"
+  if [[ "${meta}" == "none" ]]; then
+    printf '{"hook_event_name":"PreToolUse","tool_name":"%s","tool_input":{"url":"/x.md"}}' "${tool}"
+  else
+    printf '{"hook_event_name":"PreToolUse","tool_name":"%s","tool_input":{"url":"/x.md","metadata":%s}}' "${tool}" "${meta}"
+  fi
+}
+
+# gate HOME [ENV_STRICTNESS] PAYLOAD — run the gate with an isolated HOME. When
+# ENV_STRICTNESS is "-", no env override is set (so file-based strictness wins).
+gate() {
+  local home="$1" envs="$2" pl="$3"
+  if [[ "${envs}" == "-" ]]; then
+    printf '%s' "${pl}" | HOME="${home}" bash "${GATE}"
+  else
+    printf '%s' "${pl}" | HOME="${home}" DEMARKUS_MEMORY_STRICTNESS="${envs}" bash "${GATE}"
+  fi
+}
+
+# ----- tests ------------------------------------------------------------
+
+test_register_writes_registry() {
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  local ok=1
+  grep -qxF acme "${home}/.demarkus/knowledge-systems" 2>/dev/null || ok=0
+  # idempotent: a second register adds no duplicate line.
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  [[ "$(grep -cxF acme "${home}/.demarkus/knowledge-systems")" == "1" ]] || ok=0
+  rm -rf "${home}"
+  (( ok == 1 )) || { echo "register-knowledge.sh should write one acme line"; return 1; }
+}
+
+test_local_server_still_gated() {
+  local home; home="$(mktemp -d)"
+  local out; out="$(gate "${home}" block "$(payload 'mcp__plugin_demarkus-memory_demarkus-memory__mark_publish' none)")"
+  rm -rf "${home}"
+  grep -q '"permissionDecision":"deny"' <<<"${out}" \
+    || { echo "local soul publish must still be gated: ${out}"; return 1; }
+}
+
+test_foreign_server_not_gated() {
+  # A demarkus server the plugin doesn't manage (e.g. a personal soul) must be
+  # left alone, even tagless in block mode.
+  local home; home="$(mktemp -d)"
+  local out; out="$(gate "${home}" block "$(payload 'mcp__demarkus-soul__mark_publish' none)")"
+  rm -rf "${home}"
+  [[ -z "${out}" ]] || { echo "unmanaged server must not be gated; got: ${out}"; return 1; }
+}
+
+test_unregistered_ks_not_gated() {
+  # Same shape as a knowledge system but not registered → not ours → ignore.
+  local home; home="$(mktemp -d)"
+  local out; out="$(gate "${home}" block "$(payload 'mcp__acme__mark_publish' none)")"
+  rm -rf "${home}"
+  [[ -z "${out}" ]] || { echo "unregistered server must not be gated; got: ${out}"; return 1; }
+}
+
+test_registered_ks_gated() {
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  local out; out="$(gate "${home}" block "$(payload 'mcp__acme__mark_publish' none)")"
+  rm -rf "${home}"
+  grep -q '"permissionDecision":"deny"' <<<"${out}" \
+    || { echo "registered knowledge system publish should be gated: ${out}"; return 1; }
+}
+
+test_registered_ks_per_slug_strictness() {
+  # No env override, no global strictness file — only a per-slug file set to
+  # block. The gate must read the per-slug level for this system.
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  printf 'block\n' > "${home}/.demarkus/plugin-memory.strictness.acme"
+  local out; out="$(gate "${home}" - "$(payload 'mcp__acme__mark_publish' none)")"
+  rm -rf "${home}"
+  grep -q '"permissionDecision":"deny"' <<<"${out}" \
+    || { echo "per-slug strictness=block should deny tagless KS publish: ${out}"; return 1; }
+}
+
+test_registered_ks_per_slug_isolation() {
+  # A per-slug block for 'acme' must NOT affect a different registered system
+  # 'beta' (which falls back to the warn default → PostToolUse, not a pre-deny).
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  HOME="${home}" bash "${REGISTER}" beta 2>/dev/null
+  printf 'block\n' > "${home}/.demarkus/plugin-memory.strictness.acme"
+  local out; out="$(gate "${home}" - "$(payload 'mcp__beta__mark_publish' none)")"
+  rm -rf "${home}"
+  # beta defers in PreToolUse under warn (the nudge is on PostToolUse).
+  [[ -z "${out}" ]] || { echo "beta must not inherit acme's block; got: ${out}"; return 1; }
+}
+
+test_registered_ks_tagged_defers() {
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  local out; out="$(gate "${home}" block "$(payload 'mcp__acme__mark_publish' '{"tags":"team,decision"}')")"
+  rm -rf "${home}"
+  [[ -z "${out}" ]] || { echo "properly tagged KS publish should defer; got: ${out}"; return 1; }
+}
+
+# require_tags: an axis is satisfied by an "axis:value" token in the tags.
+
+test_require_tags_satisfied_defers() {
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  printf 'team, type\n' > "${home}/.demarkus/plugin-memory.require-tags.acme"
+  local out; out="$(gate "${home}" block "$(payload 'mcp__acme__mark_publish' '{"tags":"team:payments, type:decision"}')")"
+  rm -rf "${home}"
+  [[ -z "${out}" ]] || { echo "all required axes present should defer; got: ${out}"; return 1; }
+}
+
+test_require_tags_missing_axis_denied() {
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  printf 'team, type\n' > "${home}/.demarkus/plugin-memory.require-tags.acme"
+  # Has tags and a team axis, but no type axis → violation.
+  local out; out="$(gate "${home}" block "$(payload 'mcp__acme__mark_publish' '{"tags":"team:payments, design"}')")"
+  rm -rf "${home}"
+  grep -q '"permissionDecision":"deny"' <<<"${out}" \
+    || { echo "missing required axis should deny: ${out}"; return 1; }
+  grep -q 'type' <<<"${out}" \
+    || { echo "reason should name the missing axis 'type': ${out}"; return 1; }
+}
+
+test_require_tags_warn_nudges_post() {
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  printf 'team\n' > "${home}/.demarkus/plugin-memory.require-tags.acme"
+  # warn (no env): PostToolUse should nudge about the missing axis.
+  local pl; pl="$(printf '{"hook_event_name":"PostToolUse","tool_name":"mcp__acme__mark_publish","tool_input":{"url":"/d.md","metadata":{"tags":"random"}}}')"
+  local out; out="$(gate "${home}" - "${pl}")"
+  rm -rf "${home}"
+  grep -q '"additionalContext"' <<<"${out}" \
+    || { echo "warn should nudge on missing axis: ${out}"; return 1; }
+  grep -q 'team' <<<"${out}" \
+    || { echo "nudge should name the missing axis 'team': ${out}"; return 1; }
+}
+
+test_require_tags_isolation() {
+  # acme requires team; beta requires nothing — a bare-tagged beta publish defers.
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  HOME="${home}" bash "${REGISTER}" beta 2>/dev/null
+  printf 'team\n' > "${home}/.demarkus/plugin-memory.require-tags.acme"
+  local out; out="$(gate "${home}" block "$(payload 'mcp__beta__mark_publish' '{"tags":"anything"}')")"
+  rm -rf "${home}"
+  [[ -z "${out}" ]] || { echo "beta has no required axes; should defer; got: ${out}"; return 1; }
+}
+
+test_require_tags_not_applied_to_local() {
+  # A global require-tags file must not gate the local soul unless intended;
+  # here only a per-slug file exists, so the local soul is unaffected.
+  local home; home="$(mktemp -d)"; mkdir -p "${home}/.demarkus"
+  printf 'team\n' > "${home}/.demarkus/plugin-memory.require-tags.acme"
+  local out; out="$(gate "${home}" block "$(payload 'mcp__plugin_demarkus-memory_demarkus-memory__mark_publish' '{"tags":"notes"}')")"
+  rm -rf "${home}"
+  [[ -z "${out}" ]] || { echo "local soul must not inherit a per-slug require-tags; got: ${out}"; return 1; }
+}
+
+# ----- runner -----------------------------------------------------------
+
+TESTS=$(declare -F | awk '$3 ~ /^test_/ { print $3 }')
+
+echo "=== knowledge-gate shell tests ==="
+for t in ${TESTS}; do run_test "${t#test_}"; done
+
+echo
+echo "${PASS} passed, ${FAIL} failed"
+if (( FAIL > 0 )); then
+  echo "failing tests:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - ${n}"; done
+  exit 1
+fi

--- a/plugins/claude-code/tests/knowledge-gate_test.sh
+++ b/plugins/claude-code/tests/knowledge-gate_test.sh
@@ -181,6 +181,23 @@ test_require_tags_axis_matched_literally() {
     || { echo "axis 'a.c' satisfied by literal 'a.c:yes' should defer: ${tagged}"; return 1; }
 }
 
+test_require_tags_no_glob_expansion() {
+  # A tag value with a glob metacharacter must NOT expand against the filesystem.
+  # Run from a cwd that contains a decoy file named like a satisfying token; a
+  # tag of '*' must still be treated literally → category axis missing → deny.
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  printf 'category\n' > "${home}/.demarkus/plugin-memory.require-tags.acme"
+  local work; work="$(mktemp -d)"
+  : > "${work}/category:leak"   # would match 'category:'* if '*' globbed here
+  local pl; pl="$(payload 'mcp__acme__mark_publish' '{"tags":"*"}')"
+  local out
+  out="$(cd "${work}" && printf '%s' "${pl}" | HOME="${home}" DEMARKUS_MEMORY_STRICTNESS=block bash "${GATE}")"
+  rm -rf "${home}" "${work}"
+  grep -q '"permissionDecision":"deny"' <<<"${out}" \
+    || { echo "glob tag '*' must not expand to satisfy the axis; expected deny: ${out}"; return 1; }
+}
+
 test_require_tags_isolation() {
   # acme requires team; beta requires nothing — a bare-tagged beta publish defers.
   local home; home="$(mktemp -d)"

--- a/plugins/claude-code/tests/publish-gate_test.sh
+++ b/plugins/claude-code/tests/publish-gate_test.sh
@@ -130,6 +130,44 @@ test_empty_tags_string_treated_as_tagless() {
     || { echo "whitespace-only tags should be tagless → deny: ${out}"; return 1; }
 }
 
+test_escaped_whitespace_tags_treated_as_tagless() {
+  # The escape-decode bypass: raw JSON \n / \t / \r decode to whitespace and
+  # must be judged tagless, not the literal backslash sequences. Each must deny.
+  local out esc
+  for esc in '\n' '\t' '\r' '\n\t' '\r\n'; do
+    out=$(run_gate block "$(payload PreToolUse "${PUB_TOOL}" "{\"tags\":\"${esc}\"}")")
+    grep -q '"permissionDecision":"deny"' <<<"${out}" \
+      || { echo "escaped-whitespace tags '${esc}' should be tagless → deny: ${out}"; return 1; }
+  done
+}
+
+test_unicode_escape_whitespace_tags_treated_as_tagless() {
+  # \u escapes for space (0020), tab (0009), and ideographic space (3000)
+  # decode to whitespace → tagless → deny. Build the "\uXXXX" from a literal
+  # backslash var so the sequence survives verbatim into the JSON payload.
+  local out esc bs='\'
+  for esc in "${bs}u0020" "${bs}u0009" "${bs}u3000"; do
+    out=$(run_gate block "$(payload PreToolUse "${PUB_TOOL}" "{\"tags\":\"${esc}\"}")")
+    grep -q '"permissionDecision":"deny"' <<<"${out}" \
+      || { echo "unicode-whitespace tags '${esc}' should be tagless → deny: ${out}"; return 1; }
+  done
+}
+
+test_unicode_escape_real_char_tags_pass() {
+  # a = 'a' — a real non-whitespace char → not tagless → defer.
+  local out bs='\'
+  out=$(run_gate block "$(payload PreToolUse "${PUB_TOOL}" "{\"tags\":\"${bs}u0061\"}")")
+  [[ -z "${out}" ]] || { echo "unicode non-whitespace tag should defer; got: ${out}"; return 1; }
+}
+
+test_escaped_tags_with_real_content_pass() {
+  # A tag value carrying a real escape but real content (newline between two
+  # subjects) is NOT tagless — must defer.
+  local out
+  out=$(run_gate block "$(payload PreToolUse "${PUB_TOOL}" '{"tags":"alpha\nbeta"}')")
+  [[ -z "${out}" ]] || { echo "tags with escape + real content should defer; got: ${out}"; return 1; }
+}
+
 test_importance_out_of_range_flagged() {
   local out
   out=$(run_gate warn "$(payload PostToolUse "${PUB_TOOL}" '{"tags":"journal","importance":"1.5"}')")

--- a/plugins/claude-code/tests/publish-gate_test.sh
+++ b/plugins/claude-code/tests/publish-gate_test.sh
@@ -168,6 +168,32 @@ test_escaped_tags_with_real_content_pass() {
   [[ -z "${out}" ]] || { echo "tags with escape + real content should defer; got: ${out}"; return 1; }
 }
 
+test_nonstring_tags_treated_as_tagless() {
+  # tags must be a JSON string. A bare false/null/0/number scalar must NOT
+  # satisfy the gate — block must deny each.
+  local out v
+  for v in 'false' 'null' '0' '42'; do
+    out=$(run_gate block "$(payload PreToolUse "${PUB_TOOL}" "{\"tags\":${v}}")")
+    grep -q '"permissionDecision":"deny"' <<<"${out}" \
+      || { echo "non-string tags '${v}' should be tagless → deny: ${out}"; return 1; }
+  done
+}
+
+test_exponent_importance_in_range_ok() {
+  # 1e-1 == 0.1, a valid in-range number — must not be flagged (defer).
+  local out
+  out=$(run_gate warn "$(payload PostToolUse "${PUB_TOOL}" '{"tags":"x","importance":"1e-1"}')")
+  [[ -z "${out}" ]] || { echo "exponent importance 1e-1 (=0.1) should defer; got: ${out}"; return 1; }
+}
+
+test_exponent_importance_out_of_range_flagged() {
+  # 1e1 == 10, out of [0,1] — must be flagged.
+  local out
+  out=$(run_gate warn "$(payload PostToolUse "${PUB_TOOL}" '{"tags":"x","importance":"1e1"}')")
+  grep -q 'importance' <<<"${out}" \
+    || { echo "exponent importance 1e1 (=10) should be flagged: ${out}"; return 1; }
+}
+
 test_importance_out_of_range_flagged() {
   local out
   out=$(run_gate warn "$(payload PostToolUse "${PUB_TOOL}" '{"tags":"journal","importance":"1.5"}')")

--- a/plugins/claude-code/tests/publish-gate_test.sh
+++ b/plugins/claude-code/tests/publish-gate_test.sh
@@ -179,6 +179,18 @@ test_nonstring_tags_treated_as_tagless() {
   done
 }
 
+test_array_or_object_tags_treated_as_tagless() {
+  # Common mistake: passing an array of tags or an object instead of a
+  # comma-separated string. Arrays/objects are valid JSON but fail the
+  # string-type requirement — block must deny.
+  local out v
+  for v in '["a","b"]' '{}' '{"x":"y"}'; do
+    out=$(run_gate block "$(payload PreToolUse "${PUB_TOOL}" "{\"tags\":${v}}")")
+    grep -q '"permissionDecision":"deny"' <<<"${out}" \
+      || { echo "array/object tags '${v}' should be tagless → deny: ${out}"; return 1; }
+  done
+}
+
 test_exponent_importance_in_range_ok() {
   # 1e-1 == 0.1, a valid in-range number — must not be flagged (defer).
   local out

--- a/plugins/claude-code/tests/publish-gate_test.sh
+++ b/plugins/claude-code/tests/publish-gate_test.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Shell-level tests for hooks/publish-gate.sh.
+#
+# Each test_* function returns 0 on pass and non-zero on fail. The runner at
+# the bottom executes every test_* in lexical order, prints PASS/FAIL, and
+# exits non-zero if any failed.
+#
+# The gate is a pure stdin→stdout filter: it reads a Claude Code hook payload
+# on stdin and prints the decision JSON (or nothing, to defer) on stdout. We
+# drive it with synthetic payloads and assert on stdout. Strictness is forced
+# per-case via DEMARKUS_MEMORY_STRICTNESS so the tests never touch
+# ~/.demarkus/plugin-memory.strictness.
+#
+# The gate parses payloads with pure awk — no jq, no python, no external deps —
+# so there is nothing to install and nothing to skip.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+PLUGIN_DIR="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+GATE="${PLUGIN_DIR}/hooks/publish-gate.sh"
+
+[[ -x "${GATE}" ]] || { echo "publish-gate.sh not executable at ${GATE}"; exit 2; }
+
+PUB_TOOL="mcp__plugin_demarkus-memory_demarkus-memory__mark_publish"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+# run_gate STRICTNESS PAYLOAD — pipes PAYLOAD to the gate with the given
+# strictness and echoes the gate's stdout.
+run_gate() {
+  local strictness="$1" payload="$2"
+  printf '%s' "${payload}" | DEMARKUS_MEMORY_STRICTNESS="${strictness}" bash "${GATE}"
+}
+
+
+run_test() {
+  local name="$1"
+  local out rc
+  out=$( "test_${name}" 2>&1 )
+  rc=$?
+  if (( rc == 0 )); then
+    echo "PASS  ${name}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  ${name}"
+    printf '%s\n' "${out}" | sed 's/^/      /'
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("${name}")
+  fi
+}
+
+# ----- helpers ----------------------------------------------------------
+
+# payload EVENT TOOL META_JSON — builds a hook payload. META_JSON is the inner
+# value of tool_input.metadata (e.g. '{"tags":"a,b"}'), or the literal word
+# "none" to omit metadata entirely.
+payload() {
+  local event="$1" tool="$2" meta="$3"
+  if [[ "${meta}" == "none" ]]; then
+    printf '{"hook_event_name":"%s","tool_name":"%s","tool_input":{"url":"/proj/journal/2026-06-01.md"}}' \
+      "${event}" "${tool}"
+  else
+    printf '{"hook_event_name":"%s","tool_name":"%s","tool_input":{"url":"/proj/journal/2026-06-01.md","metadata":%s}}' \
+      "${event}" "${tool}" "${meta}"
+  fi
+}
+
+# ----- test functions ---------------------------------------------------
+
+test_tagged_publish_warn_pre_defers() {
+  local out
+  out=$(run_gate warn "$(payload PreToolUse "${PUB_TOOL}" '{"tags":"journal,proj"}')")
+  [[ -z "${out}" ]] || { echo "expected empty (defer); got: ${out}"; return 1; }
+}
+
+test_tagged_publish_warn_post_defers() {
+  local out
+  out=$(run_gate warn "$(payload PostToolUse "${PUB_TOOL}" '{"tags":"journal,proj"}')")
+  [[ -z "${out}" ]] || { echo "expected empty (defer); got: ${out}"; return 1; }
+}
+
+test_tagless_publish_warn_pre_defers() {
+  # In warn mode the PreToolUse half always defers — the nudge is post-call.
+  local out
+  out=$(run_gate warn "$(payload PreToolUse "${PUB_TOOL}" 'none')")
+  [[ -z "${out}" ]] || { echo "expected empty (defer); got: ${out}"; return 1; }
+}
+
+test_tagless_publish_warn_post_injects_context() {
+  local out
+  out=$(run_gate warn "$(payload PostToolUse "${PUB_TOOL}" 'none')")
+  grep -q '"additionalContext"' <<<"${out}" \
+    || { echo "missing additionalContext: ${out}"; return 1; }
+  grep -q 'metadata.tags' <<<"${out}" \
+    || { echo "reason should mention metadata.tags: ${out}"; return 1; }
+  # warn must NOT carry a permissionDecision — it is non-blocking.
+  grep -q 'permissionDecision' <<<"${out}" \
+    && { echo "warn must not emit permissionDecision: ${out}"; return 1; }
+  return 0
+}
+
+test_tagless_publish_block_pre_denies() {
+  local out
+  out=$(run_gate block "$(payload PreToolUse "${PUB_TOOL}" 'none')")
+  grep -q '"permissionDecision":"deny"' <<<"${out}" \
+    || { echo "expected deny: ${out}"; return 1; }
+}
+
+test_tagless_publish_block_post_is_noop() {
+  # In block mode the tagless publish never runs, so the post half must defer.
+  local out
+  out=$(run_gate block "$(payload PostToolUse "${PUB_TOOL}" 'none')")
+  [[ -z "${out}" ]] || { echo "expected empty (post no-op in block mode); got: ${out}"; return 1; }
+}
+
+test_tagless_publish_ask_pre_escalates() {
+  local out
+  out=$(run_gate ask "$(payload PreToolUse "${PUB_TOOL}" 'none')")
+  grep -q '"permissionDecision":"ask"' <<<"${out}" \
+    || { echo "expected ask: ${out}"; return 1; }
+}
+
+test_empty_tags_string_treated_as_tagless() {
+  local out
+  out=$(run_gate block "$(payload PreToolUse "${PUB_TOOL}" '{"tags":"   "}')")
+  grep -q '"permissionDecision":"deny"' <<<"${out}" \
+    || { echo "whitespace-only tags should be tagless → deny: ${out}"; return 1; }
+}
+
+test_importance_out_of_range_flagged() {
+  local out
+  out=$(run_gate warn "$(payload PostToolUse "${PUB_TOOL}" '{"tags":"journal","importance":"1.5"}')")
+  grep -q 'importance' <<<"${out}" \
+    || { echo "out-of-range importance should be flagged even with tags present: ${out}"; return 1; }
+}
+
+test_importance_string_in_range_ok() {
+  # Tags present + importance a valid stringified float → fully valid → defer.
+  local out
+  out=$(run_gate warn "$(payload PostToolUse "${PUB_TOOL}" '{"tags":"journal","importance":"0.4"}')")
+  [[ -z "${out}" ]] || { echo "valid importance should defer; got: ${out}"; return 1; }
+}
+
+test_append_tool_is_ignored() {
+  # A non-publish tool must never be gated, even with no metadata.
+  local out append_tool="mcp__plugin_demarkus-memory_demarkus-memory__mark_append"
+  out=$(run_gate block "$(payload PreToolUse "${append_tool}" 'none')")
+  [[ -z "${out}" ]] || { echo "append must be ignored; got: ${out}"; return 1; }
+}
+
+test_decoy_body_does_not_false_match() {
+  # The killer case for any non-real-parser: a `body` value that literally
+  # contains "tags":"DECOY", escaped quotes, and stray braces must NOT be read
+  # as the real metadata. Real metadata.tags is present → block must defer.
+  local p out
+  p='{"hook_event_name":"PreToolUse","tool_name":"'"${PUB_TOOL}"'","tool_input":{"url":"/p/a.md","body":"prose with \"tags\":\"DECOY\" and { braces } inside","metadata":{"tags":"real,subjects"}}}'
+  out=$(run_gate block "${p}")
+  [[ -z "${out}" ]] || { echo "decoy body false-matched; tagged publish should defer: ${out}"; return 1; }
+}
+
+test_decoy_body_tagless_still_caught() {
+  # Same decoy text, but NO real metadata — block must still deny (the decoy
+  # inside body must not be mistaken for real tags).
+  local p out
+  p='{"hook_event_name":"PreToolUse","tool_name":"'"${PUB_TOOL}"'","tool_input":{"url":"/p/a.md","body":"prose with \"tags\":\"DECOY\" inside"}}'
+  out=$(run_gate block "${p}")
+  grep -q '"permissionDecision":"deny"' <<<"${out}" \
+    || { echo "decoy tags in body must not satisfy the gate; expected deny: ${out}"; return 1; }
+}
+
+test_unknown_strictness_falls_back_to_warn() {
+  # A bogus strictness must not block — it degrades to warn (no pre-deny).
+  local out
+  out=$(run_gate bogus "$(payload PreToolUse "${PUB_TOOL}" 'none')")
+  [[ -z "${out}" ]] || { echo "unknown strictness must not deny (defer to warn); got: ${out}"; return 1; }
+  # ...and the post half should warn.
+  out=$(run_gate bogus "$(payload PostToolUse "${PUB_TOOL}" 'none')")
+  grep -q '"additionalContext"' <<<"${out}" \
+    || { echo "unknown strictness post should warn: ${out}"; return 1; }
+}
+
+# ----- runner -----------------------------------------------------------
+
+TESTS=$(declare -F | awk '$3 ~ /^test_/ { print $3 }')
+
+echo "=== publish-gate shell tests ==="
+for t in ${TESTS}; do
+  run_test "${t#test_}"
+done
+
+echo
+echo "${PASS} passed, ${FAIL} failed"
+if (( FAIL > 0 )); then
+  echo "failing tests:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - ${n}"; done
+  exit 1
+fi

--- a/plugins/claude-code/tests/recall-nudge_test.sh
+++ b/plugins/claude-code/tests/recall-nudge_test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Shell-level tests for hooks/recall-nudge.sh (the UserPromptSubmit hook).
+#
+# The hook reads a UserPromptSubmit payload and, when the prompt reads like a
+# recall question, emits a non-blocking additionalContext nudge. It is gated on
+# the plugin being configured (PLUGIN_CONFIG present), so each case runs with an
+# isolated HOME. Pure grep/tr — no deps.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+PLUGIN_DIR="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+HOOK="${PLUGIN_DIR}/hooks/recall-nudge.sh"
+
+[[ -x "${HOOK}" ]] || { echo "recall-nudge.sh not executable at ${HOOK}"; exit 2; }
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+run_test() {
+  local name="$1" out rc
+  out=$( "test_${name}" 2>&1 )
+  rc=$?
+  if (( rc == 0 )); then echo "PASS  ${name}"; PASS=$((PASS + 1))
+  else echo "FAIL  ${name}"; printf '%s\n' "${out}" | sed 's/^/      /'; FAIL=$((FAIL + 1)); FAILED_NAMES+=("${name}"); fi
+}
+
+# mkhome — temp HOME with a plugin config so the hook's gate passes.
+mkhome() {
+  local h; h="$(mktemp -d)"
+  mkdir -p "${h}/.demarkus"
+  printf 'SOUL_DIR=%s/.demarkus/soul\nPORT=6310\nMODE=default\n' "${h}" > "${h}/.demarkus/plugin-memory.conf"
+  printf '%s' "${h}"
+}
+
+# fire HOME PROMPT — run the hook with the given prompt (no quotes/newlines in
+# PROMPT for these tests) and echo stdout.
+fire() {
+  local home="$1" prompt="$2"
+  printf '{"session_id":"s","cwd":"/x","hook_event_name":"UserPromptSubmit","prompt":"%s"}' "${prompt}" \
+    | HOME="${home}" bash "${HOOK}"
+}
+
+# ----- tests ------------------------------------------------------------
+
+test_recall_phrase_nudges() {
+  local h; h="$(mkhome)"
+  local out; out="$(fire "${h}" "did we decide on the auth model")"
+  rm -rf "${h}"
+  grep -q '"additionalContext"' <<<"${out}" \
+    || { echo "recall phrase should nudge: ${out}"; return 1; }
+  grep -q 'mark_lookup' <<<"${out}" \
+    || { echo "nudge should mention mark_lookup: ${out}"; return 1; }
+  # Must be a non-blocking nudge — no decision/permissionDecision field.
+  grep -q 'permissionDecision\|"decision"' <<<"${out}" \
+    && { echo "recall nudge must be non-blocking (no decision): ${out}"; return 1; }
+  return 0
+}
+
+test_various_recall_phrases_nudge() {
+  local h; h="$(mkhome)"
+  local p out rc=0
+  for p in \
+    "what did we decide here" \
+    "have we shipped the broker yet" \
+    "what is our policy on tags" \
+    "do we have a note on the gateway" \
+    "last time we tried this it broke" \
+    "is there an adr for the storage format" \
+    "we already discussed the slug heuristic"; do
+    out="$(fire "${h}" "${p}")"
+    grep -q '"additionalContext"' <<<"${out}" || { echo "no nudge for: '${p}' → ${out}"; rc=1; }
+  done
+  rm -rf "${h}"
+  return "${rc}"
+}
+
+test_case_insensitive() {
+  local h; h="$(mkhome)"
+  local out; out="$(fire "${h}" "What Did We Decide About Caching")"
+  rm -rf "${h}"
+  grep -q '"additionalContext"' <<<"${out}" \
+    || { echo "should match case-insensitively: ${out}"; return 1; }
+}
+
+test_plain_prompt_no_nudge() {
+  local h; h="$(mkhome)"
+  local p out rc=0
+  for p in \
+    "write a function to sort a list" \
+    "refactor the parser to be faster" \
+    "explain how quic handshakes work" \
+    "add a test for the gate"; do
+    out="$(fire "${h}" "${p}")"
+    [[ -z "${out}" ]] || { echo "ordinary prompt should not nudge: '${p}' → ${out}"; rc=1; }
+  done
+  rm -rf "${h}"
+  return "${rc}"
+}
+
+test_no_config_no_nudge() {
+  # No plugin config → memory isn't set up → stay silent even for a recall phrase.
+  local h; h="$(mktemp -d)"
+  local out; out="$(fire "${h}" "did we decide on the auth model")"
+  rm -rf "${h}"
+  [[ -z "${out}" ]] || { echo "must not nudge when unconfigured; got: ${out}"; return 1; }
+}
+
+# ----- runner -----------------------------------------------------------
+
+TESTS=$(declare -F | awk '$3 ~ /^test_/ { print $3 }')
+
+echo "=== recall-nudge shell tests ==="
+for t in ${TESTS}; do run_test "${t#test_}"; done
+
+echo
+echo "${PASS} passed, ${FAIL} failed"
+if (( FAIL > 0 )); then
+  echo "failing tests:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - ${n}"; done
+  exit 1
+fi

--- a/plugins/claude-code/tests/seed_doc_test.sh
+++ b/plugins/claude-code/tests/seed_doc_test.sh
@@ -32,8 +32,12 @@ test_seeds_when_absent() {
   [[ ! -f "${tmp}/soul/index.md" ]] || { echo "should not seed into a missing dir"; rm -rf "${tmp}"; return 1; }
   mkdir -p "${tmp}/soul"
   seed_doc "${tmp}/seed.md" "${tmp}/soul/index.md" 2>/dev/null
+  # ...and now that the dir exists, the seed lands with the right content.
+  local ok=1
+  [[ -f "${tmp}/soul/index.md" ]] || { echo "should seed once the target dir exists"; ok=0; }
+  grep -q 'SEED BODY' "${tmp}/soul/index.md" 2>/dev/null || { echo "seeded content mismatch"; ok=0; }
   rm -rf "${tmp}"
-  return 0
+  (( ok == 1 ))
 }
 
 test_seeds_into_writable_dir() {

--- a/plugins/claude-code/tests/seed_doc_test.sh
+++ b/plugins/claude-code/tests/seed_doc_test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Shell-level tests for seed_doc() in scripts/lib.sh.
+#
+# seed_doc copies a bundled seed file into the soul only when the target is
+# absent — it must never clobber a user's customized doc. Each case uses an
+# isolated temp dir. Pure bash, no deps.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+PLUGIN_DIR="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+# shellcheck source=../scripts/lib.sh
+. "${PLUGIN_DIR}/scripts/lib.sh"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+run_test() {
+  local name="$1" out rc
+  out=$( "test_${name}" 2>&1 )
+  rc=$?
+  if (( rc == 0 )); then echo "PASS  ${name}"; PASS=$((PASS + 1))
+  else echo "FAIL  ${name}"; printf '%s\n' "${out}" | sed 's/^/      /'; FAIL=$((FAIL + 1)); FAILED_NAMES+=("${name}"); fi
+}
+
+test_seeds_when_absent() {
+  local tmp; tmp="$(mktemp -d)"
+  printf 'SEED BODY\n' > "${tmp}/seed.md"
+  seed_doc "${tmp}/seed.md" "${tmp}/soul/index.md" 2>/dev/null
+  # soul dir doesn't exist yet → seed_doc is a no-op (dir not present).
+  [[ ! -f "${tmp}/soul/index.md" ]] || { echo "should not seed into a missing dir"; rm -rf "${tmp}"; return 1; }
+  mkdir -p "${tmp}/soul"
+  seed_doc "${tmp}/seed.md" "${tmp}/soul/index.md" 2>/dev/null
+  rm -rf "${tmp}"
+  return 0
+}
+
+test_seeds_into_writable_dir() {
+  local tmp; tmp="$(mktemp -d)"
+  printf 'SEED BODY\n' > "${tmp}/seed.md"
+  mkdir -p "${tmp}/soul"
+  seed_doc "${tmp}/seed.md" "${tmp}/soul/template.md" 2>/dev/null
+  local ok=0
+  [[ -f "${tmp}/soul/template.md" ]] && grep -q 'SEED BODY' "${tmp}/soul/template.md" && ok=1
+  rm -rf "${tmp}"
+  (( ok == 1 )) || { echo "seed_doc should have copied the seed into the writable soul dir"; return 1; }
+}
+
+test_does_not_clobber_existing() {
+  local tmp; tmp="$(mktemp -d)"
+  printf 'SEED BODY\n' > "${tmp}/seed.md"
+  mkdir -p "${tmp}/soul"
+  printf 'USER CUSTOMIZED\n' > "${tmp}/soul/template.md"
+  seed_doc "${tmp}/seed.md" "${tmp}/soul/template.md" 2>/dev/null
+  local keptuser=0
+  grep -q 'USER CUSTOMIZED' "${tmp}/soul/template.md" && ! grep -q 'SEED BODY' "${tmp}/soul/template.md" && keptuser=1
+  rm -rf "${tmp}"
+  (( keptuser == 1 )) || { echo "seed_doc must not clobber an existing (user-customized) doc"; return 1; }
+}
+
+test_noop_when_seed_missing() {
+  local tmp; tmp="$(mktemp -d)"
+  mkdir -p "${tmp}/soul"
+  seed_doc "${tmp}/nope.md" "${tmp}/soul/template.md" 2>/dev/null
+  local absent=0
+  [[ ! -f "${tmp}/soul/template.md" ]] && absent=1
+  rm -rf "${tmp}"
+  (( absent == 1 )) || { echo "seed_doc should be a no-op when the seed file is missing"; return 1; }
+}
+
+test_bundled_seeds_exist() {
+  # The two docs session-start seeds must actually ship in the plugin.
+  [[ -f "${PLUGIN_DIR}/seed/index.md" ]] || { echo "seed/index.md missing"; return 1; }
+  [[ -f "${PLUGIN_DIR}/seed/project-template.md" ]] || { echo "seed/project-template.md missing"; return 1; }
+}
+
+TESTS=$(declare -F | awk '$3 ~ /^test_/ { print $3 }')
+
+echo "=== seed_doc shell tests ==="
+for t in ${TESTS}; do run_test "${t#test_}"; done
+
+echo
+echo "${PASS} passed, ${FAIL} failed"
+if (( FAIL > 0 )); then
+  echo "failing tests:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - ${n}"; done
+  exit 1
+fi

--- a/plugins/claude-code/tests/session-journal-nudge_test.sh
+++ b/plugins/claude-code/tests/session-journal-nudge_test.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Shell-level tests for hooks/session-journal-nudge.sh (the Stop hook).
+#
+# The hook is a stdin→stdout filter: it reads a Stop payload, inspects the
+# referenced transcript, and either emits a {"decision":"block",...} nudge or
+# nothing (allow stop). We build synthetic transcript JSONL fixtures + Stop
+# payloads and assert on stdout. Each case runs with its own TMPDIR so the
+# once-per-session sentinel files never collide. Pure awk/bash — no deps.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+PLUGIN_DIR="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+HOOK="${PLUGIN_DIR}/hooks/session-journal-nudge.sh"
+
+[[ -x "${HOOK}" ]] || { echo "session-journal-nudge.sh not executable at ${HOOK}"; exit 2; }
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+# Transcript fixture fragments (compact JSONL, as Claude Code serializes them).
+EDIT_LINE='{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/x"}}]}}'
+WRITE_LINE='{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{}}]}}'
+READ_LINE='{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{}}]}}'
+PUBLISH_NAME_LINE='{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__demarkus-memory__mark_publish","input":{}}]}}'
+APPEND_NAME_LINE='{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__demarkus-soul__mark_append","input":{}}]}}'
+PUBLISH_ATTR_LINE='{"type":"user","attributionMcpServer":"demarkus-memory","attributionMcpTool":"mark_publish","toolUseResult":{}}'
+PROSE_DECOY_LINE='{"type":"assistant","message":{"content":[{"type":"text","text":"I should call mark_publish and use name Edit somewhere"}]}}'
+
+run_test() {
+  local name="$1" out rc
+  out=$( "test_${name}" 2>&1 )
+  rc=$?
+  if (( rc == 0 )); then echo "PASS  ${name}"; PASS=$((PASS + 1))
+  else echo "FAIL  ${name}"; printf '%s\n' "${out}" | sed 's/^/      /'; FAIL=$((FAIL + 1)); FAILED_NAMES+=("${name}"); fi
+}
+
+# run_nudge TMP SID ACTIVE TRANSCRIPT_FILE — invoke the hook with an isolated
+# TMPDIR (for the sentinel), a session id, the stop_hook_active flag, and a
+# transcript path. Echoes the hook's stdout.
+run_nudge() {
+  local tmp="$1" sid="$2" active="$3" tfile="$4"
+  local payload
+  payload="$(printf '{"session_id":"%s","transcript_path":"%s","cwd":"/x","hook_event_name":"Stop","stop_hook_active":%s}' \
+    "${sid}" "${tfile}" "${active}")"
+  printf '%s' "${payload}" | TMPDIR="${tmp}" bash "${HOOK}"
+}
+
+# mk_transcript TMP LINE... — write the given JSONL lines to a transcript file
+# in TMP and echo its path.
+mk_transcript() {
+  local tmp="$1"; shift
+  local f="${tmp}/transcript.jsonl"
+  : > "${f}"
+  local line
+  for line in "$@"; do printf '%s\n' "${line}" >> "${f}"; done
+  printf '%s' "${f}"
+}
+
+# ----- tests ------------------------------------------------------------
+
+test_files_changed_no_soul_write_blocks() {
+  local tmp; tmp="$(mktemp -d)"
+  local t; t="$(mk_transcript "${tmp}" "${EDIT_LINE}" "${READ_LINE}")"
+  local out; out="$(run_nudge "${tmp}" "S1" "false" "${t}")"
+  rm -rf "${tmp}"
+  grep -q '"decision":"block"' <<<"${out}" \
+    || { echo "expected block nudge; got: ${out}"; return 1; }
+  grep -q 'soul-journal' <<<"${out}" \
+    || { echo "reason should point at /soul-journal: ${out}"; return 1; }
+}
+
+test_soul_write_via_attribution_no_block() {
+  local tmp; tmp="$(mktemp -d)"
+  local t; t="$(mk_transcript "${tmp}" "${EDIT_LINE}" "${PUBLISH_ATTR_LINE}")"
+  local out; out="$(run_nudge "${tmp}" "S2" "false" "${t}")"
+  rm -rf "${tmp}"
+  [[ -z "${out}" ]] || { echo "soul write (attribution) present → no nudge; got: ${out}"; return 1; }
+}
+
+test_soul_write_via_toolname_no_block() {
+  local tmp; tmp="$(mktemp -d)"
+  local t; t="$(mk_transcript "${tmp}" "${EDIT_LINE}" "${PUBLISH_NAME_LINE}")"
+  local out; out="$(run_nudge "${tmp}" "S3" "false" "${t}")"
+  rm -rf "${tmp}"
+  [[ -z "${out}" ]] || { echo "soul write (tool name) present → no nudge; got: ${out}"; return 1; }
+}
+
+test_soul_append_no_block() {
+  local tmp; tmp="$(mktemp -d)"
+  local t; t="$(mk_transcript "${tmp}" "${WRITE_LINE}" "${APPEND_NAME_LINE}")"
+  local out; out="$(run_nudge "${tmp}" "S4" "false" "${t}")"
+  rm -rf "${tmp}"
+  [[ -z "${out}" ]] || { echo "mark_append counts as soul write → no nudge; got: ${out}"; return 1; }
+}
+
+test_no_file_changes_no_block() {
+  local tmp; tmp="$(mktemp -d)"
+  local t; t="$(mk_transcript "${tmp}" "${READ_LINE}")"
+  local out; out="$(run_nudge "${tmp}" "S5" "false" "${t}")"
+  rm -rf "${tmp}"
+  [[ -z "${out}" ]] || { echo "no file mutations → no nudge; got: ${out}"; return 1; }
+}
+
+test_prose_decoy_does_not_count_as_soul_write() {
+  # A text block that says "mark_publish" must NOT be read as a real write, so a
+  # file-changing session with only a prose mention still nudges.
+  local tmp; tmp="$(mktemp -d)"
+  local t; t="$(mk_transcript "${tmp}" "${EDIT_LINE}" "${PROSE_DECOY_LINE}")"
+  local out; out="$(run_nudge "${tmp}" "S6" "false" "${t}")"
+  rm -rf "${tmp}"
+  grep -q '"decision":"block"' <<<"${out}" \
+    || { echo "prose mention of mark_publish must not suppress the nudge: ${out}"; return 1; }
+}
+
+test_stop_hook_active_suppresses() {
+  local tmp; tmp="$(mktemp -d)"
+  local t; t="$(mk_transcript "${tmp}" "${EDIT_LINE}")"
+  local out; out="$(run_nudge "${tmp}" "S7" "true" "${t}")"
+  rm -rf "${tmp}"
+  [[ -z "${out}" ]] || { echo "stop_hook_active=true must suppress the nudge; got: ${out}"; return 1; }
+}
+
+test_once_per_session() {
+  local tmp; tmp="$(mktemp -d)"
+  local t; t="$(mk_transcript "${tmp}" "${EDIT_LINE}")"
+  local first second
+  first="$(run_nudge "${tmp}" "S8" "false" "${t}")"
+  second="$(run_nudge "${tmp}" "S8" "false" "${t}")"   # same TMPDIR + sid → sentinel set
+  rm -rf "${tmp}"
+  grep -q '"decision":"block"' <<<"${first}" \
+    || { echo "first call should nudge: ${first}"; return 1; }
+  [[ -z "${second}" ]] || { echo "second call same session must be silent (sentinel); got: ${second}"; return 1; }
+}
+
+test_missing_session_id_no_block() {
+  local tmp; tmp="$(mktemp -d)"
+  local t; t="$(mk_transcript "${tmp}" "${EDIT_LINE}")"
+  local out; out="$(run_nudge "${tmp}" "" "false" "${t}")"
+  rm -rf "${tmp}"
+  [[ -z "${out}" ]] || { echo "missing session_id → no nudge; got: ${out}"; return 1; }
+}
+
+test_unreadable_transcript_no_block() {
+  local tmp; tmp="$(mktemp -d)"
+  local out; out="$(run_nudge "${tmp}" "S9" "false" "${tmp}/does-not-exist.jsonl")"
+  rm -rf "${tmp}"
+  [[ -z "${out}" ]] || { echo "missing transcript → no nudge; got: ${out}"; return 1; }
+}
+
+# ----- runner -----------------------------------------------------------
+
+TESTS=$(declare -F | awk '$3 ~ /^test_/ { print $3 }')
+
+echo "=== session-journal-nudge shell tests ==="
+for t in ${TESTS}; do
+  run_test "${t#test_}"
+done
+
+echo
+echo "${PASS} passed, ${FAIL} failed"
+if (( FAIL > 0 )); then
+  echo "failing tests:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - ${n}"; done
+  exit 1
+fi

--- a/plugins/claude-code/tests/session-journal-nudge_test.sh
+++ b/plugins/claude-code/tests/session-journal-nudge_test.sh
@@ -128,7 +128,7 @@ test_quoted_stop_hook_active_suppresses() {
   local tmp; tmp="$(mktemp -d)"
   local t; t="$(mk_transcript "${tmp}" "${EDIT_LINE}")"
   local payload out
-  payload="$(printf '{"session_id":"S7q","transcript_path":"%s","stop_hook_active":"true"}' "${t}")"
+  payload="$(printf '{"session_id":"S7q","transcript_path":"%s","cwd":"/x","hook_event_name":"Stop","stop_hook_active":"true"}' "${t}")"
   out="$(printf '%s' "${payload}" | TMPDIR="${tmp}" bash "${HOOK}")"
   rm -rf "${tmp}"
   [[ -z "${out}" ]] || { echo "quoted stop_hook_active=\"true\" must suppress; got: ${out}"; return 1; }

--- a/plugins/claude-code/tests/session-journal-nudge_test.sh
+++ b/plugins/claude-code/tests/session-journal-nudge_test.sh
@@ -122,6 +122,18 @@ test_stop_hook_active_suppresses() {
   [[ -z "${out}" ]] || { echo "stop_hook_active=true must suppress the nudge; got: ${out}"; return 1; }
 }
 
+test_quoted_stop_hook_active_suppresses() {
+  # Defensive: a nonconforming payload with stop_hook_active as a quoted string
+  # "true" must still be honored as a loop guard.
+  local tmp; tmp="$(mktemp -d)"
+  local t; t="$(mk_transcript "${tmp}" "${EDIT_LINE}")"
+  local payload out
+  payload="$(printf '{"session_id":"S7q","transcript_path":"%s","stop_hook_active":"true"}' "${t}")"
+  out="$(printf '%s' "${payload}" | TMPDIR="${tmp}" bash "${HOOK}")"
+  rm -rf "${tmp}"
+  [[ -z "${out}" ]] || { echo "quoted stop_hook_active=\"true\" must suppress; got: ${out}"; return 1; }
+}
+
 test_once_per_session() {
   local tmp; tmp="$(mktemp -d)"
   local t; t="$(mk_transcript "${tmp}" "${EDIT_LINE}")"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced publish gate that validates tags/importance and wraps publish flows
  * One-time session journal nudge when substantial work has no memory write
  * Recall reminder prompting to check recorded memory before answering
  * Project-template seeding on session start; knowledge-system registration helper
  * Read-only soul hygiene audit command

* **Documentation**
  * Clarified publish metadata guidance, canonical per-project layout, and CLI/command guides; CLAUDE doc rewritten

* **Tests**
  * Comprehensive tests for publish gate, knowledge gating, recall nudge, session nudge, and seeding

* **Chores**
  * Plugin version bumped
<!-- end of auto-generated comment: release notes by coderabbit.ai -->