### PR TITLE
feat(plugins): require_fields gate for OKF type

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "demarkus-knowledge",
       "source": "./plugins/claude-code-knowledge",
       "description": "Join an organizational demarkus knowledge system from Claude Code — a shared, broker-fronted, versioned markdown catalog. Steers sessions to the shared catalog first, makes it easy to navigate, enforces a publish tag-gate, and curates promoted notes into it via the knowledge-promote cascade. No local server or binaries.",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "category": "memory",
       "tags": ["memory", "knowledge-base", "demarkus", "mark-protocol", "broker", "team"],
       "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/claude-code-knowledge"

--- a/plugins/claude-code-knowledge/.claude-plugin/plugin.json
+++ b/plugins/claude-code-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-knowledge",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Join an organizational demarkus knowledge system (a broker-fronted, shared, versioned markdown catalog) from Claude Code. Validates and registers the broker as an MCP server, steers sessions to consult the shared catalog first, makes it easy to navigate, and enforces a publish tag-gate so shared documents stay findable. No local server, no binaries — pure broker + OAuth.",
   "author": {
     "name": "latebit",

--- a/plugins/claude-code-knowledge/commands/knowledge-join.md
+++ b/plugins/claude-code-knowledge/commands/knowledge-join.md
@@ -76,6 +76,14 @@ If the user invokes without an argument, ask them for the URL before running any
 
        Each axis is then satisfied by an `axis:value` tag (e.g. `category:project`).
 
+     - If it declares a `require_fields:` line (OKF metadata *fields* every doc must carry, e.g. `type` — the document kind), mirror them so the gate presence-checks them:
+
+       ```bash
+       printf '%s\n' "<fields from policy.md, e.g. type>" > ~/.demarkus/plugin-knowledge.require-fields.<slug>
+       ```
+
+       Each field is then satisfied by a non-empty `metadata.<field>` on publish (e.g. `metadata.type="Reference"`). Distinct from `require_tags:` — a field is its own metadata key, not an `axis:value` tag. Only `type` is enforced today.
+
    If either document is `not-found`, the system simply hasn't declared that convention yet — skip silently. See `${CLAUDE_PLUGIN_ROOT}/examples/knowledge-system/` for the format an admin publishes.
 
 6. **Confirm success.** Tell the user, in plain language:

--- a/plugins/claude-code-knowledge/hooks/publish-gate.sh
+++ b/plugins/claude-code-knowledge/hooks/publish-gate.sh
@@ -40,6 +40,7 @@ tags_ok="$(sed -n '3p' <<<"${parsed}")"
 imp_ok="$(sed -n '4p' <<<"${parsed}")"
 url="$(sed -n '5p' <<<"${parsed}")"
 tags_value="$(sed -n '6p' <<<"${parsed}")"
+type_value="$(sed -n '7p' <<<"${parsed}")"
 
 # Defensive scope: the matcher is broad (mcp__.*__mark_publish), so a stray
 # non-publish tool must not be acted on.
@@ -74,8 +75,23 @@ if [[ "${tags_ok}" == "1" ]]; then
   set +f
 fi
 
-# Properly tagged + valid importance + all required axes present → nothing to do.
-[[ "${tags_ok}" == "1" && "${imp_ok}" == "1" && -z "${missing_axes}" ]] && exit 0
+# Required OKF metadata fields (policy require_fields:, mirrored locally). A
+# field is satisfied by a non-empty metadata.<field>. Only `type` is inspected
+# today; any other declared field is skipped fail-open — the gate can't see it
+# and must never block on what it can't verify.
+missing_fields=""
+required_fields="$(configured_require_fields "${strict_slug}")"
+set -f
+for field in ${required_fields}; do
+  case "${field}" in
+    type) [[ -n "${type_value}" ]] || missing_fields="${missing_fields:+${missing_fields} }type" ;;
+    *)    warn "publish gate: unsupported require_field '${field}' (only 'type' is checked); skipping" ;;
+  esac
+done
+set +f
+
+# Properly tagged + valid importance + all required axes + all required fields → nothing to do.
+[[ "${tags_ok}" == "1" && "${imp_ok}" == "1" && -z "${missing_axes}" && -z "${missing_fields}" ]] && exit 0
 
 target="${url:-the document}"
 problems=""
