### PR TITLE
feat(broker): update chart to support domain list

### DIFF
--- a/deploy/helm/demarkus-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-config.yaml
@@ -114,6 +114,13 @@ stringData:
              it blank and main.go reads BROKER_SIGNING_KEY at startup. */}}
       brokerSigningKey: |
 {{ default "" .Values.oidc.brokerSigningKey | indent 8 }}
+      {{- /* Broker-global hd allowlist. Render an explicit `[]` when
+             unset so the rendered config is self-documenting (an
+             operator reading the Secret sees the gate is open by
+             design, not missing-by-omission). Non-empty: render as
+             a flow-style list; the broker lowercases+trims at
+             validate, so casing in values is preserved verbatim here. */}}
+      allowDomains: {{ toJson (default (list) .Values.oidc.allowDomains) }}
     worlds:
 {{- range .Values.worlds }}
       {{- /* Wrap .allow with `default (dict)` because Go templates panic on

--- a/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
@@ -81,6 +81,32 @@ tests:
           path: stringData["config.yaml"]
           pattern: 'insecureCookies: true'
 
+  - it: oidc.allowDomains defaults to empty list (gate open) when unset
+    set:
+      oidc.clientSecret: shh
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'allowDomains: \[\]'
+
+  - it: oidc.allowDomains renders single-entry list
+    set:
+      oidc.clientSecret: shh
+      oidc.allowDomains: ["example.com"]
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'allowDomains: \["example.com"\]'
+
+  - it: oidc.allowDomains renders multi-entry list verbatim
+    set:
+      oidc.clientSecret: shh
+      oidc.allowDomains: ["example.com", "acme.test"]
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'allowDomains: \["example.com","acme.test"\]'
+
   - it: existingSecretRef path leaves clientSecret blank in rendered config
     set:
       oidc.existingSecretRef.name: my-oidc-secret

--- a/deploy/helm/demarkus-broker/values.yaml
+++ b/deploy/helm/demarkus-broker/values.yaml
@@ -175,6 +175,31 @@ oidc:
   # registered with the IdP.
   redirectURL: ""
 
+  # Broker-global Google Workspace hosted-domain (`hd`) allowlist.
+  # When non-empty, every IdP exchange (device flow, auth-code flow,
+  # legacy /auth/callback) is rejected unless the verified id_token's
+  # `hd` claim matches one of these entries. Consumer Google accounts
+  # (no `hd`) and Workspace users from other tenants are denied before
+  # any authorization code, refresh token, or world dispatch is
+  # issued. Empty disables the gate — any verified identity passes
+  # the broker layer; per-world `worlds[].allow` lists still apply
+  # downstream.
+  #
+  # Keying on `hd` (not the email domain) is the spoof-resistant
+  # choice: `hd` is set by Google from the Workspace tenant binding
+  # and the user cannot influence it. See
+  # /tools/demarkus-broker/internal/broker/authz.go `oidcDomainAllowed`.
+  #
+  # Entries are lowercased+trimmed at broker startup. Set multiple
+  # to admit more than one org (Google's `hd` query param does not
+  # support multi-domain — multi-tenant gating MUST be done server-
+  # side, which is what this list does).
+  #
+  # Examples:
+  #   allowDomains: ["example.com"]                 # single org
+  #   allowDomains: ["example.com", "acme.test"]    # multi-org
+  allowDomains: []
+
   # Broker-side ECDSA P-256 private key (PR4). The broker signs
   # id_tokens on /device/token refresh-grant responses with this key
   # and serves the matching public key at /.well-known/jwks.json. Two
@@ -233,7 +258,7 @@ worlds: []
   #   # implicit.
   #   # internalAddress: "team-a-mark.team-a:6309"
   #   allow:
-  #     domains: ["nesto.ca"]
+  #     domains: ["example.com"]
   #     groups: ["engineering"]
   #     emails: ["alice@example.com"]
   #   defaultToken:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OIDC domain allowlisting configuration option enabling restriction of authentication to specific Google Workspace domains

* **Documentation**
  * Updated configuration documentation and examples with details on the new domain allowlisting capability

* **Tests**
  * Added comprehensive test coverage validating the domain allowlisting configuration behavior across various scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->