### PR TITLE
feat(plugin-memory): /soul-default sets a project's default soul

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "demarkus-memory",
       "source": "./plugins/claude-code",
       "description": "Zero-config local memory for Claude Code. Spawns a local demarkus-server and wires MCP tools for fetch/publish/append/graph/lookup over your own versioned markdown store, and self-documents sessions to it. /soul-join adds remote souls to a catalog with per-project binding and a destination gate. With a promote destination configured — a joined knowledge system or a registered plain remote demarkus server — /promote lifts ready notes up to it, /promote-scan sweeps for candidates, an ADR publish nudges promotion, and /soul-refresh pulls promoted docs back as they evolve.",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "category": "memory",
       "tags": ["memory", "demarkus", "mark-protocol", "local-first"],
       "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/claude-code"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-memory",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Local, versioned memory for Claude Code via demarkus. Zero-config install: spawns a local demarkus-server, auto-generates a token, wires MCP tools for fetch/publish/append/graph/lookup, injects standing guidance so sessions self-document to the soul, and enforces a publish tag-gate so documents stay findable via lookup.",
   "author": {
     "name": "latebit",

--- a/plugins/claude-code/commands/soul-default.md
+++ b/plugins/claude-code/commands/soul-default.md
@@ -1,0 +1,52 @@
+---
+description: Set this project's default demarkus write target — list the joined-soul catalog, pick one, and save it as the binding the destination gate enforces.
+---
+
+Choose which joined soul **this project writes to by default**. The choice is the
+per-project binding in `~/.demarkus/project-souls`; the destination gate enforces
+it on every `mark_publish` / `mark_append`. This does NOT join a soul or change
+any MCP config — it only re-points an already-joined repo. To add a new soul,
+run `/soul-join` first.
+
+Reads and one-off writes to a *different* joined soul are unaffected: call that
+soul's `mcp__<slug>__mark_*` tools directly. This command only moves the default.
+
+## Steps
+
+1. **List the catalog.** Run:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/soul-default.sh" --list --bind "${CLAUDE_PROJECT_DIR}"
+   ```
+
+   - `EMPTY` → no souls joined. Tell the user to run `/soul-join` (or `/soul-init`
+     for the local managed soul) and stop.
+   - `CATALOG` header → each following line is
+     `<id>\t<tier>\t<host>\t<insecure>\t<current>`. `tier` is `local` (the
+     plugin-managed soul, id `demarkus-memory`) or `remote`. `current` is `*` for
+     the project's existing default.
+
+2. **Ask which soul to make the default** via a single `AskUserQuestion`, one
+   option per catalog row (label = id, description = tier + host). Mark the
+   current default in its description. Do not invent souls not in the list.
+
+3. **Save it.** With the chosen `<slug>`:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/soul-default.sh" --set <slug> --bind "${CLAUDE_PROJECT_DIR}"
+   ```
+
+   - On `OK <slug>`, confirm: "This project now writes to soul **<slug>** by
+     default." If a server was joined mid-session, note that its MCP tools appear
+     only after a restart, but the binding itself is live immediately.
+   - On `FAIL: <message>`, show it verbatim (e.g. an unjoined slug → run
+     `/soul-join` first).
+
+## Don't
+
+- Don't run `claude mcp add/remove` — this command never touches MCP config.
+- Don't read, echo, or store any token.
+- Don't edit `~/.demarkus/project-souls` by hand — the script rewrites only this
+  project's row (awk upsert keyed on the exact directory), preserving the others.
+- Don't use this to join a soul — that's `/soul-join` (remote) or `/soul-init`
+  (local managed).

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -223,9 +223,14 @@ soul_catalog() {
   if local_soul_present; then
     printf 'demarkus-memory\tlocal\t-\t-\n'
   fi
-  [[ -f "${SOULS_REGISTRY}" ]] || return 0
+  # Absent registry → no remotes joined (return 0). But a present-yet-unreadable
+  # registry is an error, not "empty": let it propagate (return 1) instead of
+  # masking a read failure as "no souls" — the CLI's --list would otherwise tell
+  # the user to run /soul-join when the real problem is a permissions fault.
+  [[ -e "${SOULS_REGISTRY}" ]] || return 0
+  [[ -r "${SOULS_REGISTRY}" ]] || return 1
   awk -F '\t' 'NF && $1 !~ /^#/ { print $1 "\tremote\t" $2 "\t" $3 }' \
-    "${SOULS_REGISTRY}" 2>/dev/null || true
+    "${SOULS_REGISTRY}"
 }
 
 # is_catalog_soul SLUG — true when SLUG is a bindable write target: the local

--- a/plugins/claude-code/scripts/lib.sh
+++ b/plugins/claude-code/scripts/lib.sh
@@ -204,6 +204,41 @@ is_registered_remote_soul() {
   list_remote_souls | grep -qxF "${slug}"
 }
 
+# local_soul_present — true when the local plugin-managed soul is configured
+# (PLUGIN_CONFIG exists). Its canonical catalog id / binding slug is the reserved
+# name "demarkus-memory" (what soul_target_id echoes for the local server).
+local_soul_present() {
+  [[ -f "${PLUGIN_CONFIG}" ]]
+}
+
+# soul_catalog — emit one row per soul this plugin routes, tab-separated
+# "<id>\t<tier>\t<host>\t<insecure>", local first then remotes:
+#   - local managed soul (when configured): "demarkus-memory\tlocal\t-\t-"
+#   - each remote soul (from SOULS_REGISTRY): "<slug>\tremote\t<host>\t<insecure>"
+# The <id> column is exactly the slug a project binding stores and the dest-gate
+# compares against (see soul_target_id). Empty when nothing is joined. This is
+# the union promised by the SOULS_REGISTRY header comment — the single place that
+# knows the full set of bindable write targets.
+soul_catalog() {
+  if local_soul_present; then
+    printf 'demarkus-memory\tlocal\t-\t-\n'
+  fi
+  [[ -f "${SOULS_REGISTRY}" ]] || return 0
+  awk -F '\t' 'NF && $1 !~ /^#/ { print $1 "\tremote\t" $2 "\t" $3 }' \
+    "${SOULS_REGISTRY}" 2>/dev/null || true
+}
+
+# is_catalog_soul SLUG — true when SLUG is a bindable write target: the local
+# managed soul's reserved id, or a registered remote slug. The validation a
+# default-binding change runs before it touches PROJECT_SOULS, so a binding can
+# never point at a soul that was never joined.
+is_catalog_soul() {
+  local slug="$1"
+  [[ -n "${slug}" ]] || return 1
+  [[ "${slug}" == "demarkus-memory" ]] && { local_soul_present; return; }
+  is_registered_remote_soul "${slug}"
+}
+
 # bind_project_soul DIR SLUG — record that repo DIR writes to catalog soul SLUG
 # by default. Idempotent upsert keyed on DIR. Returns non-zero on empty input.
 bind_project_soul() {

--- a/plugins/claude-code/scripts/soul-default.sh
+++ b/plugins/claude-code/scripts/soul-default.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# /soul-default script half. Lists the joined-soul catalog for selection and
+# records the chosen soul as THIS project's default write target — the binding in
+# ~/.demarkus/project-souls that the destination gate enforces. Unlike
+# /soul-join, it joins nothing and touches no MCP config or token: it only
+# re-points an already-joined repo at a different default. The command-side
+# prompt parses the line-oriented output; do not change the output shape without
+# updating commands/soul-default.md.
+#
+# Usage:
+#   soul-default.sh --list --bind DIR        # enumerate the catalog for selection
+#   soul-default.sh --set SLUG --bind DIR    # save SLUG as DIR's default target
+#
+# --list output (stdout):
+#   CATALOG                       (header) — or EMPTY when nothing is joined
+#   <id>\t<tier>\t<host>\t<insecure>\t<current>   (one row per soul)
+# where <current> is "*" for DIR's existing default, else "-".
+# --set output (stdout): "OK <slug>" on success, "FAIL: <message>" on failure.
+# Exit 0 on success; non-zero on validation failure. Reads/echoes no token.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# shellcheck source=./lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+# fail emits the operator-readable error on stdout (so the slash command shows it
+# verbatim) AND on stderr (so a human running the script directly sees it).
+fail() {
+  local msg="$1"
+  echo "FAIL: ${msg}"
+  echo "[demarkus-memory] error: ${msg}" >&2
+  exit 1
+}
+
+MODE=""
+SLUG=""
+BIND_DIR=""
+
+while (( $# )); do
+  case "$1" in
+    --list) [[ -z "${MODE}" ]] || fail "choose one of --list / --set"; MODE="list"; shift ;;
+    --set)  [[ -z "${MODE}" ]] || fail "choose one of --list / --set"
+            [[ -n "${2:-}" ]] || fail "--set requires a soul slug"; MODE="set"; SLUG="$2"; shift 2 ;;
+    --bind) [[ -n "${2:-}" ]] || fail "--bind requires a directory"; BIND_DIR="$2"; shift 2 ;;
+    -*)     fail "unknown option: $1" ;;
+    *)      fail "unexpected argument: $1" ;;
+  esac
+done
+
+[[ -n "${MODE}" ]]     || fail "usage: soul-default.sh (--list | --set SLUG) --bind DIR"
+[[ -n "${BIND_DIR}" ]] || fail "--bind DIR is required (the project directory to set the default for)"
+
+current="$(project_soul_binding "${BIND_DIR}")"
+
+case "${MODE}" in
+  list)
+    catalog="$(soul_catalog)"
+    if [[ -z "${catalog}" ]]; then
+      echo "EMPTY"
+      exit 0
+    fi
+    echo "CATALOG"
+    # Append the current-default marker column so the command can pre-tick the row.
+    printf '%s\n' "${catalog}" | awk -F '\t' -v cur="${current}" \
+      '{ print $0 "\t" ($1 == cur ? "*" : "-") }'
+    ;;
+  set)
+    is_catalog_soul "${SLUG}" \
+      || fail "'${SLUG}' is not a joined soul — run /soul-join first (see /soul-default --list for the catalog)"
+    bind_project_soul "${BIND_DIR}" "${SLUG}" \
+      || fail "could not write the binding for ${BIND_DIR}"
+    echo "OK ${SLUG}"
+    ;;
+esac