@@ -87,6 +103,10 @@ fi
 if [[ -n "${missing_axes}" ]]; then
   [[ -n "${problems}" ]] && problems="${problems}; "
   problems="${problems}missing required tag axes for this knowledge system: ${missing_axes} (tag as \"axis:value\", e.g. ${missing_axes%% *}:<value>)"
+fi
+if [[ -n "${missing_fields}" ]]; then
+  [[ -n "${problems}" ]] && problems="${problems}; "
+  problems="${problems}missing required OKF metadata fields: ${missing_fields} (set metadata.${missing_fields%% *}, e.g. metadata.type=\"Reference\")"
 fi
 reason="demarkus publish to ${target} (knowledge system '${strict_slug}') has ${problems}. Re-issue mark_publish with a metadata object: tags (comma-separated subjects derived from the content) and, if set, importance in [0,1]. Tags are what make this document findable via mark_lookup across the shared catalog."
 

--- a/plugins/claude-code-knowledge/scripts/lib.sh
+++ b/plugins/claude-code-knowledge/scripts/lib.sh
@@ -39,6 +39,15 @@ readonly PLUGIN_STRICTNESS_FILE="${PLUGIN_HOME}/plugin-knowledge.strictness"
 # presence-checks each axis.
 readonly PLUGIN_REQUIRE_TAGS_FILE="${PLUGIN_HOME}/plugin-knowledge.require-tags"
 
+# Required OKF metadata FIELDS a knowledge system declares in its policy
+# (`require_fields:`, e.g. `type` — the document kind). Distinct from
+# require_tags: a field is satisfied by a non-empty `metadata.<field>`, not by
+# an "axis:value" token in the tags. The agent mirrors require_fields into
+# PLUGIN_REQUIRE_FIELDS_FILE.<slug>; the gate presence-checks each. Only `type`
+# is inspected today (the parser captures metadata.type); any other declared
+# field is skipped fail-open — the gate must never block on what it can't see.
+readonly PLUGIN_REQUIRE_FIELDS_FILE="${PLUGIN_HOME}/plugin-knowledge.require-fields"
+
 # Written by the demarkus-memory plugin when a local soul is configured. Read
 # (never written) here so the joined-knowledge guidance can describe the
 # soul↔knowledge-system relationship only when a soul actually exists.
@@ -97,6 +106,18 @@ configured_require_tags() {
   local slug="${1:-}" raw=""
   if [[ -n "${slug}" && -f "${PLUGIN_REQUIRE_TAGS_FILE}.${slug}" ]]; then
     raw="$(cat "${PLUGIN_REQUIRE_TAGS_FILE}.${slug}" 2>/dev/null || true)"
+  fi
+  printf '%s' "${raw}" | tr ',\r\n\t' '    ' | tr -s ' ' | sed 's/^ //;s/ $//'
+}
+
+# configured_require_fields [SLUG] — echo the required OKF metadata fields
+# (space-separated) for this system: a per-slug PLUGIN_REQUIRE_FIELDS_FILE.<slug>,
+# else empty. Same normalization as configured_require_tags. Empty → no field
+# requirement.
+configured_require_fields() {
+  local slug="${1:-}" raw=""
+  if [[ -n "${slug}" && -f "${PLUGIN_REQUIRE_FIELDS_FILE}.${slug}" ]]; then
+    raw="$(cat "${PLUGIN_REQUIRE_FIELDS_FILE}.${slug}" 2>/dev/null || true)"
   fi
   printf '%s' "${raw}" | tr ',\r\n\t' '    ' | tr -s ' ' | sed 's/^ //;s/ $//'
 }
@@ -169,7 +190,7 @@ publish_gate_scope() {
 }
 
 # publish_metadata_check — reads a Claude Code PreToolUse/PostToolUse hook
-# payload (the full JSON object) on stdin and emits exactly six lines:
+# payload (the full JSON object) on stdin and emits exactly seven lines:
 #   1: hook_event_name
 #   2: tool_name
 #   3: TAGS_OK  — "1" if tool_input.metadata.tags is a non-empty (trimmed) string, else "0"
