### PR TITLE
fix(tools): stop provision self-downloading the plugin binary

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "demarkus-memory",
       "source": "./plugins/claude-code",
       "description": "Zero-config local memory for Claude Code. Spawns a local demarkus-server and wires MCP tools for fetch/publish/append/graph/lookup over your own versioned markdown store, and self-documents sessions to it. /soul-join adds remote souls to a catalog with per-project binding and a destination gate. With a promote destination configured — a joined knowledge system or a registered plain remote demarkus server — /promote lifts ready notes up to it, /promote-scan sweeps for candidates, an ADR publish nudges promotion, and /soul-refresh pulls promoted docs back as they evolve.",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "category": "memory",
       "tags": ["memory", "demarkus", "mark-protocol", "local-first"],
       "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/claude-code"
@@ -19,7 +19,7 @@
       "name": "demarkus-knowledge",
       "source": "./plugins/claude-code-knowledge",
       "description": "Join an organizational demarkus knowledge system from Claude Code — a shared, broker-fronted, versioned markdown catalog. Steers sessions to the shared catalog first, makes it easy to navigate, enforces a publish tag-gate, and curates promoted notes into it via the knowledge-promote cascade. No local server or binaries.",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "category": "memory",
       "tags": ["memory", "knowledge-base", "demarkus", "mark-protocol", "broker", "team"],
       "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/claude-code-knowledge"

--- a/.github/scripts/bump-plugin-pins.sh
+++ b/.github/scripts/bump-plugin-pins.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 #
 # Resolve the latest released server/client/tools versions and update the demarkus
-# plugins' binary pins to match. Since the Approach-C refactor the pins live in
-# TWO places that must stay in lockstep:
+# plugins' binary pins to match. The pins live in:
 #
-#   1. tools/demarkus-plugin/internal/provision/provision.go — the Go consts
-#      serverVersion / clientVersion / toolsVersion (source of truth; what the
-#      binary provisions and self-updates to).
+#   1. tools/demarkus-plugin/internal/provision/provision.go — serverVersion /
+#      clientVersion (the server & mcp binaries provision downloads) and
+#      fallbackToolsVersion (the tools release a DEV build pulls demarkus-token
+#      from; a real build uses its own ldflags version).
 #   2. plugins/*/scripts/bootstrap.sh — TOOLS_VERSION (the chicken-and-egg pin
-#      the tiny installer needs to fetch the demarkus-plugin binary itself).
+#      the tiny installer uses to fetch the demarkus-plugin binary itself).
 #
-# toolsVersion and every bootstrap TOOLS_VERSION MUST match, or provision and
-# bootstrap fight over which demarkus-plugin to install.
+# provision no longer re-downloads demarkus-plugin (bootstrap owns it) and derives
+# the token release from the running binary's own version, so the only hard pin
+# for the plugin binary is the bootstrap TOOLS_VERSION; fallbackToolsVersion just
+# tracks it so dev builds fetch a matching token.
 #
 # It also patch-bumps the affected plugins' versions, in two lineages:
 #   - memory    (changes when server|client|tools change): claude-code +
@@ -135,7 +137,7 @@ fi
 
 cur_server=$(goconst serverVersion)
 cur_client=$(goconst clientVersion)
-cur_tools=$(goconst toolsVersion)
+cur_tools=$(goconst fallbackToolsVersion)
 
 emit server "$new_server"
 emit client "$new_client"
@@ -150,7 +152,7 @@ fi
 # Update the Go consts (source of truth) and every bootstrap's TOOLS_VERSION.
 set_goconst serverVersion "$new_server"
 set_goconst clientVersion "$new_client"
-set_goconst toolsVersion "$new_tools"
+set_goconst fallbackToolsVersion "$new_tools"
 [[ "$new_tools" != "$cur_tools" ]] && set_bootstrap_tools "$new_tools"
 
 # Patch-bump the affected lineages.

