### PR TITLE
feat(broker): Add mark_worlds MCP tool to broker

### DIFF
--- a/tools/demarkus-broker/internal/broker/mcp_gateway.go
+++ b/tools/demarkus-broker/internal/broker/mcp_gateway.go
@@ -16,7 +16,7 @@ import (
 // MCPServer and its Streamable HTTP transport, sharing auth +
 // rate-limit machinery with the parent broker Server.
 //
-// All 14 tools have real handlers. Reads dispatch with an empty bearer
+// All 15 tools have real handlers. Reads dispatch with an empty bearer
 // (the world's tokens.toml grants no read op, so the org SSO gate at
 // the broker is the only access control); writes provision a per-world
 // token through worldWriteTokens and dispatch through worldDispatcher.
@@ -38,7 +38,7 @@ type mcpGateway struct {
 	graphStore *graphstore.Store
 }
 
-// newMCPGateway constructs a gateway, registers the 14 tool
+// newMCPGateway constructs a gateway, registers the 15 tool
 // definitions (real handlers for Slice 2's read verbs, placeholders
 // for the rest), and wraps the mcp-go MCPServer in a Streamable HTTP
 // transport. The transport is an http.Handler — the caller mounts
@@ -78,7 +78,7 @@ func newMCPGateway(s *Server, version string, dispatcher worldDispatcher) *mcpGa
 	return g
 }
 
-// registerTools wires the 14 tool definitions onto the MCP server.
+// registerTools wires the 15 tool definitions onto the MCP server.
 // Tools absent from the toolHandlers map fall through to
 // notImplementedHandler. The per-tool handler map lives in
 // toolHandlers so adding new implementations is a one-line edit and
@@ -100,7 +100,7 @@ func (g *mcpGateway) registerTools() {
 // package-level var) so the handlers carry the gateway receiver
 // without indirection through a global.
 //
-// All 14 tools are real handlers — every entry below points at a
+// All 15 tools are real handlers — every entry below points at a
 // concrete implementation, and notImplementedHandler should never
 // run in production.
 func (g *mcpGateway) toolHandlers() map[string]mcpserver.ToolHandlerFunc {
@@ -119,6 +119,7 @@ func (g *mcpGateway) toolHandlers() map[string]mcpserver.ToolHandlerFunc {
 		"mark_index":         g.handleMarkIndex,
 		"mark_graph_export":  g.handleMarkGraphExport,
 		"mark_graph_publish": g.handleMarkGraphPublish,
+		"mark_worlds":        g.handleMarkWorlds,
 	}
 }
 

--- a/tools/demarkus-broker/internal/broker/mcp_tools_list.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_list.go
@@ -37,13 +37,17 @@ var mcpToolNames = []string{
 	"mark_graph",
 	"mark_graph_export",
 	"mark_graph_publish",
+	"mark_worlds",
 }
 
-// mcpTools returns the 14 tool definitions exposed by the broker MCP
-// gateway. The set mirrors client/cmd/demarkus-mcp's tool surface for
-// parity (so the agent sees the same vocabulary regardless of
+// mcpTools returns the 15 tool definitions exposed by the broker MCP
+// gateway. The first 14 mirror client/cmd/demarkus-mcp's tool surface
+// for parity (so the agent sees the same vocabulary regardless of
 // transport); only the URL-format description differs because the
-// broker addresses worlds by name rather than host:port.
+// broker addresses worlds by name rather than host:port. mark_worlds
+// is deliberately broker-only: enumerating worlds is a knowledge-system
+// concept — the local single-world MCP's universe IS its one world, so
+// there is nothing to enumerate there.
 func mcpTools() []mcp.Tool {
 	return []mcp.Tool{
 		markFetchTool(),
@@ -60,6 +64,7 @@ func mcpTools() []mcp.Tool {
 		markGraphTool(),
 		markGraphExportTool(),
 		markGraphPublishTool(),
+		markWorldsTool(),
 	}
 }
 
@@ -320,6 +325,18 @@ func markGraphExportTool() mcp.Tool {
 			"Export the broker's graph store as a publishable markdown document. "+
 				"The output contains mark:// links so crawling it naturally discovers the topology. "+
 				"Run mark_graph first to populate the store.",
+		),
+	)
+}
+
+func markWorldsTool() mcp.Tool {
+	return mcp.NewTool("mark_worlds",
+		mcp.WithDescription(
+			"List the worlds of this knowledge system that your identity may read. "+
+				"Returns a count and a markdown table of world names and public URLs. "+
+				"Each name is the {worldName} addressing primitive for every other tool "+
+				"(mark://{worldName}/{path}); use this to discover the universe before "+
+				"navigating it.",
 		),
 	)
 }

--- a/tools/demarkus-broker/internal/broker/mcp_tools_list_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_list_test.go
@@ -5,13 +5,16 @@ import (
 	"testing"
 )
 
