### PR TITLE
feat(broker):  Add confidential OAuth client registration to broker

### DIFF
--- a/deploy/helm/demarkus-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-config.yaml
@@ -153,6 +153,24 @@ stringData:
         defaultToken:
           paths: {{ .defaultToken.paths | toJson }}
 {{- end }}
+    {{- /* Confidential web-client registry. Rendered as an explicit
+           `[]` when unset (same self-documenting rationale as
+           allowDomains). The hash is not secret material, but the
+           whole config already lives in a Secret so no special
+           handling is needed. `required` guards surface a half-
+           registered client at render time instead of as a broker
+           CrashLoop on LoadConfig validation. */}}
+    {{- if .Values.webClients }}
+    webClients:
+{{- range .Values.webClients }}
+      - clientID: {{ required "webClients[].clientID is required" .clientID | quote }}
+        clientSecretHash: {{ required "webClients[].clientSecretHash is required" .clientSecretHash | quote }}
+        redirectURIs: {{ required "webClients[].redirectURIs is required" .redirectURIs | toJson }}
+        name: {{ default "" .name | quote }}
+{{- end }}
+    {{- else }}
+    webClients: []
+    {{- end }}
     sweeper:
       disabled: {{ .Values.sweeper.disabled }}
       interval: {{ .Values.sweeper.interval | quote }}

--- a/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/secret-config_test.yaml
@@ -292,6 +292,59 @@ tests:
       - failedTemplate:
           errorMessage: "oidc.existingSigningKeyRef.key is required when oidc.existingSigningKeyRef.name is set"
 
+  - it: webClients defaults to empty list (no registry) when unset
+    set:
+      oidc.clientSecret: shh
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'webClients: \[\]'
+
+  - it: webClients entry renders clientID, hash, redirect allowlist, and name
+    set:
+      oidc.clientSecret: shh
+      webClients:
+        - clientID: library-web
+          clientSecretHash: "0000000000000000000000000000000000000000000000000000000000000000"
+          redirectURIs: ["https://library.example.com/auth/callback"]
+          name: Universe Library
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'webClients:\s*\n\s*- clientID: "library-web"\s*\n\s*clientSecretHash: "0{64}"\s*\n\s*redirectURIs: \["https://library.example.com/auth/callback"\]\s*\n\s*name: "Universe Library"'
+
+  - it: webClients entry without name renders an empty name field (stable shape)
+    set:
+      oidc.clientSecret: shh
+      webClients:
+        - clientID: library-web
+          clientSecretHash: "0000000000000000000000000000000000000000000000000000000000000000"
+          redirectURIs: ["https://library.example.com/auth/callback"]
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'name: ""'
+
+  - it: fail-render when a webClient omits clientSecretHash
+    set:
+      oidc.clientSecret: shh
+      webClients:
+        - clientID: library-web
+          redirectURIs: ["https://library.example.com/auth/callback"]
+    asserts:
+      - failedTemplate:
+          errorMessage: "webClients[].clientSecretHash is required"
+
+  - it: fail-render when a webClient omits redirectURIs
+    set:
+      oidc.clientSecret: shh
+      webClients:
+        - clientID: library-web
+          clientSecretHash: "0000000000000000000000000000000000000000000000000000000000000000"
+    asserts:
+      - failedTemplate:
+          errorMessage: "webClients[].redirectURIs is required"
+
   - it: worldDialer.insecureSkipVerify defaults to false (production-correct)
     set:
       oidc.clientSecret: shh

--- a/deploy/helm/demarkus-broker/values.yaml
+++ b/deploy/helm/demarkus-broker/values.yaml
@@ -278,6 +278,25 @@ worlds: []
   #     # token never expires, so there is no operations/expiresAfter
   #     # field to set.
 
+# Registered confidential web clients (RFC 6749 §2.1) — server-side
+# apps (e.g. the Universe Library) that authenticate with a client
+# secret and receive the authorization-code redirect at a real https
+# URL instead of a native-app loopback. Explicit operator-curated
+# registry, NOT open dynamic registration. Native/CLI agents never
+# appear here. Store only the sha256-hex of the secret; the plaintext
+# lives in the web app's own deployment.
+webClients: []
+  # - clientID: library-web
+  #   # sha256-hex of the client secret, e.g.
+  #   #   printf '%s' "$SECRET" | sha256sum | cut -d' ' -f1
+  #   clientSecretHash: "0123…64 hex chars…cdef"
+  #   # Exact-match https redirect allowlist — no wildcards, no
+  #   # loopback. The broker rejects any redirect_uri not listed here.
+  #   redirectURIs:
+  #     - https://library.example.com/auth/callback
+  #   # Optional human label for logs.
+  #   name: Universe Library
+
 # Periodic expiry + drift sweeper. Leader-elected via
 # coordination.k8s.io/Lease so multi-replica deployments enforce
 # singleton sweep without coordination on the broker side. Named

--- a/deploy/kind/up.sh
+++ b/deploy/kind/up.sh
@@ -26,6 +26,12 @@
 # broker-minted code -> /device/token exchange, with negative (wrong
 # verifier -> invalid_grant) and replay (one-shot code) assertions. This is
 # the OAuth surface Claude Code's MCP SDK uses via /knowledge-join.
+#
+# It also drives the CONFIDENTIAL web-client flow (phase-1b web SSO): a
+# webClients registry entry is rendered through the local chart, then the
+# same authorize -> IdP -> callback dance runs against the registered https
+# redirect, the token exchange must present the client secret (Basic), and
+# the minted refresh token is client-bound (refresh without auth -> 401).
 
 set -euo pipefail
 
@@ -445,6 +451,16 @@ if [[ "$WITH_BROKER" == "true" ]]; then
     kind load docker-image "$MCP_SMOKE_IMAGE_REGISTRY/demarkus-broker:$MCP_SMOKE_IMAGE_TAG" --name "$CLUSTER"
 
     echo "--- installing LOCAL demarkus-broker chart from $REPO_ROOT/deploy/helm/demarkus-broker"
+    # Confidential web client for the web-SSO smoke below. The secret is
+    # generated per run and only its sha256 enters the rendered config —
+    # same posture as a real deployment. The redirect host is .invalid
+    # (RFC 2606): nothing ever connects to it, the smoke only parses the
+    # broker's 302 Location to recover the authorization code.
+    WEBCLIENT_ID="library-web-smoke"
+    WEBCLIENT_SECRET="$(openssl rand -hex 24)"
+    WEBCLIENT_SECRET_HASH="$(printf '%s' "$WEBCLIENT_SECRET" | openssl dgst -sha256 -hex | awk '{print $NF}')"
+    WEBCLIENT_REDIRECT_URI="https://library.smoke.invalid/auth/callback"
+
     # server.insecureCookies=true is set here (not in values-broker.yaml) so
     # only the --with-mcp-smoke install drops the Secure attribute on the
     # OIDC state cookie. The auth-code smoke below drives /oauth/authorize ->
@@ -459,6 +475,10 @@ if [[ "$WITH_BROKER" == "true" ]]; then
       --set "image.repository=$MCP_SMOKE_IMAGE_REGISTRY/demarkus-broker" \
       --set "image.tag=$MCP_SMOKE_IMAGE_TAG" \
       --set "image.pullPolicy=IfNotPresent" \
+      --set "webClients[0].clientID=$WEBCLIENT_ID" \
+      --set-string "webClients[0].clientSecretHash=$WEBCLIENT_SECRET_HASH" \
+      --set "webClients[0].redirectURIs[0]=$WEBCLIENT_REDIRECT_URI" \
+      --set "webClients[0].name=Web SSO smoke client" \
       --wait --timeout 5m
   else
     echo "--- installing demarkus-broker chart $BROKER_CHART_VERSION"
@@ -650,6 +670,137 @@ echo "OK: authorization code is one-shot (replay rejected)"
 echo "OK: auth-code + PKCE flow end-to-end"
 '
     echo "--- auth-code + PKCE flow passed"
