### PR TITLE
fix(plugin-memory): never kill a healthy reuse server on binary upgrade

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,8 +9,8 @@
     {
       "name": "demarkus-memory",
       "source": "./plugins/claude-code",
-      "description": "Zero-config local memory for Claude Code. Spawns a local demarkus-server and wires MCP tools for fetch/publish/append/graph/lookup over your own versioned markdown store, and self-documents sessions to it. With a promote destination configured — a joined knowledge system or a registered plain remote demarkus server — /promote lifts ready notes up to it, /promote-scan sweeps for candidates, an ADR publish nudges promotion, and /soul-refresh pulls promoted docs back as they evolve.",
-      "version": "0.9.0",
+      "description": "Zero-config local memory for Claude Code. Spawns a local demarkus-server and wires MCP tools for fetch/publish/append/graph/lookup over your own versioned markdown store, and self-documents sessions to it. /soul-join adds remote souls to a catalog with per-project binding and a destination gate. With a promote destination configured — a joined knowledge system or a registered plain remote demarkus server — /promote lifts ready notes up to it, /promote-scan sweeps for candidates, an ADR publish nudges promotion, and /soul-refresh pulls promoted docs back as they evolve.",
+      "version": "0.10.1",
       "category": "memory",
       "tags": ["memory", "demarkus", "mark-protocol", "local-first"],
       "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/claude-code"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-memory",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Local, versioned memory for Claude Code via demarkus. Zero-config install: spawns a local demarkus-server, auto-generates a token, wires MCP tools for fetch/publish/append/graph/lookup, injects standing guidance so sessions self-document to the soul, and enforces a publish tag-gate so documents stay findable via lookup.",
   "author": {
     "name": "latebit",

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -716,13 +716,17 @@ ensure_binaries() {
 # recorded config (SOUL_DIR/PORT from PLUGIN_CONFIG). No-op when no binary
 # changed or no local soul is configured.
 #
-# Two cases, by ownership:
-#   - OUR managed server (our .pid at the root): ensure_managed_server restarts
-#     it onto the new binary — it's ours to recycle.
-#   - A server we DON'T own (reuse / externally started): never kill a healthy
-#     one. If it's running we leave it alone and warn that it's still on the old
-#     binary (the user restarts it on their terms); only if it's DOWN do we start
-#     it on the new binary with the recorded config.
+# Two cases, by ownership — and ownership is the MODE, not a .pid file:
+#   - default/isolated: the server is ours. ensure_managed_server restarts it
+#     onto the new binary (handling our .pid itself).
+#   - reuse: the server is the user's, ALWAYS. A .pid is not proof of ownership
+#     here — save_config never clears stale state, so a reuse config can carry an
+#     old .pid (left by a prior managed config at this root, or written by our
+#     own down-start below). Keying the managed path on .pid would let
+#     ensure_managed_server stop that PID and kill a healthy external server —
+#     the exact regression this guards against. So reuse never takes the managed
+#     path: a running server is left alone (warn it's on the old binary), and
+#     only a DOWN one is started on the new binary with the recorded config.
 #
 # Runs in a subshell so load_config can't clobber the caller's SOUL_DIR/PORT/MODE,
 # and never fails the caller: a restart problem is warned, not propagated.
@@ -731,14 +735,16 @@ restart_local_server_on_upgrade() {
   (
     load_config 2>/dev/null || exit 0
 
-    # Our own managed server — safe to restart onto the new binary.
-    if [[ -f "${SOUL_DIR}/.pid" ]]; then
+    # Our own managed server — safe to restart onto the new binary. Gated on MODE
+    # (not just .pid) so a stale .pid under a reuse config can't trigger this.
+    if [[ "${MODE}" != "reuse" && -f "${SOUL_DIR}/.pid" ]]; then
       log "binary upgraded — restarting managed server (mode=${MODE}, soul=${SOUL_DIR}, port=${PORT}) on the new binary"
       ensure_managed_server "${SOUL_DIR}" "${PORT}"
       exit 0
     fi
 
-    # No .pid of ours: a reuse / externally-started server, or nothing running.
+    # Reuse mode, or a managed server that's down: a server we must not assume is
+    # ours. Never kill a running one; only start it if it's down.
     local ext_pid
     ext_pid="$(pid_of_server_at_root "${SOUL_DIR}" 2>/dev/null || true)"
     if [[ -n "${ext_pid}" ]]; then

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -712,18 +712,17 @@ ensure_binaries() {
 }
 
 # restart_local_server_on_upgrade — when ensure_binaries swapped the binary this
-# run, restart the configured local server onto the new binary using its OWN
-# recorded config (SOUL_DIR/PORT from PLUGIN_CONFIG), so a binary replacement is
-# never left half-applied (process serving the stale binary from memory). No-op
-# when no binary changed or no local soul is configured.
+# run, make the configured local server run on the new binary, using its OWN
+# recorded config (SOUL_DIR/PORT from PLUGIN_CONFIG). No-op when no binary
+# changed or no local soul is configured.
 #
-# Works for every mode, including reuse: a reuse/externally-started server is not
-# tracked by our .pid, so we stop the process found at the configured root first
-# (freeing the UDP port) before ensure_managed_server respawns it on the new
-# binary. This intentionally relaxes the old "never restart a reuse server"
-# policy — restarting it with the same config is what the user asked for, and an
-# upgraded binary that the running server can't see is the bug it fixes. Managed
-# servers are handled by ensure_managed_server via our own .pid as before.
+# Two cases, by ownership:
+#   - OUR managed server (our .pid at the root): ensure_managed_server restarts
+#     it onto the new binary — it's ours to recycle.
+#   - A server we DON'T own (reuse / externally started): never kill a healthy
+#     one. If it's running we leave it alone and warn that it's still on the old
+#     binary (the user restarts it on their terms); only if it's DOWN do we start
+#     it on the new binary with the recorded config.
 #
 # Runs in a subshell so load_config can't clobber the caller's SOUL_DIR/PORT/MODE,
 # and never fails the caller: a restart problem is warned, not propagated.
@@ -731,25 +730,27 @@ restart_local_server_on_upgrade() {
   [[ "${DEMARKUS_BINARIES_REPLACED:-0}" == "1" ]] || return 0
   (
     load_config 2>/dev/null || exit 0
-    # Stop an externally-started server at this root (reuse, or an orphan whose
-    # .pid we lost) so the respawn can bind the freed port. Skip when our own
-    # .pid exists — ensure_managed_server stops that one itself.
-    if [[ ! -f "${SOUL_DIR}/.pid" ]]; then
-      local ext_pid
-      ext_pid="$(pid_of_server_at_root "${SOUL_DIR}" 2>/dev/null || true)"
-      if [[ -n "${ext_pid}" ]]; then
-        log "binary upgraded — stopping server at ${SOUL_DIR} (pid=${ext_pid}) to restart on the new binary"
-        kill "${ext_pid}" 2>/dev/null || true
-        local waited=0
-        while (( waited < 30 )) && kill -0 "${ext_pid}" 2>/dev/null; do
-          sleep 0.1; waited=$((waited + 1))
-        done
-        kill -0 "${ext_pid}" 2>/dev/null && kill -9 "${ext_pid}" 2>/dev/null || true
-      fi
+
+    # Our own managed server — safe to restart onto the new binary.
+    if [[ -f "${SOUL_DIR}/.pid" ]]; then
+      log "binary upgraded — restarting managed server (mode=${MODE}, soul=${SOUL_DIR}, port=${PORT}) on the new binary"
+      ensure_managed_server "${SOUL_DIR}" "${PORT}"
+      exit 0
     fi
-    log "binary upgraded — restarting local server (mode=${MODE}, soul=${SOUL_DIR}, port=${PORT}) on the new binary"
+
+    # No .pid of ours: a reuse / externally-started server, or nothing running.
+    local ext_pid
+    ext_pid="$(pid_of_server_at_root "${SOUL_DIR}" 2>/dev/null || true)"
+    if [[ -n "${ext_pid}" ]]; then
+      # Healthy and not ours — do not touch it.
+      warn "binary upgraded, but the server at ${SOUL_DIR} (pid=${ext_pid}, mode=${MODE}) is user-managed and still running the old binary; restart it yourself to pick up the new one"
+      exit 0
+    fi
+
+    # Down — start it on the new binary with the recorded config.
+    log "binary upgraded — starting down server (mode=${MODE}, soul=${SOUL_DIR}, port=${PORT}) on the new binary"
     ensure_managed_server "${SOUL_DIR}" "${PORT}"
-  ) || warn "could not restart the local server after a binary upgrade; run /soul-init to recover"
+  ) || warn "could not (re)start the local server after a binary upgrade; run /soul-init to recover"
   return 0
 }
 

--- a/plugins/claude-code/tests/restart-on-upgrade_test.sh
+++ b/plugins/claude-code/tests/restart-on-upgrade_test.sh
@@ -72,6 +72,28 @@ test_managed_restarts_with_recorded_config() {
     || { echo "restarted with wrong config: $(cat "${mark}")"; return 1; }
 }
 
+test_reuse_stale_pid_healthy_left_alone() {
+  new_home >/dev/null; . "${LIB}"
+  save_config "${HOME}/.demarkus/content" 6309 reuse
+  mkdir -p "${HOME}/.demarkus/content"
+  echo 4242 > "${HOME}/.demarkus/content/.pid"   # stale .pid under a reuse config
+  # A healthy external server the plugin does not own.
+  sleep 30 &
+  local sp=$!
+  pid_of_server_at_root() { echo "${sp}"; }
+  local mark="${HOME}/called"
+  ensure_managed_server() { echo "$*" >"${mark}"; }
+  DEMARKUS_BINARIES_REPLACED=1
+  restart_local_server_on_upgrade
+  # The stale .pid must NOT route into the managed-restart path: healthy server
+  # left running, no respawn.
+  local rc=0
+  kill -0 "${sp}" 2>/dev/null || { echo "reuse + stale .pid killed a healthy external server"; rc=1; }
+  [[ -f "${mark}" ]] && { echo "reuse + stale .pid must not restart via ensure_managed_server"; rc=1; }
+  kill "${sp}" 2>/dev/null || true
+  return "${rc}"
+}
+
 test_reuse_no_external_process_respawns() {
   new_home >/dev/null; . "${LIB}"
   save_config "${HOME}/.demarkus/content" 6309 reuse

--- a/plugins/claude-code/tests/restart-on-upgrade_test.sh
+++ b/plugins/claude-code/tests/restart-on-upgrade_test.sh
@@ -61,6 +61,8 @@ test_noop_when_no_config() {
 test_managed_restarts_with_recorded_config() {
   new_home >/dev/null; . "${LIB}"
   save_config "${HOME}/.demarkus/soul" 6310 default
+  mkdir -p "${HOME}/.demarkus/soul"
+  echo 4242 > "${HOME}/.demarkus/soul/.pid"   # our managed server is recorded
   local mark="${HOME}/called"
   ensure_managed_server() { echo "$*" >"${mark}"; }
   DEMARKUS_BINARIES_REPLACED=1
@@ -83,10 +85,10 @@ test_reuse_no_external_process_respawns() {
     || { echo "reuse restarted with wrong config: $(cat "${mark}")"; return 1; }
 }
 
-test_reuse_stops_external_then_respawns() {
+test_reuse_healthy_external_left_alone() {
   new_home >/dev/null; . "${LIB}"
   save_config "${HOME}/.demarkus/content" 6309 reuse
-  # A stand-in for the user's externally-started server.
+  # A stand-in for the user's healthy externally-started server.
   sleep 30 &
   local sp=$!
   pid_of_server_at_root() { echo "${sp}"; }
@@ -94,14 +96,12 @@ test_reuse_stops_external_then_respawns() {
   ensure_managed_server() { echo "$*" >"${mark}"; }
   DEMARKUS_BINARIES_REPLACED=1
   restart_local_server_on_upgrade
-  # The external process must have been stopped before respawn.
-  local waited=0
-  while (( waited < 20 )) && kill -0 "${sp}" 2>/dev/null; do sleep 0.1; waited=$((waited + 1)); done
-  if kill -0 "${sp}" 2>/dev/null; then
-    kill "${sp}" 2>/dev/null || true
-    echo "external server was not stopped"; return 1
-  fi
-  [[ -f "${mark}" ]] || { echo "respawn not attempted after stopping external server"; return 1; }
+  # A healthy server we don't own must NOT be killed and must NOT be respawned.
+  local rc=0
+  kill -0 "${sp}" 2>/dev/null || { echo "healthy external server was killed"; rc=1; }
+  [[ -f "${mark}" ]] && { echo "must not respawn over a healthy external server"; rc=1; }
+  kill "${sp}" 2>/dev/null || true   # cleanup
+  return "${rc}"
 }
 
 # ----- runner -----------------------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped plugin versions to **0.10.1**.

* **Documentation**
  * Updated **soul-join** feature description to clarify remote soul catalog binding and per-project destination gate behavior.

* **Bug Fixes**
  * Improved local server upgrade/restart behavior so existing **external** servers aren’t disrupted; upgrades now restart only when appropriate and otherwise leave healthy external instances running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->