### PR TITLE
fix(fedcrawl): drop loopback link targets and normalize ports

### DIFF
--- a/client/internal/fedcrawl/crawl.go
+++ b/client/internal/fedcrawl/crawl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 
 	"slices"
 	"strings"
@@ -313,6 +314,13 @@ func (c *Crawler) discoverServers(body, currentHost string, queue chan<- string,
 			continue
 		}
 
+		// Don't crawl loopback/localhost — a dev link in a crawled body points
+		// at the crawler's own host, never a real federated world (unreachable
+		// noise + error spam).
+		if isLoopbackHost(host) {
+			continue
+		}
+
 		// Skip if same server.
 		if host == currentHost {
 			continue
@@ -473,10 +481,41 @@ func (c *Crawler) recordEdges(host, path, body string, meta map[string]string) {
 		if !strings.HasPrefix(resolved, "mark://") {
 			continue
 		}
-		c.graph.AddEdge(url, resolved)
+		// Normalize the target's host so it is port-stable (mark://h and
+		// mark://h:6309 are the same node, not two), and drop loopback/localhost
+		// targets so a dev link in a crawled body never becomes a phantom portal
+		// node on the reading-room floor. Private and cluster-internal hosts are
+		// KEPT — real federated worlds (LAN, or a Kubernetes universe) are
+		// addressed by exactly those.
+		th, tp, err := fetch.ParseMarkURL(resolved)
+		if err != nil || isLoopbackHost(th) {
+			continue
+		}
+		c.graph.AddEdge(url, "mark://"+th+tp)
 		linkCount++
 	}
 	c.graph.AddNode(&graph.Node{URL: url, Title: meta["title"], Status: "ok", LinkCount: linkCount})
+}
+
+// isLoopbackHost reports whether a mark:// host (host:port or bare) is loopback,
+// "localhost", or the unspecified address — dev artifacts that must not enter
+// the durable federation graph or the crawl frontier. Private and
+// cluster-internal hosts are deliberately NOT included: real federated worlds (a
+// LAN deployment, or a Kubernetes universe addressing worlds by in-cluster
+// service names) are reached by exactly those.
+func isLoopbackHost(host string) bool {
+	h := strings.ToLower(strings.TrimSpace(host))
+	if hh, _, err := net.SplitHostPort(h); err == nil {
+		h = hh
+	}
+	h = strings.Trim(h, "[]")
+	if h == "" || h == "localhost" || strings.HasSuffix(h, ".localhost") {
+		return true
+	}
+	if ip := net.ParseIP(h); ip != nil {
+		return ip.IsLoopback() || ip.IsUnspecified()
+	}
+	return false
 }
 
 // GraphExport renders the accumulated link graph as a mark_graph_export