+
+    # Confidential web-client flow (phase-1b web SSO). Proves the chart's
+    # webClients rendering reached the broker AND the broker enforces the
+    # confidential contract: registered https redirect accepted (loopback
+    # path untouched — covered above), token exchange demands the client
+    # secret without burning the code on a missing-auth attempt, and the
+    # minted refresh token is bound to the client.
+    WEB_CLIENT_STATE="$(openssl rand -hex 16)"
+    WEB_VERIFIER="$(openssl rand -hex 32)"
+    WEB_CHALLENGE="$(printf '%s' "$WEB_VERIFIER" \
+      | openssl dgst -sha256 -binary | openssl base64 -A | tr '+/' '-_' | tr -d '=')"
+
+    echo "--- driving confidential web-client flow from an ephemeral curl pod"
+    kubectl run -n "$NAMESPACE" webclient-smoke --rm -i --restart=Never \
+      --image="$MINT_CURL_IMAGE" --command -- sh -c '
+set -eu
+BROKER='"$BROKER_OAUTH_URL"'
+CLIENT_ID='"$WEBCLIENT_ID"'
+CLIENT_SECRET='"$WEBCLIENT_SECRET"'
+REDIRECT_URI='"$WEBCLIENT_REDIRECT_URI"'
+CLIENT_STATE='"$WEB_CLIENT_STATE"'
+VERIFIER='"$WEB_VERIFIER"'
+CHALLENGE='"$WEB_CHALLENGE"'
+CURL="curl -sS --connect-timeout 5 --max-time 15"
+
+# 0. Wait for the broker OAuth Service to answer.
+for attempt in $(seq 1 15); do
+  if $CURL -o /dev/null "$BROKER/healthz"; then break; fi
+  sleep 2
+done
+$CURL -f -o /dev/null "$BROKER/healthz" || { echo "FAIL: broker OAuth surface unreachable"; exit 1; }
+
+# 1. Discovery advertises the confidential auth methods.
+DISC=$($CURL "$BROKER/.well-known/openid-configuration")
+echo "$DISC" | grep -q "client_secret_basic" || { echo "FAIL: discovery missing client_secret_basic"; exit 1; }
+echo "OK: discovery advertises client_secret_basic"
+
+# 2. NEGATIVE — an unregistered https redirect for the registered client
+#    must be refused BEFORE redirect trust (JSON 400, no Location).
+HTTP=$($CURL -G -o /tmp/badredir.json -w "%{http_code}" \
+  --data-urlencode "response_type=code" \
+  --data-urlencode "client_id=$CLIENT_ID" \
+  --data-urlencode "redirect_uri=https://attacker.invalid/steal" \
+  --data-urlencode "code_challenge=$CHALLENGE" \
+  --data-urlencode "code_challenge_method=S256" \
+  --data-urlencode "state=$CLIENT_STATE" \
+  "$BROKER/oauth/authorize")
+[ "$HTTP" = "400" ] || { echo "FAIL: unregistered redirect did not 400 (got $HTTP)"; cat /tmp/badredir.json; exit 1; }
+echo "OK: unregistered redirect_uri rejected for registered client"
+
+# 3. /oauth/authorize with the REGISTERED https redirect -> 302 to IdP.
+$CURL -G -c /tmp/cookies -D /tmp/authz.h -o /dev/null \
+  --data-urlencode "response_type=code" \
+  --data-urlencode "client_id=$CLIENT_ID" \
+  --data-urlencode "redirect_uri=$REDIRECT_URI" \
+  --data-urlencode "code_challenge=$CHALLENGE" \
+  --data-urlencode "code_challenge_method=S256" \
+  --data-urlencode "state=$CLIENT_STATE" \
+  "$BROKER/oauth/authorize"
+IDP=$(awk "/^[Ll]ocation:/{print \$2}" /tmp/authz.h | tr -d "\r")
+[ -n "$IDP" ] || { echo "FAIL: no Location from /oauth/authorize (web client)"; cat /tmp/authz.h; exit 1; }
+
+# 4. Mock IdP auto-approves -> code+state for the broker callback.
+$CURL -D /tmp/idp.h -o /dev/null "$IDP"
+CB=$(awk "/^[Ll]ocation:/{print \$2}" /tmp/idp.h | tr -d "\r")
+IDP_CODE=$(printf "%s" "$CB" | sed -n "s/.*[?&]code=\([^&]*\).*/\1/p")
+IDP_STATE=$(printf "%s" "$CB" | sed -n "s/.*[?&]state=\([^&]*\).*/\1/p")
+[ -n "$IDP_CODE" ] && [ -n "$IDP_STATE" ] || { echo "FAIL: bad IdP callback URL: $CB"; exit 1; }
+
+# 5. /auth/callback -> 302 to the REGISTERED https redirect with the code.
+$CURL -b /tmp/cookies -D /tmp/cb.h -o /dev/null "$BROKER/auth/callback?code=$IDP_CODE&state=$IDP_STATE"
+RU=$(awk "/^[Ll]ocation:/{print \$2}" /tmp/cb.h | tr -d "\r")
+case "$RU" in
+  "$REDIRECT_URI"*) ;;
+  *) echo "FAIL: callback did not redirect to registered URI: $RU"; exit 1 ;;
+esac
+case "$RU" in
+  *"error="*) echo "FAIL: web-client callback returned an OAuth error: $RU"; exit 1 ;;
+esac
+AUTH_CODE=$(printf "%s" "$RU" | sed -n "s/.*[?&]code=\([^&]*\).*/\1/p")
+RET_STATE=$(printf "%s" "$RU" | sed -n "s/.*[?&]state=\([^&]*\).*/\1/p")
+[ -n "$AUTH_CODE" ] || { echo "FAIL: no broker authorization code in redirect: $RU"; exit 1; }
+[ "$RET_STATE" = "$CLIENT_STATE" ] || { echo "FAIL: state mismatch: got [$RET_STATE] want [$CLIENT_STATE]"; exit 1; }
+echo "OK: authorize -> callback -> code on registered https redirect"
+
+# 6. NEGATIVE — exchange WITHOUT the client secret must 401
+#    invalid_client with a Basic challenge, and must NOT burn the code.
+HTTP=$($CURL -D /tmp/noauth.h -o /tmp/noauth.json -w "%{http_code}" -X POST "$BROKER/device/token" \
+  --data-urlencode "grant_type=authorization_code" \
+  --data-urlencode "code=$AUTH_CODE" \
+  --data-urlencode "client_id=$CLIENT_ID" \
+  --data-urlencode "redirect_uri=$REDIRECT_URI" \
+  --data-urlencode "code_verifier=$VERIFIER")
+[ "$HTTP" = "401" ] || { echo "FAIL: secretless exchange did not 401 (got $HTTP)"; cat /tmp/noauth.json; exit 1; }
+grep -q "invalid_client" /tmp/noauth.json || { echo "FAIL: secretless exchange not invalid_client"; cat /tmp/noauth.json; exit 1; }
+grep -qi "^WWW-Authenticate: Basic" /tmp/noauth.h || { echo "FAIL: 401 missing WWW-Authenticate: Basic"; cat /tmp/noauth.h; exit 1; }
+echo "OK: token exchange without client secret rejected (invalid_client + Basic challenge)"
+
+# 7. POSITIVE — exchange WITH HTTP Basic mints a Bearer + refresh token,
+#    proving the failed attempt above preserved the one-shot code.
+HTTP=$($CURL -u "$CLIENT_ID:$CLIENT_SECRET" -o /tmp/tok.json -w "%{http_code}" -X POST "$BROKER/device/token" \
+  --data-urlencode "grant_type=authorization_code" \
+  --data-urlencode "code=$AUTH_CODE" \
+  --data-urlencode "client_id=$CLIENT_ID" \
+  --data-urlencode "redirect_uri=$REDIRECT_URI" \
+  --data-urlencode "code_verifier=$VERIFIER")
+[ "$HTTP" = "200" ] || { echo "FAIL: Basic-auth exchange did not 200 (got $HTTP)"; cat /tmp/tok.json; exit 1; }
+grep -q "\"token_type\":\"Bearer\"" /tmp/tok.json || { echo "FAIL: token_type Bearer missing"; exit 1; }
+REFRESH=$(sed -n "s/.*\"refresh_token\":\"\([^\"]*\)\".*/\1/p" /tmp/tok.json)
+[ -n "$REFRESH" ] || { echo "FAIL: refresh_token missing from web-client exchange"; exit 1; }
+echo "OK: Basic-auth exchange minted a Bearer token (code survived the failed attempt)"
+
+# 8. NEGATIVE — the refresh token is client-bound: refresh WITHOUT
+#    client auth must 401 invalid_client.
+HTTP=$($CURL -o /tmp/refnoauth.json -w "%{http_code}" -X POST "$BROKER/device/token" \
+  --data-urlencode "grant_type=refresh_token" \
+  --data-urlencode "refresh_token=$REFRESH")
+[ "$HTTP" = "401" ] || { echo "FAIL: unauthenticated refresh of bound token did not 401 (got $HTTP)"; cat /tmp/refnoauth.json; exit 1; }
+grep -q "invalid_client" /tmp/refnoauth.json || { echo "FAIL: unauthenticated refresh not invalid_client"; cat /tmp/refnoauth.json; exit 1; }
+echo "OK: client-bound refresh token refuses to mint without client auth"
+
+# 9. POSITIVE — refresh WITH Basic auth mints a fresh id_token.
+HTTP=$($CURL -u "$CLIENT_ID:$CLIENT_SECRET" -o /tmp/ref.json -w "%{http_code}" -X POST "$BROKER/device/token" \
+  --data-urlencode "grant_type=refresh_token" \
+  --data-urlencode "refresh_token=$REFRESH")
+[ "$HTTP" = "200" ] || { echo "FAIL: Basic-auth refresh did not 200 (got $HTTP)"; cat /tmp/ref.json; exit 1; }
+grep -Eq "\"id_token\":\"[^\"]+\"" /tmp/ref.json || { echo "FAIL: id_token missing from authenticated refresh"; exit 1; }
+echo "OK: bound refresh token mints with client auth"
+echo "OK: confidential web-client flow end-to-end"
+'
+    echo "--- confidential web-client flow passed"
   fi
 
   cat <<EOF

