### PR TITLE
feat(okf): Open Knowledge Format compatibility

### DIFF
--- a/client/cmd/demarkus/main.go
+++ b/client/cmd/demarkus/main.go
@@ -43,6 +43,9 @@ func main() {
 		case "lookup":
 			lookupMain(os.Args[2:])
 			return
+		case "okf":
+			okfMain(os.Args[2:])
+			return
 		}
 	}
 	requestMain()

--- a/client/cmd/demarkus/okf.go
+++ b/client/cmd/demarkus/okf.go
@@ -175,7 +175,7 @@ func okfExportMain(args []string) {
 	if root == "" {
 		root = "/"
 	}
-	paths, err := enumerateDocs(client, host, root, token)
+	paths, err := enumerateDocs(client, host, root, token, map[string]struct{}{})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "okf export: %v\n", err)
 		os.Exit(1)
@@ -200,7 +200,12 @@ func okfExportMain(args []string) {
 		})
 	}
 
-	for _, f := range okf.BuildExport(docs, prefix) {
+	files, err := okf.BuildExport(docs, prefix)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "okf export: %v\n", err)
+		os.Exit(1)
+	}
+	for _, f := range files {
 		full := filepath.Join(outDir, filepath.FromSlash(f.Path))
 		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
 			fmt.Fprintf(os.Stderr, "okf export: %v\n", err)
@@ -228,7 +233,12 @@ func publisherMeta(respMeta map[string]string) map[string]string {
 // enumerateDocs recursively LISTs dir and returns the mark paths of every ".md"
 // document beneath it, skipping the server's own version directories (already
 // filtered server-side).
-func enumerateDocs(client *fetch.Client, host, dir, token string) ([]string, error) {
+func enumerateDocs(client *fetch.Client, host, dir, token string, seen map[string]struct{}) ([]string, error) {
+	if _, ok := seen[dir]; ok {
+		return nil, fmt.Errorf("list cycle detected at %s", dir)
+	}
+	seen[dir] = struct{}{}
+
 	result, err := client.List(host, dir, token)
 	if err != nil {
 		return nil, fmt.Errorf("list %s: %w", dir, err)
@@ -240,10 +250,10 @@ func enumerateDocs(client *fetch.Client, host, dir, token string) ([]string, err
 	for _, dest := range links.Extract(result.Response.Body) {
 		name, err := url.PathUnescape(dest)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("list %s: decode entry %q: %w", dir, dest, err)
 		}
 		if sub, ok := strings.CutSuffix(name, "/"); ok {
-			child, err := enumerateDocs(client, host, path.Join(dir, sub), token)
+			child, err := enumerateDocs(client, host, path.Join(dir, sub), token, seen)
 			if err != nil {
 				return nil, err
 			}

--- a/client/cmd/demarkus/okf.go
+++ b/client/cmd/demarkus/okf.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/client/internal/okf"
+	"github.com/latebit-io/demarkus/client/internal/tokens"
+	"github.com/latebit-io/demarkus/client/links"
+	"github.com/latebit-io/demarkus/protocol"
+)
+
+// okfMain dispatches `demarkus okf <subcommand>`.
+func okfMain(args []string) {
+	if len(args) == 0 {
+		okfUsage()
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "validate":
+		okfValidateMain(args[1:])
+	case "import":
+		okfImportMain(args[1:])
+	case "export":
+		okfExportMain(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "okf: unknown subcommand %q\n", args[0])
+		okfUsage()
+		os.Exit(2)
+	}
+}
+
+func okfUsage() {
+	fmt.Fprintln(os.Stderr, "usage:")
+	fmt.Fprintln(os.Stderr, "  demarkus okf validate [--strict] [--quiet] <bundle-dir>")
+	fmt.Fprintln(os.Stderr, "  demarkus okf import [--dry-run] [--auth t] [--insecure] <bundle-dir> <mark://host/prefix>")
+	fmt.Fprintln(os.Stderr, "  demarkus okf export [--auth t] [--insecure] <mark://host/prefix> <out-dir>")
+}
+
+// okfValidateMain checks an OKF bundle for v0.1 conformance, prints findings,
+// and exits non-zero when the bundle does not conform.
+func okfValidateMain(args []string) {
+	fs := flag.NewFlagSet("okf validate", flag.ExitOnError)
+	strict := fs.Bool("strict", false, "treat warnings as failures")
+	quiet := fs.Bool("quiet", false, "print only the summary line")
+	_ = fs.Parse(args)
+	if fs.NArg() != 1 {
+		okfUsage()
+		os.Exit(2)
+	}
+
+	report, err := okf.ValidateBundle(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "okf validate: %v\n", err)
+		os.Exit(2)
+	}
+
+	if !*quiet {
+		for _, f := range report.Findings {
+			fmt.Printf("%s: %s: %s\n", f.Severity, f.Path, f.Message)
+		}
+	}
+	errors, warnings := report.Counts()
+	fmt.Printf("%d files, %d errors, %d warnings\n", report.Files, errors, warnings)
+
+	if errors > 0 || (*strict && warnings > 0) {
+		os.Exit(1)
+	}
+}
+
+// okfImportMain mirrors an OKF bundle into a demarkus world: it parses each
+// document, lifts the frontmatter into out-of-band metadata, rewrites
+// bundle-absolute links under the target prefix, and publishes. Documents are
+// upserted (no version check); re-importing an unchanged bundle creates no new
+// versions thanks to the store's content-hash dedup.
+func okfImportMain(args []string) {
+	fs := flag.NewFlagSet("okf import", flag.ExitOnError)
+	authToken := fs.String("auth", "", "auth token for publishing (env: DEMARKUS_AUTH)")
+	insecure := fs.Bool("insecure", false, "skip TLS certificate verification")
+	dryRun := fs.Bool("dry-run", false, "build and report the plan without publishing")
+	_ = fs.Parse(args)
+	if fs.NArg() != 2 {
+		okfUsage()
+		os.Exit(2)
+	}
+
+	host, prefix, err := fetch.ParseMarkURL(fs.Arg(1))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "okf import: %v\n", err)
+		os.Exit(2)
+	}
+	items, err := okf.BuildImport(fs.Arg(0), prefix)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "okf import: %v\n", err)
+		os.Exit(2)
+	}
+
+	for _, it := range items {
+		for _, w := range it.Warnings {
+			fmt.Printf("warning: %s: %s\n", it.Path, w)
+		}
+	}
+
+	if *dryRun {
+		fmt.Printf("%d documents planned (dry run, nothing published)\n", len(items))
+		return
+	}
+
+	token := tokens.Resolve(*authToken, host, tokens.LoadDefault())
+	client := fetch.NewClient(fetch.Options{Insecure: *insecure})
+	defer client.Close()
+
+	published, failed := 0, 0
+	for _, it := range items {
+		// expectedVersion -1 skips the optimistic-concurrency check: import is
+		// an upsert of the bundle as the source of truth.
+		result, err := client.Publish(host, it.Path, it.Body, token, -1, it.Metadata)
+		switch {
+		case err != nil:
+			fmt.Fprintf(os.Stderr, "error: %s: %v\n", it.Path, err)
+			failed++
+		case result.Response.Status != protocol.StatusOK && result.Response.Status != protocol.StatusCreated:
+			fmt.Fprintf(os.Stderr, "error: %s: server returned %q\n", it.Path, result.Response.Status)
+			failed++
+		default:
+			published++
+			fmt.Printf("published %s (v%s)\n", it.Path, result.Response.Metadata["version"])
+		}
+	}
+	fmt.Printf("%d published, %d failed\n", published, failed)
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+// serverRespKeys are response metadata fields owned by the server; everything
+// else in a FETCH response is publisher metadata to carry into the bundle.
+var serverRespKeys = map[string]bool{
+	"status": true, "version": true, "modified": true, "etag": true,
+	"content-hash": true, "current-version": true, "entries": true,
+}
+
+// okfExportMain renders a demarkus world subtree into an OKF bundle on disk:
+// it enumerates the subtree with LIST, fetches each document, reattaches OKF
+// frontmatter from its metadata, strips the world prefix from paths and links,
+// and writes the tree under <out-dir>.
+func okfExportMain(args []string) {
+	fs := flag.NewFlagSet("okf export", flag.ExitOnError)
+	authToken := fs.String("auth", "", "auth token for reads on private paths (env: DEMARKUS_AUTH)")
+	insecure := fs.Bool("insecure", false, "skip TLS certificate verification")
+	_ = fs.Parse(args)
+	if fs.NArg() != 2 {
+		okfUsage()
+		os.Exit(2)
+	}
+
+	host, prefix, err := fetch.ParseMarkURL(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "okf export: %v\n", err)
+		os.Exit(2)
+	}
+	outDir := fs.Arg(1)
+
+	token := tokens.Resolve(*authToken, host, tokens.LoadDefault())
+	client := fetch.NewClient(fetch.Options{Insecure: *insecure})
+	defer client.Close()
+
+	root := prefix
+	if root == "" {
+		root = "/"
+	}
+	paths, err := enumerateDocs(client, host, root, token)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "okf export: %v\n", err)
+		os.Exit(1)
+	}
+
+	docs := make([]okf.ExportDoc, 0, len(paths))
+	for _, p := range paths {
+		result, err := client.Fetch(host, p, token)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "okf export: fetch %s: %v\n", p, err)
+			os.Exit(1)
+		}
+		if result.Response.Status != protocol.StatusOK {
+			fmt.Fprintf(os.Stderr, "okf export: fetch %s: server returned %q\n", p, result.Response.Status)
+			os.Exit(1)
+		}
+		docs = append(docs, okf.ExportDoc{
+			Path:     p,
+			Body:     result.Response.Body,
+			Metadata: publisherMeta(result.Response.Metadata),
+			Modified: result.Response.Metadata["modified"],
+		})
+	}
+
+	for _, f := range okf.BuildExport(docs, prefix) {
+		full := filepath.Join(outDir, filepath.FromSlash(f.Path))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "okf export: %v\n", err)
+			os.Exit(1)
+		}
+		if err := os.WriteFile(full, f.Content, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "okf export: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("wrote %s\n", f.Path)
+	}
+	fmt.Printf("%d documents exported to %s\n", len(docs), outDir)
+}
+
+func publisherMeta(respMeta map[string]string) map[string]string {
+	out := make(map[string]string, len(respMeta))
+	for k, v := range respMeta {
+		if !serverRespKeys[k] {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// enumerateDocs recursively LISTs dir and returns the mark paths of every ".md"
+// document beneath it, skipping the server's own version directories (already
+// filtered server-side).
+func enumerateDocs(client *fetch.Client, host, dir, token string) ([]string, error) {
+	result, err := client.List(host, dir, token)
+	if err != nil {
+		return nil, fmt.Errorf("list %s: %w", dir, err)
+	}
+	if result.Response.Status != protocol.StatusOK {
+		return nil, fmt.Errorf("list %s: server returned %q", dir, result.Response.Status)
+	}
+	var docs []string
+	for _, dest := range links.Extract(result.Response.Body) {
+		name, err := url.PathUnescape(dest)
+		if err != nil {
+			continue
+		}
+		if sub, ok := strings.CutSuffix(name, "/"); ok {
+			child, err := enumerateDocs(client, host, path.Join(dir, sub), token)
+			if err != nil {
+				return nil, err
+			}
+			docs = append(docs, child...)
+		} else if strings.HasSuffix(name, ".md") {
+			docs = append(docs, path.Join(dir, name))
+		}
+	}
+	return docs, nil
+}

--- a/client/internal/okf/export.go
+++ b/client/internal/okf/export.go
@@ -1,0 +1,178 @@
+package okf
+
+import (
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/latebit-io/demarkus/protocol"
+	"github.com/latebit-io/demarkus/protocol/store"
+)
+
+// ExportDoc is a document fetched from a demarkus world, ready to render back
+// into an OKF bundle file.
+type ExportDoc struct {
+	Path     string            // mark path, e.g. /vendor/tables/orders.md
+	Body     string            // served markdown body (store frontmatter already stripped)
+	Metadata map[string]string // publisher metadata from FETCH (bare keys)
+	Modified string            // RFC 3339 modification time, used to synthesize timestamp
+}
+
+// BundleFile is a rendered OKF bundle file: a bundle-relative path and its bytes.
+type BundleFile struct {
+	Path    string
+	Content []byte
+}
+
+// recognizedOrder is the canonical leading order of OKF frontmatter fields.
+var recognizedOrder = []string{"type", "title", "description", "resource", "tags", "timestamp"}
+
+var recognizedSet = map[string]bool{
+	"type": true, "title": true, "description": true,
+	"resource": true, "tags": true, "timestamp": true,
+}
+
+// BuildExport renders fetched documents into OKF bundle files, stripping the
+// world prefix from both paths and bundle-absolute links. Concept documents get
+// an OKF frontmatter block reconstructed from their metadata (a required `type`
+// is synthesized when absent, and `timestamp` falls back to the document's
+// modification time). Reserved files (index.md, log.md) are written body-only,
+// except a root index.md that carries an okf-version, which is re-emitted as
+// okf_version frontmatter. It performs no network I/O.
+func BuildExport(docs []ExportDoc, prefix string) []BundleFile {
+	pfx := strings.Trim(prefix, "/")
+	files := make([]BundleFile, 0, len(docs))
+	for _, d := range docs {
+		rel := relFromPath(d.Path, pfx)
+		body := stripAbsLinks(d.Body, pfx)
+		var content string
+		if IsReserved(path.Base(rel)) {
+			content = renderReserved(rel, d.Metadata, body)
+		} else {
+			content = renderConcept(d.Metadata, body, d.Modified)
+		}
+		files = append(files, BundleFile{Path: rel, Content: []byte(content)})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return files
+}
+
+func relFromPath(markPath, pfx string) string {
+	p := strings.TrimPrefix(markPath, "/")
+	if pfx != "" {
+		p = strings.TrimPrefix(p, pfx+"/")
+	}
+	return p
+}
+
+func renderConcept(meta map[string]string, body, modified string) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+
+	typ := strings.TrimSpace(meta["type"])
+	if typ == "" {
+		typ = protocol.OKFDefaultType // OKF requires a non-empty type
+	}
+	writeScalar(&b, "type", typ)
+
+	for _, k := range recognizedOrder {
+		switch k {
+		case "type":
+			continue // already written
+		case "tags":
+			if v := meta["tags"]; v != "" {
+				b.WriteString("tags: " + store.FormatTagsList(v) + "\n")
+			}
+		case "timestamp":
+			if ts := normalizeTimestamp(meta["timestamp"], modified); ts != "" {
+				writeScalar(&b, "timestamp", ts)
+			}
+		default:
+			if v := meta[k]; v != "" {
+				writeScalar(&b, k, v)
+			}
+		}
+	}
+
+	// Producer-defined keys (including demarkus's importance) preserved bare,
+	// sorted for stable output.
+	for _, k := range sortedKeys(meta) {
+		if !recognizedSet[k] {
+			writeScalar(&b, k, meta[k])
+		}
+	}
+
+	b.WriteString("---\n")
+	b.WriteString(body)
+	return b.String()
+}
+
+// normalizeTimestamp returns an RFC 3339 timestamp. A declared value is parsed
+// (accepting RFC 3339 or a date-only form) and re-emitted in canonical RFC 3339;
+// if it is empty or unparseable, the document's modification time (already
+// RFC 3339) is used instead.
+func normalizeTimestamp(declared, modified string) string {
+	if declared != "" {
+		for _, layout := range []string{time.RFC3339, "2006-01-02"} {
+			if t, err := time.Parse(layout, declared); err == nil {
+				return t.UTC().Format(time.RFC3339)
+			}
+		}
+	}
+	return modified
+}
+
+func renderReserved(rel string, meta map[string]string, body string) string {
+	// OKF reserved files carry no frontmatter, except the root index.md which
+	// may declare okf_version (round-tripped from the okf-version metadata key
+	// the importer stashes).
+	if rel == IndexFile {
+		if v := meta["okf-version"]; v != "" {
+			return "---\nokf_version: " + yamlScalar(v) + "\n---\n" + body
+		}
+	}
+	return body
+}
+
+func writeScalar(b *strings.Builder, key, val string) {
+	b.WriteString(key + ": " + yamlScalar(val) + "\n")
+}
+
+// yamlScalar renders a value as a YAML scalar, double-quoting only when a bare
+// scalar would be ambiguous or reparse differently (a "key: value" collision, a
+// trailing comment, surrounding whitespace, an empty value, or a leading YAML
+// indicator character).
+func yamlScalar(v string) string {
+	need := v == "" ||
+		strings.Contains(v, ": ") || strings.HasSuffix(v, ":") ||
+		strings.Contains(v, " #") ||
+		v != strings.TrimSpace(v) ||
+		strings.ContainsAny(v[:1], `[]{}#&*!|>'"%@`+"`,")
+	if !need {
+		return v
+	}
+	v = strings.ReplaceAll(v, `\`, `\\`)
+	v = strings.ReplaceAll(v, `"`, `\"`)
+	return `"` + v + `"`
+}
+
+// stripAbsLinks removes the "/<pfx>" prefix from every bundle-absolute markdown
+// link destination, the inverse of import's rewriteAbsLinks. Relative links are
+// untouched. With no prefix, the body is returned unchanged.
+func stripAbsLinks(body, pfx string) string {
+	if pfx == "" {
+		return body
+	}
+	p := "/" + pfx
+	return mapAbsLinks(body, func(dest string) string {
+		switch {
+		case dest == p:
+			return "/"
+		case strings.HasPrefix(dest, p+"/"):
+			return strings.TrimPrefix(dest, p)
+		default:
+			return dest
+		}
+	})
+}

--- a/client/internal/okf/export.go
+++ b/client/internal/okf/export.go
@@ -1,6 +1,7 @@
 package okf
 
 import (
+	"fmt"
 	"path"
 	"sort"
 	"strings"
@@ -40,11 +41,14 @@ var recognizedSet = map[string]bool{
 // modification time). Reserved files (index.md, log.md) are written body-only,
 // except a root index.md that carries an okf-version, which is re-emitted as
 // okf_version frontmatter. It performs no network I/O.
-func BuildExport(docs []ExportDoc, prefix string) []BundleFile {
+func BuildExport(docs []ExportDoc, prefix string) ([]BundleFile, error) {
 	pfx := strings.Trim(prefix, "/")
 	files := make([]BundleFile, 0, len(docs))
 	for _, d := range docs {
-		rel := relFromPath(d.Path, pfx)
+		rel, err := relFromPath(d.Path, pfx)
+		if err != nil {
+			return nil, err
+		}
 		body := stripAbsLinks(d.Body, pfx)
 		var content string
 		if IsReserved(path.Base(rel)) {
@@ -55,15 +59,22 @@ func BuildExport(docs []ExportDoc, prefix string) []BundleFile {
 		files = append(files, BundleFile{Path: rel, Content: []byte(content)})
 	}
 	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
-	return files
+	return files, nil
 }
 
-func relFromPath(markPath, pfx string) string {
+// relFromPath derives the bundle-relative path for a document, failing closed if
+// the result would escape the bundle root (a hostile or malformed mark path with
+// ".." segments must not let export write outside the output directory).
+func relFromPath(markPath, pfx string) (string, error) {
 	p := strings.TrimPrefix(markPath, "/")
 	if pfx != "" {
 		p = strings.TrimPrefix(p, pfx+"/")
 	}
-	return p
+	clean := path.Clean(p)
+	if clean == ".." || strings.HasPrefix(clean, "../") || clean == "." {
+		return "", fmt.Errorf("export path escapes bundle root: %s", markPath)
+	}
+	return clean, nil
 }
 
 func renderConcept(meta map[string]string, body, modified string) string {

--- a/client/internal/okf/export_test.go
+++ b/client/internal/okf/export_test.go
@@ -43,11 +43,15 @@ func TestStripAbsLinks(t *testing.T) {
 }
 
 func TestRelFromPath(t *testing.T) {
-	if got := relFromPath("/vendor/tables/o.md", "vendor"); got != "tables/o.md" {
-		t.Errorf("relFromPath vendor = %q", got)
+	if got, err := relFromPath("/vendor/tables/o.md", "vendor"); err != nil || got != "tables/o.md" {
+		t.Errorf("relFromPath vendor = %q, %v", got, err)
 	}
-	if got := relFromPath("/o.md", ""); got != "o.md" {
-		t.Errorf("relFromPath root = %q", got)
+	if got, err := relFromPath("/o.md", ""); err != nil || got != "o.md" {
+		t.Errorf("relFromPath root = %q, %v", got, err)
+	}
+	// A path that climbs out of the bundle root must fail closed.
+	if _, err := relFromPath("/vendor/../../etc/passwd.md", "vendor"); err == nil {
+		t.Error("expected relFromPath to reject a traversing path")
 	}
 }
 
@@ -115,7 +119,10 @@ func TestBuildExport_StripsPrefix(t *testing.T) {
 		{Path: "/vendor/tables/orders.md", Body: "# Orders\n[c](/vendor/tables/customers.md)\n",
 			Metadata: map[string]string{"type": "Table", "tags": "sales"}, Modified: "2026-05-28T14:30:00Z"},
 	}
-	files := BuildExport(docs, "/vendor/")
+	files, err := BuildExport(docs, "/vendor/")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(files) != 1 || files[0].Path != "tables/orders.md" {
 		t.Fatalf("path not stripped: %+v", files)
 	}
@@ -151,7 +158,11 @@ func TestRoundTrip_ImportExportConforms(t *testing.T) {
 	}
 
 	out := t.TempDir()
-	for _, f := range BuildExport(docs, "/vendor/") {
+	files, err := BuildExport(docs, "/vendor/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range files {
 		full := filepath.Join(out, filepath.FromSlash(f.Path))
 		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
 			t.Fatal(err)

--- a/client/internal/okf/export_test.go
+++ b/client/internal/okf/export_test.go
@@ -1,0 +1,186 @@
+package okf
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestYamlScalar(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"plain", "plain"},
+		{"", `""`},
+		{"a: b", `"a: b"`},
+		{"https://x/y", "https://x/y"},
+		{"ends:", `"ends:"`},
+		{" lead", `" lead"`},
+		{"[bracket", `"[bracket"`},
+		{`has"quote`, `has"quote`}, // mid-scalar quote is valid bare YAML
+	}
+	for _, tt := range tests {
+		if got := yamlScalar(tt.in); got != tt.want {
+			t.Errorf("yamlScalar(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestStripAbsLinks(t *testing.T) {
+	tests := []struct{ name, body, pfx, want string }{
+		{"strip prefix", "[a](/vendor/x.md)", "vendor", "[a](/x.md)"},
+		{"boundary not matched", "[a](/vendorish/x.md)", "vendor", "[a](/vendorish/x.md)"},
+		{"relative untouched", "[a](x.md)", "vendor", "[a](x.md)"},
+		{"no prefix noop", "[a](/vendor/x.md)", "", "[a](/vendor/x.md)"},
+		{"fragment preserved", "[a](/vendor/x.md#s)", "vendor", "[a](/x.md#s)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripAbsLinks(tt.body, tt.pfx); got != tt.want {
+				t.Errorf("stripAbsLinks = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRelFromPath(t *testing.T) {
+	if got := relFromPath("/vendor/tables/o.md", "vendor"); got != "tables/o.md" {
+		t.Errorf("relFromPath vendor = %q", got)
+	}
+	if got := relFromPath("/o.md", ""); got != "o.md" {
+		t.Errorf("relFromPath root = %q", got)
+	}
+}
+
+func TestRenderConcept(t *testing.T) {
+	meta := map[string]string{
+		"title": "Orders", "tags": "a,b", "resource": "https://x", "importance": "0.8",
+	}
+	got := renderConcept(meta, "# Body\n", "2026-05-28T14:30:00Z")
+	for _, want := range []string{
+		"type: Document\n", // synthesized
+		"title: Orders\n",
+		"resource: https://x\n",
+		"tags: [a, b]\n",
+		"timestamp: 2026-05-28T14:30:00Z\n", // from modified
+		"importance: 0.8\n",                 // producer key preserved
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("renderConcept missing %q in:\n%s", want, got)
+		}
+	}
+	if !strings.HasSuffix(got, "---\n# Body\n") {
+		t.Errorf("body not appended after frontmatter:\n%s", got)
+	}
+}
+
+func TestNormalizeTimestamp(t *testing.T) {
+	const mod = "2026-06-22T15:56:55Z"
+	tests := []struct{ name, declared, want string }{
+		{"rfc3339 passthrough", "2026-05-28T14:30:00Z", "2026-05-28T14:30:00Z"},
+		{"date-only expanded", "2026-05-28", "2026-05-28T00:00:00Z"},
+		{"offset normalized to UTC", "2026-05-28T10:30:00-04:00", "2026-05-28T14:30:00Z"},
+		{"empty falls back to modified", "", mod},
+		{"unparseable falls back to modified", "May 28 2026", mod},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeTimestamp(tt.declared, mod); got != tt.want {
+				t.Errorf("normalizeTimestamp(%q) = %q, want %q", tt.declared, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderConcept_NormalizesTimestamp(t *testing.T) {
+	meta := map[string]string{"type": "T", "timestamp": "2026-05-28"}
+	got := renderConcept(meta, "# B\n", "2026-06-22T15:56:55Z")
+	if !strings.Contains(got, "timestamp: 2026-05-28T00:00:00Z\n") {
+		t.Errorf("declared date-only timestamp not normalized:\n%s", got)
+	}
+}
+
+func TestRenderReserved(t *testing.T) {
+	root := renderReserved("index.md", map[string]string{"okf-version": "0.1"}, "# Hub\n")
+	if !strings.HasPrefix(root, "---\nokf_version: 0.1\n---\n# Hub\n") {
+		t.Errorf("root index okf_version not emitted: %q", root)
+	}
+	sub := renderReserved("tables/index.md", map[string]string{}, "# Tables\n")
+	if sub != "# Tables\n" {
+		t.Errorf("non-root reserved file should be body-only, got %q", sub)
+	}
+}
+
+func TestBuildExport_StripsPrefix(t *testing.T) {
+	docs := []ExportDoc{
+		{Path: "/vendor/tables/orders.md", Body: "# Orders\n[c](/vendor/tables/customers.md)\n",
+			Metadata: map[string]string{"type": "Table", "tags": "sales"}, Modified: "2026-05-28T14:30:00Z"},
+	}
+	files := BuildExport(docs, "/vendor/")
+	if len(files) != 1 || files[0].Path != "tables/orders.md" {
+		t.Fatalf("path not stripped: %+v", files)
+	}
+	content := string(files[0].Content)
+	if !strings.Contains(content, "tags: [sales]\n") {
+		t.Errorf("tags not serialized as list: %s", content)
+	}
+	if !strings.Contains(content, "[c](/tables/customers.md)") {
+		t.Errorf("link prefix not stripped: %s", content)
+	}
+}
+
+// TestRoundTrip_ImportExportConforms is the payoff: an OKF bundle imported into a
+// world (then served back via FETCH) and exported again must produce a bundle
+// that passes conformance, with the document bodies preserved.
+func TestRoundTrip_ImportExportConforms(t *testing.T) {
+	src := map[string]string{
+		"index.md":            "---\nokf_version: 0.1\n---\n# Hub\n* [O](/tables/orders.md) - o\n",
+		"tables/index.md":     "# Tables\n* [O](orders.md) - o\n",
+		"tables/orders.md":    "---\ntype: BigQuery Table\ntitle: Orders\ntags: [sales, revenue]\n---\n# Orders\n[c](/tables/customers.md) [r](customers.md)\n",
+		"tables/customers.md": "---\ntype: BigQuery Table\ntitle: Customers\n---\n# Customers\n",
+	}
+	bundle := writeBundle(t, src)
+
+	items, err := BuildImport(bundle, "/vendor/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate the world: FETCH returns the stored body and metadata verbatim.
+	docs := make([]ExportDoc, len(items))
+	for i, it := range items {
+		docs[i] = ExportDoc{Path: it.Path, Body: it.Body, Metadata: it.Metadata, Modified: "2026-05-28T14:30:00Z"}
+	}
+
+	out := t.TempDir()
+	for _, f := range BuildExport(docs, "/vendor/") {
+		full := filepath.Join(out, filepath.FromSlash(f.Path))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, f.Content, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	report, err := ValidateBundle(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Conforms() {
+		t.Errorf("round-tripped bundle does not conform: %+v", report.Findings)
+	}
+	if errs, _ := report.Counts(); errs != 0 {
+		t.Errorf("expected 0 errors, got findings: %+v", report.Findings)
+	}
+
+	// Body fidelity: the exported orders body matches the original (minus its
+	// frontmatter), links round-tripped back to bundle-relative form.
+	got, err := os.ReadFile(filepath.Join(out, "tables", "orders.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, body, _ := SplitFrontmatter(got)
+	wantBody := "# Orders\n[c](/tables/customers.md) [r](customers.md)\n"
+	if string(body) != wantBody {
+		t.Errorf("body fidelity lost:\n got %q\nwant %q", body, wantBody)
+	}
+}

--- a/client/internal/okf/import.go
+++ b/client/internal/okf/import.go
@@ -1,0 +1,301 @@
+package okf
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/latebit-io/demarkus/client/links"
+	"github.com/latebit-io/demarkus/protocol"
+	"github.com/latebit-io/demarkus/protocol/store"
+)
+
+// PublishItem is a single document ready to publish into a demarkus world.
+type PublishItem struct {
+	Path     string            // mark path, e.g. /prefix/tables/orders.md
+	Body     string            // markdown body: frontmatter stripped, links rewritten
+	Metadata map[string]string // demarkus publisher metadata (sanitized, within caps)
+	Warnings []string          // non-fatal transforms applied to this document
+}
+
+// BuildImport walks an OKF bundle and produces the publish items that mirror it
+// into a demarkus world under prefix (the path within the world; "" or "/"
+// imports at the world root). It performs no network I/O. Per-document issues —
+// a missing type, an unparseable block, dropped or sanitized metadata — are
+// attached to the item's Warnings rather than failing the whole import, matching
+// the spec's permissive consumption model.
+func BuildImport(root, prefix string) ([]PublishItem, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("stat bundle: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("bundle path is not a directory: %s", root)
+	}
+	pfx := strings.Trim(prefix, "/")
+
+	var items []PublishItem
+	walkErr := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		items = append(items, buildItem(filepath.ToSlash(rel), data, pfx))
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("walk bundle: %w", walkErr)
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Path < items[j].Path })
+	return items, nil
+}
+
+func buildItem(rel string, data []byte, pfx string) PublishItem {
+	fm, body, hasFM := SplitFrontmatter(data)
+	meta := map[string]string{}
+	var warns []string
+
+	if IsReserved(path.Base(rel)) {
+		// Reserved files carry no document metadata. The root index.md may have
+		// an okf_version frontmatter block; strip it (publishing it verbatim
+		// would store it as literal body) and keep the value as metadata.
+		if hasFM {
+			if parsed, err := ParseFrontmatter(fm); err == nil {
+				if v := parsed["okf_version"]; v != "" {
+					meta["okf-version"] = v
+				}
+			}
+		}
+	} else if !hasFM {
+		warns = append(warns, "concept document has no frontmatter (OKF requires a `type`)")
+	} else if parsed, err := ParseFrontmatter(fm); err != nil {
+		warns = append(warns, fmt.Sprintf("unparseable frontmatter, importing body only: %v", err))
+	} else {
+		var mapWarns, capWarns []string
+		meta, mapWarns = mapMetadata(parsed)
+		if strings.TrimSpace(meta["type"]) == "" {
+			warns = append(warns, "source document has no `type` field (OKF requires one)")
+		}
+		meta, capWarns = enforceCaps(meta)
+		warns = append(warns, mapWarns...)
+		warns = append(warns, capWarns...)
+	}
+
+	return PublishItem{
+		Path:     joinPrefix(pfx, rel),
+		Body:     rewriteAbsLinks(string(body), pfx),
+		Metadata: meta,
+		Warnings: warns,
+	}
+}
+
+// mapMetadata converts parsed OKF frontmatter into demarkus publisher metadata.
+// Recognized OKF field names already match demarkus's bare keys, so the mapping
+// is mostly identity; the work is sanitizing keys/values that demarkus's wire
+// rules reject and dropping the bundle-level okf_version (not a document field).
+func mapMetadata(fm map[string]string) (meta map[string]string, warnings []string) {
+	meta = map[string]string{}
+	var warns []string
+	for _, k := range sortedKeys(fm) {
+		v := fm[k]
+		if k == "okf_version" {
+			continue // bundle-level marker, not a document field
+		}
+		key := k
+		if store.IsReservedMetaKey(key) || !protocol.IsValidMetaKey(key) {
+			sk := sanitizeKey(key)
+			switch {
+			case sk == "" || store.IsReservedMetaKey(sk) || !protocol.IsValidMetaKey(sk):
+				warns = append(warns, fmt.Sprintf("dropped metadata key %q (cannot be made a valid demarkus key)", k))
+				continue
+			case keyPresent(meta, sk):
+				warns = append(warns, fmt.Sprintf("dropped metadata key %q (sanitized form %q collides)", k, sk))
+				continue
+			default:
+				warns = append(warns, fmt.Sprintf("sanitized metadata key %q → %q", k, sk))
+				key = sk
+			}
+		}
+		if !protocol.IsValidMetaValue(v) {
+			v = strings.NewReplacer("\r", " ", "\n", " ").Replace(v)
+			warns = append(warns, fmt.Sprintf("flattened newlines in metadata value for %q", key))
+		}
+		meta[key] = v
+	}
+	return meta, warns
+}
+
+// enforceCaps drops the lowest-priority metadata keys until the map fits within
+// MaxMetaKeys and MaxMetaBytes (counted at on-disk serialized size, the same
+// accounting the store enforces). Producer-defined keys are shed before the
+// recognized OKF fields. Every drop is reported.
+func enforceCaps(meta map[string]string) (capped map[string]string, warnings []string) {
+	var warns []string
+	for len(meta) > protocol.MaxMetaKeys || metaSize(meta) > protocol.MaxMetaBytes {
+		drop := lowestPriorityKey(meta)
+		if drop == "" {
+			break
+		}
+		warns = append(warns, fmt.Sprintf("dropped metadata key %q to fit caps (max %d keys / %d bytes)",
+			drop, protocol.MaxMetaKeys, protocol.MaxMetaBytes))
+		delete(meta, drop)
+	}
+	return meta, warns
+}
+
+func metaSize(meta map[string]string) int {
+	n := 0
+	for k, v := range meta {
+		n += store.SerializedMetaSize(k, v)
+	}
+	return n
+}
+
+// metaPriority ranks keys for cap-driven dropping: lower rank is kept longer.
+// Catalog-visible fields (title, tags, type, importance) rank highest;
+// producer-defined keys rank lowest and are dropped first.
+func metaPriority(key string) int {
+	switch key {
+	case "title":
+		return 0
+	case "tags":
+		return 1
+	case "type":
+		return 2
+	case "importance":
+		return 3
+	case "description":
+		return 4
+	case "resource":
+		return 5
+	case "timestamp":
+		return 6
+	default:
+		return 100
+	}
+}
+
+func lowestPriorityKey(meta map[string]string) string {
+	worst := ""
+	worstRank := -1
+	for k := range meta {
+		r := metaPriority(k)
+		// Tie-break on name (descending) so dropping is deterministic.
+		if r > worstRank || (r == worstRank && k > worst) {
+			worst, worstRank = k, r
+		}
+	}
+	return worst
+}
+
+// sanitizeKey lowercases a key and replaces every character demarkus disallows
+// with '-', collapsing runs and trimming leading/trailing '-'.
+func sanitizeKey(key string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, c := range strings.ToLower(key) {
+		ok := (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-'
+		if !ok {
+			c = '-'
+		}
+		if c == '-' {
+			if lastDash {
+				continue
+			}
+			lastDash = true
+		} else {
+			lastDash = false
+		}
+		b.WriteRune(c)
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// rewriteAbsLinks prepends "/<pfx>" to every bundle-absolute markdown link
+// destination (one beginning with "/"). Relative links are left untouched: the
+// bundle's directory structure is preserved under the prefix, so they still
+// resolve. With no prefix, the body is returned unchanged.
+func rewriteAbsLinks(body, pfx string) string {
+	if pfx == "" {
+		return body
+	}
+	p := "/" + pfx
+	return mapAbsLinks(body, func(dest string) string { return p + dest })
+}
+
+// mapAbsLinks rewrites every bundle-absolute inline markdown link destination
+// (one beginning with "/") by passing it through fn. Relative and external links
+// and the surrounding text are left untouched. Only inline "[text](dest)" links
+// with non-empty text are handled (the link extractor reports no bracket span
+// for empty-text links).
+func mapAbsLinks(body string, fn func(dest string) string) string {
+	src := []byte(body)
+	type edit struct {
+		start, end int
+		dest       string
+	}
+	var edits []edit
+	for _, li := range links.ExtractWithPositions(body) {
+		if li.CloseBracket < 0 || !strings.HasPrefix(li.Dest, "/") {
+			continue
+		}
+		open := li.CloseBracket + 1
+		if open >= len(src) || src[open] != '(' {
+			continue // not an inline "[text](dest)" link
+		}
+		start := open + 1
+		end := start
+		for end < len(src) && src[end] != ')' && src[end] != ' ' && src[end] != '\t' && src[end] != '#' {
+			end++
+		}
+		orig := string(src[start:end])
+		if nw := fn(orig); nw != orig {
+			edits = append(edits, edit{start, end, nw})
+		}
+	}
+	if len(edits) == 0 {
+		return body
+	}
+	// Apply right-to-left so earlier byte offsets stay valid.
+	sort.Slice(edits, func(i, j int) bool { return edits[i].start > edits[j].start })
+	out := body
+	for _, e := range edits {
+		out = out[:e.start] + e.dest + out[e.end:]
+	}
+	return out
+}
+
+func joinPrefix(pfx, rel string) string {
+	if pfx == "" {
+		return "/" + rel
+	}
+	return "/" + pfx + "/" + rel
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func keyPresent(m map[string]string, k string) bool {
+	_, ok := m[k]
+	return ok
+}

--- a/client/internal/okf/import.go
+++ b/client/internal/okf/import.go
@@ -43,6 +43,11 @@ func BuildImport(root, prefix string) ([]PublishItem, error) {
 		if err != nil {
 			return err
 		}
+		// Reject symlinks: a crafted bundle could point a *.md symlink at local
+		// content outside the bundle and have it ingested/published.
+		if d.Type()&fs.ModeSymlink != 0 {
+			return fmt.Errorf("bundle contains a symlink, which is not allowed: %s", p)
+		}
 		if d.IsDir() || !strings.HasSuffix(d.Name(), ".md") {
 			return nil
 		}

--- a/client/internal/okf/import_test.go
+++ b/client/internal/okf/import_test.go
@@ -1,0 +1,172 @@
+package okf
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/latebit-io/demarkus/protocol"
+)
+
+func TestSanitizeKey(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"producer_field", "producer-field"},
+		{"DataSteward", "datasteward"},
+		{"a..b", "a-b"},
+		{"--x--", "x"},
+		{"123", "123"},
+		{"___", ""},
+	}
+	for _, tt := range tests {
+		if got := sanitizeKey(tt.in); got != tt.want {
+			t.Errorf("sanitizeKey(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestMapMetadata(t *testing.T) {
+	in := map[string]string{
+		"type":         "Table",
+		"title":        "Orders",
+		"tags":         "a,b",
+		"okf_version":  "0.1",  // bundle-level, dropped
+		"version":      "9",    // reserved, dropped
+		"producer_key": "v",    // sanitized
+		"note":         "x\ny", // newline flattened
+	}
+	meta, warns := mapMetadata(in)
+
+	want := map[string]string{
+		"type": "Table", "title": "Orders", "tags": "a,b",
+		"producer-key": "v", "note": "x y",
+	}
+	if !reflect.DeepEqual(meta, want) {
+		t.Errorf("mapMetadata = %v, want %v", meta, want)
+	}
+	joined := strings.Join(warns, "\n")
+	for _, sub := range []string{`dropped metadata key "version"`, `sanitized metadata key "producer_key"`, "flattened newlines"} {
+		if !strings.Contains(joined, sub) {
+			t.Errorf("warnings missing %q; got %v", sub, warns)
+		}
+	}
+	if strings.Contains(joined, "okf_version") {
+		t.Errorf("okf_version should be dropped silently, got warn: %v", warns)
+	}
+}
+
+func TestEnforceCaps_KeyCount(t *testing.T) {
+	meta := map[string]string{"type": "T", "title": "X"}
+	for i := range protocol.MaxMetaKeys + 10 {
+		meta["p"+string(rune('a'+i%26))+string(rune('0'+i/26))] = "v"
+	}
+	meta, warns := enforceCaps(meta)
+	if len(meta) > protocol.MaxMetaKeys {
+		t.Fatalf("len(meta) = %d, want <= %d", len(meta), protocol.MaxMetaKeys)
+	}
+	if meta["type"] != "T" || meta["title"] != "X" {
+		t.Errorf("recognized fields should survive cap dropping, got %v", meta)
+	}
+	if len(warns) == 0 {
+		t.Error("expected drop warnings")
+	}
+}
+
+func TestEnforceCaps_ByteSize(t *testing.T) {
+	meta := map[string]string{
+		"type":        "Table",
+		"description": strings.Repeat("x", protocol.MaxMetaBytes+50),
+	}
+	meta, warns := enforceCaps(meta)
+	if metaSize(meta) > protocol.MaxMetaBytes {
+		t.Fatalf("metaSize = %d, want <= %d", metaSize(meta), protocol.MaxMetaBytes)
+	}
+	if meta["type"] != "Table" {
+		t.Errorf("type (higher priority) should survive, got %v", meta)
+	}
+	if _, ok := meta["description"]; ok {
+		t.Errorf("oversized description should be dropped, got %v", meta)
+	}
+	if len(warns) == 0 {
+		t.Error("expected a drop warning")
+	}
+}
+
+func TestRewriteAbsLinks(t *testing.T) {
+	tests := []struct {
+		name, body, pfx, want string
+	}{
+		{"no prefix is noop", "[a](/x.md)", "", "[a](/x.md)"},
+		{"absolute rewritten", "see [a](/tables/x.md) now", "vendor", "see [a](/vendor/tables/x.md) now"},
+		{"relative untouched", "[a](x.md)", "vendor", "[a](x.md)"},
+		{"external untouched", "[a](https://e/x.md)", "vendor", "[a](https://e/x.md)"},
+		{"fragment preserved", "[a](/x.md#sec)", "vendor", "[a](/vendor/x.md#sec)"},
+		{"multiple", "[a](/a.md) [b](/b.md)", "p", "[a](/p/a.md) [b](/p/b.md)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rewriteAbsLinks(tt.body, tt.pfx); got != tt.want {
+				t.Errorf("rewriteAbsLinks = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJoinPrefix(t *testing.T) {
+	if got := joinPrefix("", "tables/orders.md"); got != "/tables/orders.md" {
+		t.Errorf("joinPrefix empty = %q", got)
+	}
+	if got := joinPrefix("vendor", "tables/orders.md"); got != "/vendor/tables/orders.md" {
+		t.Errorf("joinPrefix vendor = %q", got)
+	}
+}
+
+func TestBuildImport_Integration(t *testing.T) {
+	root := writeBundle(t, map[string]string{
+		"index.md":         "---\nokf_version: 0.1\n---\n# Hub\n* [O](/tables/orders.md) - o\n",
+		"tables/orders.md": "---\ntype: BigQuery Table\ntitle: Orders\ntags: [sales, revenue]\n---\n# Orders\n[cust](/tables/customers.md) and [rel](customers.md)\n",
+	})
+	items, err := BuildImport(root, "/vendor/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	byPath := map[string]PublishItem{}
+	for _, it := range items {
+		byPath[it.Path] = it
+	}
+
+	idx, ok := byPath["/vendor/index.md"]
+	if !ok {
+		t.Fatalf("missing index item; paths: %v", keysOf(byPath))
+	}
+	if idx.Metadata["okf-version"] != "0.1" {
+		t.Errorf("index okf-version = %q, want 0.1", idx.Metadata["okf-version"])
+	}
+	if strings.Contains(idx.Body, "okf_version") || strings.HasPrefix(idx.Body, "---") {
+		t.Errorf("root index frontmatter should be stripped from body: %q", idx.Body)
+	}
+	if !strings.Contains(idx.Body, "/vendor/tables/orders.md") {
+		t.Errorf("index absolute link not rewritten: %q", idx.Body)
+	}
+
+	ord, ok := byPath["/vendor/tables/orders.md"]
+	if !ok {
+		t.Fatalf("missing orders item; paths: %v", keysOf(byPath))
+	}
+	if ord.Metadata["type"] != "BigQuery Table" || ord.Metadata["tags"] != "sales,revenue" {
+		t.Errorf("orders metadata = %v", ord.Metadata)
+	}
+	if !strings.Contains(ord.Body, "/vendor/tables/customers.md") {
+		t.Errorf("absolute link not rewritten: %q", ord.Body)
+	}
+	if !strings.Contains(ord.Body, "[rel](customers.md)") {
+		t.Errorf("relative link should be untouched: %q", ord.Body)
+	}
+}
+
+func keysOf(m map[string]PublishItem) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/client/internal/okf/import_test.go
+++ b/client/internal/okf/import_test.go
@@ -1,12 +1,33 @@
 package okf
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/latebit-io/demarkus/protocol"
 )
+
+func TestBuildImport_RejectsSymlink(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "real.md"), []byte("---\ntype: Doc\n---\n# Real\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A .md symlink pointing at content outside the bundle must be refused, not
+	// followed and published.
+	target := filepath.Join(t.TempDir(), "secret.md")
+	if err := os.WriteFile(target, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "link.md")); err != nil {
+		t.Skipf("symlinks unsupported here: %v", err)
+	}
+	if _, err := BuildImport(root, ""); err == nil {
+		t.Error("expected BuildImport to reject a bundle containing a symlink")
+	}
+}
 
 func TestSanitizeKey(t *testing.T) {
 	tests := []struct{ in, want string }{

--- a/client/internal/okf/okf.go
+++ b/client/internal/okf/okf.go
@@ -345,6 +345,11 @@ func checkLinks(rel string, body []byte, files map[string]bool) []Finding {
 		if dest == "" || strings.Contains(dest, "://") || strings.HasPrefix(dest, "mailto:") {
 			continue
 		}
+		// links.Extract already strips fragments; drop any query/fragment too so
+		// a "/x.md?ref=1" link still resolves to the document path "/x.md".
+		if i := strings.IndexAny(dest, "?#"); i >= 0 {
+			dest = dest[:i]
+		}
 		if !strings.HasSuffix(dest, ".md") {
 			continue
 		}

--- a/client/internal/okf/okf.go
+++ b/client/internal/okf/okf.go
@@ -1,0 +1,367 @@
+// Package okf reads and validates Open Knowledge Format (OKF) bundles — a
+// directory tree of markdown files with YAML frontmatter, cross-linked into a
+// relationship graph. It provides the parse primitives shared by the demarkus
+// OKF commands (validate now; import/export later) and a conformance validator
+// for OKF v0.1.
+//
+// Spec: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
+package okf
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/latebit-io/demarkus/client/links"
+)
+
+// Reserved bundle filenames with defined structure. Every other ".md" file is a
+// concept document.
+const (
+	IndexFile = "index.md" // directory listing for progressive disclosure
+	LogFile   = "log.md"   // chronological change history
+)
+
+// IsReserved reports whether a file base name is an OKF reserved filename.
+func IsReserved(base string) bool {
+	return base == IndexFile || base == LogFile
+}
+
+// ConceptID returns the OKF concept identity for a bundle-relative markdown
+// path: the path with its ".md" suffix removed (e.g. "tables/orders.md" →
+// "tables/orders").
+func ConceptID(relPath string) string {
+	return strings.TrimSuffix(filepath.ToSlash(relPath), ".md")
+}
+
+// SplitFrontmatter separates a leading YAML frontmatter block ("---" ... "---")
+// from the markdown body. ok is false when the data has no frontmatter block, in
+// which case fm is empty and body is the whole input. CRLF and a closing
+// delimiter at end-of-file are tolerated.
+func SplitFrontmatter(data []byte) (fm string, body []byte, ok bool) {
+	lines := strings.SplitAfter(string(data), "\n")
+	if len(lines) == 0 || strings.TrimRight(lines[0], "\r\n") != "---" {
+		return "", data, false
+	}
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimRight(lines[i], "\r\n") == "---" {
+			return strings.Join(lines[1:i], ""), []byte(strings.Join(lines[i+1:], "")), true
+		}
+	}
+	return "", data, false
+}
+
+// ParseFrontmatter parses an OKF frontmatter block into a flat key→value map,
+// mirroring the protocol's "frontmatter is a flat string map" model. A YAML flow
+// list (tags: [a, b]) or block list (tags:\n  - a) is flattened to a
+// comma-separated string. Comments and blank lines are ignored. A non-empty line
+// that is neither a comment, a "key: value" pair, nor a list item is reported as
+// a parse error so a malformed block fails conformance.
+func ParseFrontmatter(fm string) (map[string]string, error) {
+	meta := map[string]string{}
+	lastListKey := ""
+	for raw := range strings.SplitSeq(fm, "\n") {
+		line := strings.TrimRight(raw, "\r")
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if item, ok := blockListItem(trimmed); ok {
+			if lastListKey == "" {
+				return nil, fmt.Errorf("list item with no parent key: %q", trimmed)
+			}
+			meta[lastListKey] = appendCSV(meta[lastListKey], item)
+			continue
+		}
+		key, val, found := strings.Cut(line, ":")
+		if !found {
+			return nil, fmt.Errorf("unparseable frontmatter line: %q", trimmed)
+		}
+		key = strings.TrimSpace(key)
+		val = strings.TrimSpace(val)
+		if key == "" {
+			return nil, fmt.Errorf("empty key in frontmatter line: %q", trimmed)
+		}
+		lastListKey = ""
+		switch {
+		case val == "":
+			// A bare "key:" introduces a block list (items follow) or is an
+			// empty scalar; either way the value starts empty.
+			meta[key] = ""
+			lastListKey = key
+		case isFlowList(val):
+			meta[key] = parseFlowList(val)
+		default:
+			meta[key] = unquote(val)
+		}
+	}
+	return meta, nil
+}
+
+func blockListItem(trimmed string) (string, bool) {
+	if trimmed == "-" {
+		return "", true
+	}
+	if strings.HasPrefix(trimmed, "- ") {
+		return unquote(strings.TrimSpace(trimmed[2:])), true
+	}
+	return "", false
+}
+
+func isFlowList(val string) bool {
+	return strings.HasPrefix(val, "[") && strings.HasSuffix(val, "]")
+}
+
+func parseFlowList(val string) string {
+	inner := val[1 : len(val)-1]
+	var items []string
+	for p := range strings.SplitSeq(inner, ",") {
+		if s := unquote(strings.TrimSpace(p)); s != "" {
+			items = append(items, s)
+		}
+	}
+	return strings.Join(items, ",")
+}
+
+func unquote(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+func appendCSV(existing, item string) string {
+	switch {
+	case item == "":
+		return existing
+	case existing == "":
+		return item
+	default:
+		return existing + "," + item
+	}
+}
+
+// Severity classifies a validation finding. Error means the bundle does not
+// conform to OKF v0.1; Warn is soft guidance the spec asks consumers to tolerate.
+type Severity int
+
+// Severity levels: Warn is soft guidance the spec asks consumers to tolerate;
+// Error means the bundle does not conform to OKF v0.1.
+const (
+	Warn Severity = iota
+	Error
+)
+
+func (s Severity) String() string {
+	if s == Error {
+		return "error"
+	}
+	return "warning"
+}
+
+// Finding is a single validation result against a bundle file.
+type Finding struct {
+	Path     string // bundle-relative file path
+	Severity Severity
+	Message  string
+}
+
+// Report is the result of validating a bundle.
+type Report struct {
+	Files    int
+	Findings []Finding
+}
+
+// Counts tallies findings by severity.
+func (r *Report) Counts() (errors, warnings int) {
+	for _, f := range r.Findings {
+		if f.Severity == Error {
+			errors++
+		} else {
+			warnings++
+		}
+	}
+	return errors, warnings
+}
+
+// Conforms reports whether the bundle has no Error-level findings.
+func (r *Report) Conforms() bool {
+	errors, _ := r.Counts()
+	return errors == 0
+}
+
+// ValidateBundle walks an OKF bundle directory and checks it against the v0.1
+// conformance rules: every non-reserved ".md" has parseable frontmatter with a
+// non-empty `type`, and reserved filenames follow their defined structure.
+// Broken cross-links are reported as warnings, per the spec's requirement that
+// consumers tolerate them.
+func ValidateBundle(root string) (*Report, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("stat bundle: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("bundle path is not a directory: %s", root)
+	}
+
+	type mdFile struct {
+		rel  string
+		data []byte
+	}
+	var mdFiles []mdFile
+	files := map[string]bool{}
+	walkErr := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		mdFiles = append(mdFiles, mdFile{rel, data})
+		files[rel] = true
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("walk bundle: %w", walkErr)
+	}
+
+	report := &Report{Files: len(mdFiles)}
+	for _, f := range mdFiles {
+		body := f.data
+		switch path.Base(f.rel) {
+		case IndexFile:
+			report.Findings = append(report.Findings, validateIndex(f.rel, f.data)...)
+			_, body, _ = SplitFrontmatter(f.data)
+		case LogFile:
+			report.Findings = append(report.Findings, validateLog(f.rel, f.data)...)
+		default:
+			report.Findings = append(report.Findings, validateConcept(f.rel, f.data)...)
+			_, body, _ = SplitFrontmatter(f.data)
+		}
+		report.Findings = append(report.Findings, checkLinks(f.rel, body, files)...)
+	}
+
+	sort.Slice(report.Findings, func(i, j int) bool {
+		a, b := report.Findings[i], report.Findings[j]
+		if a.Path != b.Path {
+			return a.Path < b.Path
+		}
+		return a.Message < b.Message
+	})
+	return report, nil
+}
+
+func validateConcept(rel string, data []byte) []Finding {
+	fm, _, ok := SplitFrontmatter(data)
+	if !ok {
+		return []Finding{{rel, Error, "missing frontmatter; OKF concept documents require a frontmatter block with a non-empty `type`"}}
+	}
+	meta, err := ParseFrontmatter(fm)
+	if err != nil {
+		return []Finding{{rel, Error, fmt.Sprintf("unparseable frontmatter: %v", err)}}
+	}
+	var out []Finding
+	if strings.TrimSpace(meta["type"]) == "" {
+		out = append(out, Finding{rel, Error, "missing required `type` field"})
+	}
+	if ts := meta["timestamp"]; ts != "" && !isRFC3339(ts) {
+		out = append(out, Finding{rel, Warn, fmt.Sprintf("timestamp %q is not RFC 3339 (ISO 8601)", ts)})
+	}
+	return out
+}
+
+func isRFC3339(s string) bool {
+	_, err := time.Parse(time.RFC3339, s)
+	return err == nil
+}
+
+func validateIndex(rel string, data []byte) []Finding {
+	fm, _, ok := SplitFrontmatter(data)
+	if !ok {
+		return nil
+	}
+	// Only the root index.md may carry frontmatter, and only to declare
+	// okf_version.
+	if rel != IndexFile {
+		return []Finding{{rel, Error, "index.md must not contain frontmatter (reserved navigation file)"}}
+	}
+	meta, err := ParseFrontmatter(fm)
+	if err != nil {
+		return []Finding{{rel, Error, fmt.Sprintf("unparseable frontmatter: %v", err)}}
+	}
+	var out []Finding
+	for k := range meta {
+		if k != "okf_version" {
+			out = append(out, Finding{rel, Warn, fmt.Sprintf("root index.md frontmatter key %q is not defined by OKF (only okf_version)", k)})
+		}
+	}
+	return out
+}
+
+func validateLog(rel string, data []byte) []Finding {
+	var out []Finding
+	for raw := range strings.SplitSeq(string(data), "\n") {
+		trimmed := strings.TrimSpace(strings.TrimRight(raw, "\r"))
+		if !strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		heading := strings.TrimSpace(strings.TrimLeft(trimmed, "#"))
+		// Only headings that look like a date (start with a digit) are checked.
+		if heading == "" || heading[0] < '0' || heading[0] > '9' {
+			continue
+		}
+		if first := strings.Fields(heading)[0]; !isISODate(first) {
+			out = append(out, Finding{rel, Warn, fmt.Sprintf("log.md date heading %q is not ISO 8601 (YYYY-MM-DD)", first)})
+		}
+	}
+	return out
+}
+
+func isISODate(s string) bool {
+	_, err := time.Parse("2006-01-02", s)
+	return err == nil
+}
+
+func checkLinks(rel string, body []byte, files map[string]bool) []Finding {
+	var out []Finding
+	dir := path.Dir(rel)
+	for _, dest := range links.Extract(string(body)) {
+		if dest == "" || strings.Contains(dest, "://") || strings.HasPrefix(dest, "mailto:") {
+			continue
+		}
+		if !strings.HasSuffix(dest, ".md") {
+			continue
+		}
+		var target string
+		if rest, ok := strings.CutPrefix(dest, "/"); ok {
+			target = rest
+		} else {
+			target = path.Join(dir, dest)
+		}
+		target = path.Clean(target)
+		if target == ".." || strings.HasPrefix(target, "../") {
+			out = append(out, Finding{rel, Warn, fmt.Sprintf("link escapes bundle: %s", dest)})
+			continue
+		}
+		if !files[target] {
+			out = append(out, Finding{rel, Warn, fmt.Sprintf("broken link: %s", dest)})
+		}
+	}
+	return out
+}

--- a/client/internal/okf/okf_test.go
+++ b/client/internal/okf/okf_test.go
@@ -1,0 +1,184 @@
+package okf
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSplitFrontmatter(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     string
+		wantFM   string
+		wantBody string
+		wantOK   bool
+	}{
+		{"no frontmatter", "# Title\nbody\n", "", "# Title\nbody\n", false},
+		{"first line not delim", "text\n---\nx\n---\n", "", "text\n---\nx\n---\n", false},
+		{"basic", "---\ntype: Table\n---\n# Body\n", "type: Table\n", "# Body\n", true},
+		{"crlf", "---\r\ntype: Table\r\n---\r\n# Body\r\n", "type: Table\r\n", "# Body\r\n", true},
+		{"closing delim at eof", "---\ntype: Table\n---", "type: Table\n", "", true},
+		{"unterminated", "---\ntype: Table\n# Body\n", "", "---\ntype: Table\n# Body\n", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fm, body, ok := SplitFrontmatter([]byte(tt.data))
+			if ok != tt.wantOK || fm != tt.wantFM || string(body) != tt.wantBody {
+				t.Errorf("SplitFrontmatter = (%q, %q, %v), want (%q, %q, %v)",
+					fm, body, ok, tt.wantFM, tt.wantBody, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestParseFrontmatter(t *testing.T) {
+	tests := []struct {
+		name    string
+		fm      string
+		want    map[string]string
+		wantErr bool
+	}{
+		{"scalars", "type: Table\ntitle: Orders\n", map[string]string{"type": "Table", "title": "Orders"}, false},
+		{"flow list", "tags: [sales, revenue]\n", map[string]string{"tags": "sales,revenue"}, false},
+		{"block list", "tags:\n  - sales\n  - revenue\n", map[string]string{"tags": "sales,revenue"}, false},
+		{"quoted", `title: "Orders, Q1"`, map[string]string{"title": "Orders, Q1"}, false},
+		{"value with colon", "resource: https://x/y:8080\n", map[string]string{"resource": "https://x/y:8080"}, false},
+		{"comment and blank", "# c\n\ntype: Table\n", map[string]string{"type": "Table"}, false},
+		{"unparseable line", "type: Table\ngarbage line\n", nil, true},
+		{"orphan list item", "  - sales\n", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseFrontmatter(tt.fm)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseFrontmatter = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConceptIDAndReserved(t *testing.T) {
+	if got := ConceptID("tables/orders.md"); got != "tables/orders" {
+		t.Errorf("ConceptID = %q, want %q", got, "tables/orders")
+	}
+	if !IsReserved("index.md") || !IsReserved("log.md") || IsReserved("orders.md") {
+		t.Error("IsReserved classification wrong")
+	}
+}
+
+// writeBundle materializes rel→content files under a temp dir and returns it.
+func writeBundle(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, content := range files {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// findings collects (path, severity, message-substring) presence checks.
+func hasFinding(r *Report, path string, sev Severity, substr string) bool {
+	for _, f := range r.Findings {
+		if f.Path == path && f.Severity == sev && strings.Contains(f.Message, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidateBundle_Conformant(t *testing.T) {
+	root := writeBundle(t, map[string]string{
+		"index.md":            "---\nokf_version: 0.1\n---\n# Sales\n* [Orders](/tables/orders.md) - orders\n",
+		"tables/index.md":     "# Tables\n* [Orders](orders.md) - one row per order\n",
+		"tables/orders.md":    "---\ntype: BigQuery Table\ntitle: Orders\ntags: [sales, revenue]\n---\n# Orders\nJoined with [customers](/tables/customers.md).\n",
+		"tables/customers.md": "---\ntype: BigQuery Table\ntitle: Customers\n---\n# Customers\n",
+		"log.md":              "# Log\n## 2026-05-28\n- created orders\n",
+	})
+	report, err := ValidateBundle(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Conforms() {
+		t.Errorf("expected conformant bundle, findings: %+v", report.Findings)
+	}
+	if report.Files != 5 {
+		t.Errorf("Files = %d, want 5", report.Files)
+	}
+}
+
+func TestValidateBundle_Errors(t *testing.T) {
+	root := writeBundle(t, map[string]string{
+		"no_fm.md":     "# No frontmatter\n",
+		"no_type.md":   "---\ntitle: Untyped\n---\n# Body\n",
+		"sub/index.md": "---\ntype: Nope\n---\n# Sub\n",
+		"good.md":      "---\ntype: Doc\n---\n# Good\nlink to [missing](/gone.md)\n",
+	})
+	report, err := ValidateBundle(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Conforms() {
+		t.Fatal("expected non-conformant bundle")
+	}
+	checks := []struct {
+		path string
+		sev  Severity
+		sub  string
+	}{
+		{"no_fm.md", Error, "missing frontmatter"},
+		{"no_type.md", Error, "missing required `type`"},
+		{"sub/index.md", Error, "must not contain frontmatter"},
+		{"good.md", Warn, "broken link: /gone.md"},
+	}
+	for _, c := range checks {
+		if !hasFinding(report, c.path, c.sev, c.sub) {
+			t.Errorf("missing finding %s/%s containing %q; got %+v", c.path, c.sev, c.sub, report.Findings)
+		}
+	}
+}
+
+func TestValidateBundle_LogAndRootIndexWarnings(t *testing.T) {
+	root := writeBundle(t, map[string]string{
+		"index.md":   "---\nokf_version: 0.1\nbogus: x\n---\n# Root\n",
+		"log.md":     "# Log\n## 05/28/2026\n- bad date\n",
+		"bad_ts.md":  "---\ntype: Doc\ntimestamp: May 28 2026\n---\n# Body\n",
+		"good_ts.md": "---\ntype: Doc\ntimestamp: 2026-05-28T14:30:00Z\n---\n# Body\n",
+	})
+	report, err := ValidateBundle(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Conforms() {
+		t.Errorf("warnings should not make a bundle non-conformant: %+v", report.Findings)
+	}
+	if !hasFinding(report, "index.md", Warn, "bogus") {
+		t.Errorf("expected root-index warning for non-OKF key; got %+v", report.Findings)
+	}
+	if !hasFinding(report, "log.md", Warn, "not ISO 8601") {
+		t.Errorf("expected log.md non-ISO date warning; got %+v", report.Findings)
+	}
+	if !hasFinding(report, "bad_ts.md", Warn, "not RFC 3339") {
+		t.Errorf("expected timestamp-format warning; got %+v", report.Findings)
+	}
+	if hasFinding(report, "good_ts.md", Warn, "RFC 3339") {
+		t.Errorf("well-formed timestamp should not warn; got %+v", report.Findings)
+	}
+}
+
+func TestValidateBundle_NotADirectory(t *testing.T) {
+	if _, err := ValidateBundle(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Error("expected error for missing bundle path")
+	}
+}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -333,7 +333,7 @@ The `created` response MUST NOT include a body.
 - If the document exists, the version number is incremented from the current highest version.
 - If the document exists as a flat file (no version history), the server MUST migrate the flat file to version 1 before creating version 2.
 
-**OKF type default**: when a published document declares no `type` metadata, the server assigns the default `type` (`Document`; see §14), so every stored concept document is a typed Open Knowledge Format concept by construction. Reserved OKF files (`index.md`, `log.md`) are exempt, as OKF defines them as navigation and history rather than concepts. A document that already declares a `type` is stored unchanged. Because the default is part of the document's metadata, it participates in duplicate detection: republishing a previously untyped document acquires the default type once, creating a single new version.
+**OKF type default**: when a written document declares no `type` metadata, the server assigns the default `type` (`Document`; see §14), so every stored concept document is a typed Open Knowledge Format concept by construction. This applies to both PUBLISH and APPEND (§6.6). Reserved OKF files (`index.md`, `log.md`) are exempt, as OKF defines them as navigation and history rather than concepts. A document that already declares a `type` is stored unchanged. Because the default is part of the document's metadata, it participates in duplicate detection: republishing a previously untyped document acquires the default type once, creating a single new version.
 
 **Optimistic concurrency** (OPTIONAL):
 
@@ -427,6 +427,7 @@ modified: <RFC 3339 timestamp>
 - The combined content (existing + newline + appended) MUST NOT exceed the document size limit.
 - The `expected-version` metadata field is REQUIRED for APPEND (unlike PUBLISH where it is optional). Since APPEND is non-idempotent, the server cannot safely retry internally. The value MUST be >= 1; the server MUST reject `expected-version: 0` or absent `expected-version` as a bad request.
 - Conflict semantics match PUBLISH (see section 6.4). On conflict, fetch the latest version and verify whether your append was applied before retrying.
+- The new version's publisher metadata is taken from the APPEND request (it is not merged with the prior version's metadata). The OKF type default (§6.4) applies, so an append that declares no `type` to a non-reserved path stores `type: Document`.
 
 **Authentication errors**:
 - `not-permitted`: No token store configured on the server.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -333,6 +333,8 @@ The `created` response MUST NOT include a body.
 - If the document exists, the version number is incremented from the current highest version.
 - If the document exists as a flat file (no version history), the server MUST migrate the flat file to version 1 before creating version 2.
 
+**OKF type default**: when a published document declares no `type` metadata, the server assigns the default `type` (`Document`; see §14), so every stored concept document is a typed Open Knowledge Format concept by construction. Reserved OKF files (`index.md`, `log.md`) are exempt, as OKF defines them as navigation and history rather than concepts. A document that already declares a `type` is stored unchanged. Because the default is part of the document's metadata, it participates in duplicate detection: republishing a previously untyped document acquires the default type once, creating a single new version.
+
 **Optimistic concurrency** (OPTIONAL):
 
 The request MAY include an `expected-version` metadata field containing a decimal integer. If present, the server compares it to the current document version:
@@ -537,6 +539,8 @@ The following status values are reserved for future use:
 | `importance` | PUBLISH | Decimal in [0,1] | Ranking weight used by LOOKUP. Interpreted by the server. Absent or invalid is treated as 0.5. |
 | `title` | PUBLISH | String | One-line title shown in LOOKUP results and matched by `query`. Defaults to the first level-1 heading, then the path base name. |
 
+Beyond the interpreted fields above, a PUBLISH request MAY carry additional publisher metadata as arbitrary `key: value` frontmatter lines. The server stores these opaquely and exposes them to LOOKUP `filter` predicates. Reserved store fields (§9.4) MUST be rejected. §9.4 specifies how publisher metadata is persisted, including the Open Knowledge Format field names that are stored as bare frontmatter fields.
+
 ### 8.2. Response Metadata
 
 | Field | Applicable verbs | Format | Description |
@@ -594,12 +598,13 @@ Version files are named `<filename>.v<N>` where N is the version number.
 
 ### 9.4. Version File Format
 
-Each version file MUST be prefixed with a store-managed frontmatter block:
+Each version file MUST be prefixed with a store-managed frontmatter block. The block carries the store's own operational fields followed by any publisher-declared metadata.
 
 **Version 1** (genesis):
 ```
 ---
 version: 1
+archived: false
 ---
 <original document content>
 ```
@@ -608,12 +613,32 @@ version: 1
 ```
 ---
 version: <N>
+archived: false
 previous-hash: sha256-<64-char lowercase hex>
 ---
 <original document content>
 ```
 
-The store frontmatter is separate from any frontmatter that may exist in the original document content. The original content is stored verbatim after the store frontmatter closing delimiter.
+`version`, `archived`, and `previous-hash` (omitted for version 1) are reserved operational fields owned by the store. Publishers MUST NOT set them, and a server MUST reject a PUBLISH whose metadata declares a reserved key.
+
+Publisher-declared metadata is written into the same block. The field names defined by the Open Knowledge Format — `type`, `title`, `description`, `resource`, `tags`, and `timestamp` — are written as **bare** frontmatter fields so the document's persisted metadata matches the OKF spec for the fields it covers; `tags` is serialized as a YAML flow list. Every other publisher key is written under a `meta.` prefix so it cannot collide with a reserved or OKF-recognized field. For example:
+
+```
+---
+version: 3
+archived: false
+previous-hash: sha256-<64-char lowercase hex>
+meta.importance: 0.8
+tags: [sales, revenue]
+title: Orders
+type: BigQuery Table
+---
+<original document content>
+```
+
+An implementation MAY bound the count and total size of publisher metadata fields (the reference implementation permits up to 50 keys totaling 1024 bytes).
+
+The store frontmatter is separate from any frontmatter that may exist in the original document content; the original content is stored verbatim after the closing delimiter. This block is stripped before a document body is served, so the relationship is one of representation, not interoperable transport: a demarkus document's *content model* is OKF-compatible, but a server does not by itself serve or ingest OKF bundles (see §13).
 
 ### 9.5. Hash Chain
 
@@ -832,6 +857,7 @@ The following features are planned but not part of this specification:
 
 - **Federation**: Cross-server content mirroring and discovery.
 - **Subscriptions**: Notification of document changes.
+- **OKF interop**: An import/export codec that reads and emits [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) bundles. demarkus already aligns its persisted document metadata with OKF field names (§9.4), so a single document's content model is OKF-compatible; the planned codec adds bundle-level round-tripping (frontmatter on the served document, `index.md`/`log.md` conventions, bundle-relative links), validated against the OKF reference sample bundles. demarkus remains a superset at the system level — it layers versioning, a hash chain, QUIC transport, capability auth, and LOOKUP discovery on top of an OKF-compatible document.
 
 These will be specified in future versions of this document.
 
@@ -851,6 +877,7 @@ These will be specified in future versions of this document.
 | Recommended max LOOKUP results | 1000 |
 | Hash algorithm | SHA-256 |
 | Hash format | `sha256-<64 lowercase hex chars>` |
+| Default OKF type | `Document` |
 
 ## 15. References
 

--- a/docs/adr/0002-okf-metadata-alignment.md
+++ b/docs/adr/0002-okf-metadata-alignment.md
@@ -1,0 +1,77 @@
+# ADR 0002 — Align store frontmatter with the Open Knowledge Format
+
+Status: accepted (2026-06-22)
+
+## Context
+
+Google published the Open Knowledge Format (OKF) v0.1 on 2026-06-12 — a
+vendor-neutral format for organizational knowledge. Its model is close to
+demarkus's own: directory bundles of markdown, a cross-link relationship graph,
+`index.md` hubs, and path-minus-`.md` as concept identity. Spec:
+https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
+
+The one structural difference is where metadata lives. OKF carries it **in the
+document body** as YAML frontmatter (required `type`; recommended `title`,
+`description`, `resource`, `tags` as a YAML list, and `timestamp`). demarkus
+carries metadata **out of band**: the on-disk version file is prefixed with a
+store-managed frontmatter block that is stripped before the body is served, and
+the catalog reads only the publisher keys. Syntactically both use a `---`
+block, but the data model differs.
+
+Before this change, every publisher key was namespaced under a `meta.` prefix
+on disk (`meta.tags`, `meta.type`). That prefix was not cosmetic — it was the
+integrity boundary that prevented a publisher from supplying `archived: true`
+or `version: 999` and forging store state, because `extractMetadata` read only
+`meta.*` keys.
+
+We are pre-1.0, so the on-disk storage format is still free to change.
+
+## Decision
+
+Adopt a **split namespace** in the store frontmatter so the persisted field
+names match OKF for the fields it defines, without losing the integrity
+boundary.
+
+- **Recognized OKF fields** (`type`, `title`, `description`, `resource`,
+  `tags`, `timestamp`) are written **bare**. `tags` is serialized as a YAML
+  flow list (`tags: [a, b]`) to match the spec exactly.
+- **Non-spec publisher keys** (e.g. `importance`, custom fields) keep the
+  `meta.` prefix — demarkus's own metadata lane, and the anti-forgery boundary
+  for the open-ended key set.
+- **Reserved store fields** (`version`, `previous-hash`, `archived`) stay bare
+  and unchanged. The boundary the prefix used to enforce is now enforced by
+  name: a `reservedMetaKeys` denylist that `validateMeta` rejects and
+  `extractMetadata` never surfaces as publisher metadata.
+
+Implementation is contained to `protocol/store/store.go` —
+`buildVersionFile` (write), `extractMetadata` (read), `validateMeta` (reject
+reserved). The **in-memory metadata map stays bare-keyed**, so the catalog,
+handler, and filter layers are untouched; `tags` round-trips list↔csv, so the
+map contract (`"a,b"`) is unchanged. The spec change is recorded in SPEC.md
+§9.4 / §8.1.
+
+## Consequences
+
+- **Back-compatible reads.** `extractMetadata` still parses pre-change
+  `meta.tags` / `meta.type` writes, so existing immutable versions and live
+  servers (e.g. `soul.demarkus.io`) keep working. New writes use the bare form.
+- **Vocabulary alignment, not interop.** A single demarkus document's content
+  model is now OKF-compatible, but the store frontmatter is stripped before
+  serving and the `versions/` layout is not an OKF bundle tree. demarkus does
+  **not** yet serve or ingest OKF bundles. We deliberately do not claim "OKF
+  compatible" as a normative conformance guarantee.
+- **Sets up a 1:1 codec.** Because the persisted field names are now the literal
+  OKF names, a future import/export codec is a direct mapping rather than a
+  translation table.
+- **Relationship framing.** At the system level demarkus remains a superset: it
+  layers versioning, a hash chain, QUIC transport, capability auth, and LOOKUP
+  discovery on top of an OKF-compatible document.
+
+## Deferred
+
+- An import/export codec (OKF bundle ↔ demarkus world) with frontmatter
+  reattachment on the served document and `index.md` / `log.md` conventions.
+- A conformance check against the OKF reference sample bundles.
+- Scope decision parked: import-only vs round-trip vs server-native
+  content-negotiated bundle serving; and where it lives (`tools/demarkus-okf`
+  CLI vs `client/okf` package).

--- a/docs/adr/0003-okf-type-default-on-publish.md
+++ b/docs/adr/0003-okf-type-default-on-publish.md
@@ -23,10 +23,13 @@ principle is "minimally opinionated — only requires `type`."
 
 ## Decision
 
-Make it opinionated **by construction, not by rejection**. On PUBLISH, when a
+Make it opinionated **by construction, not by rejection**. On a write, when a
 document declares no `type`, the server assigns the default `type` `Document`
-(`protocol.OKFDefaultType`). Implemented in `handlePublish` via
-`applyOKFTypeDefault`, after `extractPublisherMeta` and before the store write.
+(`protocol.OKFDefaultType`). Implemented via `applyOKFTypeDefault` after
+`extractPublisherMeta`, in both `handlePublish` and `handleAppend` — APPEND sets
+the new version's metadata from the request (it does not merge with the prior
+version), so the default applies there too, keeping the type guarantee on every
+write path.
 
 - **Reserved OKF files** (`index.md`, `log.md`) are exempt — OKF defines them as
   navigation/history, not concepts, and they carry no frontmatter.

--- a/docs/adr/0003-okf-type-default-on-publish.md
+++ b/docs/adr/0003-okf-type-default-on-publish.md
@@ -1,0 +1,64 @@
+# ADR 0003 — Default OKF `type` on publish
+
+Status: accepted (2026-06-22)
+
+## Context
+
+ADR 0002 aligned the store's metadata vocabulary with the Open Knowledge Format
+and added a `demarkus okf` import/export/validate codec. That made a single
+demarkus document's content model OKF-compatible, but conformance was only ever
+realized at `export` time: a normal PUBLISH does not require a `type`, and OKF's
+one hard per-concept rule is a non-empty `type`. So arbitrary writes were not
+OKF concepts, and "writes conform to OKF" was false.
+
+We want OKF-typed documents to be a core, opinionated property of demarkus, not
+an export-time afterthought — while not breaking the existing ecosystem (the
+soul, the knowledge broker worlds, journals, ADRs, the docs site all publish
+markdown with no `type`).
+
+A hard gate that rejected typeless writes was rejected: it would break every
+current writer (including the memory/knowledge MCP `mark_publish` path), and it
+would make demarkus *more* opinionated than OKF itself, whose first design
+principle is "minimally opinionated — only requires `type`."
+
+## Decision
+
+Make it opinionated **by construction, not by rejection**. On PUBLISH, when a
+document declares no `type`, the server assigns the default `type` `Document`
+(`protocol.OKFDefaultType`). Implemented in `handlePublish` via
+`applyOKFTypeDefault`, after `extractPublisherMeta` and before the store write.
+
+- **Reserved OKF files** (`index.md`, `log.md`) are exempt — OKF defines them as
+  navigation/history, not concepts, and they carry no frontmatter.
+- A document that **already declares a `type`** is stored unchanged.
+- The default is real publisher metadata, so it participates in content/metadata
+  duplicate detection: republishing a previously untyped document acquires the
+  default once (one new version), then dedups normally.
+- The same constant backs the export codec's `type` synthesis, so a world that
+  predates this change still exports conformantly; for worlds written under it,
+  export is pure passthrough.
+
+The `export` codec keeps its own `type` synthesis as a belt-and-suspenders for
+documents written before this change or sourced outside demarkus.
+
+## Consequences
+
+- **Every served demarkus document carries an OKF `type`** — the per-document
+  OKF concept rule now holds for the whole store by construction. This is the
+  maximal per-document conformance achievable at write time.
+- **Non-breaking.** Existing writers keep working and simply gain a default
+  type; the soul, journals, and ADRs stay valid and become export-ready.
+- **Still not a served bundle.** This does not make a server serve or ingest OKF
+  bundles — frontmatter is stripped on serve and the layout is `versions/`. Full
+  bundle conformance remains an `export` concern (ADR 0002).
+- One-time version bump per legacy document on its first republish (the added
+  type changes its metadata).
+
+## Deferred
+
+- A `strict` mode (server config or per-world policy) that *rejects* typeless
+  concept writes, for worlds that want hard enforcement (e.g. a data catalog).
+  Kept as an opt-in, never the global default, so it cannot break a world that
+  does not want OKF semantics.
+- Defaulting/normalizing `timestamp` on write (currently `export` synthesizes it
+  from the modification time; OKF lists it as recommended, not required).

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -35,12 +35,25 @@ const (
 	// WellKnownManifestPath is the conventional path for agent manifest discovery.
 	WellKnownManifestPath = "/.well-known/agent-manifest.md"
 
-	// MaxMetaKeys is the maximum number of publisher metadata keys.
-	MaxMetaKeys = 10
+	// MaxMetaKeys is the maximum number of publisher metadata keys. Sized to
+	// hold the recognized OKF fields (type, title, description, resource, tags,
+	// timestamp), demarkus's importance, and generous headroom for
+	// producer-defined keys. MaxMetaBytes still bounds the actual on-disk size.
+	MaxMetaKeys = 50
 
-	// MaxMetaBytes is the approximate maximum size of publisher metadata
-	// (sum of key and value lengths, excluding serialization overhead).
-	MaxMetaBytes = 512
+	// MaxMetaBytes is the approximate maximum size of publisher metadata: the
+	// sum of key lengths and on-disk-serialized value lengths, excluding
+	// per-line delimiters and the "meta." prefix. Values are counted as stored
+	// (notably "tags" as its YAML list form, see store.SerializedMetaSize), so
+	// the cap is an honest bound on frontmatter size. This total, not the key
+	// count, is the binding limit for a typical document.
+	MaxMetaBytes = 1024
+
+	// OKFDefaultType is the Open Knowledge Format `type` the server assigns to a
+	// published document that declares none, so every stored concept document is
+	// a typed OKF concept by construction. Reserved OKF files (index.md, log.md)
+	// are exempt — OKF defines them as navigation/history, not concepts.
+	OKFDefaultType = "Document"
 )
 
 // IsValidMetaKey checks that a metadata key contains only safe characters

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -1214,6 +1214,12 @@ func buildVersionFile(versionsDir, base string, version int, content []byte, met
 	return append([]byte(sb.String()), content...), nil
 }
 
+// ValidateMeta checks publisher metadata against the store's key, value, count,
+// and size rules. It is exported so a caller that mutates metadata after the
+// handler's initial validation (e.g. injecting a default OKF type) can re-check
+// before the write and surface a precise error rather than a generic failure.
+func ValidateMeta(meta map[string]string) error { return validateMeta(meta) }
+
 // validateMeta checks that metadata keys and values are safe for frontmatter
 // serialization. This is defense in depth — the handler also validates, but
 // the store is a public API callable outside the network path.
@@ -1274,7 +1280,11 @@ func extractMetadata(data []byte) map[string]string {
 		case reservedMetaKeys[key]:
 			// Operational field — never publisher metadata.
 		case strings.HasPrefix(key, metaPrefix):
-			set(key[len(metaPrefix):], val)
+			// Re-check the unprefixed key so a stored "meta.archived" cannot
+			// resurrect a reserved operational field as publisher metadata.
+			if k := key[len(metaPrefix):]; !reservedMetaKeys[k] {
+				set(k, val)
+			}
 		case key == "tags":
 			set(key, parseTagsList(val))
 		case okfKeys[key]:

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -72,12 +72,48 @@ var ErrSizeLimit = fmt.Errorf("combined content exceeds size limit")
 
 // maxStoreFrontmatter is the maximum overhead the store-managed frontmatter
 // adds to a version file (version, archived, previous-hash, publisher
-// metadata, and delimiters).
-const maxStoreFrontmatter = 1024
+// metadata, and delimiters). It must cover MaxMetaBytes of publisher metadata
+// plus the operational fields and per-line serialization overhead.
+const maxStoreFrontmatter = 2048
 
-// metaPrefix is the key prefix for publisher-provided metadata in store
-// frontmatter. On disk: "meta.type: journal". Stripped when returned to clients.
+// metaPrefix is the key prefix for non-spec publisher metadata in store
+// frontmatter. On disk: "meta.importance: 0.8". Stripped when returned to
+// clients. Keys recognized by the Open Knowledge Format (see okfKeys) are
+// written bare instead, so the store frontmatter matches the OKF spec for the
+// fields it defines.
 const metaPrefix = "meta."
+
+// okfKeys are the publisher metadata keys recognized by the Open Knowledge
+// Format (OKF) spec. They serialize as bare frontmatter fields (e.g. "tags:")
+// to conform to the spec; every other publisher key keeps the metaPrefix. The
+// in-memory metadata map is bare-keyed either way — only on-disk serialization
+// differs.
+var okfKeys = map[string]bool{
+	"type":        true,
+	"title":       true,
+	"description": true,
+	"resource":    true,
+	"tags":        true,
+	"timestamp":   true,
+}
+
+// reservedMetaKeys are bare frontmatter fields owned by the store. Publishers
+// may not set them (validateMeta rejects them) and extractMetadata never
+// surfaces them as publisher metadata, preventing a publisher from forging
+// store state such as version or archival.
+var reservedMetaKeys = map[string]bool{
+	"version":       true,
+	"previous-hash": true,
+	"archived":      true,
+}
+
+// IsReservedMetaKey reports whether a publisher metadata key is reserved by the
+// store and would be rejected on publish. Callers that build metadata from
+// untrusted sources (e.g. importing external documents) use this to drop or
+// rename colliding keys before publishing.
+func IsReservedMetaKey(key string) bool {
+	return reservedMetaKeys[key]
+}
 
 // isPerDocLayout reports whether a document uses the per-document subdirectory
 // layout (versions/{base}/v{N}) rather than the flat layout (versions/{base}.v{N}).
@@ -211,7 +247,7 @@ func (s *Store) BuildHashIndex() error {
 
 // CurrentDoc describes a current, non-archived document version surfaced by
 // WalkCurrent. Body is the markdown content with store frontmatter stripped;
-// Metadata is the publisher metadata with the "meta." prefix stripped.
+// Metadata is the publisher metadata as a bare-keyed map (see extractMetadata).
 type CurrentDoc struct {
 	Path     string
 	Body     []byte
@@ -720,7 +756,8 @@ func (s *Store) Archive(reqPath string, archived bool) error {
 //	version: N
 //	previous-hash: sha256-<hex>   ← omitted for v1
 //	archived: true|false
-//	meta.key: value               ← publisher metadata (0–10 keys)
+//	tags: [a, b]                  ← recognized OKF fields, written bare
+//	meta.key: value               ← other publisher metadata (0–10 keys total)
 //	---
 //	<original content>
 //
@@ -1163,7 +1200,14 @@ func buildVersionFile(versionsDir, base string, version int, content []byte, met
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			sb.WriteString(fmt.Sprintf("%s%s: %s\n", metaPrefix, k, meta[k]))
+			switch {
+			case k == "tags" && okfKeys[k]:
+				sb.WriteString(fmt.Sprintf("tags: %s\n", formatTagsList(meta[k])))
+			case okfKeys[k]:
+				sb.WriteString(fmt.Sprintf("%s: %s\n", k, meta[k]))
+			default:
+				sb.WriteString(fmt.Sprintf("%s%s: %s\n", metaPrefix, k, meta[k]))
+			}
 		}
 	}
 	sb.WriteString("---\n")
@@ -1176,13 +1220,16 @@ func buildVersionFile(versionsDir, base string, version int, content []byte, met
 func validateMeta(meta map[string]string) error {
 	size := 0
 	for k, v := range meta {
+		if reservedMetaKeys[k] {
+			return fmt.Errorf("metadata key %q is reserved by the store", k)
+		}
 		if !protocol.IsValidMetaKey(k) {
 			return fmt.Errorf("metadata key %q contains invalid characters", k)
 		}
 		if !protocol.IsValidMetaValue(v) {
 			return fmt.Errorf("metadata value for key %q contains newlines", k)
 		}
-		size += len(k) + len(v)
+		size += SerializedMetaSize(k, v)
 	}
 	if len(meta) > protocol.MaxMetaKeys {
 		return fmt.Errorf("too many metadata keys (max %d)", protocol.MaxMetaKeys)
@@ -1193,8 +1240,13 @@ func validateMeta(meta map[string]string) error {
 	return nil
 }
 
-// extractMetadata parses publisher metadata from store frontmatter.
-// Returns keys with the "meta." prefix stripped, or nil if none found.
+// extractMetadata parses publisher metadata from store frontmatter, returning a
+// bare-keyed map (or nil if none found). Two on-disk forms are recognized:
+// recognized OKF fields written bare (okfKeys, "tags" parsed from its YAML
+// list), and every other publisher key carried under metaPrefix (stripped
+// here). Reserved store fields (reservedMetaKeys) and any other bare key are
+// ignored, so operational state never surfaces as publisher metadata. An older
+// "meta."-prefixed tags value is read as-is, keeping prior writes readable.
 func extractMetadata(data []byte) map[string]string {
 	if len(data) < 4 || !bytes.HasPrefix(data, []byte("---\n")) {
 		return nil
@@ -1205,20 +1257,81 @@ func extractMetadata(data []byte) map[string]string {
 	}
 	block := string(data[4 : 4+end])
 	var meta map[string]string
+	set := func(k, v string) {
+		if meta == nil {
+			meta = make(map[string]string)
+		}
+		meta[k] = v
+	}
 	for line := range strings.SplitSeq(block, "\n") {
 		key, val, ok := strings.Cut(line, ": ")
 		if !ok {
 			continue
 		}
 		key = strings.TrimSpace(key)
-		if strings.HasPrefix(key, metaPrefix) {
-			if meta == nil {
-				meta = make(map[string]string)
-			}
-			meta[key[len(metaPrefix):]] = strings.TrimRight(val, "\r")
+		val = strings.TrimRight(val, "\r")
+		switch {
+		case reservedMetaKeys[key]:
+			// Operational field — never publisher metadata.
+		case strings.HasPrefix(key, metaPrefix):
+			set(key[len(metaPrefix):], val)
+		case key == "tags":
+			set(key, parseTagsList(val))
+		case okfKeys[key]:
+			set(key, val)
 		}
 	}
 	return meta
+}
+
+// SerializedMetaSize returns the byte size a publisher key/value pair counts
+// against MaxMetaBytes: the key length plus the value length as actually
+// serialized on disk. The OKF "tags" field is stored as a YAML flow list, which
+// is longer than its comma-separated map form, so counting the raw value would
+// undercount the on-disk size and let a tag-heavy document slip past the budget
+// only to overflow the frontmatter. Per-line delimiters and the "meta." prefix
+// are fixed, bounded overhead covered by maxStoreFrontmatter, not counted here.
+func SerializedMetaSize(key, value string) int {
+	if key == "tags" {
+		return len(key) + len(formatTagsList(value))
+	}
+	return len(key) + len(value)
+}
+
+// FormatTagsList serializes a comma-separated tag string as an OKF YAML flow
+// list. It is exported for the OKF export codec so a bundle's on-disk tags
+// representation matches the store's exactly (a single source of truth for the
+// serialized form that SerializedMetaSize accounts for).
+func FormatTagsList(csv string) string { return formatTagsList(csv) }
+
+// formatTagsList serializes a comma-separated tag string as an OKF YAML flow
+// list, e.g. "sales,revenue" → "[sales, revenue]". Empty input yields "[]".
+func formatTagsList(csv string) string {
+	var tags []string
+	for raw := range strings.SplitSeq(csv, ",") {
+		if t := strings.TrimSpace(raw); t != "" {
+			tags = append(tags, t)
+		}
+	}
+	return "[" + strings.Join(tags, ", ") + "]"
+}
+
+// parseTagsList parses a tags value back to the comma-separated form held in the
+// metadata map. It accepts both the OKF YAML flow list ("[sales, revenue]") and
+// a bare comma-separated string (older "meta.tags" writes), so prior versions
+// stay readable.
+func parseTagsList(v string) string {
+	v = strings.TrimSpace(v)
+	if strings.HasPrefix(v, "[") && strings.HasSuffix(v, "]") {
+		v = v[1 : len(v)-1]
+	}
+	var tags []string
+	for raw := range strings.SplitSeq(v, ",") {
+		if t := strings.TrimSpace(raw); t != "" {
+			tags = append(tags, t)
+		}
+	}
+	return strings.Join(tags, ",")
 }
 
 // metaEqual reports whether two metadata maps are equal.

--- a/protocol/store/store_test.go
+++ b/protocol/store/store_test.go
@@ -1208,6 +1208,108 @@ func TestAppend_Conflict(t *testing.T) {
 	}
 }
 
+func TestWrite_OKFTagsList(t *testing.T) {
+	root := t.TempDir()
+	s := New(root)
+
+	meta := map[string]string{"tags": "sales, revenue", "importance": "0.8"}
+	if _, err := s.Write("/doc.md", []byte("# Hi\n"), meta); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	vData, err := os.ReadFile(filepath.Join(root, "versions", "doc.md", "v1"))
+	if err != nil {
+		t.Fatalf("read version file: %v", err)
+	}
+	content := string(vData)
+	// tags is an OKF field: bare, serialized as a YAML flow list.
+	if !strings.Contains(content, "\ntags: [sales, revenue]\n") {
+		t.Errorf("expected OKF tags list, got: %q", content)
+	}
+	// importance is not an OKF field: keeps the meta. prefix.
+	if !strings.Contains(content, "\nmeta.importance: 0.8\n") {
+		t.Errorf("expected meta.importance, got: %q", content)
+	}
+
+	// Round-trips back to the bare comma-separated form in the metadata map.
+	got, err := s.Get("/doc.md", 0)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Metadata["tags"] != "sales,revenue" {
+		t.Errorf("tags = %q, want %q", got.Metadata["tags"], "sales,revenue")
+	}
+	if got.Metadata["importance"] != "0.8" {
+		t.Errorf("importance = %q, want %q", got.Metadata["importance"], "0.8")
+	}
+}
+
+func TestValidateMeta_TagsCountedAsSerialized(t *testing.T) {
+	// 400 one-char tags: the comma-separated map value is "a,a,...,a" (799 B,
+	// +4 for the key = 803, under MaxMetaBytes), but the on-disk YAML list
+	// "[a, a, ..., a]" is ~1200 B. Counting the serialized form must reject it
+	// so the write cannot overflow the frontmatter budget.
+	tags := strings.Repeat("a,", 399) + "a"
+	csvSize := len("tags") + len(tags)
+	if csvSize > protocol.MaxMetaBytes {
+		t.Fatalf("test setup: csv size %d already exceeds cap %d", csvSize, protocol.MaxMetaBytes)
+	}
+	if got := SerializedMetaSize("tags", tags); got <= protocol.MaxMetaBytes {
+		t.Fatalf("test setup: serialized size %d should exceed cap %d", got, protocol.MaxMetaBytes)
+	}
+
+	s := New(t.TempDir())
+	if _, err := s.Write("/doc.md", []byte("# Hi\n"), map[string]string{"tags": tags}); err == nil {
+		t.Fatal("expected oversized serialized tags to be rejected")
+	}
+}
+
+func TestWrite_ReservedMetaKeyRejected(t *testing.T) {
+	s := New(t.TempDir())
+	for _, k := range []string{"version", "archived", "previous-hash"} {
+		t.Run(k, func(t *testing.T) {
+			_, err := s.Write("/doc.md", []byte("# Hi\n"), map[string]string{k: "x"})
+			if err == nil {
+				t.Fatalf("expected reserved-key %q to be rejected", k)
+			}
+		})
+	}
+}
+
+func TestExtractMetadata_LegacyMetaPrefix(t *testing.T) {
+	// Versions written before the OKF rename carry meta.-prefixed OKF fields.
+	// They must still read back correctly.
+	tests := []struct {
+		name string
+		data string
+		want map[string]string
+	}{
+		{
+			"legacy meta.tags and meta.type",
+			"---\nversion: 1\narchived: false\nmeta.tags: a,b\nmeta.type: journal\n---\n# Hi\n",
+			map[string]string{"tags": "a,b", "type": "journal"},
+		},
+		{
+			"bare okf fields with list tags",
+			"---\nversion: 1\narchived: false\ntags: [a, b]\ntype: journal\n---\n# Hi\n",
+			map[string]string{"tags": "a,b", "type": "journal"},
+		},
+		{
+			"reserved fields never surface",
+			"---\nversion: 2\nprevious-hash: sha256-ff\narchived: true\n---\n# Hi\n",
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractMetadata([]byte(tt.data))
+			if !metaEqual(got, tt.want) {
+				t.Errorf("extractMetadata = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWrite_WithMetadata(t *testing.T) {
 	root := t.TempDir()
 	s := New(root)
@@ -1224,7 +1326,7 @@ func TestWrite_WithMetadata(t *testing.T) {
 		t.Errorf("metadata type = %q, want %q", doc.Metadata["type"], "journal")
 	}
 
-	// Version file should contain meta. prefixed keys.
+	// Recognized OKF fields serialize bare; other publisher keys keep meta.
 	vData, err := os.ReadFile(filepath.Join(root, "versions", "doc.md", "v1"))
 	if err != nil {
 		t.Fatalf("read version file: %v", err)
@@ -1233,8 +1335,8 @@ func TestWrite_WithMetadata(t *testing.T) {
 	if !strings.Contains(content, "meta.author: claude") {
 		t.Errorf("expected meta.author in version file, got: %q", content)
 	}
-	if !strings.Contains(content, "meta.type: journal") {
-		t.Errorf("expected meta.type in version file, got: %q", content)
+	if !strings.Contains(content, "\ntype: journal\n") {
+		t.Errorf("expected bare OKF type in version file, got: %q", content)
 	}
 
 	// Read back via Get and verify metadata is returned.

--- a/protocol/store/store_test.go
+++ b/protocol/store/store_test.go
@@ -1299,6 +1299,11 @@ func TestExtractMetadata_LegacyMetaPrefix(t *testing.T) {
 			"---\nversion: 2\nprevious-hash: sha256-ff\narchived: true\n---\n# Hi\n",
 			nil,
 		},
+		{
+			"meta-prefixed reserved key not resurrected",
+			"---\nversion: 1\narchived: false\nmeta.archived: true\nmeta.type: note\n---\n# Hi\n",
+			map[string]string{"type": "note"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -769,6 +769,10 @@ func (h *Handler) handlePublish(w io.Writer, req protocol.Request) {
 		return
 	}
 	pubMeta = applyOKFTypeDefault(req.Path, pubMeta)
+	if err := store.ValidateMeta(pubMeta); err != nil {
+		h.writeError(w, protocol.StatusBadRequest, err.Error())
+		return
+	}
 
 	expectedVersion := -1 // default: no check when expected-version is absent
 	if ev := req.Metadata["expected-version"]; ev != "" {
@@ -884,6 +888,11 @@ func (h *Handler) handleAppend(w io.Writer, req protocol.Request) {
 
 	pubMeta, err := extractPublisherMeta(req.Metadata)
 	if err != nil {
+		h.writeError(w, protocol.StatusBadRequest, err.Error())
+		return
+	}
+	pubMeta = applyOKFTypeDefault(req.Path, pubMeta)
+	if err := store.ValidateMeta(pubMeta); err != nil {
 		h.writeError(w, protocol.StatusBadRequest, err.Error())
 		return
 	}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -768,6 +768,7 @@ func (h *Handler) handlePublish(w io.Writer, req protocol.Request) {
 		h.writeError(w, protocol.StatusBadRequest, err.Error())
 		return
 	}
+	pubMeta = applyOKFTypeDefault(req.Path, pubMeta)
 
 	expectedVersion := -1 // default: no check when expected-version is absent
 	if ev := req.Metadata["expected-version"]; ev != "" {
@@ -1026,6 +1027,26 @@ func escapeURL(s string) string {
 
 // extractPublisherMeta returns non-control metadata keys from a request.
 // Returns nil if no publisher keys are present.
+// applyOKFTypeDefault gives every published concept document an Open Knowledge
+// Format `type`, demarkus's guarantee that stored documents are typed OKF
+// concepts. Documents that already declare a type, and reserved OKF files
+// (index.md, log.md, which OKF defines as navigation/history rather than
+// concepts), are left unchanged.
+func applyOKFTypeDefault(reqPath string, meta map[string]string) map[string]string {
+	base := path.Base(reqPath)
+	if base == "index.md" || base == "log.md" {
+		return meta
+	}
+	if strings.TrimSpace(meta["type"]) != "" {
+		return meta
+	}
+	if meta == nil {
+		meta = make(map[string]string, 1)
+	}
+	meta["type"] = protocol.OKFDefaultType
+	return meta
+}
+
 func extractPublisherMeta(reqMeta map[string]string) (map[string]string, error) {
 	var meta map[string]string
 	size := 0
@@ -1046,7 +1067,7 @@ func extractPublisherMeta(reqMeta map[string]string) (map[string]string, error) 
 			meta = make(map[string]string)
 		}
 		meta[k] = v
-		size += len(k) + len(v)
+		size += store.SerializedMetaSize(k, v)
 	}
 	if len(meta) > protocol.MaxMetaKeys {
 		return nil, fmt.Errorf("too many metadata keys (max %d)", protocol.MaxMetaKeys)

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1137,7 +1138,9 @@ func TestHandlePublish(t *testing.T) {
 	t.Run("duplicate content is no-op", func(t *testing.T) {
 		dir := t.TempDir()
 		s := store.New(dir)
-		if _, err := s.Write("/doc.md", []byte("# Same\n"), nil); err != nil {
+		// v1 carries the type the handler defaults to, so the republish below is
+		// a true content+metadata duplicate (not a metadata change).
+		if _, err := s.Write("/doc.md", []byte("# Same\n"), map[string]string{"type": protocol.OKFDefaultType}); err != nil {
 			t.Fatalf("write v1: %v", err)
 		}
 		h := &Handler{ContentDir: dir, Store: s, Logger: discardLogger, GetTokenStore: func() *auth.TokenStore { return publishTokenStore }}
@@ -1887,11 +1890,13 @@ func TestPublisherMetadata(t *testing.T) {
 		s := store.New(dir)
 		h := &Handler{ContentDir: dir, Store: s, Logger: discardLogger, GetTokenStore: func() *auth.TokenStore { return tokenStore }}
 
-		// Build frontmatter with 11 non-control keys.
+		// Build frontmatter with one more than MaxMetaKeys non-control keys,
+		// using short keys/values so the key-count limit trips before the
+		// byte limit.
 		var fm strings.Builder
 		fm.WriteString("---\nauth: " + testSecret + "\n")
-		for i := range 11 {
-			fm.WriteString("key" + strings.Repeat("x", i) + ": val\n")
+		for i := range protocol.MaxMetaKeys + 1 {
+			fm.WriteString("k" + strconv.Itoa(i) + ": v\n")
 		}
 		fm.WriteString("---\n# Content\n")
 
@@ -2007,6 +2012,63 @@ func TestPublisherMetadata(t *testing.T) {
 			default:
 				t.Errorf("unexpected metadata key %q in legacy document", k)
 			}
+		}
+	})
+
+	t.Run("okf type default applied when absent", func(t *testing.T) {
+		dir := t.TempDir()
+		s := store.New(dir)
+		h := &Handler{ContentDir: dir, Store: s, Logger: discardLogger, GetTokenStore: func() *auth.TokenStore { return tokenStore }}
+
+		stream := newMockStream("PUBLISH /doc.md\n---\nauth: " + testSecret + "\ntitle: Untyped\n---\n# Content\n")
+		h.HandleStream(stream)
+
+		stream = newMockStream("FETCH /doc.md\n")
+		h.HandleStream(stream)
+		resp, err := protocol.ParseResponse(&stream.output)
+		if err != nil {
+			t.Fatalf("parse fetch: %v", err)
+		}
+		if resp.Metadata["type"] != protocol.OKFDefaultType {
+			t.Errorf("type: got %q, want default %q", resp.Metadata["type"], protocol.OKFDefaultType)
+		}
+	})
+
+	t.Run("okf type default not applied to reserved index.md", func(t *testing.T) {
+		dir := t.TempDir()
+		s := store.New(dir)
+		h := &Handler{ContentDir: dir, Store: s, Logger: discardLogger, GetTokenStore: func() *auth.TokenStore { return tokenStore }}
+
+		stream := newMockStream("PUBLISH /index.md\n---\nauth: " + testSecret + "\n---\n# Hub\n")
+		h.HandleStream(stream)
+
+		stream = newMockStream("FETCH /index.md\n")
+		h.HandleStream(stream)
+		resp, err := protocol.ParseResponse(&stream.output)
+		if err != nil {
+			t.Fatalf("parse fetch: %v", err)
+		}
+		if _, ok := resp.Metadata["type"]; ok {
+			t.Errorf("reserved index.md should not get a default type, got %q", resp.Metadata["type"])
+		}
+	})
+
+	t.Run("explicit type preserved", func(t *testing.T) {
+		dir := t.TempDir()
+		s := store.New(dir)
+		h := &Handler{ContentDir: dir, Store: s, Logger: discardLogger, GetTokenStore: func() *auth.TokenStore { return tokenStore }}
+
+		stream := newMockStream("PUBLISH /doc.md\n---\nauth: " + testSecret + "\ntype: Metric\n---\n# Content\n")
+		h.HandleStream(stream)
+
+		stream = newMockStream("FETCH /doc.md\n")
+		h.HandleStream(stream)
+		resp, err := protocol.ParseResponse(&stream.output)
+		if err != nil {
+			t.Fatalf("parse fetch: %v", err)
+		}
+		if resp.Metadata["type"] != "Metric" {
+			t.Errorf("explicit type: got %q, want %q", resp.Metadata["type"], "Metric")
 		}
 	})
 

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -2041,12 +2041,22 @@ func TestPublisherMetadata(t *testing.T) {
 
 		stream := newMockStream("PUBLISH /index.md\n---\nauth: " + testSecret + "\n---\n# Hub\n")
 		h.HandleStream(stream)
+		resp, err := protocol.ParseResponse(&stream.output)
+		if err != nil {
+			t.Fatalf("parse publish: %v", err)
+		}
+		if resp.Status != protocol.StatusCreated {
+			t.Fatalf("publish status: got %q, want %q", resp.Status, protocol.StatusCreated)
+		}
 
 		stream = newMockStream("FETCH /index.md\n")
 		h.HandleStream(stream)
-		resp, err := protocol.ParseResponse(&stream.output)
+		resp, err = protocol.ParseResponse(&stream.output)
 		if err != nil {
 			t.Fatalf("parse fetch: %v", err)
+		}
+		if resp.Status != protocol.StatusOK {
+			t.Fatalf("fetch status: got %q, want %q", resp.Status, protocol.StatusOK)
 		}
 		if _, ok := resp.Metadata["type"]; ok {
 			t.Errorf("reserved index.md should not get a default type, got %q", resp.Metadata["type"])
@@ -2069,6 +2079,61 @@ func TestPublisherMetadata(t *testing.T) {
 		}
 		if resp.Metadata["type"] != "Metric" {
 			t.Errorf("explicit type: got %q, want %q", resp.Metadata["type"], "Metric")
+		}
+	})
+
+	t.Run("okf type default applied on append", func(t *testing.T) {
+		dir := t.TempDir()
+		s := store.New(dir)
+		if _, err := s.Write("/doc.md", []byte("# Start\n"), nil); err != nil {
+			t.Fatal(err)
+		}
+		h := &Handler{ContentDir: dir, Store: s, Logger: discardLogger, GetTokenStore: func() *auth.TokenStore { return tokenStore }}
+
+		stream := newMockStream("APPEND /doc.md\n---\nauth: " + testSecret + "\nexpected-version: 1\n---\nMore.\n")
+		h.HandleStream(stream)
+		resp, err := protocol.ParseResponse(&stream.output)
+		if err != nil {
+			t.Fatalf("parse append: %v", err)
+		}
+		if resp.Status != protocol.StatusCreated {
+			t.Fatalf("append status: got %q, want %q", resp.Status, protocol.StatusCreated)
+		}
+
+		stream = newMockStream("FETCH /doc.md\n")
+		h.HandleStream(stream)
+		resp, err = protocol.ParseResponse(&stream.output)
+		if err != nil {
+			t.Fatalf("parse fetch: %v", err)
+		}
+		if resp.Metadata["type"] != protocol.OKFDefaultType {
+			t.Errorf("append type default: got %q, want %q", resp.Metadata["type"], protocol.OKFDefaultType)
+		}
+	})
+
+	t.Run("type default pushing over cap returns bad-request", func(t *testing.T) {
+		dir := t.TempDir()
+		s := store.New(dir)
+		h := &Handler{ContentDir: dir, Store: s, Logger: discardLogger, GetTokenStore: func() *auth.TokenStore { return tokenStore }}
+
+		// Exactly MaxMetaKeys publisher keys and no type: the default type push
+		// the count to MaxMetaKeys+1, which must be rejected as bad-request (not
+		// fall through to a generic server error at write time).
+		var fm strings.Builder
+		fm.WriteString("---\nauth: " + testSecret + "\n")
+		for i := range protocol.MaxMetaKeys {
+			fm.WriteString("k" + strconv.Itoa(i) + ": v\n")
+		}
+		fm.WriteString("---\n# Content\n")
+
+		stream := newMockStream("PUBLISH /doc.md\n" + fm.String())
+		h.HandleStream(stream)
+		resp, err := protocol.ParseResponse(&stream.output)
+		if err != nil {
+			t.Fatalf("parse response: %v", err)
+		}
+		if resp.Status != protocol.StatusBadRequest {
+			t.Errorf("status: got %q, want %q", resp.Status, protocol.StatusBadRequest)
 		}
 	})
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `demarkus okf` CLI with `validate`, `import`, and `export` for OKF bundles.
  * Implemented OKF bundle validation with conformance reporting.
  * Added OKF import/export roundtrip, including deterministic bundle output and Markdown link rewriting.
  * Automatically assigns default OKF `type` (`Document`) on publish/append for non-reserved documents.
  * Increased publisher metadata limits (50 keys, 1024 bytes) and enforced reserved metadata key rejection.
* **Documentation**
  * Updated the protocol spec and added ADRs for OKF metadata serialization and default type behavior.
* **Tests**
  * Expanded unit/integration tests for import/export, validation, metadata caps/formatting, and default `type` handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->