### PR TITLE
feat(server): hide archived documents from LIST by default

### DIFF
--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -82,6 +82,7 @@ func main() {
 type markClient interface {
 	Fetch(host, path, token string) (fetch.Result, error)
 	List(host, path, token string) (fetch.Result, error)
+	ListWithOptions(host, path, token string, opts fetch.ListOptions) (fetch.Result, error)
 	Versions(host, path, token string) (fetch.Result, error)
 	Lookup(host, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error)
 	Publish(host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
@@ -152,12 +153,17 @@ func markListTool(host string) mcp.Tool {
 	return mcp.NewTool("mark_list",
 		mcp.WithDescription(
 			"List documents and subdirectories on a Mark Protocol server. "+
-				"Use this to discover what documents exist. "+
+				"Use this to discover what documents exist. Archived documents are "+
+				"hidden by default, along with directories that contain only archived "+
+				"documents; set include_archived to true for a recovery/audit view. "+
 				urlHint(host),
 		),
 		mcp.WithString("url",
 			mcp.Required(),
 			mcp.Description(urlDesc(host)),
+		),
+		mcp.WithBoolean("include_archived",
+			mcp.Description("Include archived documents (and all-archived directories) in the listing. Default false."),
 		),
 	)
 }
@@ -472,7 +478,8 @@ func (h *handler) markList(_ context.Context, req mcp.CallToolRequest) (*mcp.Cal
 		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", err)), nil
 	}
 
-	result, err := h.client.List(host, path, h.resolveToken(host))
+	opts := fetch.ListOptions{IncludeArchived: req.GetBool("include_archived", false)}
+	result, err := h.client.ListWithOptions(host, path, h.resolveToken(host), opts)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("list failed: %v", err)), nil
 	}

--- a/client/cmd/demarkus-mcp/main_test.go
+++ b/client/cmd/demarkus-mcp/main_test.go
@@ -502,6 +502,9 @@ func (s *stubClient) List(host, path, token string) (fetch.Result, error) {
 	}
 	return fetch.Result{}, nil
 }
