### PR TITLE
fix(deploy): Restrict StatefulSet volumeClaimTemplates to selector-only labels

### DIFF
--- a/deploy/helm/demarkus-server/templates/statefulset.yaml
+++ b/deploy/helm/demarkus-server/templates/statefulset.yaml
@@ -139,8 +139,16 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: content
+        # selectorLabels ONLY — never the full label set. volumeClaimTemplates
+        # is immutable, and the full labels carry `helm.sh/chart` +
+        # `app.kubernetes.io/version`, which change on every chart bump. Stamping
+        # those here turns each version bump into a forbidden in-place VCT update
+        # (the same immutable-field trap the volumeMode comment below guards
+        # against, via metadata instead of spec). selectorLabels (name +
+        # instance) are stable across versions, so the VCT stays byte-identical
+        # across bumps and GitOps applies them cleanly.
         labels:
-          {{- include "demarkus-server.labels" . | nindent 10 }}
+          {{- include "demarkus-server.selectorLabels" . | nindent 10 }}
       spec:
         accessModes:
           - {{ .Values.storage.accessMode }}

--- a/deploy/helm/demarkus-server/tests/statefulset_test.yaml
+++ b/deploy/helm/demarkus-server/tests/statefulset_test.yaml
@@ -205,3 +205,16 @@ tests:
       - equal:
           path: spec.volumeClaimTemplates[0].spec.volumeMode
           value: Filesystem
+
+  - it: volumeClaimTemplates carries only stable labels (immutable-safe across bumps)
+    template: statefulset.yaml
+    asserts:
+      # The PVC template is immutable, so it must carry only labels that are
+      # stable across chart bumps. selectorLabels (name + instance) qualify;
+      # the version/chart/managed-by labels would churn every release and turn
+      # each bump into a forbidden in-place VCT update.
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels
+          value:
+            app.kubernetes.io/name: demarkus-server
+            app.kubernetes.io/instance: RELEASE-NAME


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined Kubernetes deployment configuration metadata handling to prevent unnecessary infrastructure reconfigurations during version updates.
  * Enhanced persistent storage configuration stability to ensure uninterrupted operations across chart upgrades.
  * Added validation tests to verify storage configuration metadata stability during application version transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->