### PR TITLE
docs: add conventions preflight step and knowledge-system README updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,9 @@ From the demarkus-soul MCP server:
 1. `mark_fetch /index.md` — the hub
 2. `mark_fetch /patterns.md` — build commands, code style, workflow
 3. `mark_fetch /guidelines.md` — hard code-quality rules; read before writing code
-4. Fetch as needed: `/architecture.md`, `/debugging.md`, `/roadmap.md`
-5. If the MCP server is unavailable, stop and ask before proceeding.
+4. `mark_fetch /conventions.md` — collaboration + repo/plugin conventions (how I work)
+5. Fetch as needed: `/architecture.md`, `/debugging.md`, `/roadmap.md`
+6. If the MCP server is unavailable, stop and ask before proceeding.
 
 ## demarkus-soul layout (flat — one project)
 
@@ -35,6 +36,7 @@ From the demarkus-soul MCP server:
 /architecture.md  — system design, module boundaries, key decisions
 /patterns.md      — code patterns, build commands, conventions, workflow
 /guidelines.md    — hard code-quality rules
+/conventions.md   — collaboration + repo/plugin conventions (how I work)
 /debugging.md     — lessons from bugs and investigations
 /roadmap.md       — what's done, what's next
 /thoughts.md      — reflections and ideas

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 **A protocol for agents and humans, optimized for information**
 
-Demarkus implements the Mark Protocol — versioned markdown served over QUIC. No rendering pipeline, no tracking, no central authority. Read and write with capability tokens. Every change is traceable. Lightweight and installable anywhere.
+Demarkus implements the Mark Protocol: versioned markdown served over QUIC. No rendering pipeline, no tracking, no central authority. Read and write with capability tokens. Every change is traceable. Lightweight and installable anywhere.
 
