### PR TITLE
feat(agent-chart): render --publish-graph when publishGraph is set

### DIFF
--- a/deploy/helm/demarkus-agent/templates/deployment.yaml
+++ b/deploy/helm/demarkus-agent/templates/deployment.yaml
@@ -52,6 +52,9 @@ spec:
             {{- if .Values.perServer }}
             - --per-server
             {{- end }}
+            {{- if .Values.publishGraph }}
+            - --publish-graph
+            {{- end }}
             {{- if .Values.insecure }}
             - --insecure
             {{- end }}

--- a/deploy/helm/demarkus-agent/tests/deployment_test.yaml
+++ b/deploy/helm/demarkus-agent/tests/deployment_test.yaml
@@ -79,6 +79,31 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --per-server
 
+  - it: includes --publish-graph when publishGraph=true
+    template: deployment.yaml
+    set:
+      config.seeds:
+        - mark://team-a:6309
+      config.hubs:
+        - mark://hub:6309
+      publishGraph: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --publish-graph
+
+  - it: omits --publish-graph by default
+    template: deployment.yaml
+    set:
+      config.seeds:
+        - mark://team-a:6309
+      config.hubs:
+        - mark://hub:6309
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --publish-graph
+
   - it: includes --insecure when insecure=true
     template: deployment.yaml
     set:

--- a/deploy/helm/demarkus-agent/values.yaml
+++ b/deploy/helm/demarkus-agent/values.yaml
@@ -48,6 +48,11 @@ config:
 # true = one index per discovered server at /index/<host>.md.
 perServer: false
 
+# Also publish a link-graph export to each hub at /graph.md (the durable
+# topology the reading-room floor renders: nodes + edges). Independent of the
+# hash index; aggregated across servers so cross-server edges are kept.
+publishGraph: false
+
 # Skip TLS certificate verification on outbound mark:// connections.
 # Useful for self-signed dev clusters. Leave false in production.
 insecure: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graph publishing capability. When enabled via the new `publishGraph` configuration option, the agent publishes aggregated link-graph exports to hubs. Default setting is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->