### PR TITLE
feat(version): Add -version flags to three Go binaries

### DIFF
--- a/client/.goreleaser.yml
+++ b/client/.goreleaser.yml
@@ -56,7 +56,7 @@ builds:
     goarm:
       - "7"
     ldflags:
-      - -s -w
+      - -s -w -X main.version={{ .Version }}
 
   # demarkus-agent ships only as a container image (release-client job
   # bundles it into ghcr.io/.../demarkus-agent). Listed under builds:

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -36,7 +36,13 @@ func main() {
 	insecure := flag.Bool("insecure", false, "skip TLS certificate verification")
 	noCache := flag.Bool("no-cache", false, "disable response caching")
 	cacheDir := flag.String("cache-dir", cache.DefaultDir(), "cache directory")
+	showVersion := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version)
+		return
+	}
 
 	opts := fetch.Options{Insecure: *insecure}
 	if !*noCache {

--- a/client/cmd/demarkus-mcp/version_test.go
+++ b/client/cmd/demarkus-mcp/version_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildAndVersion compiles this package into a temp binary (optionally injecting
+// main.version via -ldflags, exactly as the release build does) and runs it with
+// the given version arg, returning trimmed stdout. It proves both the flag wiring
+// and that the -X main.version target is correct — a wrong package path would
+// silently leave the binary reporting "dev".
+func buildAndVersion(t *testing.T, ldVersion string, args ...string) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "demarkus-mcp")
+	buildArgs := []string{"build", "-o", bin}
+	if ldVersion != "" {
+		buildArgs = append(buildArgs, "-ldflags", "-X main.version="+ldVersion)
+	}
+	buildArgs = append(buildArgs, ".")
+	if out, err := exec.Command("go", buildArgs...).CombinedOutput(); err != nil {
+		t.Fatalf("build failed: %v\n%s", err, out)
+	}
+	out, err := exec.Command(bin, args...).Output()
+	if err != nil {
+		t.Fatalf("run %v failed: %v", args, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestVersionFlag(t *testing.T) {
+	tests := []struct {
+		name      string
+		ldVersion string
+		want      string
+	}{
+		{"injected release version", "9.9.9-test", "9.9.9-test"},
+		{"default when not injected", "", "dev"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildAndVersion(t, tt.ldVersion, "--version"); got != tt.want {
+				t.Errorf("--version = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/.goreleaser.yml
+++ b/server/.goreleaser.yml
@@ -22,7 +22,7 @@ builds:
     goarm:
       - "7"
     ldflags:
-      - -s -w
+      - -s -w -X main.version={{ .Version }}
 
 archives:
   - id: demarkus-server

--- a/server/cmd/demarkus-server/main.go
+++ b/server/cmd/demarkus-server/main.go
@@ -42,6 +42,42 @@ func buildCatalog(s *store.Store, logger *slog.Logger) *catalog.Catalog {
 	return cat
 }
 
+// version is set at build time via -ldflags "-X main.version=...".
+var version = "dev"
+
+// flagOverrides holds the CLI flag values that override env-derived config.
+type flagOverrides struct {
+	root     string
+	tlsCert  string
+	tlsKey   string
+	tokens   string
+	port     int
+	readOnly bool
+}
+
+// applyFlagOverrides applies non-empty/non-zero CLI flags onto cfg. Flags take
+// precedence over env vars.
+func applyFlagOverrides(cfg *config.Config, o *flagOverrides) {
+	if o.root != "" {
+		cfg.ContentDir = o.root
+	}
+	if o.port != 0 {
+		cfg.Port = o.port
+	}
+	if o.tlsCert != "" {
+		cfg.TLSCert = o.tlsCert
+	}
+	if o.tlsKey != "" {
+		cfg.TLSKey = o.tlsKey
+	}
+	if o.tokens != "" {
+		cfg.TokensFile = o.tokens
+	}
+	if o.readOnly {
+		cfg.ReadOnly = true
+	}
+}
+
 func main() {
 	root := flag.String("root", "", "content directory to serve (overrides DEMARKUS_ROOT)")
 	port := flag.Int("port", 0, "port to listen on (overrides DEMARKUS_PORT)")
@@ -49,6 +85,7 @@ func main() {
 	tlsKey := flag.String("tls-key", "", "path to TLS private key PEM file (overrides DEMARKUS_TLS_KEY)")
 	tokens := flag.String("tokens", "", "path to TOML tokens file for auth (overrides DEMARKUS_TOKENS)")
 	readOnly := flag.Bool("read-only", false, "reject all write operations (also enabled via DEMARKUS_READ_ONLY)")
+	showVersion := flag.Bool("version", false, "print version and exit")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: demarkus-server [options]\n\n")
 		fmt.Fprintf(os.Stderr, "Serves markdown documents over the Mark Protocol (QUIC, port %d).\n", protocol.DefaultPort)
@@ -56,6 +93,11 @@ func main() {
 		flag.PrintDefaults()
 	}
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version)
+		return
+	}
 
 	cfg, err := config.NewConfig()
 
@@ -66,25 +108,14 @@ func main() {
 		logger.Warn("config", "error", err)
 	}
 
-	// Flag overrides take precedence over env vars
-	if *root != "" {
-		cfg.ContentDir = *root
-	}
-	if *port != 0 {
-		cfg.Port = *port
-	}
-	if *tlsCert != "" {
-		cfg.TLSCert = *tlsCert
-	}
-	if *tlsKey != "" {
-		cfg.TLSKey = *tlsKey
-	}
-	if *tokens != "" {
-		cfg.TokensFile = *tokens
-	}
-	if *readOnly {
-		cfg.ReadOnly = true
-	}
+	applyFlagOverrides(cfg, &flagOverrides{
+		root:     *root,
+		port:     *port,
+		tlsCert:  *tlsCert,
+		tlsKey:   *tlsKey,
+		tokens:   *tokens,
+		readOnly: *readOnly,
+	})
 	if cfg.ContentDir == "" {
 		logger.Error("content directory is required (set DEMARKUS_ROOT or use -root flag)")
 		os.Exit(1)

--- a/server/cmd/demarkus-server/version_test.go
+++ b/server/cmd/demarkus-server/version_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildAndVersion compiles this package into a temp binary (optionally injecting
+// main.version via -ldflags, exactly as the release build does) and runs it with
+// the given version arg, returning trimmed stdout. It proves both the flag wiring
+// and that the -X main.version target is correct — a wrong package path would
+// silently leave the binary reporting "dev".
+func buildAndVersion(t *testing.T, ldVersion string, args ...string) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "demarkus-server")
+	buildArgs := []string{"build", "-o", bin}
+	if ldVersion != "" {
+		buildArgs = append(buildArgs, "-ldflags", "-X main.version="+ldVersion)
+	}
+	buildArgs = append(buildArgs, ".")
+	if out, err := exec.Command("go", buildArgs...).CombinedOutput(); err != nil {
+		t.Fatalf("build failed: %v\n%s", err, out)
+	}
+	out, err := exec.Command(bin, args...).Output()
+	if err != nil {
+		t.Fatalf("run %v failed: %v", args, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestVersionFlag(t *testing.T) {
+	tests := []struct {
+		name      string
+		ldVersion string
+		want      string
+	}{
+		{"injected release version", "9.9.9-test", "9.9.9-test"},
+		{"default when not injected", "", "dev"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildAndVersion(t, tt.ldVersion, "--version"); got != tt.want {
+				t.Errorf("--version = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/.goreleaser.yml
+++ b/tools/.goreleaser.yml
@@ -39,7 +39,7 @@ builds:
     goarm:
       - "7"
     ldflags:
-      - -s -w
+      - -s -w -X main.version={{ .Version }}
 
   - id: demarkus-publish
     main: ./demarkus-publish

--- a/tools/demarkus-token/main.go
+++ b/tools/demarkus-token/main.go
@@ -21,6 +21,9 @@ import (
 	"github.com/latebit/demarkus/protocol/token"
 )
 
+// version is set at build time via -ldflags "-X main.version=...".
+var version = "dev"
+
 func main() {
 	if len(os.Args) < 2 {
 		printUsage()
@@ -34,6 +37,8 @@ func main() {
 		cmdList(os.Args[2:])
 	case "revoke":
 		cmdRevoke(os.Args[2:])
+	case "version", "-version", "--version":
+		fmt.Println(version)
 	default:
 		printUsage()
 		os.Exit(1)
@@ -46,6 +51,7 @@ func printUsage() {
 	fmt.Fprintf(os.Stderr, "  generate  Generate a new auth token\n")
 	fmt.Fprintf(os.Stderr, "  list      List tokens in a tokens file\n")
 	fmt.Fprintf(os.Stderr, "  revoke    Revoke a token by label\n")
+	fmt.Fprintf(os.Stderr, "  version   Print version and exit\n")
 }
 
 func cmdGenerate(args []string) {

--- a/tools/demarkus-token/version_test.go
+++ b/tools/demarkus-token/version_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildAndVersion compiles this package into a temp binary (optionally injecting
+// main.version via -ldflags, exactly as the release build does) and runs the
+// given version subcommand, returning trimmed stdout. It proves both the
+// subcommand wiring and that the -X main.version target is correct — a wrong
+// package path would silently leave the binary reporting "dev".
+func buildAndVersion(t *testing.T, ldVersion string, args ...string) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "demarkus-token")
+	buildArgs := []string{"build", "-o", bin}
+	if ldVersion != "" {
+		buildArgs = append(buildArgs, "-ldflags", "-X main.version="+ldVersion)
+	}
+	buildArgs = append(buildArgs, ".")
+	if out, err := exec.Command("go", buildArgs...).CombinedOutput(); err != nil {
+		t.Fatalf("build failed: %v\n%s", err, out)
+	}
+	out, err := exec.Command(bin, args...).Output()
+	if err != nil {
+		t.Fatalf("run %v failed: %v", args, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestVersionSubcommand(t *testing.T) {
+	tests := []struct {
+		name      string
+		ldVersion string
+		arg       string
+		want      string
+	}{
+		{"version subcommand, injected", "9.9.9-test", "version", "9.9.9-test"},
+		{"--version flag form", "9.9.9-test", "--version", "9.9.9-test"},
+		{"default when not injected", "", "version", "dev"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildAndVersion(t, tt.ldVersion, tt.arg); got != tt.want {
+				t.Errorf("%s = %q, want %q", tt.arg, got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/demarkus-token/version_test.go
+++ b/tools/demarkus-token/version_test.go
@@ -38,6 +38,7 @@ func TestVersionSubcommand(t *testing.T) {
 		want      string
 	}{
 		{"version subcommand, injected", "9.9.9-test", "version", "9.9.9-test"},
+		{"-version flag form", "9.9.9-test", "-version", "9.9.9-test"},
 		{"--version flag form", "9.9.9-test", "--version", "9.9.9-test"},
 		{"default when not injected", "", "version", "dev"},
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI tools now support a version command/flag to print the build version
  * Release builds embed the version string into binaries so reported versions match releases

* **Tests**
  * Added integration tests validating version output for injected and default ("dev") builds across affected tools
<!-- end of auto-generated comment: release notes by coderabbit.ai -->