### PR TITLE
chore(docs): ofk updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For more examples (tokens, publishing, editing), see [full usage guide](https://
 | `demarkus-server` | QUIC server with versioned document store, capability-based auth |
 | `demarkus-token` | Generate and manage write tokens |
 | `demarkus-publish` | Direct-to-store writer for read-only server installs (chroot/RO mode) |
-| `demarkus` | CLI tool for all protocol operations (fetch, publish, append, graph, etc.) |
+| `demarkus` | CLI tool for all protocol operations (fetch, publish, append, graph, okf, etc.) |
 | `demarkus-tui` | Terminal browser: markdown rendering, link navigation, persistent graph |
 | `demarkus-mcp` | MCP server for LLM agents (protocol verbs + graph crawling, backlinks, indexing) |
 
@@ -69,6 +69,8 @@ modified: 2026-01-15T10:30:00Z
 ```
 
 **Verbs**: `FETCH` · `LIST` · `VERSIONS` · `LOOKUP` · `PUBLISH` · `APPEND` · `ARCHIVE`
+
+**Open Knowledge Format**: A demarkus document is content-compatible with [Google's Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog) — recognized OKF fields (`type`, `title`, `description`, `resource`, `tags`, `timestamp`) are stored as plain frontmatter, and the server types every document by default. At the system level demarkus is a superset, layering versioning, hash-chain integrity, QUIC transport, and capability auth around an OKF-compatible document. The `demarkus okf` subcommand validates, imports, and exports OKF bundles. See [SPEC §14](docs/SPEC.md).
 
 ## Use Cases
 

--- a/docs/site/architecture/index.md
+++ b/docs/site/architecture/index.md
@@ -129,6 +129,15 @@ Backlinks ("what documents link here?") are derived from the stored graph with n
 
 The graph itself is exportable as a publishable markdown document containing `mark://` links. `mark_graph_export` renders the graph; `mark_graph_publish` exports and publishes in one step. Other agents can crawl the published graph document to discover the topology without recrawling the original servers — enabling multi-agent discovery where agents share and merge knowledge maps.
 
+## Open Knowledge Format (OKF) Compatibility
+
+Demarkus aligns its document content model with [Google's Open Knowledge Format v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog). The compatibility is deliberately scoped to two layers:
+
+- **Document level — compatible.** A stored document's persisted metadata uses OKF field names for the recognized fields (`type`, `title`, `description`, `resource`, `tags`, `timestamp`), with non-spec keys namespaced under `meta.*` and store-operational fields (`version`, `previous-hash`, `archived`) reserved by name. The server assigns a default `type: Document` on PUBLISH and APPEND when none is declared, so every concept is OKF-typed by construction.
+- **System level — superset.** Demarkus layers immutable versioning, a SHA-256 hash chain, QUIC transport, capability-based auth, and LOOKUP discovery on top of an OKF-compatible document. It is *not* an OKF bundle server: frontmatter is stripped before serving and the `versions/` layout is not a bundle tree.
+
+Bundle interoperability is therefore an out-of-band codec, not a wire feature. The `demarkus okf` subcommand (`client/internal/okf`) round-trips bundles — `validate` (v0.1 conformance), `import` (bundle → world), `export` (world subtree → conformant bundle) — with verified byte-identical body round-trips. See [SPEC §14](../../SPEC.md) and ADRs 0002 (metadata alignment) and 0003 (default type).
+
 ## Deployment Topology
 
 A typical deployment looks like this:

--- a/docs/site/client/index.md
+++ b/docs/site/client/index.md
@@ -12,7 +12,7 @@ If you're new, start with the CLI and confirm you can fetch a document.
 
 ## CLI (`demarkus`)
 
-The CLI supports the read/write verbs (`FETCH`, `LIST`, `VERSIONS`, `PUBLISH`, `APPEND`, `ARCHIVE`) plus `edit`, `graph`, and `lookup` subcommands.
+The CLI supports the read/write verbs (`FETCH`, `LIST`, `VERSIONS`, `PUBLISH`, `APPEND`, `ARCHIVE`) plus `edit`, `graph`, `lookup`, and `okf` subcommands.
 
 ### Common commands
 
@@ -52,6 +52,25 @@ demarkus graph --insecure -depth 3 mark://localhost:6309/index.md
 ```
 
 Graph results are persisted to `~/.mark/graph.json` and accumulate across sessions. Each crawl merges new nodes and edges into the existing graph, so your map of the `mark://` network grows over time.
+
+### Open Knowledge Format codec
+
+`demarkus okf` interoperates with [Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog) bundles — directories of markdown files with YAML frontmatter. A demarkus document is content-compatible with OKF; the codec moves whole bundles in and out of a world.
+
+```bash
+# Validate a bundle for OKF v0.1 conformance
+demarkus okf validate ./my-bundle
+demarkus okf validate --strict ./my-bundle   # warnings become failures
+
+# Import a bundle into a world (sanitizes/caps metadata, rewrites links)
+demarkus okf import ./my-bundle mark://localhost:6309/imported
+demarkus okf import --dry-run ./my-bundle mark://localhost:6309/imported
+
+# Export a world subtree back out as a conformant bundle
+demarkus okf export mark://localhost:6309/imported ./exported
+```
+
+`import`/`export` accept `-auth <token>` and `--insecure` like the other write commands. Import is an upsert: re-importing an unchanged bundle creates no new versions (content-hash dedup). See [Markdown Reference → OKF compatibility](../reference/markdown.md#open-knowledge-format-okf-compatibility).
 
 ## TUI (`demarkus-tui`)
 

--- a/docs/site/reference/index.md
+++ b/docs/site/reference/index.md
@@ -87,6 +87,7 @@ For per-server tokens, use `demarkus token add mark://host:6309 <token>` before 
 ## Authoring
 
 - [Supported Markdown Features](markdown.md) — what the TUI renders and what the link graph tracks
+- [Open Knowledge Format compatibility](markdown.md#open-knowledge-format-okf-compatibility) — OKF field mapping, default `type`, and the `demarkus okf` validate/import/export codec
 
 ## Protocol
 

--- a/docs/site/reference/markdown.md
+++ b/docs/site/reference/markdown.md
@@ -60,19 +60,29 @@ The server persists each version with its own YAML frontmatter block prepended t
 version: 3
 archived: false
 previous-hash: sha256-abc123…
+type: Document
+title: Architecture Notes
+tags: [architecture, notes]
 meta.author: Fritz
-meta.tags: architecture,notes
 ---
 <your body here>
 ```
 
-Reserved keys: `version`, `previous-hash`, `archived`, plus any `meta.*` keys supplied by the publisher. The handler strips this block before returning the body to clients, so you never see it when you FETCH.
+The block mixes three kinds of keys:
+
+- **Operational** (`version`, `previous-hash`, `archived`) — owned by the store. They are reserved: a publisher that tries to set them is rejected.
+- **Open Knowledge Format fields** (`type`, `title`, `description`, `resource`, `tags`, `timestamp`) — stored *bare* under their OKF names, so a demarkus document is content-compatible with [OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog). `tags` is written as a YAML flow list.
+- **Other publisher metadata** — namespaced under `meta.*` to keep it clear of the reserved and OKF names.
+
+The handler strips this whole block before returning the body to clients, so you never see it when you FETCH.
 
 ### Publisher metadata
 
-To attach structured metadata to a document, pass it as request metadata on `PUBLISH` — **not** by writing YAML inside the body. The server records it under `meta.*` in the on-disk frontmatter and surfaces it in response metadata on FETCH.
+To attach structured metadata to a document, pass it as request metadata on `PUBLISH` — **not** by writing YAML inside the body. Recognized OKF fields (`type`, `title`, `description`, `resource`, `tags`, `timestamp`) are stored bare; every other key is namespaced under `meta.*`. All of it is surfaced in response metadata on FETCH.
 
-Limits: up to 10 keys totaling 512 bytes.
+If you don't declare a `type`, the server assigns `type: Document` on PUBLISH and APPEND, so every stored document is a typed OKF concept (the reserved `index.md` and `log.md` are exempt).
+
+Limits: up to 50 keys totaling 1024 bytes (`tags` counted at its serialized list length).
 
 ### Response fields (computed, not stored)
 
@@ -81,6 +91,18 @@ On FETCH, the server returns `modified`, `etag`, and `content-hash` as protocol 
 ### If you write `---` at the top of your body
 
 It's treated as body content — the server does not parse it and does not strip it. Glamour will render `---` as a horizontal rule, so an in-body frontmatter block shows up as two horizontal rules with text between them. Use publisher metadata instead.
+
+## Open Knowledge Format (OKF) compatibility
+
+A single demarkus document is content-compatible with [Google's Open Knowledge Format v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog): the recognized OKF fields are stored under their OKF names (see above), and the server assigns a default `type` so every document is a typed OKF concept.
+
+This is a **document-level** guarantee. At the system level demarkus is a superset — it layers versioning, a SHA-256 hash chain, QUIC transport, capability auth, and LOOKUP around an OKF-compatible document. Demarkus does **not** serve or ingest OKF *bundles* over the wire (frontmatter is stripped before serving, and the `versions/` store is not a bundle tree). Bundle interop is handled out of band by the `demarkus okf` codec:
+
+- `demarkus okf validate <bundle-dir>` — check a directory of markdown files for OKF v0.1 conformance.
+- `demarkus okf import <bundle-dir> mark://host/prefix` — publish an OKF bundle into a demarkus world (sanitizes/caps metadata with warnings, rewrites bundle-absolute links).
+- `demarkus okf export mark://host/prefix <out-dir>` — write a demarkus world subtree back out as a conformant OKF bundle.
+
+See [SPEC §14](../../SPEC.md) for the full field mapping and conformance details.
 
 ## What is not supported
 
@@ -113,8 +135,8 @@ If you want a link to appear in the graph, use `[text](url)` or a reference link
 ## Document size
 
 - Body: up to 1 MiB (`MaxBodyLength = 1048576` bytes)
-- Frontmatter: up to 1 KiB of protocol overhead on disk per version
-- Publisher metadata keys: up to 10 keys, 512 bytes total
+- Publisher metadata: up to 50 keys, 1024 bytes total (`tags` counted at its serialized list length)
+- Stored frontmatter: up to 2 KiB on disk per version (publisher metadata plus the store's own operational fields)
 
 ## Why so minimal?
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Open Knowledge Format (OKF) v0.1 compatibility at the document level.
  * Introduced `demarkus okf` CLI subcommand for validating, importing, and exporting OKF bundles with byte-identical body behavior.
  * OKF fields are now automatically mapped to document frontmatter; unrecognized fields are namespaced under `meta.*`.

* **Documentation**
  * Updated docs with OKF compatibility details, including field mapping, CLI workflows, and conformance references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->