-Run a single personal server, or compose many into an organizational **knowledge system** — a broker-fronted universe of servers behind one HTTPS endpoint with single sign-on. Humans and agents share the same versioned memory.
+Run a single personal server, or compose many into an organizational **knowledge system**: a broker-fronted universe of servers behind one HTTPS endpoint with single sign-on. Humans and agents share the same versioned memory.
 
 ## Install
 
 ```bash
-# macOS / Linux — server + client
+# macOS / Linux: server + client
 curl -fsSL https://raw.githubusercontent.com/latebit-io/demarkus/main/install.sh | bash
 
 # Client only (CLI, TUI, MCP)
@@ -72,23 +72,23 @@ modified: 2026-01-15T10:30:00Z
 
 ## Use Cases
 
-**Agent Memory** — Run a server as persistent memory across agent sessions. The Demarkus project itself uses this pattern at `mark://soul.demarkus.io` for architecture notes, debugging lessons, and journal entries. Hit the ground running with the [Claude Code plugin](plugins/claude-code/) or install via [OpenClaw](https://www.demarkus.io/install/openclaw/).
+**Agent Memory**: Run a server as persistent memory across agent sessions. The Demarkus project itself uses this pattern at `mark://soul.demarkus.io` for architecture notes, debugging lessons, and journal entries. Hit the ground running with the [Claude Code plugin](plugins/claude-code/) or install via [OpenClaw](https://www.demarkus.io/install/openclaw/).
 
-**Organizational Knowledge System** — Compose many servers ("worlds") into a broker-fronted universe reachable through one HTTPS endpoint with OIDC single sign-on. A whole team joins with a single command — `/knowledge-join` from the [Claude Code knowledge plugin](plugins/claude-code-knowledge/) — and their agents share organizational memory over MCP, with no per-developer server or token setup. See the [knowledge system scenario](https://www.demarkus.io/scenarios/knowledge-system/).
+**Organizational Knowledge System**: Compose many servers ("worlds") into a broker-fronted universe reachable through one HTTPS endpoint with OIDC single sign-on. A whole team joins with a single command, `/knowledge-join` from the [Claude Code knowledge plugin](plugins/claude-code-knowledge/), and their agents share organizational memory over MCP, with no per-developer server or token setup. See the [knowledge system scenario](https://www.demarkus.io/scenarios/knowledge-system/).
 
-**Personal Knowledge Base** — Local server, versioned documents, TUI browser. Everything from first write.
+**Personal Knowledge Base**: Local server, versioned documents, TUI browser. Everything from first write.
 
-**Public Documentation** — Deploy on a VPS, share links, gate writes with tokens.
+**Public Documentation**: Deploy on a VPS, share links, gate writes with tokens.
 
-**Demarkus Hubs** — Link to content on other servers, building a federated directory of knowledge. Hubs can link to hubs.
+**Demarkus Hubs**: Link to content on other servers, building a federated directory of knowledge. Hubs can link to hubs.
 
 ## Ecosystem
 
-- [Caztor](https://github.com/kevinboone/caztor) — cross-platform Java GUI browser with preliminary Demarkus support
-- [Obsidian plugin](https://github.com/latebit-io/obsidian-demarkus) — publish and browse from Obsidian
-- [Claude Code memory plugin](plugins/claude-code/) — zero-config local memory for Claude Code
-- [Claude Code knowledge plugin](plugins/claude-code-knowledge/) — join an organizational knowledge system (broker-fronted, MCP OAuth)
-- [OpenClaw skill](https://clawhub.ai/ontehfritz/demarkus) — ClawHub skill for OpenClaw agents (see [install guide](https://www.demarkus.io/install/openclaw/))
+- [Caztor](https://github.com/kevinboone/caztor): cross-platform Java GUI browser with preliminary Demarkus support
+- [Obsidian plugin](https://github.com/latebit-io/obsidian-demarkus): publish and browse from Obsidian
+- [Claude Code memory plugin](plugins/claude-code/): zero-config local memory for Claude Code
+- [Claude Code knowledge plugin](plugins/claude-code-knowledge/): join an organizational knowledge system (broker-fronted, MCP OAuth)
+- [OpenClaw skill](https://clawhub.ai/ontehfritz/demarkus): ClawHub skill for OpenClaw agents (see [install guide](https://www.demarkus.io/install/openclaw/))
 
 See [www.demarkus.io/ecosystem](https://www.demarkus.io/ecosystem/) for the full list.
 
@@ -104,18 +104,18 @@ Requires Go 1.26+. Binaries land in `server/bin/`, `client/bin/`, and `tools/bin
 
 ## Documentation
 
-- [Website](https://www.demarkus.io/) — install guides, scenarios, troubleshooting
-- [Protocol Specification](docs/SPEC.md) — complete wire format
-- [Design Rationale](docs/DESIGN.md) — why things are built the way they are
+- [Website](https://www.demarkus.io/): install guides, scenarios, troubleshooting
+- [Protocol Specification](docs/SPEC.md): complete wire format
+- [Design Rationale](docs/DESIGN.md): why things are built the way they are
 
 ## Core Principles
 
-1. **Optimized for Information** — Markdown is the common language: structured enough for agents, readable enough for humans
-2. **Privacy First** — No user tracking, minimal logging, anonymity by default
-3. **Security Minded** — Encryption mandatory, capability-based auth, secure by default
-4. **Simplicity** — Human-readable protocol, minimal complexity
-5. **Anti-Commercialization** — No ads, no tracking, no central authority
-6. **Federation** — Anyone can run a server, content can be mirrored freely
+1. **Optimized for Information**: Markdown is the common language: structured enough for agents, readable enough for humans
+2. **Privacy First**: No user tracking, minimal logging, anonymity by default
+3. **Security Minded**: Encryption mandatory, capability-based auth, secure by default
+4. **Simplicity**: Human-readable protocol, minimal complexity
+5. **Anti-Commercialization**: No ads, no tracking, no central authority
+6. **Federation**: Anyone can run a server, content can be mirrored freely
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Demarkus implements the Mark Protocol — versioned markdown served over QUIC. No rendering pipeline, no tracking, no central authority. Read and write with capability tokens. Every change is traceable. Lightweight and installable anywhere.
 
+Run a single personal server, or compose many into an organizational **knowledge system** — a broker-fronted universe of servers behind one HTTPS endpoint with single sign-on. Humans and agents share the same versioned memory.
+
 ## Install
 
 ```bash
@@ -14,7 +16,7 @@ curl -fsSL https://raw.githubusercontent.com/latebit-io/demarkus/main/install.sh
 curl -fsSL https://raw.githubusercontent.com/latebit-io/demarkus/main/install.sh | bash -s -- --client-only
 ```
 
-See [full install docs](https://latebit-io.github.io/demarkus/getting-started/) for platform-specific guides and other options.
+See [full install docs](https://www.demarkus.io/install/) for platform-specific guides and other options.
 
 ### See it in action
 
@@ -33,7 +35,7 @@ demarkus-tui mark://soul.demarkus.io/index.md
 demarkus-server -root ./docs/site
 ```
 
-For more examples (tokens, publishing, editing), see [full usage guide](https://latebit-io.github.io/demarkus/).
+For more examples (tokens, publishing, editing), see [full usage guide](https://www.demarkus.io/).
 
 ## What's Included
 
@@ -70,7 +72,9 @@ modified: 2026-01-15T10:30:00Z
 
 ## Use Cases
 
-**Agent Memory** — Run a server as persistent memory across agent sessions. The Demarkus project itself uses this pattern at `mark://soul.demarkus.io` for architecture notes, debugging lessons, and journal entries. Hit the ground running with the [Claude Code plugin](plugins/claude-code/) or install via [OpenClaw](https://demarkus.io/install/openclaw/).
+**Agent Memory** — Run a server as persistent memory across agent sessions. The Demarkus project itself uses this pattern at `mark://soul.demarkus.io` for architecture notes, debugging lessons, and journal entries. Hit the ground running with the [Claude Code plugin](plugins/claude-code/) or install via [OpenClaw](https://www.demarkus.io/install/openclaw/).
+
+**Organizational Knowledge System** — Compose many servers ("worlds") into a broker-fronted universe reachable through one HTTPS endpoint with OIDC single sign-on. A whole team joins with a single command — `/knowledge-join` from the [Claude Code knowledge plugin](plugins/claude-code-knowledge/) — and their agents share organizational memory over MCP, with no per-developer server or token setup. See the [knowledge system scenario](https://www.demarkus.io/scenarios/knowledge-system/).
 
 **Personal Knowledge Base** — Local server, versioned documents, TUI browser. Everything from first write.
 
@@ -82,10 +86,11 @@ modified: 2026-01-15T10:30:00Z
 
 - [Caztor](https://github.com/kevinboone/caztor) — cross-platform Java GUI browser with preliminary Demarkus support
 - [Obsidian plugin](https://github.com/latebit-io/obsidian-demarkus) — publish and browse from Obsidian
-- [Claude Code plugin](plugins/claude-code/) — zero-config local memory for Claude Code
-- [OpenClaw skill](https://clawhub.ai/ontehfritz/demarkus) — ClawHub skill for OpenClaw agents (see [install guide](https://demarkus.io/install/openclaw/))
+- [Claude Code memory plugin](plugins/claude-code/) — zero-config local memory for Claude Code
+- [Claude Code knowledge plugin](plugins/claude-code-knowledge/) — join an organizational knowledge system (broker-fronted, MCP OAuth)
+- [OpenClaw skill](https://clawhub.ai/ontehfritz/demarkus) — ClawHub skill for OpenClaw agents (see [install guide](https://www.demarkus.io/install/openclaw/))
 
-See [demarkus.io/ecosystem](https://demarkus.io/ecosystem/) for the full list.
+See [www.demarkus.io/ecosystem](https://www.demarkus.io/ecosystem/) for the full list.
 
 ## Build from Source
 
@@ -95,11 +100,11 @@ cd demarkus
 make all   # or: make server / make client
 ```
 
-Requires Go 1.26+. Binaries land in `server/bin/` and `client/bin/`.
+Requires Go 1.26+. Binaries land in `server/bin/`, `client/bin/`, and `tools/bin/`.
 
 ## Documentation
 
-- [Website](https://latebit-io.github.io/demarkus/) — install guides, scenarios, troubleshooting
+- [Website](https://www.demarkus.io/) — install guides, scenarios, troubleshooting
 - [Protocol Specification](docs/SPEC.md) — complete wire format
 - [Design Rationale](docs/DESIGN.md) — why things are built the way they are
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a preflight step to fetch the conventions document from the MCP server and included it in the layout links.
  * Updated website URLs and resource links across docs.
  * Expanded organizational knowledge system descriptions and ecosystem entries (including a Claude Code plugin mention).
  * Clarified build instructions with Go 1.26+ requirement and binary placement details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->