--- a/plugins/claude-code/scripts/soul-default.sh
+++ b/plugins/claude-code/scripts/soul-default.sh
@@ -41,7 +41,11 @@ while (( $# )); do
   case "$1" in
     --list) [[ -z "${MODE}" ]] || fail "choose one of --list / --set"; MODE="list"; shift ;;
     --set)  [[ -z "${MODE}" ]] || fail "choose one of --list / --set"
-            [[ -n "${2:-}" ]] || fail "--set requires a soul slug"; MODE="set"; SLUG="$2"; shift 2 ;;
+            # A slug is sanitized [a-z0-9-] and never leads with '-', so a
+            # dash-prefixed value is a misplaced flag (e.g. `--set --bind X`),
+            # not a slug — reject it directly instead of a misleading later error.
+            [[ -n "${2:-}" && "${2}" != -* ]] || fail "--set requires a soul slug"
+            MODE="set"; SLUG="$2"; shift 2 ;;
     --bind) [[ -n "${2:-}" ]] || fail "--bind requires a directory"; BIND_DIR="$2"; shift 2 ;;
     -*)     fail "unknown option: $1" ;;
     *)      fail "unexpected argument: $1" ;;

--- a/plugins/claude-code/tests/soul-default_test.sh
+++ b/plugins/claude-code/tests/soul-default_test.sh
@@ -109,6 +109,22 @@ test_set_binds_and_upserts() {
   [[ "${n}" -eq 1 ]] || { echo "expected 1 binding row, got ${n}"; return 1; }
 }
 
