### PR TITLE
feat(broker): add writable column to mark_worlds

### DIFF
--- a/plugins/claude-code-knowledge/examples/knowledge-system/README.md
+++ b/plugins/claude-code-knowledge/examples/knowledge-system/README.md
@@ -13,6 +13,16 @@ mark://root/.well-known/demarkus/template.md   ← required per-world structure 
 
 `template.md` is the same layout the local soul seeds as `/project-template.md` — publish a copy of that to `root` (tailored as needed). `policy.md` is the example in this directory.
 
+## Per-world descriptors (`world.md`)
+
+`policy.md` and `template.md` live once on `root` and govern the whole system. A **world descriptor** is different — it is per-world, published by each world's owner to its own well-known prefix:
+
+```text
+mark://<world>/.well-known/demarkus/world.md   ← team, domain, partition role, autonomy ceiling (see world.md here)
+```
+
+It declares who owns the world, what subject domain it holds, its partition role (`hub`/`team`/`project`/`scratch`), and the most autonomous a promotion *into it* may be (`autonomy_ceiling`). The curation pipeline reads these to route a promotion to the right world among the ones the caller may write (the `writable` column of `mark_worlds`) and to cap promotion autonomy at the destination's ceiling. A world without a descriptor still works — it appears in the manual pick-list and defaults to `human-only`. `world.md` is the example in this directory.
+
 ## How a joined agent consumes them
 
 `/knowledge-join` registers the system so the publish tag-gate enforces on its writes (the same tag check as the local soul; tags travel in the tool call, so no broker access is needed for that). For the rest:

--- a/plugins/claude-code-knowledge/examples/knowledge-system/world.md
+++ b/plugins/claude-code-knowledge/examples/knowledge-system/world.md
@@ -1,0 +1,37 @@
+# World Descriptor — <worldName>
+
+descriptor_version: 1
+team: <owning team / contact, e.g. platform-eng (#platform)>
+domain: <subject domain(s), comma-separated, e.g. infrastructure, deployment>
+partition_role: team
+autonomy_ceiling: human-only
+
+How a world describes itself. Unlike `policy.md` and `template.md`, which live once on `root` and govern the whole system, this descriptor is **per-world**: each world publishes its own copy to `mark://<thisWorld>/.well-known/demarkus/world.md`. The world owner is the source of truth — a world declares its own scope, self-sovereign. `root` may aggregate these into a discovery index, but only when **derived** (crawled from the per-world descriptors), never hand-maintained, or the central map drifts from what worlds actually hold.
+
+The five lines above are the **structured core** the curation pipeline reads when routing a promotion. Everything below is convention.
+
+## The core fields
+
+- `descriptor_version` — schema version of this file. `1` today.
+- `team` — the owning team or contact. Maps to the human who approves writes here (the `owner:` in the system `policy.md`). Decide who approves before wiring promotion triggers at this world.
+- `domain` — the subject area(s) this world holds, comma-separated. Destination-selection matches a promotion candidate's subject against this to auto-route, or to label the world in a pick-list when routing is ambiguous.
+- `partition_role` — the world's place in the topology: `hub` (the global tracker; usually `root`), `team` (a team's shared catalog), `project` (a single project's docs), or `scratch` (low-stakes, experimental). Keep the set small and stable.
+- `autonomy_ceiling` — the most autonomous a promotion *into this world* may be, set by the world owner. The promotion pipeline applies `min(local preference, autonomy_ceiling)`, so a client can never exceed what the destination allows:
+  - `human-only` — every promotion is approved by a human before publish. The safe default; `root` and any authoritative world should stay here.
+  - `verify-then-auto` — a model verification step (a refute-check against the source) may stand in for the human.
+  - `auto` — publish without a gate. Only for a low-stakes `scratch` world; never an authoritative one.
+
+## How the pipeline consumes it
+
+When promoting a soul document up to this knowledge system, the destination-selection step:
+
+1. Enumerates the worlds the caller may **write** (the `writable` column of `mark_worlds` — readable is not writable).
+2. Fetches each writable world's `world.md`.
+3. Routes the candidate by matching its subject/team against each world's declared `domain`/`team` — auto-routing on a clear match, or presenting a write-filtered, labeled pick-list otherwise.
+4. Caps promotion autonomy at the chosen world's `autonomy_ceiling`.
+
+A world with no descriptor still works: it is writable-but-unlabeled, so it only ever appears in the manual pick-list and defaults to `human-only`. The descriptor is what lets routing be automatic and lets an owner relax the gate deliberately.
+
+## Why per-world, not on root
+
+Partitioning is **discovered, not designed**: where knowledge lands falls out of who can write where (token-encoded access) plus what each world says it holds. The pipeline conforms to that topology; it does not invent a partition scheme. Hosting the descriptor on the world it describes keeps the declaration next to the authority that owns it, and lets the root index be a derived view rather than a second source of truth that can drift.

--- a/tools/demarkus-broker/internal/broker/mcp_tools_list.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_list.go
@@ -332,13 +332,17 @@ func markGraphExportTool() mcp.Tool {
 func markWorldsTool() mcp.Tool {
 	return mcp.NewTool("mark_worlds",
 		mcp.WithDescription(
-			"List the worlds of this knowledge system that your identity may read. "+
+			"List the worlds of this knowledge system that your identity may read, "+
+				"each flagged with whether you may also write it. "+
 				"Returns a count and a markdown table with columns: world (the "+
 				"{worldName} addressing primitive for every other tool — "+
 				"mark://{worldName}/{path}), url (the world's external address for a "+
-				"direct client, may be blank), and address (the world's internal dial "+
-				"address — its identity in the topology graph). Use this to discover "+
-				"the universe before navigating it.",
+				"direct client, may be blank), address (the world's internal dial "+
+				"address — its identity in the topology graph), and writable (yes/no — "+
+				"whether your identity may publish to the world; reading a world does "+
+				"not imply you can write it). Use this to discover the universe before "+
+				"navigating it, and to pick a write destination among the worlds you "+
+				"may publish to.",
 		),
 	)
 }

--- a/tools/demarkus-broker/internal/broker/mcp_tools_worlds.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_worlds.go
@@ -10,13 +10,17 @@ import (
 )
 
 // handleMarkWorlds implements the mark_worlds tool: the worlds of this
-// knowledge system the calling identity may read. Reads are gated by the
-// broker's SSO org gate alone (not the per-world Allow, which is the writer
-// allowlist), so this lists readableWorlds — every configured world — for any
-// authenticated identity. It deliberately does NOT use authorizedWorlds:
-// filtering the read list by the writer allowlist hid readable worlds from
-// non-writers (the reading-room floor rendered empty for them). A pure read
-// over config — no dispatch, no Secret access, no per-world traffic.
+// knowledge system the calling identity may read, each flagged with whether
+// the identity may also write it. Reads are gated by the broker's SSO org gate
+// alone (not the per-world Allow, which is the writer allowlist), so this lists
+// readableWorlds — every configured world — for any authenticated identity. It
+// deliberately does NOT filter the LIST by authorizedWorlds: that hid readable
+// worlds from non-writers (the reading-room floor rendered empty for them).
+// Instead the writer Allow surfaces per row as the `writable` column, so a
+// caller learns both its {readable, writable} sets in one call — the
+// access-discovery seam the curation pipeline routes promotions on (readable is
+// not writable, the #189 distinction). A pure read over config — no dispatch,
+// no Secret access, no per-world traffic.
 //
 // Output follows the formatToolResult shape (status line, metadata,
 // blank line, body) with a markdown table body mirroring mark_lookup's
@@ -25,10 +29,10 @@ import (
 //	status: ok
 //	count: 2
 //
-//	| world | url | address |
-//	|-------|-----|---------|
-//	| team-a | mark://team-a.example.org:6309 | mark://team-a.team-a.svc.cluster.local:6309 |
-//	| hub | | mark://hub.hub.svc.cluster.local:6309 |
+//	| world | url | address | writable |
+//	|-------|-----|---------|----------|
+//	| team-a | mark://team-a.example.org:6309 | mark://team-a.team-a.svc.cluster.local:6309 | yes |
+//	| hub | | mark://hub.hub.svc.cluster.local:6309 | no |
 //
 // Two addresses, deliberately distinct:
 //   - url: the world's externally reachable address (WorldConfig.PublicURL),
@@ -42,7 +46,8 @@ import (
 //
 // The worldName remains the addressing primitive for every tool regardless.
 func (g *mcpGateway) handleMarkWorlds(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
-	if _, ok := claimsFromCtx(ctx); !ok {
+	claims, ok := claimsFromCtx(ctx)
+	if !ok {
 		return mcp.NewToolResultError("internal: missing identity on tool-call context"), nil
 	}
 	worlds := readableWorlds(g.srv.cfg)
@@ -51,12 +56,25 @@ func (g *mcpGateway) handleMarkWorlds(ctx context.Context, _ mcp.CallToolRequest
 	b.WriteString("status: ok\n")
 	fmt.Fprintf(&b, "count: %d\n", len(worlds))
 	if len(worlds) > 0 {
-		b.WriteString("\n| world | url | address |\n|-------|-----|---------|\n")
+		b.WriteString("\n| world | url | address | writable |\n|-------|-----|---------|----------|\n")
 		for _, w := range worlds {
-			fmt.Fprintf(&b, "| %s | %s | mark://%s |\n", w.Name, w.PublicURL, resolveWorldAddress(w))
+			fmt.Fprintf(&b, "| %s | %s | mark://%s | %s |\n",
+				w.Name, w.PublicURL, resolveWorldAddress(w), yesNo(worldAllows(&w.Allow, claims)))
 		}
 	}
 	return mcp.NewToolResultText(b.String()), nil
+}
+
+// yesNo renders a writable predicate as a stable table cell. The column is
+// the writer-discovery seam the curation pipeline routes on: every world is
+// readable (the SSO org gate), but only worlds whose Allow admits the caller
+// are writable, so a promotion targets one of these. readable-not-writable is
+// exactly the #189 distinction made legible in one call.
+func yesNo(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
 }
 
 // compile-time check that the handler matches mcp-go's expected shape.

--- a/tools/demarkus-broker/internal/broker/mcp_tools_worlds_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_worlds_test.go
@@ -55,12 +55,14 @@ func TestHandleMarkWorldsListsAllReadable(t *testing.T) {
 	for _, want := range []string{
 		"status: ok",
 		"count: 2",
-		"| world | url | address |",
+		"| world | url | address | writable |",
 		// url = PublicURL; address = internal dial address (the topology graph's
 		// node host) so the floor can join graph edges back to the worldName.
-		"| team-a | mark://team-a.example.org:6309 | mark://team-a.team-a.svc.cluster.local:6309 |",
-		// readable despite alice not matching its writer Allow.
-		"secret-b",
+		// writable = yes: alice (example.com) matches team-a's writer Allow.
+		"| team-a | mark://team-a.example.org:6309 | mark://team-a.team-a.svc.cluster.local:6309 | yes |",
+		// readable despite alice not matching its writer Allow (otherco.test),
+		// so it lists but flags writable = no — the read/write split made legible.
+		"| secret-b |  | mark://secret-b.secret-b.svc.cluster.local:6309 | no |",
 	} {
 		if !strings.Contains(text, want) {
 			t.Errorf("missing %q in %q", want, text)
@@ -76,7 +78,7 @@ func TestHandleMarkWorldsBlankPublicURL(t *testing.T) {
 	g := newGatewayWithDispatcher(t, mcpTestConfig(), &fakeDispatcher{})
 	res, err := g.handleMarkWorlds(withAliceClaims(context.Background()), callToolReq("mark_worlds", nil))
 	text := toolResultText(t, mustToolResult(t, res, err))
-	if !strings.Contains(text, "| team-a |  | mark://team-a.team-a.svc.cluster.local:6309 |") {
+	if !strings.Contains(text, "| team-a |  | mark://team-a.team-a.svc.cluster.local:6309 | yes |") {
 		t.Errorf("blank-URL row missing or address cell not populated: %q", text)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced world listing to display write-permission status for each world.

* **Documentation**
  * Added documentation describing the world descriptor system and per-world metadata management used in the promotion routing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->