### PR TITLE
feat(agent): publish link-graph export to hubs

### DIFF
--- a/client/cmd/demarkus-agent/main.go
+++ b/client/cmd/demarkus-agent/main.go
@@ -79,6 +79,7 @@ func crawlMain(args []string) {
 	verbose := fs.Bool("v", false, "verbose output")
 	publish := fs.Bool("publish", false, "publish indexes to hubs after crawl")
 	perServer := fs.Bool("per-server", false, "publish per-server indexes instead of aggregated")
+	publishGraph := fs.Bool("publish-graph", false, "publish a link-graph export (/graph.md) to hubs after crawl")
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: demarkus-agent crawl [options]\n\n")
 		fmt.Fprintf(os.Stderr, "Runs a single federation crawl.\n\n")
@@ -169,6 +170,16 @@ func crawlMain(args []string) {
 			logger.Info("publish: complete", "indexes", pubCount, "hubs", len(cfg.Hubs))
 		}
 	}
+
+	// Publish the link-graph export to hubs if requested.
+	if *publishGraph && len(cfg.Hubs) > 0 {
+		gCount, err := crawler.PublishGraphToHubs(ctx, client)
+		if err != nil {
+			logger.Warn("publish-graph: hub push failed", "err", err)
+		} else if *verbose {
+			logger.Info("publish-graph: complete", "graphs", gCount, "hubs", len(cfg.Hubs))
+		}
+	}
 }
 
 func daemonMain(args []string) {
@@ -179,6 +190,7 @@ func daemonMain(args []string) {
 	insecure := fs.Bool("insecure", false, "skip TLS certificate verification")
 	publish := fs.Bool("publish", false, "publish indexes to hubs after each crawl")
 	perServer := fs.Bool("per-server", false, "publish per-server indexes instead of aggregated")
+	publishGraph := fs.Bool("publish-graph", false, "publish a link-graph export (/graph.md) to hubs after each crawl")
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: demarkus-agent daemon [options]\n\n")
 		fmt.Fprintf(os.Stderr, "Runs federation crawl as a daemon on a schedule.\n\n")
@@ -239,7 +251,7 @@ func daemonMain(args []string) {
 	defer cancel()
 
 	// Run initial crawl.
-	runCrawl(ctx, &cfg, client, state, tokenStore, *publish, *perServer)
+	runCrawl(ctx, &cfg, client, state, tokenStore, *publish, *perServer, *publishGraph)
 
 	// Schedule subsequent crawls.
 	ticker := time.NewTicker(cfg.Schedule.Interval)
@@ -251,12 +263,12 @@ func daemonMain(args []string) {
 			logger.Info("daemon: stopping")
 			return
 		case <-ticker.C:
-			runCrawl(ctx, &cfg, client, state, tokenStore, *publish, *perServer)
+			runCrawl(ctx, &cfg, client, state, tokenStore, *publish, *perServer, *publishGraph)
 		}
 	}
 }
 
-func runCrawl(ctx context.Context, cfg *fedcrawl.Config, client *fetch.Client, state *fedcrawl.State, tokenStore *tokens.Store, publish, perServer bool) {
+func runCrawl(ctx context.Context, cfg *fedcrawl.Config, client *fetch.Client, state *fedcrawl.State, tokenStore *tokens.Store, publish, perServer, publishGraph bool) {
 	crawler := fedcrawl.NewCrawler(*cfg, client, state, tokenStore)
 
 	start := time.Now()
@@ -286,6 +298,16 @@ func runCrawl(ctx context.Context, cfg *fedcrawl.Config, client *fetch.Client, s
 			logger.Warn("publish: hub push failed", "err", err)
 		} else {
 			logger.Info("publish: complete", "indexes", pubCount, "hubs", len(cfg.Hubs))
+		}
+	}
+
+	// Publish the link-graph export to hubs if requested.
+	if publishGraph && len(cfg.Hubs) > 0 {
+		gCount, err := crawler.PublishGraphToHubs(ctx, client)
+		if err != nil {
+			logger.Warn("publish-graph: hub push failed", "err", err)
+		} else {
+			logger.Info("publish-graph: complete", "graphs", gCount, "hubs", len(cfg.Hubs))
 		}
 	}
 }

--- a/client/internal/fedcrawl/crawl.go
+++ b/client/internal/fedcrawl/crawl.go
@@ -484,8 +484,14 @@ func (c *Crawler) recordEdges(host, path, body string, meta map[string]string) {
 // format stays identical to mark_graph_export / mark_graph_publish — the same
 // document any agent or the library floor reads.
 func (c *Crawler) GraphExport() string {
+	// Snapshot the graph pointer under the lock: Run reassigns c.graph under
+	// c.mu, so an export racing a re-crawl must not read the field unguarded
+	// (the graph's own methods are synchronized; the field reassignment is not).
+	c.mu.Lock()
+	g := c.graph
+	c.mu.Unlock()
 	store := graphstore.New()
-	store.Merge(c.graph, nil)
+	store.Merge(g, nil)
 	return store.Export()
 }
 

--- a/client/internal/fedcrawl/crawl.go
+++ b/client/internal/fedcrawl/crawl.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/client/graph"
+	"github.com/latebit-io/demarkus/client/graphstore"
 	"github.com/latebit-io/demarkus/client/index"
 	"github.com/latebit-io/demarkus/client/internal/tokens"
 	"github.com/latebit-io/demarkus/client/links"
@@ -35,6 +37,7 @@ type Crawler struct {
 	mu      sync.Mutex
 	hashes  map[string][]index.Entry // content-hash -> all observed locations
 	servers map[string]bool          // discovered servers (host)
+	graph   *graph.Graph             // link graph accumulated during the walk (concurrency-safe itself)
 }
 
 // NewCrawler creates a new federation crawler.
@@ -48,6 +51,7 @@ func NewCrawler(cfg Config, client FetchClient, state *State, tokenStore *tokens
 		tokens:  tokenStore,
 		hashes:  make(map[string][]index.Entry),
 		servers: make(map[string]bool),
+		graph:   graph.New(),
 	}
 }
 
@@ -71,6 +75,7 @@ func (c *Crawler) Run(ctx context.Context) (*CrawlResult, error) {
 	c.mu.Lock()
 	c.hashes = make(map[string][]index.Entry)
 	c.servers = make(map[string]bool)
+	c.graph = graph.New()
 	c.mu.Unlock()
 
 	result := &CrawlResult{}
@@ -278,6 +283,10 @@ func (c *Crawler) walkDir(ctx context.Context, host, dirPath, token string, docC
 			c.mu.Unlock()
 		}
 
+		// Record this document's outbound links into the graph (the durable
+		// topology map the hub publishes for the reading room's floor).
+		c.recordEdges(host, fullPath, doc.Response.Body, doc.Response.Metadata)
+
 		// Discover cross-server links.
 		c.discoverServers(doc.Response.Body, host, queue, wg)
 
@@ -445,6 +454,66 @@ func (c *Crawler) PublishToHubs(ctx context.Context, client PublishClient, perSe
 			}
 			successCount++
 		}
+	}
+
+	return successCount, errors.Join(publishErrs...)
+}
+
+// recordEdges adds a crawled document and its outbound mark:// links to the
+// link graph. Only mark:// targets are kept (the floor's edges are between
+// demarkus documents); external links are left out. The graph is the source
+// for the hub graph export — the durable, transport-symmetric topology the
+// reading-room floor renders (plans "Floor enrichment", decision 11).
+func (c *Crawler) recordEdges(host, path, body string, meta map[string]string) {
+	url := "mark://" + host + path
+	base := "mark://" + host
+	var linkCount int
+	for _, link := range links.Extract(body) {
+		resolved := links.Resolve(base, link)
+		if !strings.HasPrefix(resolved, "mark://") {
+			continue
+		}
+		c.graph.AddEdge(url, resolved)
+		linkCount++
+	}
+	c.graph.AddNode(&graph.Node{URL: url, Title: meta["title"], Status: "ok", LinkCount: linkCount})
+}
+
+// GraphExport renders the accumulated link graph as a mark_graph_export
+// document (Nodes + Edges tables). It reuses graphstore's exporter so the
+// format stays identical to mark_graph_export / mark_graph_publish — the same
+// document any agent or the library floor reads.
+func (c *Crawler) GraphExport() string {
+	store := graphstore.New()
+	store.Merge(c.graph, nil)
+	return store.Export()
+}
+
+// PublishGraphToHubs publishes the link-graph export to each configured hub at
+// /graph.md. Unlike the hash index this is always aggregated (cross-server
+// edges are the whole point — they make portal nodes on the floor). Returns
+// the number of successful publications.
+func (c *Crawler) PublishGraphToHubs(ctx context.Context, client PublishClient) (int, error) {
+	if len(c.cfg.Hubs) == 0 {
+		return 0, nil
+	}
+
+	body := c.GraphExport()
+	successCount := 0
+	var publishErrs []error
+
+	for _, hub := range c.cfg.Hubs {
+		host, _, err := fetch.ParseMarkURL(hub + "/")
+		if err != nil {
+			publishErrs = append(publishErrs, fmt.Errorf("parse hub URL %q: %w", hub, err))
+			continue
+		}
+		token := c.resolveToken(host)
+		if err := c.publishIndex(ctx, client, host, "/graph.md", body, token); err != nil {
+			publishErrs = append(publishErrs, fmt.Errorf("publish /graph.md to hub %s: %w", hub, err))
+			continue
+		}
+		successCount++
 	}
 
 	return successCount, errors.Join(publishErrs...)

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -541,6 +541,61 @@ func TestPublishToHubs(t *testing.T) {
 	})
 }
 
