### PR TITLE
feat(broker): add internal dial address column to mark_worlds

### DIFF
--- a/tools/demarkus-broker/internal/broker/mcp_tools_list.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_list.go
@@ -333,10 +333,12 @@ func markWorldsTool() mcp.Tool {
 	return mcp.NewTool("mark_worlds",
 		mcp.WithDescription(
 			"List the worlds of this knowledge system that your identity may read. "+
-				"Returns a count and a markdown table of world names and public URLs. "+
-				"Each name is the {worldName} addressing primitive for every other tool "+
-				"(mark://{worldName}/{path}); use this to discover the universe before "+
-				"navigating it.",
+				"Returns a count and a markdown table with columns: world (the "+
+				"{worldName} addressing primitive for every other tool — "+
+				"mark://{worldName}/{path}), url (the world's external address for a "+
+				"direct client, may be blank), and address (the world's internal dial "+
+				"address — its identity in the topology graph). Use this to discover "+
+				"the universe before navigating it.",
 		),
 	)
 }

--- a/tools/demarkus-broker/internal/broker/mcp_tools_worlds.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_worlds.go
@@ -22,14 +22,22 @@ import (
 //	status: ok
 //	count: 2
 //
-//	| world | url |
-//	|-------|-----|
-//	| team-a | mark://team-a.example.org:6309 |
-//	| hub | |
+//	| world | url | address |
+//	|-------|-----|---------|
+//	| team-a | mark://team-a.example.org:6309 | mark://team-a.team-a.svc.cluster.local:6309 |
+//	| hub | | mark://hub.hub.svc.cluster.local:6309 |
 //
-// url is the world's externally reachable address (WorldConfig.PublicURL)
-// and may be empty — the worldName remains the addressing primitive for
-// every tool either way.
+// Two addresses, deliberately distinct:
+//   - url: the world's externally reachable address (WorldConfig.PublicURL),
+//     for a client that wants to connect directly. May be empty.
+//   - address: the world's internal dial address (resolveWorldAddress — the
+//     same host:port the broker routes to and the federation agent crawls
+//     by). Always populated. This is the world's identity in the topology
+//     graph (graph.md keys nodes by it), so a consumer like the reading-room
+//     floor can join host-keyed graph edges back to the worldName. Internal
+//     cluster DNS, but only ever shown to an already-authorized identity.
+//
+// The worldName remains the addressing primitive for every tool regardless.
 func (g *mcpGateway) handleMarkWorlds(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
 	claims, ok := claimsFromCtx(ctx)
 	if !ok {
@@ -41,9 +49,9 @@ func (g *mcpGateway) handleMarkWorlds(ctx context.Context, _ mcp.CallToolRequest
 	b.WriteString("status: ok\n")
 	fmt.Fprintf(&b, "count: %d\n", len(worlds))
 	if len(worlds) > 0 {
-		b.WriteString("\n| world | url |\n|-------|-----|\n")
+		b.WriteString("\n| world | url | address |\n|-------|-----|---------|\n")
 		for _, w := range worlds {
-			fmt.Fprintf(&b, "| %s | %s |\n", w.Name, w.PublicURL)
+			fmt.Fprintf(&b, "| %s | %s | mark://%s |\n", w.Name, w.PublicURL, resolveWorldAddress(w))
 		}
 	}
 	return mcp.NewToolResultText(b.String()), nil

--- a/tools/demarkus-broker/internal/broker/mcp_tools_worlds_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_worlds_test.go
@@ -48,8 +48,10 @@ func TestHandleMarkWorldsListsAuthorizedOnly(t *testing.T) {
 	for _, want := range []string{
 		"status: ok",
 		"count: 1",
-		"| world | url |",
-		"| team-a | mark://team-a.example.org:6309 |",
+		"| world | url | address |",
+		// url = PublicURL; address = internal dial address (the topology graph's
+		// node host) so the floor can join graph edges back to the worldName.
+		"| team-a | mark://team-a.example.org:6309 | mark://team-a.team-a.svc.cluster.local:6309 |",
 	} {
 		if !strings.Contains(text, want) {
 			t.Errorf("missing %q in %q", want, text)
@@ -64,13 +66,14 @@ func TestHandleMarkWorldsListsAuthorizedOnly(t *testing.T) {
 
 func TestHandleMarkWorldsBlankPublicURL(t *testing.T) {
 	// PublicURL is optional config; the worldName alone still addresses
-	// the world through every tool, so the row renders with an empty cell
-	// rather than being dropped.
+	// the world through every tool, so the url cell renders empty rather than
+	// the row being dropped. The address cell is always populated (the
+	// internal dial address the broker derives from Name + Namespace).
 	g := newGatewayWithDispatcher(t, mcpTestConfig(), &fakeDispatcher{})
 	res, err := g.handleMarkWorlds(withAliceClaims(context.Background()), callToolReq("mark_worlds", nil))
 	text := toolResultText(t, mustToolResult(t, res, err))
-	if !strings.Contains(text, "| team-a |  |") {
-		t.Errorf("blank-URL row missing: %q", text)
+	if !strings.Contains(text, "| team-a |  | mark://team-a.team-a.svc.cluster.local:6309 |") {
+		t.Errorf("blank-URL row missing or address cell not populated: %q", text)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `mark_worlds` tool now displays an internal dial address column in its output table, alongside world names and external URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->