### PR TITLE
feat(server):  Add wildcard support to catalog lookup

### DIFF
--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -214,7 +214,7 @@ func markLookupTool(host string) mcp.Tool {
 		),
 		mcp.WithString("query",
 			mcp.Required(),
-			mcp.Description("subject to look up; matched against document tags and titles (minimum 2 characters)"),
+			mcp.Description("subject to look up; matched against document tags and titles (minimum 2 characters), or '*' to match every catalogued document under the scope (importance order)"),
 		),
 		mcp.WithString("filter",
 			mcp.Description("comma-separated key=value predicates applied before ranking; built-ins: tag=, modified-after=, modified-before="),

--- a/server/internal/catalog/catalog.go
+++ b/server/internal/catalog/catalog.go
@@ -83,9 +83,15 @@ type Options struct {
 // Lookup returns documents whose tags or title match at least one query term,
 // satisfy every filter predicate, and fall under the scope, ordered by
 // descending match count, then importance, then modification time, then path.
+//
+// The query "*" matches every catalogued document under the scope (filters
+// still apply): with all match scores equal, the ordering reduces to
+// importance — "the most important documents here" without guessing a
+// subject. This is the whole-catalog view that universe browsers build on.
 func (c *Catalog) Lookup(query string, opts Options) []Result {
+	matchAll := strings.TrimSpace(query) == "*"
 	terms := tokenize(query)
-	if len(terms) == 0 {
+	if !matchAll && len(terms) == 0 {
 		return nil
 	}
 	scope := normalizeScope(opts.Scope)
@@ -97,6 +103,10 @@ func (c *Catalog) Lookup(query string, opts Options) []Result {
 			continue
 		}
 		if !matchesAll(e, opts.Filter) {
+			continue
+		}
+		if matchAll {
+			results = append(results, Result{Entry: *e})
 			continue
 		}
 		if score := matchScore(e, terms); score > 0 {

--- a/server/internal/catalog/catalog_test.go
+++ b/server/internal/catalog/catalog_test.go
@@ -179,3 +179,44 @@ func TestLookupScorePopulated(t *testing.T) {
 		t.Fatalf("expected one result with score 2, got %+v", got)
 	}
 }
+
+func TestLookupMatchAll(t *testing.T) {
+	c := New()
+	c.Set(&Entry{Path: "/low.md", Tags: []string{"go"}, Importance: 0.2})
+	c.Set(&Entry{Path: "/hub.md", Tags: []string{"hub"}, Importance: 0.9})
+	c.Set(&Entry{Path: "/mid.md", Tags: []string{"rust"}, Importance: 0.5})
+	c.Set(&Entry{Path: "/docs/deep.md", Tags: []string{"go"}, Importance: 0.7})
+
+	// "*" returns every catalogued doc, importance-ranked (scores all zero,
+	// so the tiebreak chain starts at importance).
+	got := paths(c.Lookup("*", Options{}))
+	want := []string{"/hub.md", "/docs/deep.md", "/mid.md", "/low.md"}
+	if !equalPaths(got, want) {
+		t.Fatalf("match-all order = %v, want %v", got, want)
+	}
+
+	// Scope and filters still narrow the universe.
+	if got := paths(c.Lookup("*", Options{Scope: "/docs/"})); !equalPaths(got, []string{"/docs/deep.md"}) {
+		t.Errorf("scoped match-all = %v", got)
+	}
+	preds, perr := ParseFilter("tag=go")
+	if perr != nil {
+		t.Fatalf("ParseFilter: %v", perr)
+	}
+	if got := paths(c.Lookup("*", Options{Filter: preds})); !equalPaths(got, []string{"/docs/deep.md", "/low.md"}) {
+		t.Errorf("filtered match-all = %v", got)
+	}
+	// Max caps it like any lookup.
+	if got := paths(c.Lookup("*", Options{Max: 1})); !equalPaths(got, []string{"/hub.md"}) {
+		t.Errorf("capped match-all = %v", got)
+	}
+	// Whitespace-padded star still counts; a star mixed with other terms is
+	// a normal query (star becomes a literal term) — "go" matches its two
+	// docs, NOT the whole catalog.
+	if got := paths(c.Lookup("  *  ", Options{})); len(got) != 4 {
+		t.Errorf("padded star = %v", got)
+	}
+	if got := paths(c.Lookup("* go", Options{})); len(got) != 2 {
+		t.Errorf("star-with-terms must behave as a term query, got %v", got)
+	}
+}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -542,7 +542,9 @@ func (h *Handler) handleLookup(w io.Writer, req protocol.Request) {
 	}
 
 	query := strings.TrimSpace(req.Metadata["query"])
-	if len([]rune(query)) < 2 {
+	// "*" is the match-all query (whole catalog under scope, importance
+	// order); anything else needs at least 2 characters of subject.
+	if query != "*" && len([]rune(query)) < 2 {
 		h.writeError(w, protocol.StatusBadRequest, "query must be at least 2 characters")
 		return
 	}

--- a/server/internal/handler/handler_lookup_test.go
+++ b/server/internal/handler/handler_lookup_test.go
@@ -229,3 +229,22 @@ func TestHandleLookupCatalogUpdates(t *testing.T) {
 		t.Errorf("post-archive matches = %q, want 0", resp.Metadata["matches"])
 	}
 }
+
+func TestHandleLookupMatchAll(t *testing.T) {
+	// "*" passes the length validation and returns the whole catalog under
+	// the scope in importance order — the universe-browser query.
+	h := lookupHandler(t,
+		&catalog.Entry{Path: "/hub.md", Tags: []string{"hub"}, Title: "Hub", Importance: 0.9},
+		&catalog.Entry{Path: "/note.md", Tags: []string{"misc"}, Title: "Note", Importance: 0.3},
+	)
+	resp := sendLookup(t, h, lookupReq("/", "query: '*'"))
+	if resp.Status != protocol.StatusOK {
+		t.Fatalf("status = %q, want ok (match-all must pass validation)", resp.Status)
+	}
+	if resp.Metadata["matches"] != "2" {
+		t.Errorf("matches = %q, want 2", resp.Metadata["matches"])
+	}
+	if hub, note := strings.Index(resp.Body, "/hub.md"), strings.Index(resp.Body, "/note.md"); hub == -1 || note == -1 || hub > note {
+		t.Errorf("want both paths, importance order:\n%s", resp.Body)
+	}
+}

--- a/tools/demarkus-broker/internal/broker/mcp_tools_list.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_list.go
@@ -128,7 +128,7 @@ func markLookupTool() mcp.Tool {
 		),
 		mcp.WithString("query",
 			mcp.Required(),
-			mcp.Description("subject to look up; matched against document tags and titles (minimum 2 characters)"),
+			mcp.Description("subject to look up; matched against document tags and titles (minimum 2 characters), or '*' to match every catalogued document under the scope (importance order)"),
 		),
 		mcp.WithString("filter",
 			mcp.Description("comma-separated key=value predicates applied before ranking; built-ins: tag=, modified-after=, modified-before="),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wildcard query support: use `'*'` to retrieve all catalogued documents within the specified scope, ordered by importance.

* **Documentation**
  * Updated tool parameter descriptions to document the new wildcard query functionality and its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->