--- a/plugins/claude-code-knowledge/.claude-plugin/plugin.json
+++ b/plugins/claude-code-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-knowledge",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Join an organizational demarkus knowledge system (a broker-fronted, shared, versioned markdown catalog) from Claude Code. Validates and registers the broker as an MCP server, steers sessions to consult the shared catalog first, makes it easy to navigate, and enforces a publish tag-gate so shared documents stay findable. No local server, no binaries — pure broker + OAuth.",
   "author": {
     "name": "latebit",

--- a/plugins/claude-code-knowledge/scripts/bootstrap.sh
+++ b/plugins/claude-code-knowledge/scripts/bootstrap.sh
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-TOOLS_VERSION="0.3.1"   # demarkus-plugin ships in the tools/ release
+TOOLS_VERSION="0.3.3"   # demarkus-plugin ships in the tools/ release
 BIN_DIR="${HOME}/.demarkus/bin"
 BIN="${BIN_DIR}/demarkus-plugin"
 

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-memory",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Local, versioned memory for Claude Code via demarkus. Zero-config install: spawns a local demarkus-server, auto-generates a token, wires MCP tools for fetch/publish/append/graph/lookup, injects standing guidance so sessions self-document to the soul, and enforces a publish tag-gate so documents stay findable via lookup.",
   "author": {
     "name": "latebit",

--- a/plugins/claude-code/scripts/bootstrap.sh
+++ b/plugins/claude-code/scripts/bootstrap.sh
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-TOOLS_VERSION="0.3.1"   # demarkus-plugin ships in the tools/ release
+TOOLS_VERSION="0.3.3"   # demarkus-plugin ships in the tools/ release
 BIN_DIR="${HOME}/.demarkus/bin"
 BIN="${BIN_DIR}/demarkus-plugin"
 

--- a/plugins/pi-knowledge/package.json
+++ b/plugins/pi-knowledge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-pi-knowledge",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Join an organizational demarkus knowledge system (a broker-fronted, shared, versioned markdown catalog) from the pi coding agent. Validates and registers the broker as an HTTP/OAuth MCP server via pi-mcp-adapter, steers sessions to consult the shared catalog first, makes it easy to navigate, and enforces a publish tag-gate (tags + required axes + required fields) so shared documents stay findable. No local server, no binaries — pure broker + OAuth.",
   "author": "latebit",
   "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/pi-knowledge",

--- a/plugins/pi-knowledge/scripts/bootstrap.sh
+++ b/plugins/pi-knowledge/scripts/bootstrap.sh
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-TOOLS_VERSION="0.3.1"   # demarkus-plugin ships in the tools/ release
+TOOLS_VERSION="0.3.3"   # demarkus-plugin ships in the tools/ release
 BIN_DIR="${HOME}/.demarkus/bin"
 BIN="${BIN_DIR}/demarkus-plugin"
 

--- a/plugins/pi-memory/package.json
+++ b/plugins/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-pi-memory",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Local, versioned memory for the pi coding agent via demarkus. Provisions a local demarkus-server, auto-generates a token, wires the demarkus-memory MCP server through pi-mcp-adapter, injects standing guidance so sessions self-document to the soul, and enforces a publish tag-gate plus a destination gate so documents stay findable and land on the right soul.",
   "author": "latebit",
   "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/pi-memory",

--- a/plugins/pi-memory/scripts/bootstrap.sh
+++ b/plugins/pi-memory/scripts/bootstrap.sh
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-TOOLS_VERSION="0.3.1"   # demarkus-plugin ships in the tools/ release
+TOOLS_VERSION="0.3.3"   # demarkus-plugin ships in the tools/ release
 BIN_DIR="${HOME}/.demarkus/bin"
 BIN="${BIN_DIR}/demarkus-plugin"
 

--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -38,16 +38,35 @@ import (
 	"github.com/latebit-io/demarkus/tools/demarkus-plugin/internal/config"
 )
 
-// Version pins — the source of truth for the managed binaries. demarkus-plugin
-// ships in the same tools/ release as demarkus-token, so its pin == toolsVersion;
-// toolsVersion MUST match the TOOLS_VERSION in every plugin's bootstrap.sh (the
-// bump workflow keeps them in lockstep) or provision would fight bootstrap over
-// which demarkus-plugin to install.
+// Version pins for the SEPARATE server/client modules (their own release
+// cadence; the bump workflow tracks their latest existing releases).
 const (
 	serverVersion = "0.18.0"
 	clientVersion = "0.13.1"
-	toolsVersion  = "0.3.1"
+	// fallbackToolsVersion is used ONLY by dev builds (Version == "dev"), where
+	// there's no real release to derive the tools version from. A real release
+	// uses its own ldflags Version — see toolsRef.
+	fallbackToolsVersion = "0.3.3"
 )
+
+// Version is the binary's own release version, injected from main's ldflags
+// value. demarkus-plugin ships INSIDE the tools release, so the running binary's
+// version is exactly the tools release to fetch demarkus-token from. provision
+// never re-downloads demarkus-plugin itself (bootstrap.sh owns that), which is
+// what avoids the self-referential version skew where a binary would download an
+// older copy of itself.
+var Version = "dev"
+
+var semverRe = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
+
+// toolsRef is the tools release to pull demarkus-token from: the binary's own
+// version when it's a real release, else the dev fallback.
+func toolsRef() string {
+	if semverRe.MatchString(Version) {
+		return Version
+	}
+	return fallbackToolsVersion
+}
 
 // Port/range constants (lib.sh).
 const (
@@ -220,23 +239,26 @@ func shellQuote(s string) string {
 
 // --- version drift (lib.sh _installed_versions/_desired_versions) ------------
 
-// desiredVersions is the pin string the plugin expects, in the bash shape.
+// desiredVersions is the pin string provision expects, in the bash shape. It
+// covers only the binaries provision manages — server, mcp, token. demarkus-plugin
+// is deliberately excluded: bootstrap.sh installs/updates it, and having provision
+// re-fetch it (against a pin that can't match the auto-assigned release tag)
+// caused a self-downgrade cascade.
 func desiredVersions() string {
-	return fmt.Sprintf("server=%s,client=%s,tools=%s,plugin=%s",
-		serverVersion, clientVersion, toolsVersion, toolsVersion)
+	return fmt.Sprintf("server=%s,client=%s,tools=%s",
+		serverVersion, clientVersion, toolsRef())
 }
 
 // installedVersions queries each on-disk binary via --version and assembles the
 // same shape as desiredVersions. A missing/unexecutable/too-old binary yields an
 // empty field, which never equals a desired version, so ensureBinaries
 // re-downloads. demarkus-token accepts --version as well as its `version`
-// subcommand, so one flag form covers all four.
+// subcommand.
 func installedVersions() string {
-	return fmt.Sprintf("server=%s,client=%s,tools=%s,plugin=%s",
+	return fmt.Sprintf("server=%s,client=%s,tools=%s",
 		binaryVersion("demarkus-server"),
 		binaryVersion("demarkus-mcp"),
 		binaryVersion("demarkus-token"),
-		binaryVersion("demarkus-plugin"),
 	)
 }
 
@@ -266,8 +288,13 @@ func binaryVersion(name string) string {
 const (
 	serverReleaseBase = "https://github.com/latebit-io/demarkus/releases/download/server%2Fv" + serverVersion
 	clientReleaseBase = "https://github.com/latebit-io/demarkus/releases/download/client%2Fv" + clientVersion
-	toolsReleaseBase  = "https://github.com/latebit-io/demarkus/releases/download/tools%2Fv" + toolsVersion
 )
+
+// toolsReleaseBase is the release that ships demarkus-token (the same one this
+// binary came from), resolved at runtime from toolsRef.
+func toolsReleaseBase() string {
+	return "https://github.com/latebit-io/demarkus/releases/download/tools%2Fv" + toolsRef()
+}
 
 // ensureBinaries downloads + installs the pinned binaries to ~/.demarkus/bin
 // whenever the installed binaries don't report exactly the pinned versions
@@ -305,7 +332,7 @@ func ensureBinaries() (replaced bool, err error) {
 	defer os.RemoveAll(tmp)
 
 	logf("downloading demarkus binaries (server v%s, client v%s, tools v%s, %s)",
-		serverVersion, clientVersion, toolsVersion, plat)
+		serverVersion, clientVersion, toolsRef(), plat)
 
 	// server archive + checksums.
 	serverArchive := fmt.Sprintf("demarkus-server_%s_%s.tar.gz", serverVersion, plat)
@@ -337,12 +364,17 @@ func ensureBinaries() (replaced bool, err error) {
 		return false, err
 	}
 
-	// token archive (tools release) + tools checksums.
-	tokenArchive := fmt.Sprintf("demarkus-token_%s_%s.tar.gz", toolsVersion, plat)
-	if err := download(toolsReleaseBase+"/"+tokenArchive, filepath.Join(tmp, tokenArchive)); err != nil {
+	// token archive (tools release) + tools checksums. demarkus-token ships in the
+	// same tools release as this binary, so toolsRef() (the running binary's own
+	// version) is exactly the release that has a matching token. demarkus-plugin is
+	// NOT fetched here — bootstrap.sh installs it; provision re-fetching itself is
+	// the self-downgrade bug this fix removes.
+	base := toolsReleaseBase()
+	tokenArchive := fmt.Sprintf("demarkus-token_%s_%s.tar.gz", toolsRef(), plat)
+	if err := download(base+"/"+tokenArchive, filepath.Join(tmp, tokenArchive)); err != nil {
 		return false, fmt.Errorf("download %s: %w", tokenArchive, err)
 	}
-	if err := download(toolsReleaseBase+"/demarkus-tools_checksums.txt", filepath.Join(tmp, "tools_checksums.txt")); err != nil {
+	if err := download(base+"/demarkus-tools_checksums.txt", filepath.Join(tmp, "tools_checksums.txt")); err != nil {
 		return false, fmt.Errorf("download tools checksums: %w", err)
 	}
 	if err := sha256Verify(filepath.Join(tmp, "tools_checksums.txt"), filepath.Join(tmp, tokenArchive)); err != nil {
@@ -352,20 +384,8 @@ func ensureBinaries() (replaced bool, err error) {
 		return false, err
 	}
 
-	// demarkus-plugin archive (same tools release + checksum file as the token).
-	pluginArchive := fmt.Sprintf("demarkus-plugin_%s_%s.tar.gz", toolsVersion, plat)
-	if err := download(toolsReleaseBase+"/"+pluginArchive, filepath.Join(tmp, pluginArchive)); err != nil {
-		return false, fmt.Errorf("download %s: %w", pluginArchive, err)
-	}
-	if err := sha256Verify(filepath.Join(tmp, "tools_checksums.txt"), filepath.Join(tmp, pluginArchive)); err != nil {
-		return false, err
-	}
-	if err := extractTarGz(filepath.Join(tmp, pluginArchive), tmp); err != nil {
-		return false, err
-	}
-
 	// Install 0755 to the bin dir (bash install -m 0755).
-	for _, name := range []string{"demarkus-server", "demarkus-token", "demarkus-mcp", "demarkus-plugin"} {
+	for _, name := range []string{"demarkus-server", "demarkus-token", "demarkus-mcp"} {
 		if err := installFile(filepath.Join(tmp, name), filepath.Join(binDir, name)); err != nil {
 			return false, fmt.Errorf("install %s: %w", name, err)
 		}

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -151,16 +151,17 @@ func TestArgsRootMatches(t *testing.T) {
 }
 
 func TestVersionDriftFormatting(t *testing.T) {
-	want := "server=" + serverVersion + ",client=" + clientVersion + ",tools=" + toolsVersion + ",plugin=" + toolsVersion
+	want := "server=" + serverVersion + ",client=" + clientVersion + ",tools=" + toolsRef()
 	if got := desiredVersions(); got != want {
 		t.Errorf("desiredVersions() = %q, want %q", got, want)
 	}
 
 	// With no binaries installed, installedVersions reports all-empty fields,
-	// which never equals desired → ensureBinaries would re-download.
+	// which never equals desired → ensureBinaries would re-download. (No plugin
+	// field: provision doesn't manage demarkus-plugin — bootstrap.sh does.)
 	t.Setenv("HOME", t.TempDir())
 	got := installedVersions()
-	if got != "server=,client=,tools=,plugin=" {
+	if got != "server=,client=,tools=" {
 		t.Errorf("installedVersions() with no bins = %q", got)
 	}
 	if got == desiredVersions() {

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -151,9 +151,21 @@ func TestArgsRootMatches(t *testing.T) {
 }
 
 func TestVersionDriftFormatting(t *testing.T) {
-	want := "server=" + serverVersion + ",client=" + clientVersion + ",tools=" + toolsRef()
+	old := Version
+	t.Cleanup(func() { Version = old })
+
+	// A dev build (no real ldflags version) falls back to fallbackToolsVersion.
+	Version = "dev"
+	want := "server=" + serverVersion + ",client=" + clientVersion + ",tools=" + fallbackToolsVersion
 	if got := desiredVersions(); got != want {
-		t.Errorf("desiredVersions() = %q, want %q", got, want)
+		t.Errorf("desiredVersions() [dev] = %q, want %q", got, want)
+	}
+
+	// A real release derives the tools pin from the binary's own version.
+	Version = "9.9.9"
+	want = "server=" + serverVersion + ",client=" + clientVersion + ",tools=9.9.9"
+	if got := desiredVersions(); got != want {
+		t.Errorf("desiredVersions() [release] = %q, want %q", got, want)
 	}
 
 	// With no binaries installed, installedVersions reports all-empty fields,

--- a/tools/demarkus-plugin/registry_cmd.go
+++ b/tools/demarkus-plugin/registry_cmd.go
@@ -18,6 +18,9 @@ import (
 // cmdProvision runs the server lifecycle (binary install, config, managed server,
 // token, seed). Replaces setup.sh / provision.sh / the lib.sh lifecycle.
 func cmdProvision(args []string) {
+	// Hand the binary's own release version to provision so it fetches the token
+	// from the tools release it shipped in (and never re-downloads itself).
+	provision.Version = version
 	if len(args) == 0 {
 		if err := provision.Provision(); err != nil {
 			fail(err.Error())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated marketplace/plugin/package versions for memory, knowledge, and code plugins (0.12.1→0.12.2, 0.5.1→0.5.2).
  * Refreshed the bundled tools pin used during setup for multiple plugins to improve release-artifact alignment.
* **Bug Fixes**
  * Improved provisioning to select the correct tools release at runtime and fetch/verify the right token artifact.
  * Reduced version-drift behavior by aligning installed components with the running tools release.
  * Streamlined binary installation so only the required tools are managed (plugin binaries no longer targeted).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->