--- a/docs/adr/0001-broker-confidential-web-clients.md
+++ b/docs/adr/0001-broker-confidential-web-clients.md
@@ -1,0 +1,78 @@
+# ADR 0001 — Broker confidential web-client registry
+
+Status: accepted (2026-06-11)
+
+## Context
+
+The broker's `/oauth/authorize` endpoint was loopback-only (RFC 8252 §7.3),
+built for native/CLI agents whose MCP SDKs spin up a localhost listener. A
+deployed web application (the Universe Library reading room) has no loopback,
+so the authorization-code redirect flow was a dead end for server-side apps.
+The device flow works without a redirect but gives web users the TV-login
+experience (tab hop, code entry, polling) — rejected as the primary web UX.
+
+Every client was public/PKCE: `/oauth/authorize` treated `client_id` as
+opaque, `/register` (RFC 7591 DCR) pins `token_endpoint_auth_method=none`,
+and the token endpoint never checked a client secret.
+
+The full decision trail lives in the demarkus-soul document
+`/demarkus-library/adr/0004-broker-web-sso.md`; this ADR records the
+broker-side mechanics.
+
+## Decision
+
+Add a registered **confidential web client** class alongside the existing
+native path, as an explicit operator-curated registry — not open DCR.
+
+- **Registry** — `webClients` in broker config: `clientID`, `clientSecretHash`
+  (sha256-hex of the secret; plaintext never in config), `redirectURIs`
+  (exact-match https allowlist), optional `name`. Validated at load: unique
+  ids, 64-hex-char hash, ≥1 redirect, each redirect absolute https with no
+  userinfo/fragment and no loopback host.
+- **`/oauth/authorize`** — a registered `client_id` validates `redirect_uri`
+  by exact match against its allowlist (no loopback exemption); an
+  unregistered `client_id` keeps the loopback-only public path unchanged.
+- **Token endpoint (`/device/token`)** — the `authorization_code` grant
+  requires client authentication (HTTP Basic per RFC 6749 §2.3.1, or
+  `client_secret_post`) when the presented `client_id` is registered. The
+  secret is verified constant-time against the stored hash *before* the code
+  is redeemed, so a failed authentication does not burn the code. Failure →
+  `401 invalid_client` + `WWW-Authenticate: Basic`.
+- **Refresh binding** — refresh tokens minted through a confidential exchange
+  record the `clientID`; the `refresh_token` grant then requires the same
+  client to authenticate. A leaked bound refresh token alone mints nothing.
+  Tokens from the device flow and the loopback auth-code path stay unbound
+  and refresh as before.
+- **Discovery** — `token_endpoint_auth_methods_supported` advertises
+  `["none","client_secret_basic","client_secret_post"]`.
+
+## Notable choices
+
+- **No `Confidential` flag in the auth-code store.** The plan called for
+  stamping pending entries; it is redundant. `Redeem` already binds
+  `client_id` constant-time and the registry is immutable for the process
+  lifetime, so "entry's client_id is registered" is exactly "entry was issued
+  confidential". The token handler's registry lookup of the presented
+  client_id is therefore authoritative, and doing the secret check before
+  `Redeem` preserves the store's keep-code-on-client-error retry semantics.
+- **sha256, not bcrypt, for the secret hash.** The secret is
+  operator-generated high-entropy randomness, not a human password — there is
+  no low-entropy input for a fast hash to endanger, and it avoids a new
+  direct dependency.
+- **No per-client `scopes` field.** Scopes are declared-not-enforced
+  broker-wide today; a per-client list would be dead config. Add it when
+  scope enforcement exists.
+- **PKCE stays required for confidential clients** — defense in depth; the
+  authorize handler enforces S256 for both client classes.
+
+## Consequences
+
+- Native/CLI clients (Claude Code MCP SDK, demarkus-join) are untouched: no
+  registry entry → identical behavior on every endpoint.
+- The Universe Library (and future first-party web apps) can run standard
+  redirect SSO against the broker with a deploy-time client registration.
+- Operators must generate the client secret out of band and put only its
+  sha256 into config; the chart needs a values surface for `webClients`
+  (follow-up, not in this change).
+- A client deregistered from config invalidates its bound refresh tokens at
+  the refresh gate until re-registered or users re-authenticate.

--- a/tools/demarkus-broker/internal/broker/client_auth.go
+++ b/tools/demarkus-broker/internal/broker/client_auth.go
@@ -1,0 +1,81 @@
+package broker
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// clientAuth is the client identity a token-endpoint request presented,
+// extracted from HTTP Basic (RFC 6749 §2.3.1) or client_secret_post
+// form parameters. Secret is empty when the client presented no
+// credential at all — the public-client shape; whether that is
+// acceptable is the caller's decision based on the WebClients registry.
+type clientAuth struct {
+	ClientID string
+	Secret   string
+}
+
+// parseClientAuth extracts the client credentials from a token-endpoint
+// request. Precedence and error rules follow RFC 6749 §2.3:
+//
+//   - HTTP Basic wins when present. Username and password are
+//     form-urlencoded before Basic-encoding per §2.3.1, so both halves
+//     are unescaped here. A form client_id that contradicts the Basic
+//     username, or a form client_secret alongside Basic, is "more than
+//     one authentication mechanism" and is rejected.
+//   - Otherwise client_id + client_secret come from the form
+//     (client_secret_post). Either may be empty — a bare client_id
+//     with no secret is the existing public-client request shape.
+//
+// Errors are client mistakes; callers map them to invalid_request.
+func parseClientAuth(r *http.Request) (clientAuth, error) {
+	basicID, basicSecret, ok := r.BasicAuth()
+	if !ok {
+		return clientAuth{
+			ClientID: r.PostFormValue("client_id"),
+			Secret:   r.PostFormValue("client_secret"),
+		}, nil
+	}
+	if r.PostFormValue("client_secret") != "" {
+		return clientAuth{}, errors.New("client must not use both Basic and client_secret_post")
+	}
+	id, err := url.QueryUnescape(basicID)
+	if err != nil {
+		return clientAuth{}, fmt.Errorf("basic auth client_id: %w", err)
+	}
+	secret, err := url.QueryUnescape(basicSecret)
+	if err != nil {
+		return clientAuth{}, fmt.Errorf("basic auth client_secret: %w", err)
+	}
+	if formID := r.PostFormValue("client_id"); formID != "" && formID != id {
+		return clientAuth{}, errors.New("client_id mismatch between Basic auth and form")
+	}
+	return clientAuth{ClientID: id, Secret: secret}, nil
+}
+
+// verifyWebClientSecret reports whether the presented plaintext secret
+// matches the client's registered sha256 hash. The compare runs over
+// the two hex digests in constant time; hashing the presented secret
+// first means the comparison length is fixed regardless of what the
+// client sent, so neither length nor content leaks through timing.
+func verifyWebClientSecret(wc *WebClientConfig, secret string) bool {
+	if secret == "" {
+		return false
+	}
+	sum := sha256.Sum256([]byte(secret))
+	presented := hex.EncodeToString(sum[:])
+	return subtle.ConstantTimeCompare([]byte(presented), []byte(wc.ClientSecretHash)) == 1
+}
+
+// writeInvalidClient emits the RFC 6749 §5.2 invalid_client response:
+// 401 with a WWW-Authenticate challenge naming the Basic scheme the
+// broker prefers for confidential clients.
+func writeInvalidClient(w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", `Basic realm="demarkus-broker"`)
+	writeJSON(w, http.StatusUnauthorized, deviceTokenError{Error: "invalid_client"})
+}

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -20,9 +21,63 @@ type Config struct {
 	Server      ServerConfig      `yaml:"server"`
 	OIDC        OIDCConfig        `yaml:"oidc"`
 	Worlds      []WorldConfig     `yaml:"worlds"`
+	WebClients  []WebClientConfig `yaml:"webClients"`
 	Sweeper     SweeperConfig     `yaml:"sweeper"`
 	RateLimit   RateLimitConfig   `yaml:"rateLimit"`
 	WorldDialer WorldDialerConfig `yaml:"worldDialer"`
+}
+
+// WebClientConfig registers one confidential web client (RFC 6749 §2.1)
+// at the broker — a server-side app that can keep a secret and receives
+// the authorization-code redirect at a real https URL instead of a
+// native-app loopback. The registry is the explicit operator-curated
+// list of first-party apps (e.g. the Universe Library); it is NOT open
+// dynamic registration — /register stays public-client-only.
+//
+// Public/native clients (Claude Code's MCP SDK, demarkus-join) never
+// appear here: an unregistered client_id keeps the existing
+// loopback-only PKCE path on /oauth/authorize untouched.
+type WebClientConfig struct {
+	// ClientID is the registered identifier the web app presents on
+	// /oauth/authorize and the token endpoint. Must be unique across
+	// the registry.
+	ClientID string `yaml:"clientID"`
+	// ClientSecretHash is the lowercase sha256-hex of the client
+	// secret. The plaintext secret never appears in broker config —
+	// the operator generates a high-entropy secret, hands it to the
+	// web app's deployment, and stores only the hash here. sha256
+	// (not bcrypt) is sufficient because the secret is
+	// operator-generated randomness, not a human password — there is
+	// no low-entropy input for a fast hash to endanger.
+	ClientSecretHash string `yaml:"clientSecretHash"`
+	// RedirectURIs is the exact-match allowlist for this client's
+	// redirect_uri. Each entry must be an absolute https URL; no
+	// wildcards, no prefix matching, no loopback exemption — the web
+	// app's callback URL is known at deploy time and anything looser
+	// is an open-redirect foothold.
+	RedirectURIs []string `yaml:"redirectURIs"`
+	// Name is an optional human label for logs and operator grep.
+	Name string `yaml:"name"`
+}
+
+// webClient returns the registered confidential client for clientID,
+// or false when the id is unregistered (the public/native path).
+// Linear scan — the registry is a handful of first-party apps.
+func (c *Config) webClient(clientID string) (*WebClientConfig, bool) {
+	for i := range c.WebClients {
+		if c.WebClients[i].ClientID == clientID {
+			return &c.WebClients[i], true
+		}
+	}
+	return nil, false
+}
+
+// allowsRedirect reports whether raw exactly matches one of the
+// client's registered redirect URIs. Byte-for-byte compare per OAuth
+// 2.1 — normalization tricks (case, default ports, dot segments) are
+// how redirect allowlists get bypassed.
+func (wc *WebClientConfig) allowsRedirect(raw string) bool {
+	return slices.Contains(wc.RedirectURIs, raw)
 }
 
 // WorldDialerConfig holds knobs governing how the broker's MCP gateway
@@ -523,6 +578,9 @@ func (c *Config) validate() error {
 		}
 		seen[w.Name] = true
 	}
+	if err := validateWebClients(c.WebClients); err != nil {
+		return err
+	}
 	// Sweeper defaults. Disabled is the zero-value opt-out — see the
 	// SweeperConfig doc for why it's named "Disabled" rather than
 	// "Enabled". Interval and LeaseName get production-safe defaults
@@ -768,6 +826,83 @@ func validateWorld(i int, w *WorldConfig) error {
 		return err
 	}
 	return normalizeAllowList(i, w.Name, "groups", w.Allow.Groups)
