### PR TITLE
fix(client): recover from timeouts on pooled QUIC connections

### DIFF
--- a/client/fetch/classify_test.go
+++ b/client/fetch/classify_test.go
@@ -1,0 +1,61 @@
+package fetch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// Every error this package returns is wrapped (fmt.Errorf("open stream: %w", …)
+// etc.), so the transient-failure classifier must unwrap. The bug it guards
+// against: a bare type assertion on the *wrapper* misses the underlying
+// context.DeadlineExceeded, classes a timed-out OpenStreamSync as non-transient,
+// and doWithRetry then never evicts+redials the dead pooled connection — wedging
+// every later request on that host.
+func TestIsTransientError_UnwrapsWrappedTimeout(t *testing.T) {
+	wrapped := fmt.Errorf("open stream: %w", context.DeadlineExceeded)
+
+	if !isTimeoutError(wrapped) {
+		t.Fatalf("isTimeoutError(%q) = false, want true (must unwrap to context.DeadlineExceeded)", wrapped)
+	}
+	if !isTransientError(wrapped) {
+		t.Fatalf("isTransientError(%q) = false, want true", wrapped)
+	}
+}
+
+func TestIsTransientError_BareTimeout(t *testing.T) {
+	if !isTimeoutError(context.DeadlineExceeded) {
+		t.Fatal("isTimeoutError(context.DeadlineExceeded) = false, want true")
+	}
+}
+
+type temporaryErr struct{}
+
+func (temporaryErr) Error() string   { return "temporary" }
+func (temporaryErr) Temporary() bool { return true }
+
+func TestIsTransientError_UnwrapsWrappedTemporary(t *testing.T) {
+	wrapped := fmt.Errorf("send request: %w", temporaryErr{})
+
+	if !isTemporaryError(wrapped) {
+		t.Fatalf("isTemporaryError(%q) = false, want true (must unwrap)", wrapped)
+	}
+	if !isTransientError(wrapped) {
+		t.Fatalf("isTransientError(%q) = false, want true", wrapped)
+	}
+}
+
+func TestIsTransientError_NonTransient(t *testing.T) {
+	err := errors.New("malformed response")
+
+	if isTimeoutError(err) {
+		t.Error("isTimeoutError(plain error) = true, want false")
+	}
+	if isTemporaryError(err) {
+		t.Error("isTemporaryError(plain error) = true, want false")
+	}
+	if isTransientError(err) {
+		t.Error("isTransientError(plain error) = true, want false")
+	}
+}

--- a/client/fetch/fetch.go
+++ b/client/fetch/fetch.go
@@ -4,6 +4,7 @@ package fetch
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log"
 	"maps"
@@ -393,18 +394,19 @@ func isTransientError(err error) bool {
 	return false
 }
 
+// isTimeoutError reports whether err (or anything it wraps) is a timeout.
+// It must use errors.As, not a bare type assertion: every error returned from
+// this package is wrapped (e.g. fmt.Errorf("open stream: %w", …)), and a
+// *fmt.wrapError does not itself implement Timeout(). A bare assertion misses
+// the wrapped context.DeadlineExceeded, so a timed-out OpenStreamSync would be
+// classed non-transient and doWithRetry would never evict+redial the dead
+// pooled connection — wedging every subsequent request on that host.
 func isTimeoutError(err error) bool {
-	type timeoutError interface {
-		Timeout() bool
-	}
-	te, ok := err.(timeoutError)
-	return ok && te.Timeout()
+	var te interface{ Timeout() bool }
+	return errors.As(err, &te) && te.Timeout()
 }
 
 func isTemporaryError(err error) bool {
-	type temporaryError interface {
-		Temporary() bool
-	}
-	te, ok := err.(temporaryError)
-	return ok && te.Temporary()
+	var te interface{ Temporary() bool }
+	return errors.As(err, &te) && te.Temporary()
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling so wrapped timeout and temporary errors are now recognized correctly during retry and connection pooling logic.
  * Non-transient errors continue to be treated as non-retryable.

* **Tests**
  * Added coverage for wrapped and unwrapped timeout/temporary error cases, plus non-transient error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->