--- a/client/internal/fedcrawl/crawl.go
+++ b/client/internal/fedcrawl/crawl.go
@@ -505,8 +505,14 @@ func (c *Crawler) recordEdges(host, path, body string, meta map[string]string) {
 // service names) are reached by exactly those.
 func isLoopbackHost(host string) bool {
 	h := strings.ToLower(strings.TrimSpace(host))
+	// Strip the port. SplitHostPort handles host:port and [ipv6]:port; an
+	// unbracketed IPv6 with a port (::1:6309) defeats it (the colons are
+	// ambiguous), so fall back to trimming a trailing :port only when the head
+	// is itself a valid IP.
 	if hh, _, err := net.SplitHostPort(h); err == nil {
 		h = hh
+	} else if i := strings.LastIndex(h, ":"); i > 0 && net.ParseIP(h[:i]) != nil {
+		h = h[:i]
 	}
 	h = strings.Trim(h, "[]")
 	if h == "" || h == "localhost" || strings.HasSuffix(h, ".localhost") {

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -596,6 +596,37 @@ func TestCrawlerGraphExportAndPublish(t *testing.T) {
 	}
 }
 
+func TestCrawlerGraphExportFiltersLoopbackAndNormalizesPorts(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Seeds = []string{"mark://a.example.com"}
+	cfg.Crawl.MaxDocuments = 100
+
+	client := newMockClient()
+	client.addList("a.example.com:6309", "/", "- [index.md](index.md)\n")
+	// The doc links to loopback + localhost (dev artifacts) and a port-less
+	// external world.
+	client.addDoc("a.example.com:6309", "/index.md",
+		"# A\n[loop](mark://127.0.0.1:6401/x.md) [local](mark://localhost/y.md) [ext](mark://ext.example.com/page.md)",
+		"sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+	crawler := NewCrawler(cfg, client, nil, nil)
+	if _, err := crawler.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	exp := crawler.GraphExport()
+
+	// loopback / localhost targets never enter the durable graph.
+	for _, bad := range []string{"127.0.0.1", "localhost"} {
+		if containsMiddle(exp, bad) {
+			t.Errorf("graph export must not contain %q\n---\n%s", bad, exp)
+		}
+	}
+	// the external target is kept, port-normalized to the canonical :6309 form.
+	if !containsMiddle(exp, "mark://a.example.com:6309/index.md | mark://ext.example.com:6309/page.md") {
+		t.Errorf("graph export missing normalized external edge\n---\n%s", exp)
+	}
+}
+
 func contains(s, substr string) bool {
 	return s != "" && substr != "" && (s == substr || len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || containsMiddle(s, substr)))
 }

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -603,10 +603,10 @@ func TestCrawlerGraphExportFiltersLoopbackAndNormalizesPorts(t *testing.T) {
 
 	client := newMockClient()
 	client.addList("a.example.com:6309", "/", "- [index.md](index.md)\n")
-	// The doc links to loopback + localhost (dev artifacts) and a port-less
-	// external world.
+	// The doc links to IPv4 loopback, IPv6 loopback, localhost (dev artifacts)
+	// and a port-less external world.
 	client.addDoc("a.example.com:6309", "/index.md",
-		"# A\n[loop](mark://127.0.0.1:6401/x.md) [local](mark://localhost/y.md) [ext](mark://ext.example.com/page.md)",
+		"# A\n[loop](mark://127.0.0.1:6401/x.md) [loop6](mark://[::1]/q.md) [local](mark://localhost/y.md) [ext](mark://ext.example.com/page.md)",
 		"sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
 	crawler := NewCrawler(cfg, client, nil, nil)
@@ -615,8 +615,8 @@ func TestCrawlerGraphExportFiltersLoopbackAndNormalizesPorts(t *testing.T) {
 	}
 	exp := crawler.GraphExport()
 
-	// loopback / localhost targets never enter the durable graph.
-	for _, bad := range []string{"127.0.0.1", "localhost"} {
+	// loopback (v4 + v6) / localhost targets never enter the durable graph.
+	for _, bad := range []string{"127.0.0.1", "::1", "localhost"} {
 		if containsMiddle(exp, bad) {
 			t.Errorf("graph export must not contain %q\n---\n%s", bad, exp)
 		}
@@ -624,6 +624,26 @@ func TestCrawlerGraphExportFiltersLoopbackAndNormalizesPorts(t *testing.T) {
 	// the external target is kept, port-normalized to the canonical :6309 form.
 	if !containsMiddle(exp, "mark://a.example.com:6309/index.md | mark://ext.example.com:6309/page.md") {
 		t.Errorf("graph export missing normalized external edge\n---\n%s", exp)
+	}
+}
+
+func TestIsLoopbackHost(t *testing.T) {
+	cases := map[string]bool{
+		"127.0.0.1:6401":        true,  // IPv4 loopback + port
+		"localhost":             true,  // bare localhost
+		"localhost:6309":        true,  // localhost + port
+		"0.0.0.0:6309":          true,  // unspecified
+		"[::1]:6309":            true,  // bracketed IPv6 loopback + port
+		"::1":                   true,  // bare IPv6 loopback
+		"::1:6309":              true,  // unbracketed IPv6 loopback + port
+		"soul.demarkus.io:6309": false, // real external world
+		"10.0.0.5:6309":         false, // private IP — a real LAN/cluster world, kept
+		"2001:db8::5":           false, // routable IPv6
+	}
+	for in, want := range cases {
+		if got := isLoopbackHost(in); got != want {
+			t.Errorf("isLoopbackHost(%q) = %v, want %v", in, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
…graph export

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Federation crawler now skips loopback/localhost targets during both server discovery and durable federation graph edge creation, preventing development addresses from being included.
  * Federation link graph edges are normalized into stable host+port node identifiers, and edges with invalid targets are ignored.
* **Tests**
  * Added coverage to verify loopback/localhost filtering and port normalization in exported graph results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->