+func (s *stubClient) ListWithOptions(host, path, token string, _ fetch.ListOptions) (fetch.Result, error) {
+	return s.List(host, path, token)
+}
 func (s *stubClient) Publish(host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error) {
 	if s.publishFn != nil {
 		return s.publishFn(host, path, body, token, expectedVersion, meta)

--- a/client/cmd/demarkus/main.go
+++ b/client/cmd/demarkus/main.go
@@ -58,6 +58,7 @@ func requestMain() {
 	expectedVersion := flag.Int("expected-version", -1, "version check: -1 skip (default), 0 create-only, >0 require match; required (>0) for APPEND")
 	meta := metaFlag{}
 	flag.Var(meta, "meta", "publisher metadata key=value for PUBLISH/APPEND (repeatable); e.g. -meta tags=go,auth -meta importance=0.9")
+	includeArchived := flag.Bool("include-archived", false, "LIST only: include archived documents (and all-archived directories) in the listing")
 	verbose := flag.Bool("v", false, "show status and metadata header before body")
 	noCache := flag.Bool("no-cache", false, "disable caching")
 	insecure := flag.Bool("insecure", false, "skip TLS certificate verification")
@@ -114,7 +115,7 @@ func requestMain() {
 	case protocol.VerbFetch:
 		result, err = client.Fetch(host, path, token)
 	case protocol.VerbList:
-		result, err = client.List(host, path, token)
+		result, err = client.ListWithOptions(host, path, token, fetch.ListOptions{IncludeArchived: *includeArchived})
 	case protocol.VerbVersions:
 		result, err = client.Versions(host, path, token)
 	case protocol.VerbPublish:

--- a/client/fetch/fetch.go
+++ b/client/fetch/fetch.go
@@ -121,10 +121,27 @@ func (c *Client) Fetch(host, path, token string) (Result, error) {
 	return c.cachedRequest(host, path, token, protocol.VerbFetch)
 }
 
+// ListOptions carries optional parameters for a LIST request.
+type ListOptions struct {
+	// IncludeArchived asks the server to include archived documents (and
+	// directories that contain only archived documents) in the listing.
+	// Default false: archived entries are hidden.
+	IncludeArchived bool
+}
+
 // List retrieves a directory listing from a Mark Protocol server.
 // If token is non-empty, it is sent as the auth metadata for read access to private paths.
 func (c *Client) List(host, path, token string) (Result, error) {
-	return c.cachedRequest(host, path, token, protocol.VerbList)
+	return c.ListWithOptions(host, path, token, ListOptions{})
+}
+
+// ListWithOptions is List with explicit LIST options (e.g. IncludeArchived).
+func (c *Client) ListWithOptions(host, path, token string, opts ListOptions) (Result, error) {
+	var extra map[string]string
+	if opts.IncludeArchived {
+		extra = map[string]string{"include-archived": "true"}
+	}
+	return c.cachedRequestMeta(host, path, token, protocol.VerbList, extra)
 }
 
 // Versions retrieves the version history of a document.
@@ -222,16 +239,29 @@ func (c *Client) Archive(host, path, token string) (Result, error) {
 
 // cachedRequest handles FETCH and LIST with conditional caching.
 func (c *Client) cachedRequest(host, path, token, verb string) (Result, error) {
+	return c.cachedRequestMeta(host, path, token, verb, nil)
+}
+
+// cachedRequestMeta is cachedRequest with extra request metadata (e.g. LIST
+// options). When extra is non-empty the response cache is bypassed: the cache
+// key is (host, path, verb) and does not encode the extra metadata, so a
+// cached option-free response must not satisfy an option-bearing request, nor
+// the reverse.
+func (c *Client) cachedRequestMeta(host, path, token, verb string, extra map[string]string) (Result, error) {
 	return c.doWithRetry(host, func(conn *quic.Conn) (Result, error) {
 		req := protocol.Request{Verb: verb, Path: path, Metadata: make(map[string]string)}
 
 		if token != "" {
 			req.Metadata["auth"] = token
 		}
+		for k, v := range extra {
+			req.Metadata[k] = v
+		}
 
-		// Skip cache for authenticated requests to avoid persisting
-		// private content to disk.
-		useCache := c.opts.Cache != nil && token == ""
+		// Skip cache for authenticated requests (to avoid persisting private
+		// content to disk) and for option-bearing requests (the cache key does
+		// not encode the extra metadata).
+		useCache := c.opts.Cache != nil && token == "" && len(extra) == 0
 
 		var cached *cache.Entry
 		if useCache {

--- a/client/fetch/fetch.go
+++ b/client/fetch/fetch.go
@@ -254,9 +254,7 @@ func (c *Client) cachedRequestMeta(host, path, token, verb string, extra map[str
 		if token != "" {
 			req.Metadata["auth"] = token
 		}
-		for k, v := range extra {
-			req.Metadata[k] = v
-		}
+		maps.Copy(req.Metadata, extra)
 
 		// Skip cache for authenticated requests (to avoid persisting private
 		// content to disk) and for option-bearing requests (the cache key does

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -401,7 +401,12 @@ func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, er
 		}
 		if !includeArchived {
 			if e.IsDir() {
-				if _, ok := liveDirs[name]; !ok {
+				// Fast path: the index names this child as holding a live
+				// versioned doc. Fallback: the index only tracks versioned
+				// documents, so a child it misses may still hold visible
+				// entries (regular/legacy flat files) — scan disk before
+				// pruning rather than hide content the listing would show.
+				if _, ok := liveDirs[name]; !ok && !dirHasVisibleEntry(filepath.Join(dirPath, name)) {
 					continue // subtree holds only archived documents
 				}
 			} else if entryArchived(filepath.Join(dirPath, name)) {
@@ -443,6 +448,39 @@ func (s *Store) liveChildDirs(dirReq string) map[string]struct{} {
 		}
 	}
 	return out
+}
+
+// dirHasVisibleEntry reports whether the directory subtree rooted at dirAbs
+// holds at least one entry a filtered listing would show — any non-archived
+// file, including regular/legacy flat files that pathIdx does not track
+// (entryArchived errs toward visibility for those). It is the slow-path
+// complement to liveChildDirs: only consulted for child directories the index
+// does not already name, so an indexed (common-case) directory never pays for
+// a disk walk, and an all-archived directory is scanned rather than a live
+// flat file being wrongly hidden. Returns false on an unreadable directory so
+// an inaccessible subtree is pruned rather than shown empty.
+func dirHasVisibleEntry(dirAbs string) bool {
+	entries, err := os.ReadDir(dirAbs)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if isHiddenEntry(name) {
+			continue
+		}
+		child := filepath.Join(dirAbs, name)
+		if e.IsDir() {
+			if dirHasVisibleEntry(child) {
+				return true
+			}
+			continue
+		}
+		if !entryArchived(child) {
+			return true
+		}
+	}
+	return false
 }
 
 // entryArchived reports whether a directory entry that is a current-version

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -360,8 +360,13 @@ func (s *Store) Get(reqPath string, version int) (*Document, error) {
 	}, nil
 }
 
-// ListDir returns directory entries at the given path, excluding dot-files.
-func (s *Store) ListDir(reqPath string) ([]os.DirEntry, error) {
+// ListDir returns directory entries at the given path, excluding dot-files
+// and the versions/ directory. When includeArchived is false, archived
+// documents are omitted, as are subdirectories whose entire subtree contains
+// only archived documents (an all-archived directory would otherwise linger as
+// an empty shell). When true, every current entry is returned regardless of
+// archival — the recovery/audit view.
+func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, error) {
 	dirPath, err := s.resolve(reqPath)
 	if err != nil {
 		return nil, err
@@ -380,16 +385,76 @@ func (s *Store) ListDir(reqPath string) ([]os.DirEntry, error) {
 		return nil, err
 	}
 
-	// Filter dot-files and the versions directory.
+	// Filter dot-files and the versions directory, plus archived entries
+	// unless the caller asked to see them.
 	filtered := entries[:0]
 	for _, e := range entries {
 		name := e.Name()
 		if strings.HasPrefix(name, ".") || name == "versions" {
 			continue
 		}
+		if !includeArchived {
+			child := filepath.Join(dirPath, name)
+			if e.IsDir() {
+				if !dirHasLiveDoc(child) {
+					continue // subtree holds only archived documents
+				}
+			} else if entryArchived(child) {
+				continue
+			}
+		}
 		filtered = append(filtered, e)
 	}
 	return filtered, nil
+}
+
+// entryArchived reports whether a directory entry that is a current-version
+// document symlink points at an archived version. It mirrors the resolve-and-
+// read that walkCurrentFiles performs. A non-symlink entry, a broken link, or
+// an unreadable target is treated as not archived (shown) — the listing errs
+// toward visibility, never hiding something it could not positively classify.
+func entryArchived(childPath string) bool {
+	fi, err := os.Lstat(childPath)
+	if err != nil || fi.Mode()&os.ModeSymlink == 0 {
+		return false
+	}
+	resolved, err := filepath.EvalSymlinks(childPath)
+	if err != nil {
+		return false
+	}
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return false
+	}
+	return isArchived(data)
+}
+
+// dirHasLiveDoc reports whether the directory subtree rooted at dirAbs holds at
+// least one non-archived document. Used to prune directories that contain only
+// archived documents from a filtered listing. Returns false on an unreadable
+// directory so an inaccessible subtree is pruned rather than shown empty.
+func dirHasLiveDoc(dirAbs string) bool {
+	entries, err := os.ReadDir(dirAbs)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasPrefix(name, ".") || name == "versions" {
+			continue
+		}
+		child := filepath.Join(dirAbs, name)
+		if e.IsDir() {
+			if dirHasLiveDoc(child) {
+				return true
+			}
+			continue
+		}
+		if !entryArchived(child) {
+			return true
+		}
+	}
+	return false
 }
 
 // IsDir reports whether the given path is a directory within the content root.

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -390,22 +390,35 @@ func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, er
 	filtered := entries[:0]
 	for _, e := range entries {
 		name := e.Name()
-		if strings.HasPrefix(name, ".") || name == "versions" {
+		if isHiddenEntry(name) {
 			continue
 		}
 		if !includeArchived {
-			child := filepath.Join(dirPath, name)
 			if e.IsDir() {
-				if !dirHasLiveDoc(child) {
+				if !s.dirHasLiveDoc(childReqPath(reqPath, name)) {
 					continue // subtree holds only archived documents
 				}
-			} else if entryArchived(child) {
+			} else if entryArchived(filepath.Join(dirPath, name)) {
 				continue
 			}
 		}
 		filtered = append(filtered, e)
 	}
 	return filtered, nil
+}
+
+// isHiddenEntry reports whether a directory entry name is always excluded from
+// a listing, regardless of archival: dot-files and the per-document versions/
+// directory. Shared by ListDir so the exclusion list lives in one place.
+func isHiddenEntry(name string) bool {
+	return strings.HasPrefix(name, ".") || name == "versions"
+}
+
+// childReqPath joins a directory's request path and an entry name into the
+// child's request path — always slash-separated with a leading slash, matching
+// the keys the store holds in pathIdx.
+func childReqPath(dirReq, name string) string {
+	return strings.TrimRight(dirReq, "/") + "/" + name
 }
 
 // entryArchived reports whether a directory entry that is a current-version
@@ -429,28 +442,18 @@ func entryArchived(childPath string) bool {
 	return isArchived(data)
 }
 
-// dirHasLiveDoc reports whether the directory subtree rooted at dirAbs holds at
-// least one non-archived document. Used to prune directories that contain only
-// archived documents from a filtered listing. Returns false on an unreadable
-// directory so an inaccessible subtree is pruned rather than shown empty.
-func dirHasLiveDoc(dirAbs string) bool {
-	entries, err := os.ReadDir(dirAbs)
-	if err != nil {
-		return false
-	}
-	for _, e := range entries {
-		name := e.Name()
-		if strings.HasPrefix(name, ".") || name == "versions" {
-			continue
-		}
-		child := filepath.Join(dirAbs, name)
-		if e.IsDir() {
-			if dirHasLiveDoc(child) {
-				return true
-			}
-			continue
-		}
-		if !entryArchived(child) {
+// dirHasLiveDoc reports whether any current (non-archived) document lives under
+// the directory request path dirReq. It reads the in-memory pathIdx — which the
+// store maintains incrementally on every write and archive/unarchive (see
+// UpdateHashIndex / RemoveHashEntry) — so pruning an all-archived directory from
+// a listing costs an index scan rather than a recursive filesystem walk on the
+// hot LIST/FETCH path.
+func (s *Store) dirHasLiveDoc(dirReq string) bool {
+	prefix := strings.TrimRight(dirReq, "/") + "/"
+	s.hashMu.RLock()
+	defer s.hashMu.RUnlock()
+	for p := range s.pathIdx {
+		if strings.HasPrefix(p, prefix) {
 			return true
 		}
 	}

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -386,7 +386,13 @@ func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, er
 	}
 
 	// Filter dot-files and the versions directory, plus archived entries
-	// unless the caller asked to see them.
+	// unless the caller asked to see them. liveChildDirs is computed once (a
+	// single pathIdx pass) so pruning is an O(1) lookup per child directory
+	// rather than a per-directory index scan.
+	var liveDirs map[string]struct{}
+	if !includeArchived {
+		liveDirs = s.liveChildDirs(reqPath)
+	}
 	filtered := entries[:0]
 	for _, e := range entries {
 		name := e.Name()
@@ -395,7 +401,7 @@ func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, er
 		}
 		if !includeArchived {
 			if e.IsDir() {
-				if !s.dirHasLiveDoc(childReqPath(reqPath, name)) {
+				if _, ok := liveDirs[name]; !ok {
 					continue // subtree holds only archived documents
 				}
 			} else if entryArchived(filepath.Join(dirPath, name)) {
@@ -414,11 +420,29 @@ func isHiddenEntry(name string) bool {
 	return strings.HasPrefix(name, ".") || name == "versions"
 }
 
-// childReqPath joins a directory's request path and an entry name into the
-// child's request path — always slash-separated with a leading slash, matching
-// the keys the store holds in pathIdx.
-func childReqPath(dirReq, name string) string {
-	return strings.TrimRight(dirReq, "/") + "/" + name
+// liveChildDirs returns the set of immediate child-directory names under the
+// directory request path dirReq that contain at least one current (non-
+// archived) document somewhere in their subtree. It makes a single pass over
+// the in-memory pathIdx — which the store maintains incrementally on every
+// write and archive/unarchive (see UpdateHashIndex / RemoveHashEntry) — so a
+// LIST prunes all-archived directories with one index scan and O(1) lookups,
+// never a recursive filesystem walk on the hot path.
+func (s *Store) liveChildDirs(dirReq string) map[string]struct{} {
+	prefix := strings.TrimRight(dirReq, "/") + "/"
+	out := make(map[string]struct{})
+	s.hashMu.RLock()
+	defer s.hashMu.RUnlock()
+	for p := range s.pathIdx {
+		if !strings.HasPrefix(p, prefix) {
+			continue
+		}
+		// The first segment after the prefix names an immediate child; a
+		// remaining slash means that child is a directory holding the doc.
+		if child, _, ok := strings.Cut(p[len(prefix):], "/"); ok {
+			out[child] = struct{}{}
+		}
+	}
+	return out
 }
 
 // entryArchived reports whether a directory entry that is a current-version
@@ -440,24 +464,6 @@ func entryArchived(childPath string) bool {
 		return false
 	}
 	return isArchived(data)
-}
-
-// dirHasLiveDoc reports whether any current (non-archived) document lives under
-// the directory request path dirReq. It reads the in-memory pathIdx — which the
-// store maintains incrementally on every write and archive/unarchive (see
-// UpdateHashIndex / RemoveHashEntry) — so pruning an all-archived directory from
-// a listing costs an index scan rather than a recursive filesystem walk on the
-// hot LIST/FETCH path.
-func (s *Store) dirHasLiveDoc(dirReq string) bool {
-	prefix := strings.TrimRight(dirReq, "/") + "/"
-	s.hashMu.RLock()
-	defer s.hashMu.RUnlock()
-	for p := range s.pathIdx {
-		if strings.HasPrefix(p, prefix) {
-			return true
-		}
-	}
-	return false
 }
 
 // IsDir reports whether the given path is a directory within the content root.

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -26,7 +26,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	slashpath "path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -157,7 +159,12 @@ type Store struct {
 	root    string
 	hashMu  sync.RWMutex
 	hashIdx map[string]string // content hash → request path
-	pathIdx map[string]string // request path → content hash (reverse index)
+	// pathIdx maps request path → content hash (reverse index). Beyond hash
+	// lookups, ListDir's archived-filtering treats membership as "current,
+	// non-archived versioned doc" (see liveChildren) — a change to what this
+	// index tracks changes listing behavior. A miss only degrades to a disk
+	// scan, but keep membership semantics exact.
+	pathIdx map[string]string
 }
 
 // New creates a store rooted at the given directory.
@@ -386,12 +393,16 @@ func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, er
 	}
 
 	// Filter dot-files and the versions directory, plus archived entries
-	// unless the caller asked to see them. liveChildDirs is computed once (a
-	// single pathIdx pass) so pruning is an O(1) lookup per child directory
-	// rather than a per-directory index scan.
-	var liveDirs map[string]struct{}
+	// unless the caller asked to see them. liveChildren is computed once (a
+	// single pathIdx pass) so classification is an O(1) lookup per entry —
+	// files and directories the index names as live never touch disk.
+	var live liveChildren
+	var absRoot string
 	if !includeArchived {
-		liveDirs = s.liveChildDirs(reqPath)
+		live = s.liveChildren(reqPath)
+		if absRoot, err = s.resolvedRoot(); err != nil {
+			return nil, err
+		}
 	}
 	filtered := entries[:0]
 	for _, e := range entries {
@@ -406,10 +417,10 @@ func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, er
 				// documents, so a child it misses may still hold visible
 				// entries (regular/legacy flat files) — scan disk before
 				// pruning rather than hide content the listing would show.
-				if _, ok := liveDirs[name]; !ok && !dirHasVisibleEntry(filepath.Join(dirPath, name)) {
+				if _, ok := live.dirs[name]; !ok && !dirHasVisibleEntry(filepath.Join(dirPath, name), absRoot) {
 					continue // subtree holds only archived documents
 				}
-			} else if entryArchived(filepath.Join(dirPath, name)) {
+			} else if _, ok := live.files[name]; !ok && entryArchived(filepath.Join(dirPath, name), absRoot) {
 				continue
 			}
 		}
@@ -425,41 +436,70 @@ func isHiddenEntry(name string) bool {
 	return strings.HasPrefix(name, ".") || name == "versions"
 }
 
-// liveChildDirs returns the set of immediate child-directory names under the
-// directory request path dirReq that contain at least one current (non-
-// archived) document somewhere in their subtree. It makes a single pass over
-// the in-memory pathIdx — which the store maintains incrementally on every
-// write and archive/unarchive (see UpdateHashIndex / RemoveHashEntry) — so a
-// LIST prunes all-archived directories with one index scan and O(1) lookups,
-// never a recursive filesystem walk on the hot path.
-func (s *Store) liveChildDirs(dirReq string) map[string]struct{} {
-	prefix := strings.TrimRight(dirReq, "/") + "/"
-	out := make(map[string]struct{})
+// liveChildren names the immediate children of a listed directory that the
+// index proves live: files is the live documents directly in the directory,
+// dirs is the child directories holding a live document somewhere beneath.
+type liveChildren struct {
+	files map[string]struct{}
+	dirs  map[string]struct{}
+}
+
+// liveChildren makes a single pass over the in-memory pathIdx — which the
+// store maintains incrementally on every write and archive/unarchive (see
+// UpdateHashIndex / RemoveHashEntry) — and classifies the live docs under the
+// directory request path dirReq, so a LIST answers both "is this file live?"
+// and "does this child directory hold live docs?" with O(1) lookups, never
+// touching disk for indexed entries.
+//
+// The request path is canonicalized first: pathIdx keys are canonical
+// ("/"+filepath.Rel), so a non-canonical caller path ("//docs", "/docs/.")
+// would otherwise match nothing and silently force the disk fallback for
+// every child. Docs with a hidden path segment (dot-named) are skipped even
+// though the index tracks them: a listing never shows them, so counting one
+// as live would keep its parent visible as an empty shell.
+func (s *Store) liveChildren(dirReq string) liveChildren {
+	canon := slashpath.Clean("/" + strings.Trim(dirReq, "/"))
+	prefix := strings.TrimRight(canon, "/") + "/"
+	out := liveChildren{files: make(map[string]struct{}), dirs: make(map[string]struct{})}
 	s.hashMu.RLock()
 	defer s.hashMu.RUnlock()
 	for p := range s.pathIdx {
-		if !strings.HasPrefix(p, prefix) {
+		rest, ok := strings.CutPrefix(p, prefix)
+		if !ok || hasHiddenSegment(rest) {
 			continue
 		}
-		// The first segment after the prefix names an immediate child; a
-		// remaining slash means that child is a directory holding the doc.
-		if child, _, ok := strings.Cut(p[len(prefix):], "/"); ok {
-			out[child] = struct{}{}
+		// A remaining slash means the first segment is a child directory
+		// holding the doc; otherwise the doc is a file directly in dirReq.
+		if child, _, isDir := strings.Cut(rest, "/"); isDir {
+			out.dirs[child] = struct{}{}
+		} else {
+			out.files[rest] = struct{}{}
 		}
 	}
 	return out
+}
+
+// hasHiddenSegment reports whether any segment of the relative slash path
+// would be excluded from a listing by isHiddenEntry.
+func hasHiddenSegment(rel string) bool {
+	for seg := range strings.SplitSeq(rel, "/") {
+		if isHiddenEntry(seg) {
+			return true
+		}
+	}
+	return false
 }
 
 // dirHasVisibleEntry reports whether the directory subtree rooted at dirAbs
 // holds at least one entry a filtered listing would show — any non-archived
 // file, including regular/legacy flat files that pathIdx does not track
 // (entryArchived errs toward visibility for those). It is the slow-path
-// complement to liveChildDirs: only consulted for child directories the index
+// complement to liveChildren: only consulted for child directories the index
 // does not already name, so an indexed (common-case) directory never pays for
 // a disk walk, and an all-archived directory is scanned rather than a live
 // flat file being wrongly hidden. Returns false on an unreadable directory so
 // an inaccessible subtree is pruned rather than shown empty.
-func dirHasVisibleEntry(dirAbs string) bool {
+func dirHasVisibleEntry(dirAbs, absRoot string) bool {
 	entries, err := os.ReadDir(dirAbs)
 	if err != nil {
 		return false
@@ -471,12 +511,12 @@ func dirHasVisibleEntry(dirAbs string) bool {
 		}
 		child := filepath.Join(dirAbs, name)
 		if e.IsDir() {
-			if dirHasVisibleEntry(child) {
+			if dirHasVisibleEntry(child, absRoot) {
 				return true
 			}
 			continue
 		}
-		if !entryArchived(child) {
+		if !entryArchived(child, absRoot) {
 			return true
 		}
 	}
@@ -484,11 +524,16 @@ func dirHasVisibleEntry(dirAbs string) bool {
 }
 
 // entryArchived reports whether a directory entry that is a current-version
-// document symlink points at an archived version. It mirrors the resolve-and-
-// read that walkCurrentFiles performs. A non-symlink entry, a broken link, or
-// an unreadable target is treated as not archived (shown) — the listing errs
+// document symlink points at an archived version. It applies the same guards
+// walkCurrentFiles uses for this resolve-and-read pattern: a target escaping
+// the content root is never opened (isContained), and a non-regular target
+// (FIFO, device — opening one can block forever) is never opened either. The
+// read itself is a bounded prefix: the store-managed frontmatter that carries
+// the archived flag is capped at maxStoreFrontmatter, so the document body is
+// never pulled in. A non-symlink entry, a broken link, an unreadable target,
+// or any guarded state is treated as not archived (shown) — the listing errs
 // toward visibility, never hiding something it could not positively classify.
-func entryArchived(childPath string) bool {
+func entryArchived(childPath, absRoot string) bool {
 	fi, err := os.Lstat(childPath)
 	if err != nil || fi.Mode()&os.ModeSymlink == 0 {
 		return false
@@ -497,11 +542,26 @@ func entryArchived(childPath string) bool {
 	if err != nil {
 		return false
 	}
-	data, err := os.ReadFile(resolved)
+	if !isContained(resolved, absRoot) {
+		return false
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	f, err := os.Open(resolved)
 	if err != nil {
 		return false
 	}
-	return isArchived(data)
+	defer func() { _ = f.Close() }()
+	// maxStoreFrontmatter bounds the frontmatter block, so this prefix is
+	// guaranteed to contain the closing fence; the slack covers the fences.
+	buf := make([]byte, maxStoreFrontmatter+256)
+	n, err := io.ReadFull(f, buf)
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
+		return false
+	}
+	return isArchived(buf[:n])
 }
 
 // IsDir reports whether the given path is a directory within the content root.

--- a/protocol/store/store_test.go
+++ b/protocol/store/store_test.go
@@ -180,6 +180,15 @@ func TestListDir_HidesArchived(t *testing.T) {
 	if err := s.Archive("/attic/old.md", true); err != nil {
 		t.Fatalf("Archive /attic/old.md: %v", err)
 	}
+	// A directory holding only a regular (unversioned, legacy/flat) file:
+	// pathIdx never tracks it, but the listing shows such files, so the
+	// directory must not be pruned.
+	if err := os.MkdirAll(filepath.Join(root, "flatdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "flatdir", "plain.md"), []byte("# flat\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	names := func(entries []os.DirEntry) map[string]bool {
 		m := map[string]bool{}
@@ -207,6 +216,9 @@ func TestListDir_HidesArchived(t *testing.T) {
 	}
 	if !h["nested"] {
 		t.Errorf("hide: want nested/ kept (live doc several levels down), got %v", h)
+	}
+	if !h["flatdir"] {
+		t.Errorf("hide: want flatdir/ kept (visible unversioned file, unindexed), got %v", h)
 	}
 
 	// include-archived: everything current is listed, including attic/.

--- a/protocol/store/store_test.go
+++ b/protocol/store/store_test.go
@@ -166,9 +166,10 @@ func TestListDir_HidesArchived(t *testing.T) {
 	root := t.TempDir()
 	s := New(root)
 
-	// Two live docs at root, one that will be archived, and a directory whose
-	// only document is archived (should be pruned when archived are hidden).
-	for _, p := range []string{"/live.md", "/gone.md", "/attic/old.md"} {
+	// Live docs at root, one that will be archived, a directory whose only
+	// document is archived (pruned when hidden), and a nested directory that
+	// keeps a live doc several levels down (must survive pruning).
+	for _, p := range []string{"/live.md", "/gone.md", "/attic/old.md", "/nested/a/b/keep.md"} {
 		if _, err := s.Write(p, []byte("# "+p+"\n"), nil); err != nil {
 			t.Fatalf("Write %s: %v", p, err)
 		}
@@ -203,6 +204,9 @@ func TestListDir_HidesArchived(t *testing.T) {
 	}
 	if h["attic"] {
 		t.Errorf("hide: want all-archived dir attic/ pruned, got %v", h)
+	}
+	if !h["nested"] {
+		t.Errorf("hide: want nested/ kept (live doc several levels down), got %v", h)
 	}
 
 	// include-archived: everything current is listed, including attic/.

--- a/protocol/store/store_test.go
+++ b/protocol/store/store_test.go
@@ -232,6 +232,47 @@ func TestListDir_HidesArchived(t *testing.T) {
 			t.Errorf("show: want %s present, got %v", want, sh)
 		}
 	}
+
+	// Non-canonical request paths must behave identically — the index fast
+	// path canonicalizes before prefix-matching pathIdx's canonical keys.
+	for _, p := range []string{"//", "/."} {
+		nc, err := s.ListDir(p, false)
+		if err != nil {
+			t.Fatalf("ListDir %q: %v", p, err)
+		}
+		if got := names(nc); !got["live.md"] || got["gone.md"] || got["attic"] {
+			t.Errorf("ListDir %q: filtering differs from canonical /: got %v", p, got)
+		}
+	}
+}
+
+func TestListDir_DotNamedDocDoesNotKeepShellDir(t *testing.T) {
+	root := t.TempDir()
+	s := New(root)
+
+	// A directory whose only doc is dot-named: the listing of the directory
+	// hides the doc (isHiddenEntry), so the directory must be pruned from its
+	// parent too — the index and the disk fallback must agree, or the parent
+	// shows an empty-shell directory.
+	if _, err := s.Write("/work/.scratch.md", []byte("# hidden\n"), nil); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	entries, err := s.ListDir("/", false)
+	if err != nil {
+		t.Fatalf("ListDir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() == "work" {
+			t.Errorf("want work/ pruned (only content is a hidden dot-file), got listed")
+		}
+	}
+	inner, err := s.ListDir("/work", false)
+	if err != nil {
+		t.Fatalf("ListDir /work: %v", err)
+	}
+	if len(inner) != 0 {
+		t.Errorf("LIST /work should hide the dot-file, got %d entries", len(inner))
+	}
 }
 
 func TestListDir_NotADirectory(t *testing.T) {

--- a/protocol/store/store_test.go
+++ b/protocol/store/store_test.go
@@ -153,12 +153,68 @@ func TestListDir(t *testing.T) {
 	}
 
 	s := New(root)
-	entries, err := s.ListDir("/")
+	entries, err := s.ListDir("/", false)
 	if err != nil {
 		t.Fatalf("ListDir: %v", err)
 	}
 	if len(entries) != 2 {
 		t.Errorf("entries = %d, want 2 (excluding .hidden and versions)", len(entries))
+	}
+}
+
+func TestListDir_HidesArchived(t *testing.T) {
+	root := t.TempDir()
+	s := New(root)
+
+	// Two live docs at root, one that will be archived, and a directory whose
+	// only document is archived (should be pruned when archived are hidden).
+	for _, p := range []string{"/live.md", "/gone.md", "/attic/old.md"} {
+		if _, err := s.Write(p, []byte("# "+p+"\n"), nil); err != nil {
+			t.Fatalf("Write %s: %v", p, err)
+		}
+	}
+	if err := s.Archive("/gone.md", true); err != nil {
+		t.Fatalf("Archive /gone.md: %v", err)
+	}
+	if err := s.Archive("/attic/old.md", true); err != nil {
+		t.Fatalf("Archive /attic/old.md: %v", err)
+	}
+
+	names := func(entries []os.DirEntry) map[string]bool {
+		m := map[string]bool{}
+		for _, e := range entries {
+			m[e.Name()] = true
+		}
+		return m
+	}
+
+	// Default (hide archived): live.md stays; gone.md is hidden; attic/ is
+	// pruned because its only document is archived.
+	hidden, err := s.ListDir("/", false)
+	if err != nil {
+		t.Fatalf("ListDir hide: %v", err)
+	}
+	h := names(hidden)
+	if !h["live.md"] {
+		t.Errorf("hide: want live.md present, got %v", h)
+	}
+	if h["gone.md"] {
+		t.Errorf("hide: want gone.md hidden, got %v", h)
+	}
+	if h["attic"] {
+		t.Errorf("hide: want all-archived dir attic/ pruned, got %v", h)
+	}
+
+	// include-archived: everything current is listed, including attic/.
+	shown, err := s.ListDir("/", true)
+	if err != nil {
+		t.Fatalf("ListDir show: %v", err)
+	}
+	sh := names(shown)
+	for _, want := range []string{"live.md", "gone.md", "attic"} {
+		if !sh[want] {
+			t.Errorf("show: want %s present, got %v", want, sh)
+		}
 	}
 }
 
@@ -169,7 +225,7 @@ func TestListDir_NotADirectory(t *testing.T) {
 	}
 	s := New(root)
 
-	_, err := s.ListDir("/file.md")
+	_, err := s.ListDir("/file.md", false)
 	if err == nil {
 		t.Fatal("expected error for file")
 	}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -410,7 +410,13 @@ func buildLookupResults(query, scope string, rows []catalog.Result) string {
 }
 
 func (h *Handler) handleFetchDirectory(w io.Writer, req protocol.Request) {
-	// Try index.md first — if the directory has an explicit index, serve it as a normal document.
+	includeArchived := req.Metadata["include-archived"] == "true"
+
+	// Try index.md first — if the directory has an explicit index, serve it as
+	// a normal document. An ARCHIVED index.md is treated like a missing one:
+	// serveDocument would tombstone it, blocking the whole directory view while
+	// LIST still shows the directory's live entries. Fetching the archived
+	// index.md itself (by its own path) still returns the tombstone.
 	indexPath := path.Join(req.Path, "index.md")
 	doc, err := h.Store.Get(indexPath, 0)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -418,13 +424,12 @@ func (h *Handler) handleFetchDirectory(w io.Writer, req protocol.Request) {
 		h.writeError(w, protocol.StatusServerError, "internal error")
 		return
 	}
-	if err == nil {
+	if err == nil && !doc.Archived {
 		h.serveDocument(w, req, doc, req.Path)
 		return
 	}
 
-	// No index.md — generate a directory listing.
-	includeArchived := req.Metadata["include-archived"] == "true"
+	// No (visible) index.md — generate a directory listing.
 	entries, err := h.Store.ListDir(req.Path, includeArchived)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -343,7 +343,8 @@ func (h *Handler) handleList(w io.Writer, req protocol.Request) {
 		h.writeError(w, protocol.StatusNotFound, reqPath+" not found")
 		return
 	}
-	entries, err := h.Store.ListDir(reqPath)
+	includeArchived := req.Metadata["include-archived"] == "true"
+	entries, err := h.Store.ListDir(reqPath, includeArchived)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			h.logger().Info("not found", "path", sanitize(reqPath))
@@ -423,7 +424,8 @@ func (h *Handler) handleFetchDirectory(w io.Writer, req protocol.Request) {
 	}
 
 	// No index.md — generate a directory listing.
-	entries, err := h.Store.ListDir(req.Path)
+	includeArchived := req.Metadata["include-archived"] == "true"
+	entries, err := h.Store.ListDir(req.Path, includeArchived)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			h.logger().Info("not found", "path", sanitize(req.Path))

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -529,7 +529,7 @@ func TestFetchDirectory(t *testing.T) {
 		}
 	})
 
-	t.Run("directory with archived index.md returns archived", func(t *testing.T) {
+	t.Run("directory with archived index.md falls back to listing", func(t *testing.T) {
 		if err := s.Archive("/docs/index.md", true); err != nil {
 			t.Fatalf("archive index.md: %v", err)
 		}
@@ -539,8 +539,30 @@ func TestFetchDirectory(t *testing.T) {
 		if err != nil {
 			t.Fatalf("parse response: %v", err)
 		}
-		if resp.Status != protocol.StatusArchived {
-			t.Errorf("status: got %q, want %q", resp.Status, protocol.StatusArchived)
+		// An archived index.md must not tombstone the whole directory: the
+		// generated listing of live entries is served instead, and the hidden
+		// index.md stays out of it.
+		if resp.Status != protocol.StatusOK {
+			t.Errorf("status: got %q, want %q", resp.Status, protocol.StatusOK)
+		}
+		if !strings.Contains(resp.Body, "# Index of /docs/") {
+			t.Errorf("body should contain generated index header, got %q", resp.Body)
+		}
+		if !strings.Contains(resp.Body, "[guide.md]") {
+			t.Error("body should list live guide.md")
+		}
+		if strings.Contains(resp.Body, "[index.md]") {
+			t.Error("body should not list the archived index.md")
+		}
+		// The archived index.md itself still fetches as a tombstone.
+		docStream := newMockStream("FETCH /docs/index.md\n")
+		h.HandleStream(docStream)
+		docResp, err := protocol.ParseResponse(&docStream.output)
+		if err != nil {
+			t.Fatalf("parse doc response: %v", err)
+		}
+		if docResp.Status != protocol.StatusArchived {
+			t.Errorf("doc status: got %q, want %q", docResp.Status, protocol.StatusArchived)
 		}
 		// Unarchive to avoid affecting subsequent tests
 		if err := s.Archive("/docs/index.md", false); err != nil {

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
@@ -436,7 +436,7 @@ func (g *mcpGateway) walkIndexDir(ctx context.Context, claims *Claims, worldName
 		return errIndexTruncated
 	}
 	listResult, err := g.dispatchWithAuth(ctx, claims, worldName, func(token string) (fetch.Result, error) {
-		return g.dispatcher.List(worldName, dirPath, token)
+		return g.dispatcher.List(worldName, dirPath, token, fetch.ListOptions{})
 	})
 	if err != nil {
 		return fmt.Errorf("list %s: %w", dirPath, err)

--- a/tools/demarkus-broker/internal/broker/mcp_tools_list.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_list.go
@@ -86,12 +86,17 @@ func markListTool() mcp.Tool {
 	return mcp.NewTool("mark_list",
 		mcp.WithDescription(
 			"List documents and subdirectories on a Mark Protocol server. "+
-				"Use this to discover what documents exist. "+
+				"Use this to discover what documents exist. Archived documents are "+
+				"hidden by default, along with directories that contain only archived "+
+				"documents; set include_archived to true for a recovery/audit view. "+
 				mcpURLHint,
 		),
 		mcp.WithString("url",
 			mcp.Required(),
 			mcp.Description(mcpURLDesc),
+		),
+		mcp.WithBoolean("include_archived",
+			mcp.Description("Include archived documents (and all-archived directories) in the listing. Default false."),
 		),
 	)
 }

--- a/tools/demarkus-broker/internal/broker/mcp_tools_read.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_read.go
@@ -190,7 +190,8 @@ func (g *mcpGateway) handleMarkList(_ context.Context, req mcp.CallToolRequest) 
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", err)), nil
 	}
-	result, err := g.dispatcher.List(worldName, path, "")
+	opts := fetch.ListOptions{IncludeArchived: req.GetBool("include_archived", false)}
+	result, err := g.dispatcher.List(worldName, path, "", opts)
 	if err != nil {
 		return g.toolErrorFor("list", worldName, err), nil
 	}

--- a/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
@@ -79,7 +79,7 @@ func (f *fakeDispatcher) Fetch(worldName, path, token string) (fetch.Result, err
 	return fn(worldName, path, token)
 }
 
-func (f *fakeDispatcher) List(worldName, path, token string) (fetch.Result, error) {
+func (f *fakeDispatcher) List(worldName, path, token string, _ fetch.ListOptions) (fetch.Result, error) {
 	f.mu.Lock()
 	f.listCalls = append(f.listCalls, dispatchCall{worldName, path, token})
 	fn := f.listFn

--- a/tools/demarkus-broker/internal/broker/world_pool.go
+++ b/tools/demarkus-broker/internal/broker/world_pool.go
@@ -22,7 +22,7 @@ import (
 // tools land in Slices 4–5.
 type worldDispatcher interface {
 	Fetch(worldName, path, token string) (fetch.Result, error)
-	List(worldName, path, token string) (fetch.Result, error)
+	List(worldName, path, token string, opts fetch.ListOptions) (fetch.Result, error)
 	Versions(worldName, path, token string) (fetch.Result, error)
 	Lookup(worldName, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error)
 	Publish(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
@@ -110,13 +110,14 @@ func (p *worldPool) Fetch(worldName, path, token string) (fetch.Result, error) {
 }
 
 // List dispatches a LIST against worldName. Same proxy contract
-// as Fetch — the world's response shape is preserved.
-func (p *worldPool) List(worldName, path, token string) (fetch.Result, error) {
+// as Fetch — the world's response shape is preserved. opts forwards
+// LIST options (e.g. IncludeArchived) to the world verbatim.
+func (p *worldPool) List(worldName, path, token string, opts fetch.ListOptions) (fetch.Result, error) {
 	c, host, err := p.clientFor(worldName)
 	if err != nil {
 		return fetch.Result{}, err
 	}
-	return c.List(host, path, token)
+	return c.ListWithOptions(host, path, token, opts)
 }
 
 // Versions dispatches a VERSIONS against worldName. Same proxy

--- a/tools/demarkus-broker/internal/broker/world_pool_test.go
+++ b/tools/demarkus-broker/internal/broker/world_pool_test.go
@@ -92,7 +92,7 @@ func TestWorldPoolDispatchesUnknownWorldThroughTopLevelMethods(t *testing.T) {
 		fn   func() (fetch.Result, error)
 	}{
 		{"Fetch", func() (fetch.Result, error) { return pool.Fetch("nope", "/foo", "tok") }},
-		{"List", func() (fetch.Result, error) { return pool.List("nope", "/", "tok") }},
+		{"List", func() (fetch.Result, error) { return pool.List("nope", "/", "tok", fetch.ListOptions{}) }},
 		{"Versions", func() (fetch.Result, error) { return pool.Versions("nope", "/foo", "tok") }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added archived-document support to browse/list flows via an `include_archived` request parameter and a CLI `-include-archived` flag (archived items are hidden by default).
  * Extended the listing tool schema to let you opt into archived discovery.

* **Bug Fixes**
  * “All-archived” directories are now pruned/hidden when archived items are not requested.
  * Directory fetching now honors the archived-visibility setting, including when an archived `index.md` is present.
  * Prevented cached directory results from being reused across different archived-visibility options.

* **Tests**
  * Updated and added coverage for archived hiding/inclusion and the new listing flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->