+test_set_local_when_configured() {
+  new_home >/dev/null; . "${LIB}"
+  seed_local
+  [[ "$(def --set demarkus-memory --bind /repo/x)" == "OK demarkus-memory" ]] \
+    || { echo "set local failed"; return 1; }
+  [[ "$(project_soul_binding /repo/x)" == "demarkus-memory" ]] \
+    || { echo "local binding not applied"; return 1; }
+}
+
+test_set_rejects_flaglike_slug() {
+  new_home >/dev/null
+  local out; out="$(def --set --bind /repo/x 2>&1 || true)"
+  grep -q '^FAIL:' <<<"${out}"               || { echo "flag-like slug should FAIL: ${out}"; return 1; }
+  grep -q 'requires a soul slug' <<<"${out}" || { echo "wrong message: ${out}"; return 1; }
+}
+
 test_set_unjoined_fails() {
   new_home >/dev/null
   local out; out="$(def --set ghost --bind /repo/x 2>&1 || true)"

--- a/plugins/claude-code/tests/soul-default_test.sh
+++ b/plugins/claude-code/tests/soul-default_test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Shell-level tests for /soul-default: the lib.sh catalog helpers (soul_catalog,
+# is_catalog_soul, local_soul_present) and scripts/soul-default.sh list/set.
+#
+# Each test_* runs in its own throwaway HOME so the real ~/.demarkus is never
+# touched. Pure bash/awk — nothing to install, nothing to skip.
+
+# shellcheck disable=SC1090
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+PLUGIN_DIR="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+LIB="${PLUGIN_DIR}/scripts/lib.sh"
+DEF="${PLUGIN_DIR}/scripts/soul-default.sh"
+
+[[ -f "${LIB}" ]]  || { echo "lib.sh not found at ${LIB}"; exit 2; }
+[[ -x "${DEF}" ]]  || { echo "soul-default.sh not executable at ${DEF}"; exit 2; }
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+run_test() {
+  local name="$1" out rc
+  out=$( "test_${name}" 2>&1 )
+  rc=$?
+  if (( rc == 0 )); then
+    echo "PASS  ${name}"; PASS=$((PASS + 1))
+  else
+    echo "FAIL  ${name}"
+    printf '%s\n' "${out}" | sed 's/^/      /'
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("${name}")
+  fi
+}
+
+new_home() { local t; t="$(mktemp -d)"; export HOME="${t}"; echo "${t}"; }
+
+# def — run soul-default.sh against the current HOME. Echoes stdout.
+def() { bash "${DEF}" "$@"; }
+
+# seed_local — make the local managed soul "present" by writing a minimal conf.
+seed_local() { mkdir -p "${HOME}/.demarkus"; printf 'SOUL_DIR=/x\nPORT=6309\nMODE=reuse\n' > "${HOME}/.demarkus/plugin-memory.conf"; }
+
+# ----- lib helper tests -------------------------------------------------------
+
+test_catalog_unions_local_and_remote() {
+  new_home >/dev/null; . "${LIB}"
+  seed_local
+  register_remote_soul "soul" "mark://soul.demarkus.io" 1 "-"
+  local out; out="$(soul_catalog)"
+  [[ "$(printf '%s\n' "${out}" | head -1)" == $'demarkus-memory\tlocal\t-\t-' ]] \
+    || { echo "local row wrong / not first: ${out}"; return 1; }
+  printf '%s\n' "${out}" | grep -qF $'soul\tremote\tmark://soul.demarkus.io\t1' \
+    || { echo "remote row missing: ${out}"; return 1; }
+}
+
+test_catalog_empty_when_nothing_joined() {
+  new_home >/dev/null; . "${LIB}"
+  [[ -z "$(soul_catalog)" ]] || { echo "expected empty catalog"; return 1; }
+}
+
+test_catalog_remote_only_when_no_local() {
+  new_home >/dev/null; . "${LIB}"
+  register_remote_soul "soul" "mark://s" 0 "-"
+  local out; out="$(soul_catalog)"
+  printf '%s\n' "${out}" | grep -q 'demarkus-memory' && { echo "local row should be absent: ${out}"; return 1; }
+  return 0
+}
+
+test_is_catalog_soul() {
+  new_home >/dev/null; . "${LIB}"
+  register_remote_soul "soul" "mark://s" 0 "-"
+  is_catalog_soul soul             || { echo "remote slug not accepted"; return 1; }
+  is_catalog_soul demarkus-memory  && { echo "local accepted with no conf"; return 1; }
+  seed_local
+  is_catalog_soul demarkus-memory  || { echo "local not accepted with conf"; return 1; }
+  is_catalog_soul nope             && { echo "unjoined slug accepted"; return 1; }
+  return 0
+}
+
+# ----- soul-default.sh tests --------------------------------------------------
+
+test_list_empty() {
+  new_home >/dev/null
+  local out; out="$(def --list --bind /repo/x)"
+  [[ "${out}" == "EMPTY" ]] || { echo "expected EMPTY, got: ${out}"; return 1; }
+}
+
+test_list_marks_current() {
+  new_home >/dev/null; . "${LIB}"
+  register_remote_soul "soul" "mark://s" 0 "-"
+  register_remote_soul "hub"  "mark://h" 0 "-"
+  bind_project_soul /repo/x soul
+  local out; out="$(def --list --bind /repo/x)"
+  [[ "$(printf '%s\n' "${out}" | head -1)" == "CATALOG" ]] || { echo "no CATALOG header: ${out}"; return 1; }
+  printf '%s\n' "${out}" | grep -qF $'soul\tremote\tmark://s\t0\t*' || { echo "current not marked: ${out}"; return 1; }
+  printf '%s\n' "${out}" | grep -qF $'hub\tremote\tmark://h\t0\t-'  || { echo "non-current marked: ${out}"; return 1; }
+}
+
+test_set_binds_and_upserts() {
+  new_home >/dev/null; . "${LIB}"
+  register_remote_soul "soul" "mark://s" 0 "-"
+  register_remote_soul "hub"  "mark://h" 0 "-"
+  [[ "$(def --set soul --bind /repo/x)" == "OK soul" ]] || { echo "set soul failed"; return 1; }
+  [[ "$(project_soul_binding /repo/x)" == "soul" ]]     || { echo "binding not soul"; return 1; }
+  [[ "$(def --set hub --bind /repo/x)" == "OK hub" ]]   || { echo "rebind failed"; return 1; }
+  [[ "$(project_soul_binding /repo/x)" == "hub" ]]      || { echo "rebind not applied"; return 1; }
+  local n; n="$(awk -F'\t' '$1=="/repo/x"' "${HOME}/.demarkus/project-souls" | wc -l | tr -d ' ')"
+  [[ "${n}" -eq 1 ]] || { echo "expected 1 binding row, got ${n}"; return 1; }
+}
+
+test_set_unjoined_fails() {
+  new_home >/dev/null
+  local out; out="$(def --set ghost --bind /repo/x 2>&1 || true)"
+  grep -q '^FAIL:' <<<"${out}"        || { echo "unjoined slug should FAIL: ${out}"; return 1; }
+  grep -q 'soul-join' <<<"${out}"     || { echo "should point to /soul-join: ${out}"; return 1; }
+}
+
+test_requires_bind() {
+  new_home >/dev/null
+  local out; out="$(def --list 2>&1 || true)"
+  grep -q '^FAIL:' <<<"${out}" || { echo "missing --bind should FAIL: ${out}"; return 1; }
+}
+
+test_other_project_rows_preserved() {
+  new_home >/dev/null; . "${LIB}"
+  register_remote_soul "soul" "mark://s" 0 "-"
+  bind_project_soul /repo/other soul
+  def --set soul --bind /repo/x >/dev/null
+  [[ "$(project_soul_binding /repo/other)" == "soul" ]] || { echo "other project row clobbered"; return 1; }
+}
+
+# ----- runner -----------------------------------------------------------------
+
+TESTS=$(declare -F | awk '$3 ~ /^test_/ { print $3 }')
+
+echo "=== soul-default shell tests ==="
+for t in ${TESTS}; do
+  run_test "${t#test_}"
+done
+
+echo
+echo "${PASS} passed, ${FAIL} failed"
+if (( FAIL > 0 )); then
+  echo "failing tests:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - ${n}"; done
+  exit 1
+fi


### PR DESCRIPTION
…hout re-joining

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new command to view and set your project’s default soul binding using a catalog of available bindable destinations (with interactive selection and confirmation).
* **Bug Fixes**
  * Improved catalog validation so only valid destinations are accepted for setting as default.
* **Documentation**
  * Documented the new command, including expected output and supported constraints.
* **Tests**
  * Added comprehensive automated coverage for catalog behavior and default binding set/list scenarios.
* **Chores**
  * Bumped the marketplace plugin version to 0.11.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->