+}
+
+// validateWebClients enforces the confidential-client registry
+// invariants and normalizes secret hashes in place. Every axis is an
+// operator typo that must fail at load: a half-registered client
+// would either lock out the web app (bad hash) or silently fall back
+// to the loopback-only path (missing redirect), both of which present
+// as confusing runtime auth failures instead of a startup error.
+func validateWebClients(clients []WebClientConfig) error {
+	seen := make(map[string]bool, len(clients))
+	for i := range clients {
+		wc := &clients[i]
+		if wc.ClientID == "" {
+			return fmt.Errorf("webClients[%d]: clientID is required", i)
+		}
+		if seen[wc.ClientID] {
+			return fmt.Errorf("webClients[%d]: duplicate clientID %q", i, wc.ClientID)
+		}
+		seen[wc.ClientID] = true
+		// Normalize to lowercase so the runtime constant-time compare
+		// never misses on an uppercase-hex operator paste.
+		wc.ClientSecretHash = strings.ToLower(strings.TrimSpace(wc.ClientSecretHash))
+		if !isSHA256Hex(wc.ClientSecretHash) {
+			return fmt.Errorf("webClients[%d] (%s): clientSecretHash must be 64 hex chars (sha256 of the client secret)", i, wc.ClientID)
+		}
+		if len(wc.RedirectURIs) == 0 {
+			return fmt.Errorf("webClients[%d] (%s): at least one redirectURI is required", i, wc.ClientID)
+		}
+		for j, raw := range wc.RedirectURIs {
+			if err := validateWebRedirectURI(raw); err != nil {
+				return fmt.Errorf("webClients[%d] (%s): redirectURIs[%d]: %w", i, wc.ClientID, j, err)
+			}
+		}
+	}
+	return nil
+}
+
+// validateWebRedirectURI enforces the registered-redirect shape:
+// absolute https URL, no userinfo, no fragment. Loopback hosts are
+// rejected too — a web client registering http://localhost belongs on
+// the native path, and letting it in here would blur the one boundary
+// this registry exists to draw.
+func validateWebRedirectURI(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid URL %q: %w", raw, err)
+	}
+	switch {
+	case u.Scheme != "https":
+		return fmt.Errorf("%q: scheme must be https", raw)
+	case u.Host == "":
+		return fmt.Errorf("%q: host is required", raw)
+	case u.User != nil:
+		return fmt.Errorf("%q: userinfo is not allowed", raw)
+	case u.Fragment != "" || u.RawFragment != "":
+		return fmt.Errorf("%q: fragment is not allowed", raw)
+	}
+	switch u.Hostname() {
+	case "127.0.0.1", "localhost", "::1":
+		return fmt.Errorf("%q: loopback hosts use the native-app flow, not the web-client registry", raw)
+	}
+	return nil
+}
+
+// isSHA256Hex reports whether s is exactly 64 lowercase hex chars —
+// the shape of a sha256 hex digest. Validation-time gate so a
+// truncated or plaintext-pasted secret fails at load.
+func isSHA256Hex(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 func normalizeAllowList(worldIdx int, worldName, field string, list []string) error {

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -147,6 +147,43 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: "server.stateTTL must be > 0",
 		},
 		{
+			// YAML round-trip for the webClients registry — the chart
+			// renders exactly this shape, and LoadConfig's
+			// KnownFields(true) would reject a yaml-tag typo that the
+			// direct validateWebClients tests can't catch.
+			name: "webClients block parses and normalizes",
+			body: validConfig + `webClients:
+  - clientID: library-web
+    clientSecretHash: "` + strings.ToUpper(strings.Repeat("ab", 32)) + `"
+    redirectURIs: ["https://library.example.com/auth/callback"]
+    name: Universe Library
+`,
+			validate: func(t *testing.T, c *Config) {
+				if len(c.WebClients) != 1 {
+					t.Fatalf("webClients = %+v", c.WebClients)
+				}
+				wc := c.WebClients[0]
+				if wc.ClientID != "library-web" {
+					t.Errorf("clientID = %q", wc.ClientID)
+				}
+				if wc.ClientSecretHash != strings.Repeat("ab", 32) {
+					t.Errorf("hash not lowercased: %q", wc.ClientSecretHash)
+				}
+				if !wc.allowsRedirect("https://library.example.com/auth/callback") {
+					t.Errorf("redirectURIs = %v", wc.RedirectURIs)
+				}
+			},
+		},
+		{
+			name: "webClients loopback redirect rejected at load",
+			body: validConfig + `webClients:
+  - clientID: library-web
+    clientSecretHash: "` + strings.Repeat("ab", 32) + `"
+    redirectURIs: ["https://localhost:8443/cb"]
+`,
+			wantErr: "loopback hosts",
+		},
+		{
 			name:    "sweeper.interval over 24h rejected",
 			body:    validConfig + "sweeper:\n  interval: 48h\n",
 			wantErr: "sweeper.interval must be <= 24h0m0s",

--- a/tools/demarkus-broker/internal/broker/device.go
+++ b/tools/demarkus-broker/internal/broker/device.go
@@ -279,10 +279,23 @@ func (s *Server) deviceTokenDeviceFlow(w http.ResponseWriter, r *http.Request) {
 // per-broker quirk. Same string in both fields keeps the
 // OIDC-client-library default codepath working.
 //
+// Client authentication: a record carrying a non-empty ClientID was
+// issued to a confidential web client and the request must
+// authenticate as that client (Basic or client_secret_post) — a
+// leaked refresh token alone mints nothing. The binding check runs
+// after the store lookup because the record IS the source of the
+// requirement; the only side effect before the gate is the record's
+// LastUsedAt bump, which is observability metadata, not credential
+// state. Unbound records (device flow, loopback auth-code) refresh
+// without client auth, unchanged.
+//
 // Error mapping:
-//   - Missing refresh_token form param → invalid_request
+//   - Missing refresh_token form param / malformed client auth →
+//     invalid_request
 //   - refreshStore rejects (unknown / expired / revoked) →
 //     invalid_grant per RFC 6749 §5.2
+//   - Missing or wrong client auth for a client-bound record →
+//     401 invalid_client + WWW-Authenticate: Basic
 //   - Signing failure (programming error) → 500 server_error
 //   - id-token-signer not wired (operator misconfig) → 500
 //     server_error; PR4 wiring requires it always
@@ -296,6 +309,12 @@ func (s *Server) deviceTokenRefresh(w http.ResponseWriter, r *http.Request) {
 		// fails loudly.
 		s.log.ErrorContext(r.Context(), "broker: refresh grant requested but id_token signer not wired")
 		writeJSON(w, http.StatusInternalServerError, deviceTokenError{Error: "server_error"})
+		return
+	}
+	creds, err := parseClientAuth(r)
+	if err != nil {
+		s.log.DebugContext(r.Context(), "broker: refresh client auth malformed", "err", err)
+		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "invalid_request"})
 		return
 	}
 	rawRefresh := r.PostFormValue("refresh_token")
@@ -312,6 +331,21 @@ func (s *Server) deviceTokenRefresh(w http.ResponseWriter, r *http.Request) {
 		s.log.ErrorContext(r.Context(), "broker: refresh store read failed", "err", err)
 		writeJSON(w, http.StatusInternalServerError, deviceTokenError{Error: "server_error"})
 		return
+	}
+	if record.ClientID != "" {
+		// Client-bound token: the presented identity must be the bound
+		// client and its secret must verify against the registry. A
+		// client deregistered since issuance also lands here — the
+		// binding can no longer be verified, so the token mints
+		// nothing until the operator restores the registration or the
+		// user re-authenticates.
+		webClient, ok := s.cfg.webClient(record.ClientID)
+		if !ok || creds.ClientID != record.ClientID || !verifyWebClientSecret(webClient, creds.Secret) {
+			s.log.InfoContext(r.Context(), "broker: refresh client auth failed",
+				"bound_client_id", record.ClientID, "subject", hashSubject(record.Claims.Subject))
+			writeInvalidClient(w)
+			return
+		}
 	}
 	now := s.clock()
 	idToken, err := s.idTokenSigner.Sign(&record.Claims, s.cfg.Server.PublicURL, s.cfg.Server.IDTokenTTL, now)
@@ -347,8 +381,22 @@ func (s *Server) deviceTokenRefresh(w http.ResponseWriter, r *http.Request) {
 // field, and empty access_token would force every client to learn
 // a per-broker quirk.
 //
+// Client authentication: a client_id registered in the WebClients
+// registry is confidential and MUST authenticate (RFC 6749 §3.2.1)
+// via HTTP Basic or client_secret_post. The check runs BEFORE
+// Redeem so a bad secret does not consume the code — mirroring the
+// store's keep-code-on-client-error semantics. An unregistered
+// client_id is the public/native path and presents no secret, as
+// before. The store's client_id binding inside Redeem is what makes
+// the registry lookup here authoritative: a code minted for a
+// confidential client can only redeem under that client_id, and
+// that client_id always trips this gate.
+//
 // Error mapping:
-//   - Missing required form params → invalid_request
+//   - Missing required form params / malformed client auth →
+//     invalid_request
+//   - Missing or wrong client secret for a registered web client →
+//     401 invalid_client + WWW-Authenticate: Basic
 //   - authCodeStore.Redeem error (unknown code, mismatch, PKCE) →
 //     invalid_grant. We deliberately collapse the store's distinct
 //     sentinels into one wire code so the response surface does
@@ -369,13 +417,33 @@ func (s *Server) deviceTokenAuthCode(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, deviceTokenError{Error: "server_error"})
 		return
 	}
+	creds, err := parseClientAuth(r)
+	if err != nil {
+		s.log.DebugContext(r.Context(), "broker: auth code client auth malformed", "err", err)
+		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "invalid_request"})
+		return
+	}
 	code := r.PostFormValue("code")
-	clientID := r.PostFormValue("client_id")
+	clientID := creds.ClientID
 	redirectURI := r.PostFormValue("redirect_uri")
 	codeVerifier := r.PostFormValue("code_verifier")
 	if code == "" || clientID == "" || redirectURI == "" || codeVerifier == "" {
 		writeJSON(w, http.StatusBadRequest, deviceTokenError{Error: "invalid_request"})
 		return
+	}
+
+	// boundClientID is recorded into the refresh token for confidential
+	// clients so the refresh grant can demand the same authentication.
+	// Stays empty on the public path — an unbound token refreshes as
+	// before.
+	var boundClientID string
+	if webClient, ok := s.cfg.webClient(clientID); ok {
+		if !verifyWebClientSecret(webClient, creds.Secret) {
+			s.log.InfoContext(r.Context(), "broker: auth code client auth failed", "client_id", clientID)
+			writeInvalidClient(w)
+			return
+		}
+		boundClientID = clientID
 	}
 
 	exchange, err := s.authCodeStore.Redeem(code, clientID, redirectURI, codeVerifier)
