### PR TITLE
fix(broker): mark_worlds lists readable worlds, not the writer Allow set

### DIFF
--- a/tools/demarkus-broker/internal/broker/authz.go
+++ b/tools/demarkus-broker/internal/broker/authz.go
@@ -50,11 +50,15 @@ func oidcDomainAllowed(allowDomains []string, hd string) bool {
 }
 
 // authorizedWorlds returns the configured worlds whose Allow predicate
-// admits claims. Used by /auth/callback and /me/install to list the
-// worlds an identity may reach. The broker no longer mints per-user
-// tokens — SSO at the broker is the org gate and WorldConfig.Allow is
-// the writer allowlist (enforced at the MCP write handlers) — so this
-// is a pure read over config, no Secret writes.
+// admits claims — the WRITER set. Used by /auth/callback and /me/install
+// (which wire writable worlds into a plugin) and mirrored by the MCP write
+// gate. WorldConfig.Allow is the writer allowlist; SSO at the broker is the
+// org gate. A pure read over config, no Secret writes.
+//
+// Do NOT use this for read-discovery (mark_worlds) — reads are gated by the
+// SSO org gate alone, not Allow (a world's tokens.toml grants no read op), so
+// filtering the world LIST by the writer allowlist wrongly hides readable
+// worlds from non-writers. Use readableWorlds for that.
 func authorizedWorlds(cfg *Config, claims *Claims) []*WorldConfig {
 	out := make([]*WorldConfig, 0, len(cfg.Worlds))
 	for j := range cfg.Worlds {
@@ -62,6 +66,23 @@ func authorizedWorlds(cfg *Config, claims *Claims) []*WorldConfig {
 		if worldAllows(&w.Allow, claims) {
 			out = append(out, w)
 		}
+	}
+	return out
+}
+
+// readableWorlds returns the worlds an authenticated identity may READ.
+// Reads are gated only by the broker's SSO/allowDomains org gate — not by
+// per-world Allow (that is the writer allowlist) — so every configured world
+// is readable by any identity that cleared the broker login gate. This is the
+// read-discovery seam mark_worlds lists from, kept separate from the writer
+// Allow so "all logins read everything, writes are allow-listed" is
+// expressible: opening reads here never widens writes. Per-world READ
+// restrictions (Phase 2 restricted collections) would filter here, on a
+// dedicated read predicate, never on the write Allow.
+func readableWorlds(cfg *Config) []*WorldConfig {
+	out := make([]*WorldConfig, 0, len(cfg.Worlds))
+	for j := range cfg.Worlds {
+		out = append(out, &cfg.Worlds[j])
 	}
 	return out
 }

--- a/tools/demarkus-broker/internal/broker/authz_test.go
+++ b/tools/demarkus-broker/internal/broker/authz_test.go
@@ -50,6 +50,31 @@ func testConfig() *Config {
 	}
 }
 
+// TestReadableWorldsIgnoresWriterAllow pins the read/write split: reads are
+// gated by the broker SSO org gate alone, so readableWorlds returns every
+// configured world regardless of its writer Allow. (authorizedWorlds — the
+// writer set — is tested via TestWorldAllowsPredicate.)
+func TestReadableWorldsIgnoresWriterAllow(t *testing.T) {
+	cfg := testConfig() // team-a: Allow domains=example.com
+	cfg.Worlds = append(cfg.Worlds, WorldConfig{
+		Name:         "locked",
+		Namespace:    "locked",
+		TokensSecret: "locked-tokens",
+		Allow:        AllowConfig{Emails: []string{"only-admin@nowhere.test"}},
+	})
+	got := readableWorlds(cfg)
+	if len(got) != 2 {
+		t.Fatalf("readableWorlds = %d, want 2 (a restrictive writer Allow must not hide a world from readers)", len(got))
+	}
+	seen := map[string]bool{}
+	for _, w := range got {
+		seen[w.Name] = true
+	}
+	if !seen["team-a"] || !seen["locked"] {
+		t.Errorf("readableWorlds names = %v, want both team-a and locked", seen)
+	}
+}
+
 // TestWorldAllowsPredicate is the authorization table for the
 // AllowConfig predicate. Each row pins one AllowConfig shape and asserts
 // whether a given Claims qualifies. Tests worldAllows directly — the

--- a/tools/demarkus-broker/internal/broker/mcp_tools_worlds.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_worlds.go
@@ -10,10 +10,13 @@ import (
 )
 
 // handleMarkWorlds implements the mark_worlds tool: the worlds of this
