### PR TITLE
fix(tools): command triggers

### DIFF
--- a/plugins/pi-knowledge/CHANGELOG.md
+++ b/plugins/pi-knowledge/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.5.3
+
+- Fix: slash commands (`/knowledge`, `/knowledge-join`, `/knowledge-doctor`)
+  registered but never executed. The command handler injected the skill body with
+  `pi.sendMessage(...)` and no options; on an idle session pi appends the message
+  to history without starting a turn, so the agent never acted on it. Pass
+  `{ triggerTurn: true }` so the command starts a turn.

--- a/plugins/pi-knowledge/package.json
+++ b/plugins/pi-knowledge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-pi-knowledge",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Join an organizational demarkus knowledge system (a broker-fronted, shared, versioned markdown catalog) from the pi coding agent. Validates and registers the broker as an HTTP/OAuth MCP server via pi-mcp-adapter, steers sessions to consult the shared catalog first, makes it easy to navigate, and enforces a publish tag-gate (tags + required axes + required fields) so shared documents stay findable. No local server, no binaries — pure broker + OAuth.",
   "author": "latebit",
   "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/pi-knowledge",
@@ -30,7 +30,8 @@
     "skills",
     "commands",
     "context",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "devDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.74.0",

--- a/plugins/pi-knowledge/src/index.ts
+++ b/plugins/pi-knowledge/src/index.ts
@@ -154,7 +154,10 @@ export default function demarkusKnowledgeExtension(pi: ExtensionAPI): void {
           return;
         }
         const content = args && args.trim() ? `${body}\n\n---\nUser arguments: ${args.trim()}` : body;
-        pi.sendMessage({ customType: `${CUSTOM}-${name}`, content, display: false });
+        // triggerTurn: the command injects the skill body and must start a turn
+        // so the agent acts on it. Without it, an idle session just appends the
+        // message to history and never runs (the command appears to do nothing).
+        pi.sendMessage({ customType: `${CUSTOM}-${name}`, content, display: false }, { triggerTurn: true });
       },
     });
   }

--- a/plugins/pi-memory/CHANGELOG.md
+++ b/plugins/pi-memory/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.12.3
+
+- Fix: slash commands (`/soul`, `/soul-context`, `/soul-journal`, `/soul-init`,
+  `/soul-join`, `/soul-default`, `/soul-status`, `/soul-doctor`, `/soul-refresh`,
+  `/promote`, `/promote-scan`) registered but never executed. The command handler
+  injected the skill body with `pi.sendMessage(...)` and no options; on an idle
+  session pi appends the message to history without starting a turn, so the agent
+  never acted on it. Pass `{ triggerTurn: true }` so the command starts a turn.

--- a/plugins/pi-memory/package.json
+++ b/plugins/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-pi-memory",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Local, versioned memory for the pi coding agent via demarkus. Provisions a local demarkus-server, auto-generates a token, wires the demarkus-memory MCP server through pi-mcp-adapter, injects standing guidance so sessions self-document to the soul, and enforces a publish tag-gate plus a destination gate so documents stay findable and land on the right soul.",
   "author": "latebit",
   "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/pi-memory",
@@ -30,7 +30,8 @@
     "skills",
     "commands",
     "context",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "devDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.74.0",

--- a/plugins/pi-memory/src/index.ts
+++ b/plugins/pi-memory/src/index.ts
@@ -211,7 +211,10 @@ export default function demarkusMemoryExtension(pi: ExtensionAPI): void {
           return;
         }
         const content = args && args.trim() ? `${body}\n\n---\nUser arguments: ${args.trim()}` : body;
-        pi.sendMessage({ customType: `${CUSTOM}-${name}`, content, display: false });
+        // triggerTurn: the command injects the skill body and must start a turn
+        // so the agent acts on it. Without it, an idle session just appends the
+        // message to history and never runs (the command appears to do nothing).
+        pi.sendMessage({ customType: `${CUSTOM}-${name}`, content, display: false }, { triggerTurn: true });
       },
     });
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed slash commands in the knowledge and memory plugins so they now execute as expected instead of only appearing in chat history.
  * Improved command handling for `/knowledge`, `/knowledge-join`, `/knowledge-doctor`, `/soul-*`, and `/promote` so they start the appropriate turn automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->