@@ -389,7 +457,7 @@ func (s *Server) deviceTokenAuthCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rawRefresh, err := s.refreshStore.Issue(r.Context(), &exchange.Claims, s.cfg.Server.RefreshTokenTTL)
+	rawRefresh, err := s.refreshStore.Issue(r.Context(), &exchange.Claims, boundClientID, s.cfg.Server.RefreshTokenTTL)
 	if err != nil {
 		// Code is already consumed by Redeem (one-shot). The user
 		// has to retry from /oauth/authorize; that's acceptable
@@ -524,7 +592,9 @@ func (s *Server) deviceCallback(w http.ResponseWriter, r *http.Request, deviceCo
 	// statusComplete state goes out without its refresh token.
 	// Orphaned refresh-tokens Secret entries (mint succeeded, Bind
 	// then races a sweep) age out on Sweep via their expiry.
-	rawRefresh, err := s.refreshStore.Issue(r.Context(), &exchange.Claims, s.cfg.Server.RefreshTokenTTL)
+	// Device-flow tokens are never client-bound — the polling clients
+	// are public/native by construction.
+	rawRefresh, err := s.refreshStore.Issue(r.Context(), &exchange.Claims, "", s.cfg.Server.RefreshTokenTTL)
 	if err != nil {
 		s.log.WarnContext(r.Context(), "broker: device callback refresh mint failed",
 			"err", err, "subject", hashSubject(exchange.Claims.Subject))

--- a/tools/demarkus-broker/internal/broker/device_test.go
+++ b/tools/demarkus-broker/internal/broker/device_test.go
@@ -958,7 +958,7 @@ func TestDeviceTokenRefreshGrant(t *testing.T) {
 		t.Fatalf("Authorize: %v", err)
 	}
 	rawRefresh, err := broker.refreshStore.Issue(context.Background(),
-		&verifier.claims, broker.cfg.Server.RefreshTokenTTL)
+		&verifier.claims, "", broker.cfg.Server.RefreshTokenTTL)
 	if err != nil {
 		t.Fatalf("refresh Issue: %v", err)
 	}
@@ -1074,7 +1074,7 @@ func TestDeviceTokenRefreshRejectsRevoked(t *testing.T) {
 	signer := newTestIDTokenSigner(t)
 	srv, broker := newTestServerWithSigner(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), signer)
 	rawRefresh, err := broker.refreshStore.Issue(context.Background(),
-		&Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+		&Claims{Email: "a@b.com", EmailVerified: true}, "", time.Hour)
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
@@ -1109,7 +1109,7 @@ func TestDeviceTokenRefreshCrossGrantIsolation(t *testing.T) {
 
 	// Issue a refresh token; try it on the device_code branch.
 	rawRefresh, err := broker.refreshStore.Issue(context.Background(),
-		&Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+		&Claims{Email: "a@b.com", EmailVerified: true}, "", time.Hour)
 	if err != nil {
 		t.Fatalf("Issue refresh: %v", err)
 	}

--- a/tools/demarkus-broker/internal/broker/discovery.go
+++ b/tools/demarkus-broker/internal/broker/discovery.go
@@ -299,6 +299,19 @@ func applyDiscoveryOverrides(raw []byte, brokerURL string) ([]byte, error) {
 	// that probe for OAuth 2.1 compliance check this list before
 	// they kick off /oauth/authorize.
 	doc["response_types_supported"] = []string{"code"}
+	// token_endpoint_auth_methods_supported reflects the broker's
+	// two client classes: public/native clients authenticate with
+	// nothing but PKCE (`none`), registered confidential web clients
+	// present their secret via HTTP Basic (preferred) or
+	// client_secret_post. Overridden rather than passed through so
+	// the IdP's own method list (often including private_key_jwt
+	// etc.) doesn't promise mechanisms the broker's token endpoint
+	// would reject.
+	doc["token_endpoint_auth_methods_supported"] = []string{
+		"none",
+		"client_secret_basic",
+		"client_secret_post",
+	}
 	// code_challenge_methods_supported declares S256-only PKCE.
 	// `plain` is excluded by policy (see oauth_authorize.go). The
 	// override replaces any upstream value verbatim so the broker's

--- a/tools/demarkus-broker/internal/broker/oauth_authorize.go
+++ b/tools/demarkus-broker/internal/broker/oauth_authorize.go
@@ -16,11 +16,20 @@ import (
 //
 // Two-phase validation matches RFC 6749 §4.1.2.1: errors that
 // happen BEFORE the redirect_uri is trusted (missing client_id,
-// non-loopback redirect_uri) surface as a JSON 400 directly to the
+// unacceptable redirect_uri) surface as a JSON 400 directly to the
 // user agent. Errors AFTER trust is established (bad response_type,
 // missing PKCE, store failure) redirect to the client's
 // redirect_uri with `error=...&state=...` so the MCP SDK can surface
 // the failure programmatically.
+//
+// Redirect trust is two-class: a client_id registered in the
+// WebClients registry (confidential web app) must present an exact
+// match against its registered https redirect allowlist; every other
+// client_id is the native/public path and must present a loopback
+// redirect per RFC 8252 §7.3. Whether the grant then requires client
+// authentication at the token endpoint is decided there by the same
+// registry lookup — the auth-code store's client_id binding
+// guarantees the two lookups see the same client.
 //
 // PKCE is required: the broker accepts only `code_challenge_method=
 // S256` and rejects requests missing `code_challenge`. OAuth 2.1
@@ -51,7 +60,16 @@ func (s *Server) oauthAuthorize(w http.ResponseWriter, r *http.Request) {
 		writeAuthorizeJSONError(w, "invalid_request", "redirect_uri required")
 		return
 	}
-	if !isLoopbackRedirectURI(redirectURI) {
+	if webClient, ok := s.cfg.webClient(clientID); ok {
+		// Registered confidential web client: the redirect target is
+		// the operator-curated exact-match allowlist, not loopback.
+		// RFC 6749 §3.1.2.3 — pre-registered redirect URIs are the
+		// redirect-trust mechanism for confidential clients.
+		if !webClient.allowsRedirect(redirectURI) {
+			writeAuthorizeJSONError(w, "invalid_request", "redirect_uri is not registered for this client")
+			return
+		}
+	} else if !isLoopbackRedirectURI(redirectURI) {
 		// RFC 8252 §7.3: native apps MUST use loopback. Any other
 		// host is a configuration mistake or an attack; either way
 		// the broker refuses BEFORE the redirect is trusted, so the

--- a/tools/demarkus-broker/internal/broker/refresh.go
+++ b/tools/demarkus-broker/internal/broker/refresh.go
@@ -71,6 +71,14 @@ type refreshTokenRecord struct {
 	IssuedAt   time.Time `json:"issuedAt"`
 	ExpiresAt  time.Time `json:"expiresAt"`
 	LastUsedAt time.Time `json:"lastUsedAt,omitzero"`
+	// ClientID binds the token to the confidential web client it was
+	// issued to: the refresh grant then requires that client to
+	// authenticate, so a leaked refresh token alone mints nothing.
+	// Empty for tokens issued on the public/native paths (device
+	// flow, loopback auth-code), which refresh without client auth
+	// as before. omitempty keeps pre-existing Secret records valid —
+	// they decode with an empty ClientID, i.e. unbound.
+	ClientID string `json:"clientID,omitempty"`
 }
 
 // refreshTokens is the on-disk shape of the broker's refresh-tokens
@@ -118,12 +126,14 @@ func NewRefreshStore(cfg *Config, k8s kubernetes.Interface) *RefreshStore {
 // in the Secret, and returns the raw token for the caller to hand
 // back to the polling client. ttl must be > 0; callers (the
 // /device/token success branch in Step 2) pass
-// ServerConfig.RefreshTokenTTL.
+// ServerConfig.RefreshTokenTTL. clientID is the confidential web
+// client the token is bound to, or "" for the public/native paths —
+// see refreshTokenRecord.ClientID for the binding semantics.
 //
 // The raw token is hex-encoded 32-byte randomness (64 chars). The
 // caller is responsible for treating it as bearer credential material
 // — no logging, no retries that would surface it in error messages.
-func (s *RefreshStore) Issue(ctx context.Context, claims *Claims, ttl time.Duration) (string, error) {
+func (s *RefreshStore) Issue(ctx context.Context, claims *Claims, clientID string, ttl time.Duration) (string, error) {
 	if ttl <= 0 {
 		return "", fmt.Errorf("refresh ttl must be > 0 (got %s)", ttl)
 	}
@@ -139,6 +149,7 @@ func (s *RefreshStore) Issue(ctx context.Context, claims *Claims, ttl time.Durat
 		Claims:    *claims,
 		IssuedAt:  now,
 		ExpiresAt: now.Add(ttl),
+		ClientID:  clientID,
 	}
 	err := mutateSecret(ctx, s.k8s, s.cfg.Server.BrokerNamespace, s.cfg.Server.RefreshTokensSecret, RefreshTokensSecretKey, func(existing []byte) ([]byte, error) {
 		store, err := decodeRefreshTokens(existing)

--- a/tools/demarkus-broker/internal/broker/refresh_test.go
+++ b/tools/demarkus-broker/internal/broker/refresh_test.go
@@ -50,7 +50,7 @@ func TestRefreshStoreIssueRoundTrip(t *testing.T) {
 	ctx := context.Background()
 
 	claims := Claims{Subject: "user-1", Email: "alice@example.com", EmailVerified: true, Groups: []string{"eng"}}
-	raw, err := s.Issue(ctx, &claims, s.cfg.Server.RefreshTokenTTL)
+	raw, err := s.Issue(ctx, &claims, "", s.cfg.Server.RefreshTokenTTL)
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
@@ -91,10 +91,10 @@ func TestRefreshStoreIssueRoundTrip(t *testing.T) {
 func TestRefreshStoreIssueRejectsZeroTTL(t *testing.T) {
 	k8s := fake.NewSimpleClientset()
 	s := newRefreshStoreForTest(t, k8s)
-	if _, err := s.Issue(context.Background(), &Claims{}, 0); err == nil {
+	if _, err := s.Issue(context.Background(), &Claims{}, "", 0); err == nil {
 		t.Fatalf("Issue with ttl=0 should error")
 	}
-	if _, err := s.Issue(context.Background(), &Claims{}, -time.Second); err == nil {
+	if _, err := s.Issue(context.Background(), &Claims{}, "", -time.Second); err == nil {
 		t.Fatalf("Issue with negative ttl should error")
 	}
 }
@@ -133,7 +133,7 @@ func TestRefreshStoreRefreshErrors(t *testing.T) {
 			k8s := fake.NewSimpleClientset()
 			s := newRefreshStoreForTest(t, k8s)
 			ctx := context.Background()
-			raw, err := s.Issue(ctx, &Claims{Subject: "u", Email: "a@b.com", EmailVerified: true}, time.Hour)
+			raw, err := s.Issue(ctx, &Claims{Subject: "u", Email: "a@b.com", EmailVerified: true}, "", time.Hour)
 			if err != nil {
 				t.Fatalf("setup Issue: %v", err)
 			}
@@ -150,7 +150,7 @@ func TestRefreshStoreRevoke(t *testing.T) {
 		k8s := fake.NewSimpleClientset()
 		s := newRefreshStoreForTest(t, k8s)
 		ctx := context.Background()
-		raw, err := s.Issue(ctx, &Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+		raw, err := s.Issue(ctx, &Claims{Email: "a@b.com", EmailVerified: true}, "", time.Hour)
 		if err != nil {
 			t.Fatalf("Issue: %v", err)
 		}
@@ -175,7 +175,7 @@ func TestRefreshStoreRevoke(t *testing.T) {
 			t.Errorf("Secret should not exist after no-op Revoke; Get err = %v", err)
 		}
 		// Now after an Issue + Revoke, revoke-unknown still succeeds.
-		raw, err := s.Issue(context.Background(), &Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+		raw, err := s.Issue(context.Background(), &Claims{Email: "a@b.com", EmailVerified: true}, "", time.Hour)
 		if err != nil {
 			t.Fatalf("Issue: %v", err)
 		}
@@ -207,11 +207,11 @@ func TestRefreshStoreSweep(t *testing.T) {
 		base := s.clock()
 
 		// Mint one short-lived (1h) and one long-lived (48h) token.
-		shortRaw, err := s.Issue(ctx, &Claims{Email: "short@x.com", EmailVerified: true}, time.Hour)
+		shortRaw, err := s.Issue(ctx, &Claims{Email: "short@x.com", EmailVerified: true}, "", time.Hour)
 		if err != nil {
 			t.Fatalf("Issue short: %v", err)
 		}
-		longRaw, err := s.Issue(ctx, &Claims{Email: "long@x.com", EmailVerified: true}, 48*time.Hour)
+		longRaw, err := s.Issue(ctx, &Claims{Email: "long@x.com", EmailVerified: true}, "", 48*time.Hour)
 		if err != nil {
 			t.Fatalf("Issue long: %v", err)
 		}
@@ -253,7 +253,7 @@ func TestRefreshStoreSweep(t *testing.T) {
 	t.Run("no-op when nothing expired", func(t *testing.T) {
 		k8s := fake.NewSimpleClientset()
 		s := newRefreshStoreForTest(t, k8s)
-		_, err := s.Issue(context.Background(), &Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+		_, err := s.Issue(context.Background(), &Claims{Email: "a@b.com", EmailVerified: true}, "", time.Hour)
 		if err != nil {
 			t.Fatalf("Issue: %v", err)
 		}
@@ -272,7 +272,7 @@ func TestRefreshStoreSecretShape(t *testing.T) {
 	s := newRefreshStoreForTest(t, k8s)
 	ctx := context.Background()
 
-	raw, err := s.Issue(ctx, &Claims{Subject: "u1", Email: "a@example.com", EmailVerified: true, Groups: []string{"g"}}, time.Hour)
+	raw, err := s.Issue(ctx, &Claims{Subject: "u1", Email: "a@example.com", EmailVerified: true, Groups: []string{"g"}}, "", time.Hour)
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
@@ -321,7 +321,7 @@ func TestRefreshStoreConcurrentRefresh(t *testing.T) {
 	const n = 50
 	tokens := make([]string, n)
 	for i := range n {
-		raw, err := s.Issue(ctx, &Claims{Subject: fmt.Sprintf("u%d", i), Email: fmt.Sprintf("u%d@x.com", i), EmailVerified: true}, time.Hour)
+		raw, err := s.Issue(ctx, &Claims{Subject: fmt.Sprintf("u%d", i), Email: fmt.Sprintf("u%d@x.com", i), EmailVerified: true}, "", time.Hour)
 		if err != nil {
 			t.Fatalf("setup Issue[%d]: %v", i, err)
 		}
@@ -385,7 +385,7 @@ func TestRefreshStoreIssueConflictRetries(t *testing.T) {
 	}
 
 	s := newRefreshStoreForTest(t, k8s)
-	raw, err := s.Issue(context.Background(), &Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+	raw, err := s.Issue(context.Background(), &Claims{Email: "a@b.com", EmailVerified: true}, "", time.Hour)
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
@@ -415,10 +415,10 @@ func TestRefreshStoreCollisionRetry(t *testing.T) {
 		return len(b), nil
 	}
 	ctx := context.Background()
-	if _, err := s.Issue(ctx, &Claims{Email: "a@b.com", EmailVerified: true}, time.Hour); err != nil {
+	if _, err := s.Issue(ctx, &Claims{Email: "a@b.com", EmailVerified: true}, "", time.Hour); err != nil {
 		t.Fatalf("first Issue: %v", err)
 	}
-	if _, err := s.Issue(ctx, &Claims{Email: "a@b.com", EmailVerified: true}, time.Hour); err == nil {
+	if _, err := s.Issue(ctx, &Claims{Email: "a@b.com", EmailVerified: true}, "", time.Hour); err == nil {
 		t.Fatalf("second Issue with identical randomness should fail with collision")
 	}
 	if calls != 2 {

--- a/tools/demarkus-broker/internal/broker/revoke_test.go
+++ b/tools/demarkus-broker/internal/broker/revoke_test.go
@@ -19,7 +19,7 @@ import (
 func TestTokenRevokeValid(t *testing.T) {
 	srv, broker := newTestServerWithSigner(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
 	rawRefresh, err := broker.refreshStore.Issue(context.Background(),
-		&Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+		&Claims{Email: "a@b.com", EmailVerified: true}, "", time.Hour)
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestTokenRevokeAcceptsTokenTypeHint(t *testing.T) {
 	// eager future validator).
 	srv, broker := newTestServerWithSigner(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
 	rawRefresh, err := broker.refreshStore.Issue(context.Background(),
-		&Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+		&Claims{Email: "a@b.com", EmailVerified: true}, "", time.Hour)
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestTokenRevokeAcceptsTokenTypeHint(t *testing.T) {
 func TestTokenRevokeIdempotent(t *testing.T) {
 	srv, broker := newTestServerWithSigner(t, deviceTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
 	rawRefresh, err := broker.refreshStore.Issue(context.Background(),
-		&Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+		&Claims{Email: "a@b.com", EmailVerified: true}, "", time.Hour)
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestTokenRevokeServerErrorIsJSON(t *testing.T) {
 	// (the no-Secret-exists path returns nil and skips the failure
 	// surface).
 	rawRefresh, err := broker.refreshStore.Issue(context.Background(),
-		&Claims{Email: "a@b.com", EmailVerified: true}, time.Hour)
+		&Claims{Email: "a@b.com", EmailVerified: true}, "", time.Hour)
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}

--- a/tools/demarkus-broker/internal/broker/sweeper_test.go
+++ b/tools/demarkus-broker/internal/broker/sweeper_test.go
@@ -20,11 +20,11 @@ func TestSweepRemovesExpiredRefreshTokens(t *testing.T) {
 	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
 	rs.clock = func() time.Time { return base }
 
-	short, err := rs.Issue(context.Background(), &Claims{Email: "short@x.com", EmailVerified: true}, time.Hour)
+	short, err := rs.Issue(context.Background(), &Claims{Email: "short@x.com", EmailVerified: true}, "", time.Hour)
 	if err != nil {
 		t.Fatalf("Issue short: %v", err)
 	}
-	long, err := rs.Issue(context.Background(), &Claims{Email: "long@x.com", EmailVerified: true}, 48*time.Hour)
+	long, err := rs.Issue(context.Background(), &Claims{Email: "long@x.com", EmailVerified: true}, "", 48*time.Hour)
 	if err != nil {
 		t.Fatalf("Issue long: %v", err)
 	}

--- a/tools/demarkus-broker/internal/broker/web_client_test.go
+++ b/tools/demarkus-broker/internal/broker/web_client_test.go
@@ -1,0 +1,667 @@
+package broker
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// testWebClientSecret is the plaintext secret the registered test web
+// client authenticates with; only its sha256 hash enters the config.
+const testWebClientSecret = "web-client-secret-0123456789abcdef"
+
+const testWebClientID = "library-web"
+
+const testWebRedirectURI = "https://library.example.com/auth/callback"
+
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// webTestConfig is testConfig plus one registered confidential web
+// client — the Universe Library shape from the phase-1b plan.
+func webTestConfig() *Config {
+	cfg := testConfig()
+	cfg.WebClients = []WebClientConfig{{
+		ClientID:         testWebClientID,
+		ClientSecretHash: sha256Hex(testWebClientSecret),
+		RedirectURIs:     []string{testWebRedirectURI},
+		Name:             "Universe Library",
+	}}
+	return cfg
+}
+
+func TestValidateWebClients(t *testing.T) {
+	valid := func() []WebClientConfig {
+		return []WebClientConfig{{
+			ClientID:         testWebClientID,
+			ClientSecretHash: sha256Hex(testWebClientSecret),
+			RedirectURIs:     []string{testWebRedirectURI},
+		}}
+	}
+	tests := []struct {
+		name    string
+		mutate  func([]WebClientConfig) []WebClientConfig
+		wantErr string
+	}{
+		{
+			"valid entry passes",
+			func(c []WebClientConfig) []WebClientConfig { return c },
+			"",
+		},
+		{
+			"empty registry passes",
+			func([]WebClientConfig) []WebClientConfig { return nil },
+			"",
+		},
+		{
+			"missing clientID",
+			func(c []WebClientConfig) []WebClientConfig { c[0].ClientID = ""; return c },
+			"clientID is required",
+		},
+		{
+			"duplicate clientID",
+			func(c []WebClientConfig) []WebClientConfig { return append(c, c[0]) },
+			"duplicate clientID",
+		},
+		{
+			"missing secret hash",
+			func(c []WebClientConfig) []WebClientConfig { c[0].ClientSecretHash = ""; return c },
+			"clientSecretHash must be 64 hex chars",
+		},
+		{
+			"plaintext secret instead of hash",
+			func(c []WebClientConfig) []WebClientConfig { c[0].ClientSecretHash = testWebClientSecret; return c },
+			"clientSecretHash must be 64 hex chars",
+		},
+		{
+			"uppercase hash normalized",
+			func(c []WebClientConfig) []WebClientConfig {
+				c[0].ClientSecretHash = strings.ToUpper(c[0].ClientSecretHash)
+				return c
+			},
+			"",
+		},
+		{
+			"no redirect URIs",
+			func(c []WebClientConfig) []WebClientConfig { c[0].RedirectURIs = nil; return c },
+			"at least one redirectURI is required",
+		},
+		{
+			"http redirect rejected",
+			func(c []WebClientConfig) []WebClientConfig {
+				c[0].RedirectURIs = []string{"http://library.example.com/cb"}
+				return c
+			},
+			"scheme must be https",
+		},
+		{
+			"https loopback rejected",
+			func(c []WebClientConfig) []WebClientConfig {
+				c[0].RedirectURIs = []string{"https://localhost:8443/cb"}
+				return c
+			},
+			"loopback hosts",
+		},
+		{
+			"userinfo redirect rejected",
+			func(c []WebClientConfig) []WebClientConfig {
+				c[0].RedirectURIs = []string{"https://user@library.example.com/cb"}
+				return c
+			},
+			"userinfo is not allowed",
+		},
+		{
+			"fragment redirect rejected",
+			func(c []WebClientConfig) []WebClientConfig {
+				c[0].RedirectURIs = []string{"https://library.example.com/cb#frag"}
+				return c
+			},
+			"fragment is not allowed",
+		},
+		{
+			"relative redirect rejected",
+			func(c []WebClientConfig) []WebClientConfig {
+				c[0].RedirectURIs = []string{"/auth/callback"}
+				return c
+			},
+			"scheme must be https",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateWebClients(tt.mutate(valid()))
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("err = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("err = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateWebClientsNormalizesHash(t *testing.T) {
+	clients := []WebClientConfig{{
+		ClientID:         testWebClientID,
+		ClientSecretHash: " " + strings.ToUpper(sha256Hex(testWebClientSecret)) + " ",
+		RedirectURIs:     []string{testWebRedirectURI},
+	}}
+	if err := validateWebClients(clients); err != nil {
+		t.Fatalf("validateWebClients: %v", err)
+	}
+	if got, want := clients[0].ClientSecretHash, sha256Hex(testWebClientSecret); got != want {
+		t.Errorf("hash not normalized: got %q, want %q", got, want)
+	}
+}
+
+func TestParseClientAuth(t *testing.T) {
+	// makeReq builds a /device/token-shaped POST. basicID/basicSecret
+	// empty means no Authorization header.
+	makeReq := func(form url.Values, basicID, basicSecret string) *http.Request {
+		r := httptest.NewRequest(http.MethodPost, "/device/token", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		if basicID != "" || basicSecret != "" {
+			r.SetBasicAuth(basicID, basicSecret)
+		}
+		return r
+	}
+	tests := []struct {
+		name        string
+		form        url.Values
+		basicID     string
+		basicSecret string
+		want        clientAuth
+		wantErr     bool
+	}{
+		{
+			name: "no credentials is the public shape",
+			form: url.Values{"client_id": {"client-abc"}},
+			want: clientAuth{ClientID: "client-abc"},
+		},
+		{
+			name: "client_secret_post",
+			form: url.Values{"client_id": {testWebClientID}, "client_secret": {testWebClientSecret}},
+			want: clientAuth{ClientID: testWebClientID, Secret: testWebClientSecret},
+		},
+		{
+			name:        "basic auth",
+			form:        url.Values{},
+			basicID:     testWebClientID,
+			basicSecret: testWebClientSecret,
+			want:        clientAuth{ClientID: testWebClientID, Secret: testWebClientSecret},
+		},
+		{
+			name:        "basic auth halves are form-urlencoded (RFC 6749 §2.3.1)",
+			form:        url.Values{},
+			basicID:     "web%20app",
+			basicSecret: "s%3Acret",
+			want:        clientAuth{ClientID: "web app", Secret: "s:cret"},
+		},
+		{
+			name:        "basic plus matching form client_id is fine",
+			form:        url.Values{"client_id": {testWebClientID}},
+			basicID:     testWebClientID,
+			basicSecret: testWebClientSecret,
+			want:        clientAuth{ClientID: testWebClientID, Secret: testWebClientSecret},
+		},
+		{
+			name:        "basic plus contradicting form client_id rejected",
+			form:        url.Values{"client_id": {"someone-else"}},
+			basicID:     testWebClientID,
+			basicSecret: testWebClientSecret,
+			wantErr:     true,
+		},
+		{
+			name:        "basic plus client_secret_post rejected (two methods)",
+			form:        url.Values{"client_secret": {testWebClientSecret}},
+			basicID:     testWebClientID,
+			basicSecret: testWebClientSecret,
+			wantErr:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseClientAuth(makeReq(tt.form, tt.basicID, tt.basicSecret))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("err = nil, want error; got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseClientAuth: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerifyWebClientSecret(t *testing.T) {
+	wc := &WebClientConfig{
+		ClientID:         testWebClientID,
+		ClientSecretHash: sha256Hex(testWebClientSecret),
+	}
+	tests := []struct {
+		name   string
+		secret string
+		want   bool
+	}{
+		{"correct secret", testWebClientSecret, true},
+		{"wrong secret", "not-the-secret", false},
+		{"empty secret", "", false},
+		{"hash itself presented as secret", sha256Hex(testWebClientSecret), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := verifyWebClientSecret(wc, tt.secret); got != tt.want {
+				t.Errorf("verifyWebClientSecret = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestOAuthAuthorizeWebClient locks the registry branch on
+// /oauth/authorize: a registered client gets its https redirect
+// allowlist (exact match) and nothing else — the loopback exemption
+// belongs to unregistered native clients only.
+func TestOAuthAuthorizeWebClient(t *testing.T) {
+	verifier := &fakeVerifier{authURL: "https://idp.example.com/authorize"}
+	srv, _ := newTestServer(t, webTestConfig(), verifier, fake.NewSimpleClientset())
+	client := testClient(srv)
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	webQuery := func() url.Values {
+		q := authorizeQuery()
+		q.Set("client_id", testWebClientID)
+		q.Set("redirect_uri", testWebRedirectURI)
+		return q
+	}
+
+	tests := []struct {
+		name       string
+		mutate     func(url.Values)
+		wantStatus int
+	}{
+		{
+			name:       "registered redirect accepted",
+			mutate:     func(url.Values) {},
+			wantStatus: http.StatusFound,
+		},
+		{
+			name:       "unregistered https redirect rejected",
+			mutate:     func(q url.Values) { q.Set("redirect_uri", "https://attacker.example/steal") },
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "prefix variant of registered redirect rejected (exact match only)",
+			mutate:     func(q url.Values) { q.Set("redirect_uri", testWebRedirectURI+"/extra") },
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "loopback redirect rejected for registered client",
+			mutate:     func(q url.Values) { q.Set("redirect_uri", "http://127.0.0.1:55408/callback") },
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := webQuery()
+			tt.mutate(q)
+			resp, err := client.Get(srv.URL + "/oauth/authorize?" + q.Encode())
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != tt.wantStatus {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want %d; body=%s", resp.StatusCode, tt.wantStatus, body)
+			}
+			if tt.wantStatus == http.StatusFound {
+				if loc := resp.Header.Get("Location"); !strings.HasPrefix(loc, verifier.authURL) {
+					t.Errorf("Location = %q, want IdP redirect", loc)
+				}
+				return
+			}
+			doc := decodeJSONError(t, resp.Body)
+			if doc.Error != "invalid_request" {
+				t.Errorf("error = %q, want invalid_request", doc.Error)
+			}
+			if got := resp.Header.Get("Location"); got != "" {
+				t.Errorf("Location set on rejected redirect: %q", got)
+			}
+		})
+	}
+}
+
+// seedWebClientCode plants a bound auth-code-store entry for the
+// registered web client and returns the redeemable code.
+func seedWebClientCode(t *testing.T, brokerSrv *Server, challenge string) string {
+	t.Helper()
+	id, err := brokerSrv.authCodeStore.Begin(&AuthCodeRequest{
+		ClientID:            testWebClientID,
+		RedirectURI:         testWebRedirectURI,
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: "S256",
+	})
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	code, _, err := brokerSrv.authCodeStore.Bind(id, &ExchangeResult{
+		Claims: Claims{Subject: "google|alice", Email: "alice@example.com", EmailVerified: true},
+	})
+	if err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	return code
+}
+
+// TestDeviceTokenAuthCodeWebClient locks client authentication on the
+// authorization_code grant for registered confidential clients: the
+// secret is required, verified constant-time against the registry
+// hash, and a failed attempt does not burn the code.
+func TestDeviceTokenAuthCodeWebClient(t *testing.T) {
+	codeVerifier := "test-verifier-must-be-43-to-128-chars-long-1234"
+	sum := sha256.Sum256([]byte(codeVerifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	tokenForm := func(code string) url.Values {
+		return url.Values{
+			"grant_type":    {"authorization_code"},
+			"code":          {code},
+			"redirect_uri":  {testWebRedirectURI},
+			"code_verifier": {codeVerifier},
+		}
+	}
+	postToken := func(t *testing.T, client *http.Client, srvURL string, form url.Values, basic bool) *http.Response {
+		t.Helper()
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+			srvURL+"/device/token", strings.NewReader(form.Encode()))
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		if basic {
+			req.SetBasicAuth(testWebClientID, testWebClientSecret)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("POST /device/token: %v", err)
+		}
+		return resp
+	}
+
+	t.Run("basic auth succeeds and binds the refresh token", func(t *testing.T) {
+		srv, brokerSrv := newTestServerWithSigner(t, webTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
+		code := seedWebClientCode(t, brokerSrv, challenge)
+		resp := postToken(t, testClient(srv), srv.URL, tokenForm(code), true)
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+		}
+		var doc deviceTokenSuccess
+		if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if doc.RefreshToken == "" {
+			t.Fatal("missing refresh_token")
+		}
+		// The minted refresh token must be client-bound: refreshing it
+		// without client auth is rejected.
+		noAuth, err := testClient(srv).PostForm(srv.URL+"/device/token", url.Values{
+			"grant_type":    {refreshGrantType},
+			"refresh_token": {doc.RefreshToken},
+		})
+		if err != nil {
+			t.Fatalf("refresh POST: %v", err)
+		}
+		defer func() { _ = noAuth.Body.Close() }()
+		if noAuth.StatusCode != http.StatusUnauthorized {
+			body, _ := io.ReadAll(noAuth.Body)
+			t.Fatalf("unauthenticated refresh of bound token: status = %d, want 401; body=%s", noAuth.StatusCode, body)
+		}
+	})
+
+	t.Run("client_secret_post succeeds", func(t *testing.T) {
+		srv, brokerSrv := newTestServerWithSigner(t, webTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
+		code := seedWebClientCode(t, brokerSrv, challenge)
+		form := tokenForm(code)
+		form.Set("client_id", testWebClientID)
+		form.Set("client_secret", testWebClientSecret)
+		resp := postToken(t, testClient(srv), srv.URL, form, false)
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+		}
+	})
+
+	t.Run("missing secret is invalid_client and preserves the code", func(t *testing.T) {
+		srv, brokerSrv := newTestServerWithSigner(t, webTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
+		code := seedWebClientCode(t, brokerSrv, challenge)
+		form := tokenForm(code)
+		form.Set("client_id", testWebClientID)
+		resp := postToken(t, testClient(srv), srv.URL, form, false)
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 401; body=%s", resp.StatusCode, body)
+		}
+		if got := resp.Header.Get("WWW-Authenticate"); !strings.HasPrefix(got, "Basic") {
+			t.Errorf("WWW-Authenticate = %q, want Basic challenge", got)
+		}
+		var doc deviceTokenError
+		if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if doc.Error != "invalid_client" {
+			t.Errorf("error = %q, want invalid_client", doc.Error)
+		}
+		// The failed attempt must not consume the code — a retry with
+		// the correct secret succeeds.
+		retry := postToken(t, testClient(srv), srv.URL, tokenForm(code), true)
+		defer func() { _ = retry.Body.Close() }()
+		if retry.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(retry.Body)
+			t.Fatalf("retry status = %d, want 200 (code burned by failed client auth); body=%s", retry.StatusCode, body)
+		}
+	})
+
+	t.Run("wrong secret is invalid_client", func(t *testing.T) {
+		srv, brokerSrv := newTestServerWithSigner(t, webTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
+		code := seedWebClientCode(t, brokerSrv, challenge)
+		form := tokenForm(code)
+		form.Set("client_id", testWebClientID)
+		form.Set("client_secret", "wrong-secret")
+		resp := postToken(t, testClient(srv), srv.URL, form, false)
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 401; body=%s", resp.StatusCode, body)
+		}
+	})
+
+	t.Run("both basic and post secret is invalid_request", func(t *testing.T) {
+		srv, brokerSrv := newTestServerWithSigner(t, webTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
+		code := seedWebClientCode(t, brokerSrv, challenge)
+		form := tokenForm(code)
+		form.Set("client_secret", testWebClientSecret)
+		resp := postToken(t, testClient(srv), srv.URL, form, true)
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusBadRequest {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 400; body=%s", resp.StatusCode, body)
+		}
+		var doc deviceTokenError
+		if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if doc.Error != "invalid_request" {
+			t.Errorf("error = %q, want invalid_request", doc.Error)
+		}
+	})
+}
+
+// TestDeviceTokenRefreshWebClientBinding locks the refresh-grant gate
+// for client-bound tokens: the bound client must authenticate; an
+// unbound token (device flow / loopback) is unaffected by the registry.
+func TestDeviceTokenRefreshWebClientBinding(t *testing.T) {
+	issueBound := func(t *testing.T, brokerSrv *Server) string {
+		t.Helper()
+		raw, err := brokerSrv.refreshStore.Issue(t.Context(),
+			&Claims{Subject: "google|alice", Email: "alice@example.com", EmailVerified: true},
+			testWebClientID, time.Hour)
+		if err != nil {
+			t.Fatalf("Issue: %v", err)
+		}
+		return raw
+	}
+	refresh := func(t *testing.T, client *http.Client, srvURL, rawRefresh string, mutate func(*http.Request)) *http.Response {
+		t.Helper()
+		form := url.Values{
+			"grant_type":    {refreshGrantType},
+			"refresh_token": {rawRefresh},
+		}
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+			srvURL+"/device/token", strings.NewReader(form.Encode()))
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		if mutate != nil {
+			mutate(req)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		return resp
+	}
+
+	t.Run("bound token with correct basic auth refreshes", func(t *testing.T) {
+		srv, brokerSrv := newTestServerWithSigner(t, webTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
+		raw := issueBound(t, brokerSrv)
+		resp := refresh(t, testClient(srv), srv.URL, raw, func(r *http.Request) {
+			r.SetBasicAuth(testWebClientID, testWebClientSecret)
+		})
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+		}
+	})
+
+	t.Run("bound token without client auth is invalid_client", func(t *testing.T) {
+		srv, brokerSrv := newTestServerWithSigner(t, webTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
+		raw := issueBound(t, brokerSrv)
+		resp := refresh(t, testClient(srv), srv.URL, raw, nil)
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 401; body=%s", resp.StatusCode, body)
+		}
+		if got := resp.Header.Get("WWW-Authenticate"); !strings.HasPrefix(got, "Basic") {
+			t.Errorf("WWW-Authenticate = %q, want Basic challenge", got)
+		}
+		var doc deviceTokenError
+		if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if doc.Error != "invalid_client" {
+			t.Errorf("error = %q, want invalid_client", doc.Error)
+		}
+	})
+
+	t.Run("bound token with wrong secret is invalid_client", func(t *testing.T) {
+		srv, brokerSrv := newTestServerWithSigner(t, webTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
+		raw := issueBound(t, brokerSrv)
+		resp := refresh(t, testClient(srv), srv.URL, raw, func(r *http.Request) {
+			r.SetBasicAuth(testWebClientID, "wrong-secret")
+		})
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+
+	t.Run("bound token under a different client_id is invalid_client", func(t *testing.T) {
+		srv, brokerSrv := newTestServerWithSigner(t, webTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
+		raw := issueBound(t, brokerSrv)
+		resp := refresh(t, testClient(srv), srv.URL, raw, func(r *http.Request) {
+			r.SetBasicAuth("someone-else", testWebClientSecret)
+		})
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+
+	t.Run("bound token whose client was deregistered is invalid_client", func(t *testing.T) {
+		// Config WITHOUT the registry entry, but the store carries a
+		// bound record (issued before the deregistration).
+		srv, brokerSrv := newTestServerWithSigner(t, testConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
+		raw := issueBound(t, brokerSrv)
+		resp := refresh(t, testClient(srv), srv.URL, raw, func(r *http.Request) {
+			r.SetBasicAuth(testWebClientID, testWebClientSecret)
+		})
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+
+	t.Run("unbound token still refreshes without client auth", func(t *testing.T) {
+		srv, brokerSrv := newTestServerWithSigner(t, webTestConfig(), &fakeVerifier{}, fake.NewSimpleClientset(), newTestIDTokenSigner(t))
+		raw, err := brokerSrv.refreshStore.Issue(t.Context(),
+			&Claims{Subject: "google|bob", Email: "bob@example.com", EmailVerified: true}, "", time.Hour)
+		if err != nil {
+			t.Fatalf("Issue: %v", err)
+		}
+		resp := refresh(t, testClient(srv), srv.URL, raw, nil)
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+		}
+	})
+}
+
+func TestDiscoveryOverridesTokenEndpointAuthMethods(t *testing.T) {
+	idp := newFakeDiscoveryIdP(t)
+	d, _ := newTestDiscovery(t, idp, time.Minute)
+	doc := serveAndDecode(t, d)
+	raw, ok := doc["token_endpoint_auth_methods_supported"].([]any)
+	if !ok {
+		t.Fatalf("token_endpoint_auth_methods_supported missing or wrong type: %v", doc["token_endpoint_auth_methods_supported"])
+	}
+	got := make([]string, 0, len(raw))
+	for _, v := range raw {
+		got = append(got, v.(string))
+	}
+	want := []string{"none", "client_secret_basic", "client_secret_post"}
+	if len(got) != len(want) {
+		t.Fatalf("methods = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("methods = %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for registering confidential web clients with client credentials (client ID, secret hash, and redirect URI allowlists).
  * Enabled client authentication on the token endpoint via HTTP Basic or form-based client secret submission.
  * Client-authenticated refresh tokens are now bound to their client and require re-authentication to refresh.
  * Authorization code exchange now enforces client authentication for registered web clients.
  * Discovery document now advertises supported token endpoint authentication methods.

* **Documentation**
  * Added architectural decision record documenting confidential web client flow mechanics and design choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->