-// knowledge system the calling identity may read, per the same
-// authorizedWorlds predicate /auth/callback and /me/install already
-// apply. A pure read over config and claims — no dispatch, no Secret
-// access, no per-world traffic.
+// knowledge system the calling identity may read. Reads are gated by the
+// broker's SSO org gate alone (not the per-world Allow, which is the writer
+// allowlist), so this lists readableWorlds — every configured world — for any
+// authenticated identity. It deliberately does NOT use authorizedWorlds:
+// filtering the read list by the writer allowlist hid readable worlds from
+// non-writers (the reading-room floor rendered empty for them). A pure read
+// over config — no dispatch, no Secret access, no per-world traffic.
 //
 // Output follows the formatToolResult shape (status line, metadata,
 // blank line, body) with a markdown table body mirroring mark_lookup's
@@ -39,11 +42,10 @@ import (
 //
 // The worldName remains the addressing primitive for every tool regardless.
 func (g *mcpGateway) handleMarkWorlds(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
-	claims, ok := claimsFromCtx(ctx)
-	if !ok {
+	if _, ok := claimsFromCtx(ctx); !ok {
 		return mcp.NewToolResultError("internal: missing identity on tool-call context"), nil
 	}
-	worlds := authorizedWorlds(g.srv.cfg, claims)
+	worlds := readableWorlds(g.srv.cfg)
 
 	var b strings.Builder
 	b.WriteString("status: ok\n")

--- a/tools/demarkus-broker/internal/broker/mcp_tools_worlds_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_worlds_test.go
@@ -34,7 +34,14 @@ func worldsTestConfig() *Config {
 	return cfg
 }
 
-func TestHandleMarkWorldsListsAuthorizedOnly(t *testing.T) {
+func TestHandleMarkWorldsListsAllReadable(t *testing.T) {
+	// Reads are gated by the broker SSO org gate alone, not the per-world
+	// Allow (which is the WRITER allowlist). So mark_worlds lists EVERY
+	// configured world to any authenticated identity — "secret-b" appears
+	// even though alice does not match its writer Allow. Filtering the read
+	// list by the writer allowlist is exactly the bug this corrects (it left
+	// non-writers with an empty reading-room floor). Per-world READ
+	// restrictions are a separate, not-yet-built predicate (Phase 2).
 	g := newGatewayWithDispatcher(t, worldsTestConfig(), &fakeDispatcher{})
 	res, err := g.handleMarkWorlds(withAliceClaims(context.Background()), callToolReq("mark_worlds", nil))
 	if err != nil {
@@ -47,20 +54,17 @@ func TestHandleMarkWorldsListsAuthorizedOnly(t *testing.T) {
 
 	for _, want := range []string{
 		"status: ok",
-		"count: 1",
+		"count: 2",
 		"| world | url | address |",
 		// url = PublicURL; address = internal dial address (the topology graph's
 		// node host) so the floor can join graph edges back to the worldName.
 		"| team-a | mark://team-a.example.org:6309 | mark://team-a.team-a.svc.cluster.local:6309 |",
+		// readable despite alice not matching its writer Allow.
+		"secret-b",
 	} {
 		if !strings.Contains(text, want) {
 			t.Errorf("missing %q in %q", want, text)
 		}
-	}
-	// alice@example.com does not match secret-b's otherco.test allowlist:
-	// the world must not leak into her universe.
-	if strings.Contains(text, "secret-b") {
-		t.Errorf("unauthorized world leaked: %q", text)
 	}
 }
 
@@ -78,8 +82,11 @@ func TestHandleMarkWorldsBlankPublicURL(t *testing.T) {
 }
 
 func TestHandleMarkWorldsEmptyUniverse(t *testing.T) {
+	// Only a genuinely world-less config yields an empty list now — a world's
+	// writer Allow no longer hides it from the read list. Exercises the
+	// count: 0 / no-table rendering branch.
 	cfg := mcpTestConfig()
-	cfg.Worlds[0].Allow = AllowConfig{Domains: []string{"otherco.test"}}
+	cfg.Worlds = nil
 	g := newGatewayWithDispatcher(t, cfg, &fakeDispatcher{})
 	res, err := g.handleMarkWorlds(withAliceClaims(context.Background()), callToolReq("mark_worlds", nil))
 	text := toolResultText(t, mustToolResult(t, res, err))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed world read-access visibility to properly reflect SSO/org authentication gates instead of per-world write restrictions. Authenticated users now see all configured worlds available for read access.

* **Documentation**
  * Clarified the distinction between broker write permissions and read-access controls in authorization flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->