### PR TITLE
feat(plugin-memory): /soul-join, soul catalog

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-memory",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Local, versioned memory for Claude Code via demarkus. Zero-config install: spawns a local demarkus-server, auto-generates a token, wires MCP tools for fetch/publish/append/graph/lookup, injects standing guidance so sessions self-document to the soul, and enforces a publish tag-gate so documents stay findable via lookup.",
   "author": {
     "name": "latebit",
@@ -26,6 +26,15 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/publish-gate.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__.*__mark_(publish|append)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/dest-gate.sh"
           }
         ]
       }

--- a/plugins/claude-code/commands/soul-join.md
+++ b/plugins/claude-code/commands/soul-join.md
@@ -1,0 +1,100 @@
+---
+description: Join a remote demarkus soul (direct-QUIC) — validates the host, stores the token in a 0600 file (not inline in config), registers it as a managed MCP server, and binds it to this project.
+---
+
+Connect this Claude Code installation to a **remote demarkus soul** — a
+direct-QUIC demarkus-server reached over the network (e.g. `soul.demarkus.io`),
+as opposed to the local soul that `/soul-init` manages or the broker-fronted
+knowledge system that `/knowledge-join` joins.
+
+This replaces hand-wiring a `demarkus-mcp` entry into `.mcp.json`. The managed
+form is strictly better: the auth token lives in a `0600` file and is injected at
+launch via a wrapper, so it never sits in plaintext in `.mcp.json` or in
+`claude mcp list` output.
+
+## Argument
+
+```bash
+/soul-join mark://soul.demarkus.io --token <TOKEN> --insecure
+```
+
+- The host may be a `mark://host[:port]` URL or a bare host (scheme inferred).
+- `--token <TOKEN>` is the capability token for the soul. Omit only for a
+  read-only / public soul. The plugin cannot mint a token for a remote server
+  (its `tokens.toml` is not local) — the user supplies one.
+- `--insecure` skips TLS cert verification (needed for some self-hosted souls;
+  `soul.demarkus.io` uses it).
+
+If invoked without a host, ask for it. Do NOT guess. If the user does not give a
+token, ask whether the soul needs one before proceeding.
+
+## Steps
+
+1. **Check for hand-wired souls to adopt.** Run:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/detect-manual-souls.sh"
+   ```
+
+   - If the output is `NONE`, continue to step 2.
+   - If it starts with `MANUAL`, each following line is
+     `<name>\t<host>\t<insecure>\t<has-token>`. Show the user the unmanaged
+     entries and offer to adopt one: re-join it under managed config. To adopt,
+     use that row's host/insecure as the `/soul-join` arguments below, ask the
+     user for the token (it is in their existing entry — never read or echo it
+     yourself), and after a successful join run `claude mcp remove <name>` to
+     drop the old hand-wired entry. If they decline, continue.
+
+2. **Validate + register.** Run the helper, passing this project's directory so
+   the soul is bound to the repo:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/soul-join.sh" <host> [--token <TOKEN>] [--insecure] --bind "${CLAUDE_PROJECT_DIR}"
+   ```
+
+   The script normalizes the host, derives a slug from the first DNS label,
+   installs the launch wrapper to a stable path, writes the token to
+   `~/.demarkus/soul-<slug>.token` (mode 600), records the soul in the catalog
+   (`~/.demarkus/souls`), and binds the project. Output is line-oriented
+   `key=value`.
+
+   - On `OK`, parse `slug=`, `host=`, `insecure=`, `token-file=`, `wrapper=`.
+   - On `FAIL: <message>`, do NOT run `claude mcp add`. Show the message verbatim.
+     Common cases: an `https://` URL → tell them to use `/knowledge-join`; a
+     reserved `demarkus-memory` slug → tell them to join a host with a different
+     first label.
+
+   Reachability is not probed (demarkus is QUIC — no HTTP metadata to check like
+   a broker). The first tool call is the real validation; if it fails, re-join
+   (often the fix is adding `--insecure` or a token).
+
+3. **Register the MCP server** against the installed wrapper. Default to project
+   scope so the soul travels with this repo; use `--scope user` if the user wants
+   it available in every project:
+
+   ```bash
+   claude mcp add <slug> --scope project -- bash <wrapper> <slug>
+   ```
+
+   (`<wrapper>` and `<slug>` come from step 2's output.) The token is NOT passed
+   here — the wrapper injects it from the 0600 file.
+
+4. **Confirm.** Tell the user, in plain language:
+
+   > Joined remote soul **<slug>** at <host>, bound to this project. Its
+   > `mark_*` tools appear as the `<slug>` MCP server, with the token injected
+   > from `<token-file>` (not stored in your MCP config). The publish tag-gate
+   > now enforces tags on writes to it, same as the local soul.
+
+   Mention `claude mcp list` to see it and `claude mcp remove <slug>` to undo.
+
+## Don't
+
+- Don't run `claude mcp add` if step 2 emitted `FAIL`.
+- Don't read, echo, or store the token yourself — pass it to `soul-join.sh`,
+  which writes it to the 0600 file. It must never land in the transcript.
+- Don't use this for an `https://` broker — that is `/knowledge-join`.
+- Don't conflate the three soul surfaces:
+  - `/soul-init`: local, plugin-managed demarkus-server, plugin-minted token.
+  - `/soul-join`: remote, direct-QUIC demarkus-server, user-supplied token.
+  - `/knowledge-join`: organizational, HTTPS broker, OAuth via Claude Code.

--- a/plugins/claude-code/context/session-guidance.md
+++ b/plugins/claude-code/context/session-guidance.md
@@ -6,6 +6,16 @@ You have a local, versioned memory store (the "soul") wired through the `demarku
 
 **Project slug:** basename of `CLAUDE_PROJECT_DIR`, lowercased, spaces → hyphens. Everything for a project lives under `/<slug>/`.
 
+## Which soul to write to (catalog + binding)
+
+More than one demarkus surface can be configured: the local managed soul (`/soul-init`), one or more remote souls joined via `/soul-join`, and organizational knowledge systems joined via `/knowledge-join`. They all expose identical `mark_*` tools, so be deliberate about the write target:
+
+- **Reads** are unambiguous — fetch by explicit URL, or look up across whichever surface holds the subject.
+- **Writes** route by **role**, then by the project's **binding**: personal/draft/working notes → a soul; shared/authoritative knowledge → a knowledge system (via `/promote`, never a direct write). When several souls exist, this repo's bound soul (set by `/soul-join` inside the repo, recorded in `~/.demarkus/project-souls`) is the default soul target — prefer it over the local soul. If no binding exists, use the local managed soul.
+- If the intended write target is genuinely ambiguous, ask the user once rather than guessing.
+
+This binding is **enforced**, not just advisory: when a project is bound to a soul, a write aimed at a different soul is denied at write time (the destination gate) — re-issue it against the bound soul's `mcp__<slug>__mark_*` tools. The publish tag-gate fires the same way on the local soul and any joined remote soul, so tag every publish regardless of which one you target.
+
 ## Recall first (proactively)
 
 Before answering "what do I know about / did we decide / have we seen X" — and at the start of substantive work — check the soul instead of relying on the current context alone:

--- a/plugins/claude-code/hooks/dest-gate.sh
+++ b/plugins/claude-code/hooks/dest-gate.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Destination gate for the demarkus-memory plugin.
+#
+# Wired in plugin.json as a PreToolUse hook on mark_publish AND mark_append. When
+# a project is bound to a specific soul (recorded by /soul-join in
+# ~/.demarkus/project-souls), a write aimed at a DIFFERENT soul is a misroute —
+# the exact "which soul did I just write to?" confusion this whole feature exists
+# to kill. This gate makes the misroute loud at write time instead of letting it
+# land silently on the wrong store.
+#
+#   STRICTNESS=block (default) → deny the misrouted write (agent self-corrects to
+#                                the bound soul — no human interruption).
+#   STRICTNESS=ask             → escalate to the user.
+#   STRICTNESS=warn            → allow, but inject a warning into the model.
+#
+# Scope is narrow and fails OPEN: it acts ONLY when (a) the tool targets a soul
+# this plugin routes (local or a joined remote — never a knowledge system or an
+# unrelated server) AND (b) this project has an explicit binding. No binding →
+# defer, so the overwhelming majority of projects see zero behavior change.
+#
+# Zero runtime deps: payload parsed with pure awk (publish_metadata_check). -e is
+# deliberately NOT set — a stray non-zero from a probe must not abort into a
+# misread hook exit. On any parse hiccup the gate defers.
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="${HOOK_DIR}/../scripts"
+# shellcheck source=../scripts/lib.sh
+. "${SCRIPTS_DIR}/lib.sh"
+
+input="$(cat)"
+
+parsed="$(printf '%s' "${input}" | publish_metadata_check)" || {
+  warn "dest gate: payload parse failed; deferring"
+  exit 0
+}
+
+event="$(sed -n '1p' <<<"${parsed}")"
+tool="$(sed -n '2p' <<<"${parsed}")"
+url="$(sed -n '5p' <<<"${parsed}")"
+
+# PreToolUse only — the whole point is to stop the write before it lands.
+[[ "${event}" == "PreToolUse" ]] || exit 0
+
+# Defensive scope: the matcher is broad, so act only on the write verbs.
+case "${tool}" in
+  *mark_publish | *mark_append) ;;
+  *) exit 0 ;;
+esac
+
+# Only soul writes this plugin routes are in scope (empty → knowledge system or
+# an unrelated server: not ours to gate).
+target_id="$(soul_target_id "${tool}")"
+[[ -n "${target_id}" ]] || exit 0
+
+# No project binding → no destination to enforce against. Fail open.
+project_dir="${CLAUDE_PROJECT_DIR:-${PWD}}"
+bound="$(project_soul_binding "${project_dir}")"
+[[ -n "${bound}" ]] || exit 0
+
+# Correct destination → nothing to do.
+[[ "${target_id}" == "${bound}" ]] && exit 0
+
+target="${url:-this document}"
+reason="demarkus write to ${target} is going to soul '${target_id}', but this project is bound to soul '${bound}'. Re-issue the write against the bound soul's tools (mcp__${bound}__mark_publish / mcp__${bound}__mark_append). To change which soul this project uses, run /soul-join in this repo; to relax this check, set DEMARKUS_MEMORY_DEST_STRICTNESS=warn (or ask)."
+
+emit_decision() {
+  local decision="$1" why="$2"
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"%s","permissionDecisionReason":%s}}\n' \
+    "${decision}" "$(printf '%s' "${why}" | json_escape)"
+}
+
+emit_context() {
+  local ctx="$1"
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":%s}}\n' \
+    "$(printf '%s' "${ctx}" | json_escape)"
+}
+
+case "$(configured_dest_strictness)" in
+  block) emit_decision "deny" "${reason}" ;;
+  ask)   emit_decision "ask"  "${reason}" ;;
+  warn)  emit_context  "⚠️ ${reason}" ;;
+  *)     exit 0 ;;
+esac

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -83,6 +83,11 @@ main() {
 
     ensure_binaries
 
+    # If ensure_binaries swapped the binary, restart the configured server (any
+    # mode, including reuse) onto it from its own config — a binary the running
+    # server can't see is the bug this closes. No-op when nothing was upgraded.
+    restart_local_server_on_upgrade
+
     case "${MODE}" in
       default|isolated)
         ensure_managed_server "${SOUL_DIR}" "${PORT}"

--- a/plugins/claude-code/scripts/detect-manual-souls.sh
+++ b/plugins/claude-code/scripts/detect-manual-souls.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# detect-manual-souls.sh — report hand-wired remote demarkus souls so /soul-join
+# can offer to adopt them into managed config.
+#
+# A "manual soul" is an MCP server that invokes demarkus-mcp DIRECTLY against a
+# remote mark:// host — i.e. a soul wired by editing .mcp.json by hand, with its
+# token sitting inline in the config (and in `claude mcp list` output). Entries
+# that go through our launch wrappers (soul-remote-wrapper.sh / mcp-wrapper.sh)
+# are already managed and are NOT reported.
+#
+# Output:
+#   "NONE"                     — nothing to adopt (or `claude` unavailable)
+#   "MANUAL" then one row each: "<name>\t<host>\t<insecure 0|1>\t<has-token 0|1>"
+#
+# The token VALUE is deliberately never emitted — only its presence — so it does
+# not leak into the agent transcript. Adoption re-joins with the user supplying
+# the token (they have it in their existing entry).
+#
+# Detection reads `claude mcp list` (the live, scope-merged registry) rather than
+# parsing .mcp.json files: it is authoritative and avoids a hand-rolled JSON
+# parser. The list format is a human one, so this is best-effort by nature.
+
+set -uo pipefail
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "NONE"
+  exit 0
+fi
+
+# `claude mcp list` runs a health check and prints a header + one line per
+# server: "<name>: <command...> - <status>". We only care about lines whose
+# command runs demarkus-mcp directly against a mark:// host.
+LIST="$(claude mcp list 2>/dev/null || true)"
+
+ROWS="$(printf '%s\n' "${LIST}" | awk '
+  # Skip our managed wrappers and the local-soul wrapper outright.
+  /soul-remote-wrapper\.sh/ { next }
+  /mcp-wrapper\.sh/         { next }
+  # Must invoke demarkus-mcp directly against a remote mark:// host.
+  /demarkus-mcp/ && /mark:\/\// {
+    line = $0
+    # name = text before the first ": "
+    ci = index(line, ": ")
+    if (ci == 0) next
+    name = substr(line, 1, ci - 1)
+    cmd  = substr(line, ci + 2)
+
+    # host = the token following "-host "
+    host = ""
+    if (match(cmd, /-host[ =]+mark:\/\/[^ ]+/)) {
+      h = substr(cmd, RSTART, RLENGTH)
+      sub(/^-host[ =]+/, "", h)
+      host = h
+    }
+    if (host == "") next
+
+    insecure = (cmd ~ /(^| )-insecure( |$)/) ? "1" : "0"
+    hastoken = (cmd ~ /(^| )-token([ =]|$)/) ? "1" : "0"
+
+    printf "%s\t%s\t%s\t%s\n", name, host, insecure, hastoken
+  }
+')"
+
+if [[ -z "${ROWS}" ]]; then
+  echo "NONE"
+  exit 0
+fi
+
+echo "MANUAL"
+printf '%s\n' "${ROWS}"

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -23,6 +23,13 @@ readonly TOKEN_LABEL="claude-code-plugin"
 # strictness live in the separate demarkus-knowledge plugin, not here.)
 readonly PLUGIN_STRICTNESS_FILE="${PLUGIN_HOME}/plugin-memory.strictness"
 
+# Strictness for the destination gate (hooks/dest-gate.sh): warn | block | ask.
+# Separate file from the tag-gate strictness so the two enforcement axes are set
+# independently. Absent file means the block default — an explicit project→soul
+# binding means writes belong to the bound soul, so a misroute is an error to
+# deny, not merely warn.
+readonly PLUGIN_DEST_STRICTNESS_FILE="${PLUGIN_HOME}/plugin-memory.dest-strictness"
+
 # Registry of joined knowledge-system MCP server slugs, written by the SEPARATE
 # demarkus-knowledge plugin's /knowledge-join (one slug per line). We read it
 # (never write it) purely to detect that a knowledge endpoint exists — the
@@ -31,6 +38,21 @@ readonly PLUGIN_STRICTNESS_FILE="${PLUGIN_HOME}/plugin-memory.strictness"
 # bridge (soul → knowledge): with no endpoint there is nothing to promote to, so
 # /promote stays dormant. We never touch the broker — detection only.
 readonly KNOWLEDGE_REGISTRY="${PLUGIN_HOME}/knowledge-systems"
+
+# Catalog of joined REMOTE souls (direct-QUIC demarkus servers reached over the
+# network, e.g. soul.demarkus.io), written by /soul-join. Tab-separated, one row
+# per soul: "<slug>\t<host>\t<insecure 0|1>\t<token-file|->". This is the managed
+# replacement for hand-wiring a remote demarkus-mcp into .mcp.json: the token
+# lives in a 0600 file (token-file column), never inline in the MCP config. The
+# local plugin-managed soul stays in PLUGIN_CONFIG (tier "local"); these rows are
+# tier "remote". soul_catalog() unions both for a full view.
+readonly SOULS_REGISTRY="${PLUGIN_HOME}/souls"
+
+# Per-project binding: which catalog soul a given repo writes to by default.
+# Tab-separated "<project-dir>\t<slug>", one row per bound repo, written by
+# /soul-join when run inside a repo. The routing key that disambiguates "which
+# soul does THIS project use" when several are configured.
+readonly PROJECT_SOULS="${PLUGIN_HOME}/project-souls"
 
 # Soul dirs that setup.sh may choose.
 readonly SHARED_SOUL_DIR="${PLUGIN_HOME}/soul"
@@ -101,6 +123,22 @@ configured_strictness() {
   esac
 }
 
+# configured_dest_strictness — destination-gate strictness: warn|block|ask.
+# Precedence: DEMARKUS_MEMORY_DEST_STRICTNESS env override, then
+# PLUGIN_DEST_STRICTNESS_FILE, then the block default. Unlike the tag gate (which
+# floors at warn so a typo can't silently escalate), block IS the intended
+# default here, so an unrecognized value falls back to block.
+configured_dest_strictness() {
+  local s="${DEMARKUS_MEMORY_DEST_STRICTNESS:-}"
+  if [[ -z "${s}" && -f "${PLUGIN_DEST_STRICTNESS_FILE}" ]]; then
+    s="$(tr -d '[:space:]' < "${PLUGIN_DEST_STRICTNESS_FILE}" 2>/dev/null || true)"
+  fi
+  case "${s}" in
+    warn|block|ask) echo "${s}" ;;
+    *)              echo "block" ;;
+  esac
+}
+
 # knowledge_endpoints — emit each joined knowledge-system slug on its own line
 # (empty when none). Read-only peek at the demarkus-knowledge registry; blank
 # lines and surrounding whitespace are stripped. Mirrors that plugin's own
@@ -116,6 +154,76 @@ knowledge_endpoints() {
 # joined (via the demarkus-knowledge plugin's /knowledge-join).
 knowledge_present() {
   [[ -n "$(knowledge_endpoints)" ]]
+}
+
+# --- remote soul catalog (written by /soul-join) -------------------------------
+#
+# Rows are tab-separated "<slug>\t<host>\t<insecure>\t<token-file>". All readers
+# below skip blank lines and #-comments and split on tab only, so a host or path
+# containing spaces survives intact.
+
+# register_remote_soul SLUG HOST INSECURE TOKEN_FILE — idempotent upsert. Any
+# existing row for SLUG is replaced (a re-join can change host/token), so the
+# catalog never carries two rows for one slug. INSECURE is normalized to 0|1;
+# TOKEN_FILE of "" is stored as "-" (no auth). Returns non-zero on empty slug.
+register_remote_soul() {
+  local slug="$1" host="$2" insecure="$3" token_file="$4"
+  [[ -n "${slug}" && -n "${host}" ]] || return 1
+  case "${insecure}" in 1|true|yes) insecure=1 ;; *) insecure=0 ;; esac
+  [[ -n "${token_file}" ]] || token_file="-"
+  mkdir -p "${PLUGIN_HOME}"
+  touch "${SOULS_REGISTRY}"
+  local tmp="${SOULS_REGISTRY}.tmp"
+  # Drop any prior row for this slug, then append the new one.
+  awk -F '\t' -v s="${slug}" 'NF && $1 !~ /^#/ && $1 != s' "${SOULS_REGISTRY}" > "${tmp}" 2>/dev/null || true
+  printf '%s\t%s\t%s\t%s\n' "${slug}" "${host}" "${insecure}" "${token_file}" >> "${tmp}"
+  mv "${tmp}" "${SOULS_REGISTRY}"
+}
+
+# remote_soul_fields SLUG — echo the row's "HOST\tINSECURE\tTOKEN_FILE" (tab-
+# separated) for SLUG, empty when not registered. The caller reads the three
+# fields with `IFS=$'\t' read -r host insecure token_file <<<"$(...)"`.
+remote_soul_fields() {
+  local slug="$1"
+  [[ -n "${slug}" && -f "${SOULS_REGISTRY}" ]] || return 0
+  awk -F '\t' -v s="${slug}" 'NF && $1 !~ /^#/ && $1 == s { print $2 "\t" $3 "\t" $4; exit }' \
+    "${SOULS_REGISTRY}" 2>/dev/null || true
+}
+
+# list_remote_souls — emit each registered remote-soul slug on its own line
+# (empty when none). Blank lines and #-comments are skipped.
+list_remote_souls() {
+  [[ -f "${SOULS_REGISTRY}" ]] || return 0
+  awk -F '\t' 'NF && $1 !~ /^#/ { print $1 }' "${SOULS_REGISTRY}" 2>/dev/null || true
+}
+
+# is_registered_remote_soul SLUG — true if SLUG is in the catalog.
+is_registered_remote_soul() {
+  local slug="$1"
+  [[ -n "${slug}" ]] || return 1
+  list_remote_souls | grep -qxF "${slug}"
+}
+
+# bind_project_soul DIR SLUG — record that repo DIR writes to catalog soul SLUG
+# by default. Idempotent upsert keyed on DIR. Returns non-zero on empty input.
+bind_project_soul() {
+  local dir="$1" slug="$2"
+  [[ -n "${dir}" && -n "${slug}" ]] || return 1
+  mkdir -p "${PLUGIN_HOME}"
+  touch "${PROJECT_SOULS}"
+  local tmp="${PROJECT_SOULS}.tmp"
+  awk -F '\t' -v d="${dir}" 'NF && $1 !~ /^#/ && $1 != d' "${PROJECT_SOULS}" > "${tmp}" 2>/dev/null || true
+  printf '%s\t%s\n' "${dir}" "${slug}" >> "${tmp}"
+  mv "${tmp}" "${PROJECT_SOULS}"
+}
+
+# project_soul_binding DIR — echo the catalog slug bound to repo DIR, empty when
+# unbound. Exact directory match (no prefix/parent resolution).
+project_soul_binding() {
+  local dir="$1"
+  [[ -n "${dir}" && -f "${PROJECT_SOULS}" ]] || return 0
+  awk -F '\t' -v d="${dir}" 'NF && $1 !~ /^#/ && $1 == d { print $2; exit }' \
+    "${PROJECT_SOULS}" 2>/dev/null || true
 }
 
 # Registry of plain remote promote targets — demarkus servers (no broker) you
@@ -145,20 +253,51 @@ promote_destination_present() {
   knowledge_present || [[ -n "$(promote_targets)" ]]
 }
 
-# publish_gate_scope TOOLNAME — echoes "local" only when the tool targets this
-# plugin's own soul server, empty otherwise. The server is the segment between
-# the leading "mcp__" and the trailing "__mark_publish": either the manually-
-# configured name "demarkus-memory" or the plugin-prefixed "..._demarkus-memory".
-# Matched exactly (not as a "*demarkus-memory*" substring) so an unrelated server
-# whose name merely contains that token isn't swept in. Organizational knowledge
-# systems are gated by the separate demarkus-knowledge plugin, never here.
+# publish_gate_scope TOOLNAME — echoes "local" when the tool targets a soul this
+# plugin owns (so the publish tag-gate fires), empty otherwise. The server is the
+# segment between the leading "mcp__" and the trailing "__mark_publish". Two soul
+# kinds qualify:
+#   - the local managed soul: server name "demarkus-memory" or the plugin-
+#     prefixed "..._demarkus-memory". Matched exactly (not as a
+#     "*demarkus-memory*" substring) so an unrelated server whose name merely
+#     contains that token isn't swept in.
+#   - a remote soul joined via /soul-join: server name equals the registered
+#     catalog slug. Slugs are sanitized to [a-z0-9-] (no underscores) by
+#     soul-join.sh, so they can never collide with the "*_demarkus-memory" arm.
+# Organizational knowledge systems are gated by the separate demarkus-knowledge
+# plugin, never here.
 publish_gate_scope() {
   local tool="$1" server
   server="${tool#mcp__}"
   server="${server%__mark_publish}"
   case "${server}" in
-    demarkus-memory | *_demarkus-memory) echo "local" ;;
+    demarkus-memory | *_demarkus-memory) echo "local"; return ;;
   esac
+  if is_registered_remote_soul "${server}"; then
+    echo "local"
+  fi
+}
+
+# soul_target_id TOOLNAME — echoes the canonical id of the soul a mark_publish /
+# mark_append tool writes to, for comparison against a project binding:
+#   "demarkus-memory"  — the local managed soul (server "demarkus-memory" or the
+#                        plugin-prefixed "..._demarkus-memory")
+#   "<slug>"           — a remote soul joined via /soul-join (server == slug)
+#   (empty)            — the tool targets something else (a knowledge system or an
+#                        unrelated demarkus server): not a soul this plugin routes,
+#                        so the destination gate leaves it alone.
+# The server is the segment between "mcp__" and the trailing "__mark_<verb>", so
+# this handles both publish and append.
+soul_target_id() {
+  local tool="$1" server
+  server="${tool#mcp__}"
+  server="${server%__mark_*}"
+  case "${server}" in
+    demarkus-memory | *_demarkus-memory) echo "demarkus-memory"; return ;;
+  esac
+  if is_registered_remote_soul "${server}"; then
+    echo "${server}"
+  fi
 }
 
 # publish_metadata_check — reads a Claude Code PreToolUse/PostToolUse hook
@@ -492,7 +631,13 @@ _desired_versions() {
 # re-download on the next session start). No sidecar to keep in sync: the
 # binaries are the source of truth, and a partial/failed install simply reads as
 # a mismatch and re-downloads next time.
+# DEMARKUS_BINARIES_REPLACED is a plain (unexported) global ensure_binaries sets
+# to 1 when it actually swapped the on-disk binary this run, 0 otherwise;
+# restart_local_server_on_upgrade reads it (defaulting to 0 when never set) to
+# decide whether to restart the running server onto the new binary. Unexported so
+# it never leaks into the spawned server's environment.
 ensure_binaries() {
+  DEMARKUS_BINARIES_REPLACED=0
   local desired installed
   desired="$(_desired_versions)"
   installed="$(_installed_versions)"
@@ -562,7 +707,50 @@ ensure_binaries() {
     return "${install_rc}"
   fi
 
+  DEMARKUS_BINARIES_REPLACED=1
   log "binaries installed to ${PLUGIN_BIN_DIR}"
+}
+
+# restart_local_server_on_upgrade — when ensure_binaries swapped the binary this
+# run, restart the configured local server onto the new binary using its OWN
+# recorded config (SOUL_DIR/PORT from PLUGIN_CONFIG), so a binary replacement is
+# never left half-applied (process serving the stale binary from memory). No-op
+# when no binary changed or no local soul is configured.
+#
+# Works for every mode, including reuse: a reuse/externally-started server is not
+# tracked by our .pid, so we stop the process found at the configured root first
+# (freeing the UDP port) before ensure_managed_server respawns it on the new
+# binary. This intentionally relaxes the old "never restart a reuse server"
+# policy — restarting it with the same config is what the user asked for, and an
+# upgraded binary that the running server can't see is the bug it fixes. Managed
+# servers are handled by ensure_managed_server via our own .pid as before.
+#
+# Runs in a subshell so load_config can't clobber the caller's SOUL_DIR/PORT/MODE,
+# and never fails the caller: a restart problem is warned, not propagated.
+restart_local_server_on_upgrade() {
+  [[ "${DEMARKUS_BINARIES_REPLACED:-0}" == "1" ]] || return 0
+  (
+    load_config 2>/dev/null || exit 0
+    # Stop an externally-started server at this root (reuse, or an orphan whose
+    # .pid we lost) so the respawn can bind the freed port. Skip when our own
+    # .pid exists — ensure_managed_server stops that one itself.
+    if [[ ! -f "${SOUL_DIR}/.pid" ]]; then
+      local ext_pid
+      ext_pid="$(pid_of_server_at_root "${SOUL_DIR}" 2>/dev/null || true)"
+      if [[ -n "${ext_pid}" ]]; then
+        log "binary upgraded — stopping server at ${SOUL_DIR} (pid=${ext_pid}) to restart on the new binary"
+        kill "${ext_pid}" 2>/dev/null || true
+        local waited=0
+        while (( waited < 30 )) && kill -0 "${ext_pid}" 2>/dev/null; do
+          sleep 0.1; waited=$((waited + 1))
+        done
+        kill -0 "${ext_pid}" 2>/dev/null && kill -9 "${ext_pid}" 2>/dev/null || true
+      fi
+    fi
+    log "binary upgraded — restarting local server (mode=${MODE}, soul=${SOUL_DIR}, port=${PORT}) on the new binary"
+    ensure_managed_server "${SOUL_DIR}" "${PORT}"
+  ) || warn "could not restart the local server after a binary upgrade; run /soul-init to recover"
+  return 0
 }
 
 # _proc_env PID VAR — echoes the value of env var VAR for process PID, or empty.

--- a/plugins/claude-code/scripts/soul-join.sh
+++ b/plugins/claude-code/scripts/soul-join.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# /soul-join script half. Validates a remote demarkus (direct-QUIC) soul URL,
+# derives an MCP server slug, stores the auth token in a 0600 file (NOT inline in
+# the MCP config), installs the self-contained launch wrapper to a stable path,
+# and records the soul in the catalog. The command-side prompt parses our
+# key=value output and runs `claude mcp add` against the wrapper; do not change
+# the output shape without updating commands/soul-join.md.
+#
+# Usage: soul-join.sh <mark://host[:port] | host[:port]> [--token T] [--insecure] [--bind DIR]
+# Output (stdout, on success):
+#   OK
+#   slug=<sanitized first DNS label>
+#   host=<normalized mark:// host>
+#   insecure=<0|1>
+#   token-file=<path|->
+#   wrapper=<absolute path to the installed launch wrapper>
+# Output (stdout, on failure):
+#   FAIL: <one-line operator-readable message>
+# Exit codes: 0 on success, non-zero on validation failure. The slash command
+# treats any non-OK output as "do not run claude mcp add."
+#
+# Reachability is NOT probed here: demarkus is QUIC (no HTTP .well-known to curl
+# like the broker), and the first MCP tool call is the real validation. The
+# command doc says so explicitly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# shellcheck source=./lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+# fail emits the operator-readable error on stdout (so the slash command can show
+# it verbatim) AND on stderr (so a human running the script directly sees it).
+fail() {
+  local msg="$1"
+  echo "FAIL: ${msg}"
+  echo "[demarkus-memory] error: ${msg}" >&2
+  exit 1
+}
+
+HOST_ARG=""
+TOKEN=""
+INSECURE=0
+BIND_DIR=""
+
+while (( $# )); do
+  case "$1" in
+    --token)    [[ -n "${2:-}" ]] || fail "--token requires a value"; TOKEN="$2"; shift 2 ;;
+    --insecure) INSECURE=1; shift ;;
+    --bind)     [[ -n "${2:-}" ]] || fail "--bind requires a value"; BIND_DIR="$2"; shift 2 ;;
+    -* )        fail "unknown option: $1" ;;
+    *)          [[ -z "${HOST_ARG}" ]] || fail "unexpected extra argument: $1"; HOST_ARG="$1"; shift ;;
+  esac
+done
+
+[[ -n "${HOST_ARG}" ]] || fail "usage: soul-join.sh <mark://host[:port] | host[:port]> [--token T] [--insecure] [--bind DIR]"
+
+# Scheme handling. A remote soul is direct-QUIC (mark://). Accept a bare host
+# (scheme inferred) or an explicit mark:// URL; reject http(s):// outright —
+# that is a broker/knowledge endpoint and belongs to /knowledge-join, not here.
+# Scheme matching is case-insensitive per RFC 3986; bracketed classes work on
+# Bash 3.2 (macOS) which lacks ${var,,}.
+case "${HOST_ARG}" in
+  [Mm][Aa][Rr][Kk]://*) HOST="mark://${HOST_ARG#*://}" ;;
+  [Hh][Tt][Tt][Pp][Ss]://* | [Hh][Tt][Tt][Pp]://*)
+    fail "remote souls are direct-QUIC (mark://). For an https:// broker-fronted knowledge system use /knowledge-join (got: ${HOST_ARG})" ;;
+  *://*)
+    fail "unsupported scheme — a remote soul URL is mark://host[:port] or a bare host (got: ${HOST_ARG})" ;;
+  *) HOST="mark://${HOST_ARG}" ;;
+esac
+
+# Strip a trailing slash / path so -host is well-formed; demarkus-mcp wants just
+# mark://host[:port].
+HOST="${HOST%%/}"
+HOSTPORT="${HOST#mark://}"
+HOSTPORT="${HOSTPORT%%/*}"
+[[ -n "${HOSTPORT}" ]] || fail "could not parse a host from ${HOST_ARG}"
+HOST="mark://${HOSTPORT}"
+
+# Derive the slug from the first DNS label of the host (port stripped). Same
+# rule + sanitization as the knowledge plugin's join: lowercase, non-[a-z0-9-]
+# → '-', collapse, trim. The slug is the MCP server name (mcp__<slug>__mark_*).
+HOSTNAME_ONLY="${HOSTPORT%%:*}"
+SLUG_RAW="${HOSTNAME_ONLY%%.*}"
+SLUG=$(printf '%s' "${SLUG_RAW}" \
+       | tr '[:upper:]' '[:lower:]' \
+       | tr -c 'a-z0-9-' '-' \
+       | tr -s '-' \
+       | sed 's/^-*//;s/-*$//')
+
+[[ -n "${SLUG}" ]] || fail "could not derive a usable MCP server slug from ${HOST_ARG} (host: ${HOSTNAME_ONLY})"
+
+# "demarkus-memory" is the local managed soul's reserved server name; a remote
+# soul must not shadow it (the publish gate and tool routing key on the name).
+[[ "${SLUG}" == "demarkus-memory" ]] && \
+  fail "slug 'demarkus-memory' is reserved for the local managed soul — re-run with an explicit different name once renaming is supported, or join a host with a different first label"
+
+# Ensure demarkus-mcp (the wrapper's exec target) is installed + pinned. The
+# test harness sets DEMARKUS_SOUL_JOIN_SKIP_BINARIES=1 to exercise validation +
+# registration offline without the network download. The env var is deliberately
+# long + namespaced so an accidental shell export can't silently skip it.
+if [[ "${DEMARKUS_SOUL_JOIN_SKIP_BINARIES:-}" != "1" ]]; then
+  ensure_binaries || fail "could not install demarkus binaries (see log above)"
+  # If that upgrade swapped the SERVER binary too, the running local managed soul
+  # would otherwise keep serving the stale binary until the next session start.
+  # Restart it now from its own config.
+  restart_local_server_on_upgrade
+fi
+
+# Install the self-contained launch wrapper to a STABLE, version-independent path
+# under ${PLUGIN_BIN_DIR}. claude mcp add records an absolute command path; if we
+# pointed it at the versioned plugin-cache copy, a plugin upgrade would move the
+# script out from under the registered MCP server. The wrapper sources nothing
+# and reads the catalog directly, so the stable copy never goes stale.
+WRAPPER_SRC="${SCRIPT_DIR}/soul-remote-wrapper.sh"
+WRAPPER_DST="${PLUGIN_BIN_DIR}/soul-remote-wrapper.sh"
+[[ -f "${WRAPPER_SRC}" ]] || fail "launch wrapper missing at ${WRAPPER_SRC}"
+mkdir -p "${PLUGIN_BIN_DIR}"
+install -m 0755 "${WRAPPER_SRC}" "${WRAPPER_DST}" \
+  || fail "could not install launch wrapper to ${WRAPPER_DST}"
+
+# Token → 0600 file, never inline. "-" means no auth (a read-only / public soul).
+TOKEN_FILE="-"
+if [[ -n "${TOKEN}" ]]; then
+  TOKEN_FILE="${PLUGIN_HOME}/soul-${SLUG}.token"
+  mkdir -p "${PLUGIN_HOME}"
+  printf '%s' "${TOKEN}" > "${TOKEN_FILE}.tmp"
+  chmod 600 "${TOKEN_FILE}.tmp"
+  mv "${TOKEN_FILE}.tmp" "${TOKEN_FILE}"
+  log "stored auth token for '${SLUG}' at ${TOKEN_FILE} (mode 600)"
+fi
+
+register_remote_soul "${SLUG}" "${HOST}" "${INSECURE}" "${TOKEN_FILE}" \
+  || fail "could not record soul '${SLUG}' in the catalog (${SOULS_REGISTRY})"
+log "registered remote soul '${SLUG}' (host=${HOST}, insecure=${INSECURE})"
+
+# Bind this repo to the soul when invoked inside a project (project scope).
+if [[ -n "${BIND_DIR}" ]]; then
+  bind_project_soul "${BIND_DIR}" "${SLUG}" \
+    || fail "could not bind project ${BIND_DIR} to soul '${SLUG}'"
+  log "bound project ${BIND_DIR} → soul '${SLUG}'"
+fi
+
+echo "OK"
+echo "slug=${SLUG}"
+echo "host=${HOST}"
+echo "insecure=${INSECURE}"
+echo "token-file=${TOKEN_FILE}"
+echo "wrapper=${WRAPPER_DST}"

--- a/plugins/claude-code/scripts/soul-remote-wrapper.sh
+++ b/plugins/claude-code/scripts/soul-remote-wrapper.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# soul-remote-wrapper.sh — launches demarkus-mcp for a joined REMOTE soul.
+#
+# Claude Code launches MCP subprocesses with a fixed env, so the token can't be
+# handed over at spawn time. .mcp.json invokes this wrapper (via `claude mcp add
+# <slug> -- bash <this> <slug>`); it looks the slug up in the soul catalog,
+# exports DEMARKUS_AUTH from the slug's 0600 token file, and execs demarkus-mcp
+# pointed at the remote host. Keeping the token here (env, from a 0600 file)
+# rather than inline in the MCP config is the whole point of /soul-join over
+# hand-wiring.
+#
+# Self-contained ON PURPOSE: /soul-join installs this to the stable path
+# ~/.demarkus/bin/soul-remote-wrapper.sh and registers THAT path. It sources no
+# lib.sh and reads the catalog directly, so a plugin upgrade (which moves the
+# versioned plugin-cache copy) never strands the registered MCP server.
+#
+# Usage: soul-remote-wrapper.sh <slug>
+
+set -euo pipefail
+
+SLUG="${1:-}"
+if [[ -z "${SLUG}" ]]; then
+  echo "[demarkus-memory] soul-remote-wrapper: missing slug argument" >&2
+  exit 1
+fi
+# Consume the slug so it isn't forwarded to demarkus-mcp as a stray positional;
+# the trailing "$@" then carries only any args Claude Code appends at launch.
+shift
+
+PLUGIN_HOME="${HOME}/.demarkus"
+SOULS_REGISTRY="${PLUGIN_HOME}/souls"
+MCP_BIN="${PLUGIN_HOME}/bin/demarkus-mcp"
+
+if [[ ! -f "${SOULS_REGISTRY}" ]]; then
+  echo "[demarkus-memory] no soul catalog at ${SOULS_REGISTRY} — re-run /soul-join" >&2
+  exit 1
+fi
+
+# Pull the row for this slug: tab-separated "<slug>\t<host>\t<insecure>\t<token-file>".
+ROW="$(awk -F '\t' -v s="${SLUG}" 'NF && $1 !~ /^#/ && $1 == s { print $2 "\t" $3 "\t" $4; exit }' \
+        "${SOULS_REGISTRY}" 2>/dev/null || true)"
+if [[ -z "${ROW}" ]]; then
+  echo "[demarkus-memory] soul '${SLUG}' not in the catalog — re-run /soul-join" >&2
+  exit 1
+fi
+
+IFS=$'\t' read -r HOST INSECURE TOKEN_FILE <<<"${ROW}"
+if [[ -z "${HOST}" ]]; then
+  echo "[demarkus-memory] catalog row for '${SLUG}' has no host — re-run /soul-join" >&2
+  exit 1
+fi
+
+if [[ ! -x "${MCP_BIN}" ]]; then
+  echo "[demarkus-memory] demarkus-mcp not installed at ${MCP_BIN} — run /soul-init or /soul-join" >&2
+  exit 1
+fi
+
+# Auth: a "-" token-file means a no-auth (read-only/public) soul. Otherwise the
+# file must exist and be non-empty; a present-but-empty file is a setup error
+# worth surfacing rather than silently launching unauthenticated.
+if [[ -n "${TOKEN_FILE}" && "${TOKEN_FILE}" != "-" ]]; then
+  if [[ ! -f "${TOKEN_FILE}" ]]; then
+    echo "[demarkus-memory] token file ${TOKEN_FILE} for '${SLUG}' is missing — re-run /soul-join --token" >&2
+    exit 1
+  fi
+  DEMARKUS_AUTH="$(cat "${TOKEN_FILE}")"
+  if [[ -z "${DEMARKUS_AUTH}" ]]; then
+    echo "[demarkus-memory] token file ${TOKEN_FILE} for '${SLUG}' is empty — re-run /soul-join --token" >&2
+    exit 1
+  fi
+  export DEMARKUS_AUTH
+fi
+
+ARGS=(-host "${HOST}")
+[[ "${INSECURE}" == "1" ]] && ARGS+=(-insecure)
+
+exec "${MCP_BIN}" "${ARGS[@]}" "$@"

--- a/plugins/claude-code/tests/dest-gate_test.sh
+++ b/plugins/claude-code/tests/dest-gate_test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Shell-level tests for hooks/dest-gate.sh — the project→soul destination gate.
+#
+# Each test runs in its own throwaway HOME with a registered remote soul "soul"
+# and a binding /repo → soul, then drives the gate with synthetic PreToolUse
+# payloads and asserts on the decision JSON. Strictness and project dir are
+# forced per-case via env. Pure bash/awk — nothing to install.
+
+# Lib path is computed at runtime (${LIB}); the sourced file is checked on its own.
+# shellcheck disable=SC1090
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+PLUGIN_DIR="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+LIB="${PLUGIN_DIR}/scripts/lib.sh"
+GATE="${PLUGIN_DIR}/hooks/dest-gate.sh"
+
+[[ -f "${LIB}" ]]  || { echo "lib.sh not found at ${LIB}"; exit 2; }
+[[ -x "${GATE}" ]] || { echo "dest-gate.sh not executable at ${GATE}"; exit 2; }
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+run_test() {
+  local name="$1" out rc
+  out=$( "test_${name}" 2>&1 )
+  rc=$?
+  if (( rc == 0 )); then
+    echo "PASS  ${name}"; PASS=$((PASS + 1))
+  else
+    echo "FAIL  ${name}"; printf '%s\n' "${out}" | sed 's/^/      /'
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("${name}")
+  fi
+}
+
+# setup_env — fresh HOME with remote soul "soul" registered + /repo bound to it.
+setup_env() {
+  local t; t="$(mktemp -d)"; export HOME="${t}"
+  . "${LIB}"
+  register_remote_soul "soul" "mark://soul.demarkus.io" 1 "-"
+  bind_project_soul "/repo" "soul"
+}
+
+# run_gate STRICTNESS PROJECT_DIR EVENT TOOL — drive the gate, echo its stdout.
+run_gate() {
+  local strictness="$1" proj="$2" event="$3" tool="$4"
+  local payload
+  payload="$(printf '{"hook_event_name":"%s","tool_name":"%s","tool_input":{"url":"/proj/x.md"}}' "${event}" "${tool}")"
+  printf '%s' "${payload}" \
+    | CLAUDE_PROJECT_DIR="${proj}" DEMARKUS_MEMORY_DEST_STRICTNESS="${strictness}" bash "${GATE}"
+}
+
+LOCAL="mcp__demarkus-memory__mark_publish"
+LOCAL_PREFIXED="mcp__plugin_demarkus-memory_demarkus-memory__mark_publish"
+BOUND="mcp__soul__mark_publish"
+BOUND_APPEND="mcp__soul__mark_append"
+LOCAL_APPEND="mcp__demarkus-memory__mark_append"
+KNOWLEDGE="mcp__knowledge__mark_publish"
+
+# ----- tests ------------------------------------------------------------------
+
+test_correct_destination_defers() {
+  setup_env
+  local out; out="$(run_gate block /repo PreToolUse "${BOUND}")"
+  [[ -z "${out}" ]] || { echo "write to bound soul should defer; got: ${out}"; return 1; }
+}
+
+test_correct_destination_append_defers() {
+  setup_env
+  local out; out="$(run_gate block /repo PreToolUse "${BOUND_APPEND}")"
+  [[ -z "${out}" ]] || { echo "append to bound soul should defer; got: ${out}"; return 1; }
+}
+
+test_misroute_to_local_block_denies() {
+  setup_env
+  local out; out="$(run_gate block /repo PreToolUse "${LOCAL}")"
+  grep -q '"permissionDecision":"deny"' <<<"${out}" || { echo "misroute should deny: ${out}"; return 1; }
+  grep -q "bound to soul 'soul'" <<<"${out}"        || { echo "reason should name the bound soul: ${out}"; return 1; }
+}
+
+test_misroute_prefixed_local_block_denies() {
+  setup_env
+  local out; out="$(run_gate block /repo PreToolUse "${LOCAL_PREFIXED}")"
+  grep -q '"permissionDecision":"deny"' <<<"${out}" || { echo "plugin-prefixed local misroute should deny: ${out}"; return 1; }
+}
+
+test_misroute_append_block_denies() {
+  setup_env
+  local out; out="$(run_gate block /repo PreToolUse "${LOCAL_APPEND}")"
+  grep -q '"permissionDecision":"deny"' <<<"${out}" || { echo "append misroute should deny: ${out}"; return 1; }
+}
+
+test_misroute_ask_escalates() {
+  setup_env
+  local out; out="$(run_gate ask /repo PreToolUse "${LOCAL}")"
+  grep -q '"permissionDecision":"ask"' <<<"${out}" || { echo "ask strictness should escalate: ${out}"; return 1; }
+}
+
+test_misroute_warn_injects_context_no_decision() {
+  setup_env
+  local out; out="$(run_gate warn /repo PreToolUse "${LOCAL}")"
+  grep -q '"additionalContext"' <<<"${out}"  || { echo "warn should inject context: ${out}"; return 1; }
+  grep -q 'permissionDecision' <<<"${out}"    && { echo "warn must not carry a decision: ${out}"; return 1; }
+  return 0
+}
+
+test_no_binding_defers() {
+  setup_env
+  # An unbound project dir → no enforcement, even on a "wrong" soul.
+  local out; out="$(run_gate block /elsewhere PreToolUse "${LOCAL}")"
+  [[ -z "${out}" ]] || { echo "unbound project should defer; got: ${out}"; return 1; }
+}
+
+test_knowledge_target_defers() {
+  setup_env
+  # A knowledge system is not a soul this plugin routes → never gated here.
+  local out; out="$(run_gate block /repo PreToolUse "${KNOWLEDGE}")"
+  [[ -z "${out}" ]] || { echo "knowledge target should defer; got: ${out}"; return 1; }
+}
+
+test_post_event_defers() {
+  setup_env
+  # The gate is PreToolUse-only; a PostToolUse payload must defer.
+  local out; out="$(run_gate block /repo PostToolUse "${LOCAL}")"
+  [[ -z "${out}" ]] || { echo "PostToolUse should defer; got: ${out}"; return 1; }
+}
+
+test_unknown_strictness_falls_back_to_block() {
+  setup_env
+  local out; out="$(run_gate bogus /repo PreToolUse "${LOCAL}")"
+  grep -q '"permissionDecision":"deny"' <<<"${out}" || { echo "unknown strictness should fall back to block (deny): ${out}"; return 1; }
+}
+
+# ----- runner -----------------------------------------------------------------
+
+TESTS=$(declare -F | awk '$3 ~ /^test_/ { print $3 }')
+
+echo "=== dest-gate shell tests ==="
+for t in ${TESTS}; do
+  run_test "${t#test_}"
+done
+
+echo
+echo "${PASS} passed, ${FAIL} failed"
+if (( FAIL > 0 )); then
+  echo "failing tests:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - ${n}"; done
+  exit 1
+fi

--- a/plugins/claude-code/tests/restart-on-upgrade_test.sh
+++ b/plugins/claude-code/tests/restart-on-upgrade_test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Tests for lib.sh restart_local_server_on_upgrade — the "restart the local
+# server with its own config after a binary swap" behavior.
+#
+# ensure_managed_server and pid_of_server_at_root are stubbed AFTER sourcing
+# lib.sh so no real server is spawned and no real process is scanned; the stubs
+# are inherited by the helper's subshell. Each test runs in its own throwaway
+# HOME. Pure bash — nothing to install.
+
+# Lib path is computed at runtime (${LIB}); the sourced file is checked on its
+# own. SC2034: DEMARKUS_BINARIES_REPLACED is set here but read inside lib.sh's
+# restart_local_server_on_upgrade, which shellcheck can't follow across the
+# runtime source.
+# shellcheck disable=SC1090,SC2034
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+PLUGIN_DIR="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+LIB="${PLUGIN_DIR}/scripts/lib.sh"
+[[ -f "${LIB}" ]] || { echo "lib.sh not found at ${LIB}"; exit 2; }
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+run_test() {
+  local name="$1" out rc
+  out=$( "test_${name}" 2>&1 )
+  rc=$?
+  if (( rc == 0 )); then
+    echo "PASS  ${name}"; PASS=$((PASS + 1))
+  else
+    echo "FAIL  ${name}"; printf '%s\n' "${out}" | sed 's/^/      /'
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("${name}")
+  fi
+}
+
+new_home() { local t; t="$(mktemp -d)"; export HOME="${t}"; echo "${t}"; }
+
+# ----- tests ------------------------------------------------------------------
+
+test_noop_when_nothing_replaced() {
+  new_home >/dev/null; . "${LIB}"
+  save_config "${HOME}/.demarkus/soul" 6310 default
+  local mark="${HOME}/called"
+  ensure_managed_server() { echo "$*" >"${mark}"; }
+  DEMARKUS_BINARIES_REPLACED=0
+  restart_local_server_on_upgrade
+  [[ ! -f "${mark}" ]] || { echo "must not restart when no binary was replaced"; return 1; }
+}
+
+test_noop_when_no_config() {
+  new_home >/dev/null; . "${LIB}"   # no save_config → load_config fails
+  local mark="${HOME}/called"
+  ensure_managed_server() { echo "$*" >"${mark}"; }
+  DEMARKUS_BINARIES_REPLACED=1
+  restart_local_server_on_upgrade
+  [[ ! -f "${mark}" ]] || { echo "must not restart when no local soul is configured"; return 1; }
+}
+
+test_managed_restarts_with_recorded_config() {
+  new_home >/dev/null; . "${LIB}"
+  save_config "${HOME}/.demarkus/soul" 6310 default
+  local mark="${HOME}/called"
+  ensure_managed_server() { echo "$*" >"${mark}"; }
+  DEMARKUS_BINARIES_REPLACED=1
+  restart_local_server_on_upgrade
+  [[ -f "${mark}" ]] || { echo "managed server not restarted on upgrade"; return 1; }
+  grep -qF "${HOME}/.demarkus/soul 6310" "${mark}" \
+    || { echo "restarted with wrong config: $(cat "${mark}")"; return 1; }
+}
+
+test_reuse_no_external_process_respawns() {
+  new_home >/dev/null; . "${LIB}"
+  save_config "${HOME}/.demarkus/content" 6309 reuse
+  local mark="${HOME}/called"
+  pid_of_server_at_root() { echo ""; }            # nothing running at root
+  ensure_managed_server() { echo "$*" >"${mark}"; }
+  DEMARKUS_BINARIES_REPLACED=1
+  restart_local_server_on_upgrade
+  [[ -f "${mark}" ]] || { echo "reuse mode should also restart on upgrade"; return 1; }
+  grep -qF "${HOME}/.demarkus/content 6309" "${mark}" \
+    || { echo "reuse restarted with wrong config: $(cat "${mark}")"; return 1; }
+}
+
+test_reuse_stops_external_then_respawns() {
+  new_home >/dev/null; . "${LIB}"
+  save_config "${HOME}/.demarkus/content" 6309 reuse
+  # A stand-in for the user's externally-started server.
+  sleep 30 &
+  local sp=$!
+  pid_of_server_at_root() { echo "${sp}"; }
+  local mark="${HOME}/called"
+  ensure_managed_server() { echo "$*" >"${mark}"; }
+  DEMARKUS_BINARIES_REPLACED=1
+  restart_local_server_on_upgrade
+  # The external process must have been stopped before respawn.
+  local waited=0
+  while (( waited < 20 )) && kill -0 "${sp}" 2>/dev/null; do sleep 0.1; waited=$((waited + 1)); done
+  if kill -0 "${sp}" 2>/dev/null; then
+    kill "${sp}" 2>/dev/null || true
+    echo "external server was not stopped"; return 1
+  fi
+  [[ -f "${mark}" ]] || { echo "respawn not attempted after stopping external server"; return 1; }
+}
+
+# ----- runner -----------------------------------------------------------------
+
+TESTS=$(declare -F | awk '$3 ~ /^test_/ { print $3 }')
+
+echo "=== restart-on-upgrade shell tests ==="
+for t in ${TESTS}; do
+  run_test "${t#test_}"
+done
+
+echo
+echo "${PASS} passed, ${FAIL} failed"
+if (( FAIL > 0 )); then
+  echo "failing tests:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - ${n}"; done
+  exit 1
+fi

--- a/plugins/claude-code/tests/soul-join_test.sh
+++ b/plugins/claude-code/tests/soul-join_test.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Shell-level tests for /soul-join: the lib.sh catalog/binding helpers, the
+# publish-gate scope extension, and scripts/soul-join.sh validation/registration.
+#
+# Each test_* runs in its own throwaway HOME so the real ~/.demarkus is never
+# touched. soul-join.sh is driven with DEMARKUS_SOUL_JOIN_SKIP_BINARIES=1 so it
+# registers offline without the network binary download. Pure bash/awk — nothing
+# to install, nothing to skip.
+
+# The lib path is computed at runtime (${LIB}), so shellcheck can't follow the
+# source. The file it sources (scripts/lib.sh) is checked on its own. File-level
+# directive must precede the first command to apply throughout.
+# shellcheck disable=SC1090
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+PLUGIN_DIR="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+LIB="${PLUGIN_DIR}/scripts/lib.sh"
+JOIN="${PLUGIN_DIR}/scripts/soul-join.sh"
+
+[[ -f "${LIB}" ]]  || { echo "lib.sh not found at ${LIB}"; exit 2; }
+[[ -x "${JOIN}" ]] || { echo "soul-join.sh not executable at ${JOIN}"; exit 2; }
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+run_test() {
+  local name="$1" out rc
+  out=$( "test_${name}" 2>&1 )
+  rc=$?
+  if (( rc == 0 )); then
+    echo "PASS  ${name}"; PASS=$((PASS + 1))
+  else
+    echo "FAIL  ${name}"
+    printf '%s\n' "${out}" | sed 's/^/      /'
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("${name}")
+  fi
+}
+
+# new_home — make a throwaway dir, export it as HOME, echo it. Each test gets a
+# clean ~/.demarkus this way (lib.sh derives PLUGIN_HOME from HOME at source).
+new_home() { local t; t="$(mktemp -d)"; export HOME="${t}"; echo "${t}"; }
+
+# join — run soul-join.sh offline against the current HOME. Echoes its stdout.
+join() { DEMARKUS_SOUL_JOIN_SKIP_BINARIES=1 bash "${JOIN}" "$@"; }
+
+# val KEY OUTPUT — extract the value of a key=value line from join() output.
+val() { printf '%s\n' "$2" | awk -F= -v k="$1" '$1==k{ sub(/^[^=]*=/,""); print; exit }'; }
+
+# file_mode FILE — echo the octal perm bits, portable across macOS/Linux.
+file_mode() { stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1" 2>/dev/null; }
+
+# ----- lib helper tests -------------------------------------------------------
+
+test_register_and_fields_roundtrip() {
+  new_home >/dev/null; . "${LIB}"
+  register_remote_soul "soul" "mark://soul.demarkus.io" 1 "/tok/soul.token" || { echo "register failed"; return 1; }
+  local f; f="$(remote_soul_fields soul)"
+  [[ "${f}" == $'mark://soul.demarkus.io\t1\t/tok/soul.token' ]] || { echo "fields mismatch: ${f}"; return 1; }
+}
+
+test_register_upsert_replaces_row() {
+  new_home >/dev/null; . "${LIB}"
+  register_remote_soul "soul" "mark://old.example" 0 "-"
+  register_remote_soul "soul" "mark://new.example" 1 "/t.token"
+  local n; n="$(list_remote_souls | grep -c '^soul$')"
+  [[ "${n}" -eq 1 ]] || { echo "expected 1 row for slug, got ${n}"; return 1; }
+  local f; f="$(remote_soul_fields soul)"
+  [[ "${f}" == $'mark://new.example\t1\t/t.token' ]] || { echo "upsert did not replace: ${f}"; return 1; }
+}
+
+test_insecure_and_empty_token_normalized() {
+  new_home >/dev/null; . "${LIB}"
+  register_remote_soul "a" "mark://a" "true" ""   # true → 1, ""→ "-"
+  [[ "$(remote_soul_fields a)" == $'mark://a\t1\t-' ]] || { echo "norm A: $(remote_soul_fields a)"; return 1; }
+  register_remote_soul "b" "mark://b" "nonsense" "-"  # garbage → 0
+  [[ "$(remote_soul_fields b)" == $'mark://b\t0\t-' ]] || { echo "norm B: $(remote_soul_fields b)"; return 1; }
+}
+
+test_register_empty_slug_fails() {
+  new_home >/dev/null; . "${LIB}"
+  register_remote_soul "" "mark://x" 0 "-" 2>/dev/null && { echo "empty slug should fail"; return 1; }
+  return 0
+}
+
+test_is_registered_remote_soul() {
+  new_home >/dev/null; . "${LIB}"
+  register_remote_soul "soul" "mark://s" 0 "-"
+  is_registered_remote_soul soul   || { echo "registered slug not found"; return 1; }
+  is_registered_remote_soul nope   && { echo "unregistered slug matched"; return 1; }
+  return 0
+}
+
+test_project_binding_roundtrip_and_upsert() {
+  new_home >/dev/null; . "${LIB}"
+  bind_project_soul "/repo/demarkus" "soul" || { echo "bind failed"; return 1; }
+  [[ "$(project_soul_binding /repo/demarkus)" == "soul" ]] || { echo "binding lookup wrong"; return 1; }
+  bind_project_soul "/repo/demarkus" "other"  # rebind same dir
+  [[ "$(project_soul_binding /repo/demarkus)" == "other" ]] || { echo "rebind did not replace"; return 1; }
+  local n; n="$(awk -F'\t' '$1=="/repo/demarkus"' "${PROJECT_SOULS}" | wc -l | tr -d ' ')"
+  [[ "${n}" -eq 1 ]] || { echo "expected 1 binding row, got ${n}"; return 1; }
+  [[ -z "$(project_soul_binding /repo/unbound)" ]] || { echo "unbound dir should be empty"; return 1; }
+}
+
+test_publish_gate_scope_local_and_remote() {
+  new_home >/dev/null; . "${LIB}"
+  register_remote_soul "soul" "mark://s" 0 "-"
+  [[ "$(publish_gate_scope mcp__demarkus-memory__mark_publish)" == "local" ]] \
+    || { echo "manual local soul not scoped"; return 1; }
+  [[ "$(publish_gate_scope mcp__plugin_demarkus-memory_demarkus-memory__mark_publish)" == "local" ]] \
+    || { echo "plugin-prefixed local soul not scoped"; return 1; }
+  [[ "$(publish_gate_scope mcp__soul__mark_publish)" == "local" ]] \
+    || { echo "registered remote soul not scoped"; return 1; }
+  [[ -z "$(publish_gate_scope mcp__knowledge__mark_publish)" ]] \
+    || { echo "unregistered server must not be scoped"; return 1; }
+}
+
+# ----- soul-join.sh tests -----------------------------------------------------
+
+test_join_bare_host_ok() {
+  new_home >/dev/null
+  local out; out="$(join soul.demarkus.io)"
+  [[ "$(printf '%s\n' "${out}" | head -1)" == "OK" ]] || { echo "no OK: ${out}"; return 1; }
+  [[ "$(val slug "${out}")" == "soul" ]]                       || { echo "slug: ${out}"; return 1; }
+  [[ "$(val host "${out}")" == "mark://soul.demarkus.io" ]]    || { echo "host: ${out}"; return 1; }
+  [[ "$(val insecure "${out}")" == "0" ]]                      || { echo "insecure: ${out}"; return 1; }
+  [[ "$(val token-file "${out}")" == "-" ]]                    || { echo "token-file: ${out}"; return 1; }
+}
+
+test_join_mark_url_with_port_preserved() {
+  new_home >/dev/null
+  local out; out="$(join mark://soul.demarkus.io:6309 --insecure)"
+  [[ "$(val host "${out}")" == "mark://soul.demarkus.io:6309" ]] || { echo "host: ${out}"; return 1; }
+  [[ "$(val slug "${out}")" == "soul" ]]                          || { echo "slug: ${out}"; return 1; }
+  [[ "$(val insecure "${out}")" == "1" ]]                         || { echo "insecure: ${out}"; return 1; }
+}
+
+test_join_token_written_0600() {
+  new_home >/dev/null
+  local out; out="$(join mark://soul.demarkus.io --token SECRET123)"
+  local tf; tf="$(val token-file "${out}")"
+  [[ "${tf}" == "${HOME}/.demarkus/soul-soul.token" ]] || { echo "token-file path: ${tf}"; return 1; }
+  [[ -f "${tf}" ]]                                       || { echo "token file not written"; return 1; }
+  [[ "$(cat "${tf}")" == "SECRET123" ]]                  || { echo "token contents wrong"; return 1; }
+  [[ "$(file_mode "${tf}")" == "600" ]]                  || { echo "token mode not 600: $(file_mode "${tf}")"; return 1; }
+}
+
+test_join_installs_wrapper_to_stable_path() {
+  new_home >/dev/null
+  local out; out="$(join soul.demarkus.io)"
+  local w; w="$(val wrapper "${out}")"
+  [[ "${w}" == "${HOME}/.demarkus/bin/soul-remote-wrapper.sh" ]] || { echo "wrapper path: ${w}"; return 1; }
+  [[ -x "${w}" ]]                                                 || { echo "wrapper not installed/executable"; return 1; }
+}
+
+test_join_binds_project() {
+  local t; t="$(new_home)"
+  local out; out="$(join soul.demarkus.io --bind /repo/demarkus)"
+  [[ "$(printf '%s\n' "${out}" | head -1)" == "OK" ]] || { echo "no OK: ${out}"; return 1; }
+  # Verify via the registry file directly (independent of lib state).
+  grep -qF $'/repo/demarkus\tsoul' "${HOME}/.demarkus/project-souls" \
+    || { echo "binding not recorded: $(cat "${HOME}/.demarkus/project-souls" 2>/dev/null)"; return 1; }
+}
+
+test_join_slug_sanitized() {
+  new_home >/dev/null
+  local out; out="$(join mark://My_Soul.example.com)"
+  [[ "$(val slug "${out}")" == "my-soul" ]] || { echo "slug not sanitized: $(val slug "${out}")"; return 1; }
+}
+
+test_join_https_rejected_points_to_knowledge() {
+  new_home >/dev/null
+  local out; out="$(join https://knowledge.demarkus.io 2>&1 || true)"
+  grep -q '^FAIL:' <<<"${out}"        || { echo "https should FAIL: ${out}"; return 1; }
+  grep -q 'knowledge-join' <<<"${out}" || { echo "should point to /knowledge-join: ${out}"; return 1; }
+}
+
+test_join_reserved_slug_rejected() {
+  new_home >/dev/null
+  # first DNS label "demarkus-memory" → reserved local-soul name → FAIL.
+  local out; out="$(join mark://demarkus-memory.example 2>&1 || true)"
+  grep -q '^FAIL:' <<<"${out}"   || { echo "reserved slug should FAIL: ${out}"; return 1; }
+  grep -q 'reserved' <<<"${out}" || { echo "message should say reserved: ${out}"; return 1; }
+}
+
+test_join_no_host_fails() {
+  new_home >/dev/null
+  local out; out="$(join 2>&1 || true)"
+  grep -q '^FAIL:' <<<"${out}" || { echo "missing host should FAIL: ${out}"; return 1; }
+}
+
+# ----- runner -----------------------------------------------------------------
+
+TESTS=$(declare -F | awk '$3 ~ /^test_/ { print $3 }')
+
+echo "=== soul-join shell tests ==="
+for t in ${TESTS}; do
+  run_test "${t#test_}"
+done
+
+echo
+echo "${PASS} passed, ${FAIL} failed"
+if (( FAIL > 0 )); then
+  echo "failing tests:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - ${n}"; done
+  exit 1
+fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting to remote Claude Code installations with the new `soul-join` command.
  * Introduced multi-soul support with automatic write routing based on project bindings.

* **Documentation**
  * Added comprehensive `soul-join` command documentation with workflow and usage guidelines.
  * Clarified write routing behavior across multiple configured souls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->