@@ -177,6 +198,8 @@ publish_gate_scope() {
 #   5: url      — tool_input.url (or empty)
 #   6: tags     — the decoded tags string, internal whitespace flattened to one
 #                 line (for axis-presence checks; empty when tagless)
+#   7: type     — the decoded, trimmed metadata.type string (the OKF kind), for
+#                 require_fields presence-checks; empty when absent or non-string
 #
 # Pure awk — NO jq, NO python, nothing outside coreutils. A naive grep for
 # "tags" would false-match the arbitrary `body` value (which can contain literal
@@ -193,6 +216,7 @@ publish_metadata_check() {
       depth = 0; inStr = 0; esc = 0; buf = ""
       ev = ""; tool = ""; url = ""
       tags = ""; haveTags = 0; tagsStr = 0; imp = ""; haveImp = 0
+      mtype = ""; haveType = 0; typeStr = 0
       for (i = 1; i <= n; i++) {
         c = ch[i]
         if (inStr) {
@@ -237,7 +261,12 @@ publish_metadata_check() {
       # presence-check required axes. Only for a genuine JSON-string value.
       tags_emit = (tagsStr ? tags_d : "")
       gsub(/[\n\r\t]/, " ", tags_emit)
-      print ev; print tool; print tags_ok; print imp_ok; print url_d; print tags_emit
+      # Surface metadata.type (the OKF kind) for require_fields presence-checks —
+      # decoded, trimmed, single-line, and only for a genuine JSON-string value.
+      mtype_d = json_unescape(mtype)
+      type_emit = (typeStr ? trim(mtype_d) : "")
+      gsub(/[\n\r\t]/, " ", type_emit)
+      print ev; print tool; print tags_ok; print imp_ok; print url_d; print tags_emit; print type_emit
     }
     function trim(s) { gsub(/^[ \t\r\n]+/, "", s); gsub(/[ \t\r\n]+$/, "", s); return s }
     # json_unescape — decode JSON string escapes (\n \t \r \b \f \/ \" \\ and
@@ -310,6 +339,7 @@ publish_metadata_check() {
       else if (p == "/tool_input/url") url = v
       else if (p == "/tool_input/metadata/tags") { tags = v; haveTags = 1; tagsStr = is_string }
       else if (p == "/tool_input/metadata/importance") { imp = v; haveImp = 1 }
+      else if (p == "/tool_input/metadata/type") { mtype = v; haveType = 1; typeStr = is_string }
     }
   '
 }

--- a/plugins/claude-code-knowledge/tests/knowledge-gate_test.sh
+++ b/plugins/claude-code-knowledge/tests/knowledge-gate_test.sh
@@ -235,6 +235,67 @@ test_ks_slug_containing_memory_substring_still_gated() {
     || { echo "a KS slug containing 'demarkus-memory' must still be gated: ${out}"; return 1; }
 }
 
+# require_fields: an OKF metadata field (e.g. type) must be present non-empty in
+# the metadata object — distinct from a tag axis.
+
+test_require_fields_type_present_defers() {
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  printf 'type\n' > "${home}/.demarkus/plugin-knowledge.require-fields.acme"
+  local out; out="$(gate "${home}" block "$(payload 'mcp__acme__mark_publish' '{"tags":"x","type":"Reference"}')")"
+  rm -rf "${home}"
+  [[ -z "${out}" ]] || { echo "required field 'type' present should defer; got: ${out}"; return 1; }
+}
+
+test_require_fields_type_missing_denied() {
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  printf 'type\n' > "${home}/.demarkus/plugin-knowledge.require-fields.acme"
+  # Properly tagged but no metadata.type → field violation.
+  local out; out="$(gate "${home}" block "$(payload 'mcp__acme__mark_publish' '{"tags":"x"}')")"
+  rm -rf "${home}"
+  grep -q '"permissionDecision":"deny"' <<<"${out}" \
+    || { echo "missing required field should deny: ${out}"; return 1; }
+  grep -q 'type' <<<"${out}" \
+    || { echo "reason should name the missing field 'type': ${out}"; return 1; }
+}
+
+test_require_fields_empty_type_denied() {
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  printf 'type\n' > "${home}/.demarkus/plugin-knowledge.require-fields.acme"
+  # A present-but-empty type string must not satisfy the field.
+  local out; out="$(gate "${home}" block "$(payload 'mcp__acme__mark_publish' '{"tags":"x","type":"  "}')")"
+  rm -rf "${home}"
+  grep -q '"permissionDecision":"deny"' <<<"${out}" \
+    || { echo "whitespace-only type must not satisfy require_fields: ${out}"; return 1; }
+}
+
+test_require_fields_warn_nudges_post() {
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  printf 'type\n' > "${home}/.demarkus/plugin-knowledge.require-fields.acme"
+  # warn (no env): PostToolUse should nudge about the missing field.
+  local pl; pl="$(printf '{"hook_event_name":"PostToolUse","tool_name":"mcp__acme__mark_publish","tool_input":{"url":"/d.md","metadata":{"tags":"x"}}}')"
+  local out; out="$(gate "${home}" - "${pl}")"
+  rm -rf "${home}"
+  grep -q '"additionalContext"' <<<"${out}" \
+    || { echo "warn should nudge on missing field: ${out}"; return 1; }
+  grep -q 'type' <<<"${out}" \
+    || { echo "nudge should name the missing field 'type': ${out}"; return 1; }
+}
+
+test_require_fields_isolation() {
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  HOME="${home}" bash "${REGISTER}" beta 2>/dev/null
+  printf 'type\n' > "${home}/.demarkus/plugin-knowledge.require-fields.acme"
+  # beta declares no require-fields; an untyped beta publish must defer.
+  local out; out="$(gate "${home}" block "$(payload 'mcp__beta__mark_publish' '{"tags":"x"}')")"
+  rm -rf "${home}"
+  [[ -z "${out}" ]] || { echo "beta must not inherit acme's require-fields; got: ${out}"; return 1; }
+}
+
 # ----- runner -----------------------------------------------------------
 
 TESTS=$(declare -F | awk '$3 ~ /^test_/ { print $3 }')

--- a/plugins/claude-code-knowledge/tests/knowledge-gate_test.sh
+++ b/plugins/claude-code-knowledge/tests/knowledge-gate_test.sh
@@ -296,6 +296,18 @@ test_require_fields_isolation() {
   [[ -z "${out}" ]] || { echo "beta must not inherit acme's require-fields; got: ${out}"; return 1; }
 }
 
+test_require_fields_unsupported_field_fail_open() {
+  # The gate can only inspect `type` today; any other declared require_field is
+  # skipped fail-open so it never blocks on what it can't see. Policy lists a
+  # supported field (type, satisfied) + an unsupported one (owner) → defer.
+  local home; home="$(mktemp -d)"
+  HOME="${home}" bash "${REGISTER}" acme 2>/dev/null
+  printf 'type\nowner\n' > "${home}/.demarkus/plugin-knowledge.require-fields.acme"
+  local out; out="$(gate "${home}" block "$(payload 'mcp__acme__mark_publish' '{"tags":"x","type":"Reference"}')")"
+  rm -rf "${home}"
+  [[ -z "${out}" ]] || { echo "unsupported require_field must fail-open (defer); got: ${out}"; return 1; }
+}
+
 # ----- runner -----------------------------------------------------------
 
 TESTS=$(declare -F | awk '$3 ~ /^test_/ { print $3 }')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enforcement for required knowledge publication metadata fields, starting with a `type` field requirement (including proper denial vs warning behavior based on strictness).

* **Documentation**
  * Updated `/knowledge-join` command docs to clarify how to configure per-system required fields and how enforcement works.

* **Bug Fixes**
  * Improved publish gating to properly include missing required-field details in the decision reasons/context.

* **Chores**
  * Bumped plugin versions/manifests to 0.3.2.

* **Tests**
  * Expanded knowledge-gate coverage for required-field scenarios, strictness isolation, whitespace handling, and fail-open behavior for unsupported entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->