-func TestMCPToolsExactly14(t *testing.T) {
+func TestMCPToolsExactly15(t *testing.T) {
 	tools := mcpTools()
 	if len(tools) != len(mcpToolNames) {
 		t.Fatalf("mcpTools() returned %d tools, mcpToolNames lists %d — names + builders out of sync", len(tools), len(mcpToolNames))
 	}
-	if len(tools) != 14 {
-		t.Fatalf("expected 14 tools (parity with client/cmd/demarkus-mcp), got %d", len(tools))
+	// 14 tools mirror client/cmd/demarkus-mcp for cross-transport parity;
+	// mark_worlds is the one deliberate broker-only addition (enumerating
+	// worlds is a knowledge-system concept with no single-world analogue).
+	if len(tools) != 15 {
+		t.Fatalf("expected 15 tools (demarkus-mcp parity surface + mark_worlds), got %d", len(tools))
 	}
 	for i, tool := range tools {
 		if tool.Name != mcpToolNames[i] {

--- a/tools/demarkus-broker/internal/broker/mcp_tools_worlds.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_worlds.go
@@ -1,0 +1,53 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+// handleMarkWorlds implements the mark_worlds tool: the worlds of this
+// knowledge system the calling identity may read, per the same
+// authorizedWorlds predicate /auth/callback and /me/install already
+// apply. A pure read over config and claims — no dispatch, no Secret
+// access, no per-world traffic.
+//
+// Output follows the formatToolResult shape (status line, metadata,
+// blank line, body) with a markdown table body mirroring mark_lookup's
+// table convention, so agents and the library parse one familiar form:
+//
+//	status: ok
+//	count: 2
+//
+//	| world | url |
+//	|-------|-----|
+//	| team-a | mark://team-a.example.org:6309 |
+//	| hub | |
+//
+// url is the world's externally reachable address (WorldConfig.PublicURL)
+// and may be empty — the worldName remains the addressing primitive for
+// every tool either way.
+func (g *mcpGateway) handleMarkWorlds(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
+	claims, ok := claimsFromCtx(ctx)
+	if !ok {
+		return mcp.NewToolResultError("internal: missing identity on tool-call context"), nil
+	}
+	worlds := authorizedWorlds(g.srv.cfg, claims)
+
+	var b strings.Builder
+	b.WriteString("status: ok\n")
+	fmt.Fprintf(&b, "count: %d\n", len(worlds))
+	if len(worlds) > 0 {
+		b.WriteString("\n| world | url |\n|-------|-----|\n")
+		for _, w := range worlds {
+			fmt.Fprintf(&b, "| %s | %s |\n", w.Name, w.PublicURL)
+		}
+	}
+	return mcp.NewToolResultText(b.String()), nil
+}
+
+// compile-time check that the handler matches mcp-go's expected shape.
+var _ mcpserver.ToolHandlerFunc = (*mcpGateway)(nil).handleMarkWorlds

--- a/tools/demarkus-broker/internal/broker/mcp_tools_worlds_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_worlds_test.go
@@ -1,0 +1,100 @@
+package broker
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// mustToolResult unwraps a successful tool call for the happy-path tests.
+func mustToolResult(t *testing.T, res *mcp.CallToolResult, err error) *mcp.CallToolResult {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("tool call: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %s", toolResultText(t, res))
+	}
+	return res
+}
+
+// worldsTestConfig is mcpTestConfig plus a second world with a
+// different domain allowlist, so authorization filtering is visible.
+func worldsTestConfig() *Config {
+	cfg := mcpTestConfig()
+	cfg.Worlds[0].PublicURL = "mark://team-a.example.org:6309"
+	cfg.Worlds = append(cfg.Worlds, WorldConfig{
+		Name:         "secret-b",
+		Namespace:    "secret-b",
+		TokensSecret: "secret-b-tokens",
+		Allow:        AllowConfig{Domains: []string{"otherco.test"}},
+	})
+	return cfg
+}
+
+func TestHandleMarkWorldsListsAuthorizedOnly(t *testing.T) {
+	g := newGatewayWithDispatcher(t, worldsTestConfig(), &fakeDispatcher{})
+	res, err := g.handleMarkWorlds(withAliceClaims(context.Background()), callToolReq("mark_worlds", nil))
+	if err != nil {
+		t.Fatalf("handleMarkWorlds: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("isError = true: %s", toolResultText(t, res))
+	}
+	text := toolResultText(t, res)
+
+	for _, want := range []string{
+		"status: ok",
+		"count: 1",
+		"| world | url |",
+		"| team-a | mark://team-a.example.org:6309 |",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("missing %q in %q", want, text)
+		}
+	}
+	// alice@example.com does not match secret-b's otherco.test allowlist:
+	// the world must not leak into her universe.
+	if strings.Contains(text, "secret-b") {
+		t.Errorf("unauthorized world leaked: %q", text)
+	}
+}
+
+func TestHandleMarkWorldsBlankPublicURL(t *testing.T) {
+	// PublicURL is optional config; the worldName alone still addresses
+	// the world through every tool, so the row renders with an empty cell
+	// rather than being dropped.
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), &fakeDispatcher{})
+	res, err := g.handleMarkWorlds(withAliceClaims(context.Background()), callToolReq("mark_worlds", nil))
+	text := toolResultText(t, mustToolResult(t, res, err))
+	if !strings.Contains(text, "| team-a |  |") {
+		t.Errorf("blank-URL row missing: %q", text)
+	}
+}
+
+func TestHandleMarkWorldsEmptyUniverse(t *testing.T) {
+	cfg := mcpTestConfig()
+	cfg.Worlds[0].Allow = AllowConfig{Domains: []string{"otherco.test"}}
+	g := newGatewayWithDispatcher(t, cfg, &fakeDispatcher{})
+	res, err := g.handleMarkWorlds(withAliceClaims(context.Background()), callToolReq("mark_worlds", nil))
+	text := toolResultText(t, mustToolResult(t, res, err))
+	if !strings.Contains(text, "count: 0") {
+		t.Errorf("want count: 0, got %q", text)
+	}
+	if strings.Contains(text, "| world |") {
+		t.Errorf("empty universe should render no table: %q", text)
+	}
+}
+
+func TestHandleMarkWorldsMissingClaims(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), &fakeDispatcher{})
+	res, err := g.handleMarkWorlds(context.Background(), callToolReq("mark_worlds", nil))
+	if err != nil {
+		t.Fatalf("handleMarkWorlds: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("isError = false without identity, want tool error")
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "mark_worlds" tool that displays all worlds accessible to you based on your permissions, including world names and public URLs in a formatted table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->