### PR TITLE
feat(plugin-knowledge): deterministic policy mirroring on join

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "demarkus-knowledge",
       "source": "./plugins/claude-code-knowledge",
       "description": "Join an organizational demarkus knowledge system from Claude Code — a shared, broker-fronted, versioned markdown catalog. Steers sessions to the shared catalog first, makes it easy to navigate, enforces a publish tag-gate, and curates promoted notes into it via the knowledge-promote cascade. No local server or binaries.",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "category": "memory",
       "tags": ["memory", "knowledge-base", "demarkus", "mark-protocol", "broker", "team"],
       "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/claude-code-knowledge"

--- a/plugins/claude-code-knowledge/.claude-plugin/plugin.json
+++ b/plugins/claude-code-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-knowledge",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Join an organizational demarkus knowledge system (a broker-fronted, shared, versioned markdown catalog) from Claude Code. Validates and registers the broker as an MCP server, steers sessions to consult the shared catalog first, makes it easy to navigate, and enforces a publish tag-gate so shared documents stay findable. No local server, no binaries — pure broker + OAuth.",
   "author": {
     "name": "latebit",

--- a/plugins/claude-code-knowledge/README.md
+++ b/plugins/claude-code-knowledge/README.md
@@ -20,9 +20,10 @@ This plugin downloads no binaries and runs no server. It writes only a small reg
 - `~/.demarkus/knowledge-systems` — one joined MCP server slug per line.
 - `~/.demarkus/plugin-knowledge.strictness.<slug>` — mirrored per-system gate severity.
 - `~/.demarkus/plugin-knowledge.require-tags.<slug>` — mirrored required tag axes.
+- `~/.demarkus/plugin-knowledge.require-fields.<slug>` — mirrored required OKF metadata fields (e.g. `type`).
 
 It owns this `plugin-knowledge.*` namespace entirely and never reads or writes the demarkus-memory plugin's files — so it stands alone. The one exception is read-only: it checks for `~/.demarkus/plugin-memory.conf` to tell whether a local soul exists, so the soul↔system guidance only appears when it's relevant (and is simply omitted when it isn't).
 
 ## Admin: publishing conventions
 
-A knowledge system's org-wide policy and per-world template live on its guaranteed `root` hub under `mark://root/.well-known/demarkus/`. See [`examples/knowledge-system/`](examples/knowledge-system/) for the format an admin publishes; joined agents fetch and follow them, mirroring the enforceable knobs (strictness, required tag axes) into the local gate.
+A knowledge system's org-wide policy and per-world template live on its guaranteed `root` hub under `mark://root/.well-known/demarkus/`. See [`examples/knowledge-system/`](examples/knowledge-system/) for the format an admin publishes; joined agents fetch and follow them, mirroring the enforceable knobs (strictness, required tag axes, required OKF fields) into the local gate via `scripts/mirror-policy.sh`.

--- a/plugins/claude-code-knowledge/README.md
+++ b/plugins/claude-code-knowledge/README.md
@@ -22,7 +22,7 @@ This plugin downloads no binaries and runs no server. It writes only a small reg
 - `~/.demarkus/plugin-knowledge.require-tags.<slug>` — mirrored required tag axes.
 - `~/.demarkus/plugin-knowledge.require-fields.<slug>` — mirrored required OKF metadata fields (e.g. `type`).
 
-It owns this `plugin-knowledge.*` namespace entirely and never reads or writes the demarkus-memory plugin's files — so it stands alone. The one exception is read-only: it checks for `~/.demarkus/plugin-memory.conf` to tell whether a local soul exists, so the soul↔system guidance only appears when it's relevant (and is simply omitted when it isn't).
+It owns this `plugin-knowledge.*` namespace entirely and never **writes** the demarkus-memory plugin's files — so it stands alone. Its only touch of that state is **read-only**: it checks whether `~/.demarkus/plugin-memory.conf` exists, to tell whether a local soul is configured, so the soul↔system guidance only appears when it's relevant (and is simply omitted when it isn't).
 
 ## Admin: publishing conventions
 

--- a/plugins/claude-code-knowledge/commands/knowledge-join.md
+++ b/plugins/claude-code-knowledge/commands/knowledge-join.md
@@ -60,29 +60,15 @@ If the user invokes without an argument, ask them for the URL before running any
 5. **Adopt the system's conventions (`root` hub).** A knowledge system can publish org-wide conventions to its guaranteed `root` hub world. Once the OAuth flow is complete and you are doing real work against this system, fetch them and follow them:
 
    - `mark_fetch mark://root/.well-known/demarkus/template.md` — the required per-world structure (same shape as the local `/project-template.md`). Follow it.
-   - `mark_fetch mark://root/.well-known/demarkus/policy.md` — strictness + required tags. Mirror the enforceable knobs to local files so the gate (which cannot reach the broker) can apply them:
+   - `mark_fetch mark://root/.well-known/demarkus/policy.md` — the system's write policy. The gate runs offline (it cannot reach the broker), so its enforced core must be mirrored to local files. **Do not hand-write those files** — pipe the fetched policy **body** to the mirror script, which deterministically parses `strictness:` / `require_tags:` / `require_fields:` and writes (or clears) each per-slug file:
 
-     - If it declares a `strictness:` line, write:
+     ```bash
+     cat <<'POLICY' | bash "${CLAUDE_PLUGIN_ROOT}/scripts/mirror-policy.sh" <slug>
+     <the full body returned by the mark_fetch above>
+     POLICY
+     ```
 
-       ```bash
-       printf '%s\n' "<warn|block|ask from policy.md>" > ~/.demarkus/plugin-knowledge.strictness.<slug>
-       ```
-
-     - If it declares a `require_tags:` line (the tag axes every doc must carry, e.g. `category`), mirror the axes so the gate presence-checks them:
-
-       ```bash
-       printf '%s\n' "<axes from policy.md, e.g. category>" > ~/.demarkus/plugin-knowledge.require-tags.<slug>
-       ```
-
-       Each axis is then satisfied by an `axis:value` tag (e.g. `category:project`).
-
-     - If it declares a `require_fields:` line (OKF metadata *fields* every doc must carry, e.g. `type` — the document kind), mirror them so the gate presence-checks them:
-
-       ```bash
-       printf '%s\n' "<fields from policy.md, e.g. type>" > ~/.demarkus/plugin-knowledge.require-fields.<slug>
-       ```
-
-       Each field is then satisfied by a non-empty value for that key in the `metadata` object (e.g. `metadata: {"type": "Reference"}`). Distinct from `require_tags:` — a field is its own metadata key, not an `axis:value` tag. Only `type` is enforced today.
+     A knob absent from the policy clears its mirror file, so relaxing the policy de-enforces. The mirror is a **snapshot, not a live read** — re-run this on a fresh join whenever the policy changes. At publish time the gate then checks each enforced axis (an `axis:value` tag, e.g. `category:project`) and field (a non-empty key in the `metadata` object, e.g. `metadata: {"type": "Reference"}`).
 
    If either document is `not-found`, the system simply hasn't declared that convention yet — skip silently. See `${CLAUDE_PLUGIN_ROOT}/examples/knowledge-system/` for the format an admin publishes.
 

--- a/plugins/claude-code-knowledge/scripts/lib.sh
+++ b/plugins/claude-code-knowledge/scripts/lib.sh
@@ -197,6 +197,9 @@ _write_or_clear() {
 mirror_policy() {
   local slug="$1" body
   [[ -n "${slug}" ]] || return 2
+  # Path-safety guard: the slug is interpolated into the mirror file paths, so a
+  # separator/whitespace/control char could escape the intended file. Refuse it.
+  case "${slug}" in *[!A-Za-z0-9._-]*) return 2 ;; esac
   mkdir -p "${PLUGIN_HOME}"
   body="$(cat)"
   _write_or_clear "${PLUGIN_STRICTNESS_FILE}.${slug}"     "$(_policy_field "${body}" strictness)"

--- a/plugins/claude-code-knowledge/scripts/lib.sh
+++ b/plugins/claude-code-knowledge/scripts/lib.sh
@@ -158,6 +158,52 @@ register_knowledge_system() {
   printf '%s\n' "${slug}" >> "${PLUGIN_KNOWLEDGE_REGISTRY}"
 }
 
+# _policy_field BODY KEY — echo the value of the first BODY line of the form
+# "KEY: value", where KEY is the line's first non-space token (so a prose mention
+# of the key mid-sentence, or inside backticks, can't match). Trimmed; empty when
+# absent. Pure awk — the enforced core lines sit bare in the policy body, above
+# any prose, so the first match is the real declaration.
+_policy_field() {
+  local body="$1" key="$2"
+  printf '%s\n' "${body}" | awk -v k="${key}" '
+    { line = $0; sub(/^[ \t]+/, "", line) }
+    substr(line, 1, length(k) + 1) == k ":" {
+      v = substr(line, length(k) + 2)
+      sub(/^[ \t]+/, "", v); sub(/[ \t\r]+$/, "", v)
+      print v; exit
+    }'
+}
+
+# _write_or_clear FILE VALUE — atomically write VALUE (one line) to FILE, or
+# remove FILE when VALUE is empty. The remove path is what lets a relaxed policy
+# de-enforce: drop a knob from policy.md and the next mirror clears its file.
+_write_or_clear() {
+  local file="$1" val="$2" tmp
+  if [[ -n "${val}" ]]; then
+    tmp="${file}.tmp.$$"
+    printf '%s\n' "${val}" > "${tmp}" && mv -f "${tmp}" "${file}"
+  else
+    rm -f "${file}"
+  fi
+}
+
+# mirror_policy SLUG — read a knowledge system's policy.md BODY on stdin and
+# deterministically mirror its enforced core to the per-slug local files the
+# publish gate reads (strictness / require_tags / require_fields). A knob absent
+# from the policy clears its file. This replaces the hand-rolled agent-prose
+# mirroring: the agent still fetches policy.md over MCP (a script can't reach the
+# broker) and pipes it here, but the parse + file paths are no longer agent
+# judgment — so a join always mirrors the same way. Idempotent.
+mirror_policy() {
+  local slug="$1" body
+  [[ -n "${slug}" ]] || return 2
+  mkdir -p "${PLUGIN_HOME}"
+  body="$(cat)"
+  _write_or_clear "${PLUGIN_STRICTNESS_FILE}.${slug}"     "$(_policy_field "${body}" strictness)"
+  _write_or_clear "${PLUGIN_REQUIRE_TAGS_FILE}.${slug}"   "$(_policy_field "${body}" require_tags)"
+  _write_or_clear "${PLUGIN_REQUIRE_FIELDS_FILE}.${slug}" "$(_policy_field "${body}" require_fields)"
+}
+
 # is_registered_knowledge_system SLUG — true if SLUG is in the registry.
 is_registered_knowledge_system() {
   local slug="$1"

--- a/plugins/claude-code-knowledge/scripts/mirror-policy.sh
+++ b/plugins/claude-code-knowledge/scripts/mirror-policy.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# mirror-policy.sh <slug> — read a knowledge system's policy.md BODY on stdin and
+# deterministically mirror its enforced core (strictness / require_tags /
+# require_fields) to the per-slug local files the publish gate reads.
+#
+# Replaces the agent-prose mirroring that /knowledge-join used to do by hand: the
+# agent fetches policy.md over MCP (a script can't reach the broker) and pipes the
+# body here; the parse + file paths are no longer agent judgment, so a join always
+# mirrors the same way. A knob absent from the policy clears its mirror file, so
+# relaxing the policy de-enforces. Idempotent.
+#
+# Usage:  <policy.md body on stdin> | mirror-policy.sh <slug>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+[[ $# -eq 1 && -n "${1:-}" ]] || die "usage: mirror-policy.sh <slug> (policy.md body on stdin)"
+
+mirror_policy "$1"
+log "mirrored policy enforced core for '$1' (strictness/require_tags/require_fields)"

--- a/plugins/claude-code-knowledge/scripts/mirror-policy.sh
+++ b/plugins/claude-code-knowledge/scripts/mirror-policy.sh
@@ -18,6 +18,11 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 . "${SCRIPT_DIR}/lib.sh"
 
 [[ $# -eq 1 && -n "${1:-}" ]] || die "usage: mirror-policy.sh <slug> (policy.md body on stdin)"
+# The slug is interpolated into the mirror file paths, so constrain it to a
+# path-safe alphabet (no separators, whitespace, or control chars).
+case "$1" in
+  *[!A-Za-z0-9._-]*) die "invalid slug '$1': only [A-Za-z0-9._-] allowed (it is embedded in mirror file paths)" ;;
+esac
 
 mirror_policy "$1"
 log "mirrored policy enforced core for '$1' (strictness/require_tags/require_fields)"

--- a/plugins/claude-code-knowledge/tests/mirror-policy_test.sh
+++ b/plugins/claude-code-knowledge/tests/mirror-policy_test.sh
@@ -95,6 +95,17 @@ test_per_slug_isolation() {
   [[ "${bf}" == "<none>" ]] || { echo "beta must not inherit acme's require_fields; got ${bf}"; return 1; }
 }
 
+test_rejects_path_unsafe_slug() {
+  local h; h="$(mktemp -d)"
+  # A slug with a path separator must be refused, exit non-zero, and write nothing.
+  printf 'strictness: block\n' | HOME="${h}" bash "${MIRROR}" "../evil" >/dev/null 2>&1
+  local rc=$?
+  local wrote; wrote="$(find "${h}/.demarkus" -name 'plugin-knowledge.*' 2>/dev/null | wc -l | tr -d ' ')"
+  rm -rf "${h}"
+  [[ "${rc}" -ne 0 ]] || { echo "unsafe slug must exit non-zero"; return 1; }
+  [[ "${wrote}" == "0" ]] || { echo "unsafe slug must write no mirror file; wrote ${wrote}"; return 1; }
+}
+
 echo "=== mirror-policy tests ==="
 TESTS=$(declare -F | awk '$3 ~ /^test_/ { print $3 }')
 for t in ${TESTS}; do run_test "${t#test_}"; done

--- a/plugins/claude-code-knowledge/tests/mirror-policy_test.sh
+++ b/plugins/claude-code-knowledge/tests/mirror-policy_test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Tests for deterministic policy mirroring (mirror_policy in lib.sh, driven via
+# mirror-policy.sh). Each case runs with an isolated HOME so the per-slug mirror
+# files never touch the real environment.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+PLUGIN_DIR="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
+MIRROR="${PLUGIN_DIR}/scripts/mirror-policy.sh"
+
+[[ -x "${MIRROR}" ]] || { echo "mirror-policy.sh not executable"; exit 2; }
+
+PASS=0; FAIL=0; FAILED_NAMES=()
+run_test() {
+  local name="$1" out rc
+  out=$( "test_${name}" 2>&1 ); rc=$?
+  if (( rc == 0 )); then echo "PASS  ${name}"; PASS=$((PASS + 1))
+  else echo "FAIL  ${name}"; printf '%s\n' "${out}" | sed 's/^/      /'; FAIL=$((FAIL + 1)); FAILED_NAMES+=("${name}"); fi
+}
+
+# mirror HOME SLUG BODY — pipe BODY into mirror-policy.sh under an isolated HOME.
+mirror() { printf '%s' "$3" | HOME="$1" bash "${MIRROR}" "$2" >/dev/null 2>&1; }
+
+# mf HOME NAME — echo trimmed contents of ~/.demarkus/<NAME>, or "<none>".
+mf() { local f="$1/.demarkus/$2"; [[ -f "${f}" ]] && tr -d '\n' < "${f}" || echo "<none>"; }
+
+FULL_POLICY='# Knowledge System Policy
+
+policy_version: 3
+owner: x@example.com
+
+strictness: block
+require_tags: category
+require_fields: type
+
+The three lines above are the enforced core (`strictness:` etc).'
+
+test_mirrors_all_three() {
+  local h; h="$(mktemp -d)"
+  mirror "${h}" acme "${FULL_POLICY}"
+  local s t f
+  s="$(mf "${h}" plugin-knowledge.strictness.acme)"
+  t="$(mf "${h}" plugin-knowledge.require-tags.acme)"
+  f="$(mf "${h}" plugin-knowledge.require-fields.acme)"
+  rm -rf "${h}"
+  [[ "${s}" == "block" ]]    || { echo "strictness=${s}, want block"; return 1; }
+  [[ "${t}" == "category" ]] || { echo "require_tags=${t}, want category"; return 1; }
+  [[ "${f}" == "type" ]]     || { echo "require_fields=${f}, want type"; return 1; }
+}
+
+test_partial_policy_omits_absent_knob() {
+  local h; h="$(mktemp -d)"
+  mirror "${h}" acme 'strictness: warn
+require_tags: category, team'
+  local t f
+  t="$(mf "${h}" plugin-knowledge.require-tags.acme)"
+  f="$(mf "${h}" plugin-knowledge.require-fields.acme)"
+  rm -rf "${h}"
+  [[ "${t}" == "category, team" ]] || { echo "require_tags=${t}, want 'category, team'"; return 1; }
+  [[ "${f}" == "<none>" ]]         || { echo "require_fields should be absent; got ${f}"; return 1; }
+}
+
+test_relaxing_policy_clears_stale_file() {
+  local h; h="$(mktemp -d)"
+  mkdir -p "${h}/.demarkus"
+  printf 'type\n' > "${h}/.demarkus/plugin-knowledge.require-fields.acme"   # stale, pre-existing
+  mirror "${h}" acme 'strictness: block
+require_tags: category'                                                     # no require_fields → must clear
+  local f; f="$(mf "${h}" plugin-knowledge.require-fields.acme)"
+  rm -rf "${h}"
+  [[ "${f}" == "<none>" ]] || { echo "dropped knob must clear its mirror; got ${f}"; return 1; }
+}
+
+test_prose_mention_not_mirrored() {
+  local h; h="$(mktemp -d)"
+  # 'strictness:' appears only mid-sentence / in backticks, never as a line's
+  # first token — must not be mistaken for a declaration.
+  mirror "${h}" acme 'This policy declares no enforced core.
+The `strictness:` knob would go here but is not set.'
+  local s; s="$(mf "${h}" plugin-knowledge.strictness.acme)"
+  rm -rf "${h}"
+  [[ "${s}" == "<none>" ]] || { echo "prose mention must not mirror; got ${s}"; return 1; }
+}
+
+test_per_slug_isolation() {
+  local h; h="$(mktemp -d)"
+  mirror "${h}" acme 'require_fields: type'
+  mirror "${h}" beta 'strictness: warn'
+  local af bf
+  af="$(mf "${h}" plugin-knowledge.require-fields.acme)"
+  bf="$(mf "${h}" plugin-knowledge.require-fields.beta)"
+  rm -rf "${h}"
+  [[ "${af}" == "type" ]]  || { echo "acme require_fields=${af}, want type"; return 1; }
+  [[ "${bf}" == "<none>" ]] || { echo "beta must not inherit acme's require_fields; got ${bf}"; return 1; }
+}
+
+echo "=== mirror-policy tests ==="
+TESTS=$(declare -F | awk '$3 ~ /^test_/ { print $3 }')
+for t in ${TESTS}; do run_test "${t#test_}"; done
+echo "${PASS} passed, ${FAIL} failed"
+(( FAIL == 0 ))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `/knowledge-join` now applies deterministic, per-knowledge-slug policy mirroring to enforce gate settings consistently.
  * Mirroring now covers `strictness`, required tag axes, and required OKF metadata fields (e.g., `type`) into per-slug enforcement files, clearing them when omitted.

* **Documentation**
  * Updated `/knowledge-join` help and the plugin README to describe snapshot-based mirroring and publish-time enforcement.

* **Tests**
  * Added automated tests for mirroring, clearing behavior, safe token parsing, slug isolation, and rejection of unsafe slugs.

* **Chores**
  * Bumped marketplace and plugin versions to **0.4.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->