### PR TITLE
fix(server):  Add status rate limiting and context-aware limiter waits

### DIFF
--- a/protocol/response.go
+++ b/protocol/response.go
@@ -22,6 +22,7 @@ const (
 	StatusConflict     = "conflict"
 	StatusBadRequest   = "bad-request"
 	StatusServerError  = "server-error"
+	StatusRateLimited  = "rate-limited"
 )
 
 // Response represents a Mark Protocol response.

--- a/server/cmd/demarkus-server/main.go
+++ b/server/cmd/demarkus-server/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -254,6 +255,15 @@ func main() {
 	logger.Info("server stopped")
 }
 
+// writeRateLimited sends a rate-limited status response on the stream. Unlike a
+// bare Close (which the client reads as an empty/statusless reply it cannot tell
+// apart from a dead connection), this carries an explicit status the client can
+// recognize and back off on.
+func writeRateLimited(w io.Writer) error {
+	_, err := protocol.Response{Status: protocol.StatusRateLimited}.WriteTo(w)
+	return err
+}
+
 func handleConn(conn *quic.Conn, h *handler.Handler, requestTimeout time.Duration, rl *ratelimit.Limiter, logger *slog.Logger) {
 	for {
 		stream, err := conn.AcceptStream(context.Background())
@@ -262,8 +272,28 @@ func handleConn(conn *quic.Conn, h *handler.Handler, requestTimeout time.Duratio
 		}
 		if rl != nil {
 			ip := ratelimit.ExtractIP(conn.RemoteAddr())
-			if !rl.Allow(ip) {
-				logger.Warn("rate limited")
+			// Throttle over-limit requests to the configured rate rather than
+			// dropping them. A dropped stream is closed with no response, which
+			// the client reads as an empty/statusless reply indistinguishable
+			// from a dead connection (e.g. a graph crawl then records a node
+			// with no title). Pacing keeps bursty-but-legitimate clients working.
+			// Bound the wait by the request timeout so a sustained flood that
+			// can't be served in that window still fails fast instead of queueing.
+			waitCtx := context.Background()
+			var cancel context.CancelFunc
+			if requestTimeout > 0 {
+				waitCtx, cancel = context.WithTimeout(waitCtx, requestTimeout)
+			}
+			err := rl.Wait(waitCtx, ip)
+			if cancel != nil {
+				cancel()
+			}
+			if err != nil {
+				logger.Warn("rate limited", "ip", ip, "error", err)
+				// Reply with an explicit rate-limited status rather than closing
+				// the stream empty: an empty reply is indistinguishable from a
+				// dead connection, so a client cannot tell it was throttled.
+				_ = writeRateLimited(stream)
 				_ = stream.Close()
 				continue
 			}

--- a/server/cmd/demarkus-server/main.go
+++ b/server/cmd/demarkus-server/main.go
@@ -264,45 +264,54 @@ func writeRateLimited(w io.Writer) error {
 	return err
 }
 
+// maxRateWaitBudget caps how long a request may block on the rate limiter when
+// no request timeout is configured (DEMARKUS_REQUEST_TIMEOUT of 0 or negative).
+// An unbounded wait could pile up goroutines under a sustained flood.
+const maxRateWaitBudget = 10 * time.Second
+
+// handleConn accepts streams on a connection and dispatches each one to its own
+// goroutine. The accept loop never blocks on the rate limiter — that work lives
+// in serveStream — so a throttled request can't stall acceptance of other
+// streams on the same connection.
 func handleConn(conn *quic.Conn, h *handler.Handler, requestTimeout time.Duration, rl *ratelimit.Limiter, logger *slog.Logger) {
 	for {
 		stream, err := conn.AcceptStream(context.Background())
 		if err != nil {
 			return // connection closed
 		}
-		if rl != nil {
-			ip := ratelimit.ExtractIP(conn.RemoteAddr())
-			// Throttle over-limit requests to the configured rate rather than
-			// dropping them. A dropped stream is closed with no response, which
-			// the client reads as an empty/statusless reply indistinguishable
-			// from a dead connection (e.g. a graph crawl then records a node
-			// with no title). Pacing keeps bursty-but-legitimate clients working.
-			// Bound the wait by the request timeout so a sustained flood that
-			// can't be served in that window still fails fast instead of queueing.
-			waitCtx := context.Background()
-			var cancel context.CancelFunc
-			if requestTimeout > 0 {
-				waitCtx, cancel = context.WithTimeout(waitCtx, requestTimeout)
-			}
-			err := rl.Wait(waitCtx, ip)
-			if cancel != nil {
-				cancel()
-			}
-			if err != nil {
-				logger.Warn("rate limited", "ip", ip, "error", err)
-				// Reply with an explicit rate-limited status rather than closing
-				// the stream empty: an empty reply is indistinguishable from a
-				// dead connection, so a client cannot tell it was throttled.
-				_ = writeRateLimited(stream)
-				_ = stream.Close()
-				continue
-			}
-		}
-		if requestTimeout > 0 {
-			_ = stream.SetReadDeadline(time.Now().Add(requestTimeout))
-		}
-		go h.HandleStream(stream)
+		go serveStream(conn, stream, h, requestTimeout, rl, logger)
 	}
+}
+
+// serveStream throttles a single request to the per-IP rate, then dispatches it
+// to the handler. Over-limit requests are paced (not dropped) so bursty-but-
+// legitimate clients keep working; a request that still can't be served within
+// the wait budget gets an explicit rate-limited status response rather than an
+// empty close (which a client cannot tell apart from a dead connection).
+func serveStream(conn *quic.Conn, stream *quic.Stream, h *handler.Handler, requestTimeout time.Duration, rl *ratelimit.Limiter, logger *slog.Logger) {
+	if rl != nil {
+		ip := ratelimit.ExtractIP(conn.RemoteAddr())
+		// Always bound the wait. requestTimeout may be 0/negative (timeout
+		// disabled or misconfigured), so fall back to a fixed cap rather than
+		// waiting forever.
+		budget := requestTimeout
+		if budget <= 0 {
+			budget = maxRateWaitBudget
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), budget)
+		err := rl.Wait(ctx, ip)
+		cancel()
+		if err != nil {
+			logger.Warn("rate limited", "ip", ip, "error", err)
+			_ = writeRateLimited(stream)
+			_ = stream.Close()
+			return
+		}
+	}
+	if requestTimeout > 0 {
+		_ = stream.SetReadDeadline(time.Now().Add(requestTimeout))
+	}
+	h.HandleStream(stream)
 }
 
 var (

--- a/server/cmd/demarkus-server/main.go
+++ b/server/cmd/demarkus-server/main.go
@@ -303,12 +303,20 @@ func serveStream(conn *quic.Conn, stream *quic.Stream, h *handler.Handler, reque
 		cancel()
 		if err != nil {
 			logger.Warn("rate limited", "ip", ip, "error", err)
-			_ = writeRateLimited(stream)
+			// A failed write is the silent-close case we're trying to avoid (the
+			// client gets nothing it can distinguish from a dead connection), so
+			// surface it rather than swallowing it.
+			if werr := writeRateLimited(stream); werr != nil {
+				logger.Warn("writing rate-limited response", "ip", ip, "error", werr)
+			}
+			// Close error is non-actionable on an already-rejected stream.
 			_ = stream.Close()
 			return
 		}
 	}
 	if requestTimeout > 0 {
+		// SetReadDeadline only errors on a closed stream; HandleStream then fails
+		// fast on its first read, so the error is non-actionable here.
 		_ = stream.SetReadDeadline(time.Now().Add(requestTimeout))
 	}
 	h.HandleStream(stream)

--- a/server/cmd/demarkus-server/ratelimit_response_test.go
+++ b/server/cmd/demarkus-server/ratelimit_response_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/latebit-io/demarkus/protocol"
+)
+
+// A rate-limited rejection must send a real, parseable response carrying the
+// rate-limited status — never an empty/statusless close, which a client cannot
+// tell apart from a dead connection (the bug that silently blanked crawl nodes).
+func TestWriteRateLimited(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeRateLimited(&buf); err != nil {
+		t.Fatalf("writeRateLimited: %v", err)
+	}
+
+	if buf.Len() == 0 {
+		t.Fatal("rate-limited reply is empty; client cannot distinguish it from a dead connection")
+	}
+
+	resp, err := protocol.ParseResponse(&buf)
+	if err != nil {
+		t.Fatalf("ParseResponse on rate-limited reply: %v", err)
+	}
+	if resp.Status != protocol.StatusRateLimited {
+		t.Fatalf("status = %q, want %q", resp.Status, protocol.StatusRateLimited)
+	}
+}

--- a/server/internal/ratelimit/limiter.go
+++ b/server/internal/ratelimit/limiter.go
@@ -2,6 +2,7 @@
 package ratelimit
 
 import (
+	"context"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -64,6 +65,34 @@ func (l *Limiter) Allow(ip string) bool {
 	actual := v.(*entry)
 	actual.lastSeen.Store(now)
 	return actual.limiter.Allow()
+}
+
+// Wait blocks until a token is available for the given IP or ctx is done,
+// returning ctx.Err() in the latter case. Unlike Allow (which rejects an
+// over-limit request outright), Wait *paces* it to the configured rate. This
+// matters for bursty-but-legitimate clients — e.g. a graph crawl firing many
+// concurrent FETCHes — which should be throttled, not failed. Dropping such a
+// request closes its stream with no response, and the client cannot tell that
+// empty reply apart from a dead connection.
+//
+// The caller bounds the wait with ctx (typically the per-request timeout), so a
+// sustained flood that cannot be served within the budget still fails fast
+// rather than queueing unboundedly.
+func (l *Limiter) Wait(ctx context.Context, ip string) error {
+	now := time.Now().UnixNano()
+
+	if v, ok := l.ips.Load(ip); ok {
+		e := v.(*entry)
+		e.lastSeen.Store(now)
+		return e.limiter.Wait(ctx)
+	}
+
+	e := &entry{limiter: rate.NewLimiter(l.rate, l.burst)}
+	e.lastSeen.Store(now)
+	v, _ := l.ips.LoadOrStore(ip, e)
+	actual := v.(*entry)
+	actual.lastSeen.Store(now)
+	return actual.limiter.Wait(ctx)
 }
 
 // Stop terminates the background cleanup goroutine.

--- a/server/internal/ratelimit/limiter_test.go
+++ b/server/internal/ratelimit/limiter_test.go
@@ -1,6 +1,7 @@
 package ratelimit
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
@@ -22,6 +23,53 @@ func TestAllow(t *testing.T) {
 	// Third request exceeds burst — denied.
 	if l.Allow("10.0.0.1") {
 		t.Fatal("third request should be denied (burst exhausted)")
+	}
+}
+
+// Wait serves a burst immediately (up to the burst size) rather than rejecting,
+// so a bursty-but-legitimate client is paced, not failed.
+func TestWaitAllowsBurst(t *testing.T) {
+	l := New(1, 3) // 1/s sustained, burst of 3
+	defer l.Stop()
+
+	ctx := context.Background()
+	for i := 1; i <= 3; i++ {
+		if err := l.Wait(ctx, "10.0.0.2"); err != nil {
+			t.Fatalf("Wait #%d within burst returned %v, want nil", i, err)
+		}
+	}
+}
+
+// Once the burst is spent the next token is ~1s away; a request whose context
+// deadline passes first must return the context error (fail fast), not block
+// indefinitely — this is what bounds a sustained flood.
+func TestWaitRespectsContextDeadline(t *testing.T) {
+	l := New(1, 1) // 1/s, burst of 1
+	defer l.Stop()
+
+	ip := "10.0.0.3"
+	if err := l.Wait(context.Background(), ip); err != nil {
+		t.Fatalf("first Wait returned %v, want nil", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if err := l.Wait(ctx, ip); err == nil {
+		t.Fatal("second Wait under a tight deadline returned nil, want a context error")
+	}
+}
+
+// Throttling is per-IP: one IP exhausting its burst must not delay another.
+func TestWaitSeparateIPs(t *testing.T) {
+	l := New(1, 1) // 1/s, burst of 1
+	defer l.Stop()
+
+	ctx := context.Background()
+	if err := l.Wait(ctx, "10.0.0.4"); err != nil {
+		t.Fatalf("IP A first Wait returned %v, want nil", err)
+	}
+	if err := l.Wait(ctx, "10.0.0.5"); err != nil {
+		t.Fatalf("IP B first Wait returned %v, want nil (separate bucket)", err)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clear `rate-limited` protocol status so throttled requests receive an explicit response instead of being dropped.
  * Introduced context-aware rate limiting that waits for capacity (within the configured budget) before allowing a request through.
* **Bug Fixes**
  * Over-limit handling now cleanly times out/cancels while waiting, and throttling no longer blocks accepting other streams.
  * Rate limiting remains isolated per IP.
* **Tests**
  * Added tests to verify the `rate-limited` response output and the limiter’s `Wait` behavior (burst allowance, deadline handling, per-IP isolation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->