+func TestCrawlerGraphExportAndPublish(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Seeds = []string{"mark://a.example.com"}
+	cfg.Hubs = []string{"mark://hub.example.com"}
+	cfg.Crawl.MaxDocuments = 100
+
+	client := newMockClient()
+	client.addList("a.example.com:6309", "/", "- [index.md](index.md)\n- [notes.md](notes.md)\n")
+	// index.md links to a sibling and to a doc on another server.
+	client.addDoc("a.example.com:6309", "/index.md",
+		"# A\n[notes](notes.md) and [cross](mark://b.example.com:6309/page.md)",
+		"sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	client.addDoc("a.example.com:6309", "/notes.md", "# Notes",
+		"sha256-cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+	client.addList("b.example.com:6309", "/", "- [page.md](page.md)\n")
+	client.addDoc("b.example.com:6309", "/page.md", "# B",
+		"sha256-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+	crawler := NewCrawler(cfg, client, nil, nil)
+	if _, err := crawler.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	exp := crawler.GraphExport()
+	for _, want := range []string{
+		"# Document Graph",
+		"## Edges",
+		// intra-server edge (relative link resolved)
+		"mark://a.example.com:6309/index.md | mark://a.example.com:6309/notes.md",
+		// cross-server edge — the connection that makes a portal/edge on the floor
+		"mark://a.example.com:6309/index.md | mark://b.example.com:6309/page.md",
+	} {
+		if !contains(exp, want) {
+			t.Errorf("graph export missing %q\n---\n%s", want, exp)
+		}
+	}
+
+	n, err := crawler.PublishGraphToHubs(context.Background(), client)
+	if err != nil {
+		t.Fatalf("PublishGraphToHubs() error: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("published = %d, want 1", n)
+	}
+	var graphPublished bool
+	for _, call := range client.publishes {
+		if call.Host == "hub.example.com:6309" && call.Path == "/graph.md" {
+			graphPublished = true
+		}
+	}
+	if !graphPublished {
+		t.Errorf("no /graph.md publish to the hub: %+v", client.publishes)
+	}
+}
+
 func contains(s, substr string) bool {
 	return s != "" && substr != "" && (s == substr || len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || containsMiddle(s, substr)))
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `publish graph` option to enable exporting and publishing an aggregated link-graph (`/graph.md`) during both crawl and daemon runs.
  * Crawls now build a link-topology while fetching pages, including outbound `mark://` relationships and cross-server links, and can publish the resulting graph to configured hubs.
  * Added an automated test covering graph export contents and hub publishing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->