### PR TITLE
feat(client): size-adaptive mark_fetch, session dedup, mark_explore

### DIFF
--- a/client/cmd/demarkus-mcp/explore.go
+++ b/client/cmd/demarkus-mcp/explore.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/latebit-io/demarkus/client/links"
+	"github.com/latebit-io/demarkus/client/mdoutline"
+	"github.com/latebit-io/demarkus/protocol"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// exploreSectionCap bounds each section of the neighborhood card. Overflow
+// is reported honestly as "+N more".
+const exploreSectionCap = 10
+
+func markExploreTool(host string) mcp.Tool {
+	return mcp.NewTool("mark_explore",
+		mcp.WithDescription(
+			"Orient around one document in a single call: its outline head (heading "+
+				"tree with #anchors plus the opening paragraph), outbound links, recorded "+
+				"backlinks, and sibling documents in the same directory — each section "+
+				"capped at 10 entries. Use this instead of a fetch + backlinks + list "+
+				"chain when you need to understand what a document covers and what to "+
+				"read next; then mark_fetch url#<anchor> for the sections that matter. "+
+				"Backlinks come from the local graph store (mark_graph populates it). "+
+				urlHint(host),
+		),
+		mcp.WithString("url",
+			mcp.Required(),
+			mcp.Description(urlDesc(host)),
+		),
+	)
+}
+
+func (h *handler) markExplore(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go
+	rawURL, err := req.RequireString("url")
+	if err != nil {
+		return mcp.NewToolResultError("url is required"), nil
+	}
+	docURL, _, _ := strings.Cut(rawURL, "#")
+
+	host, path, err := h.resolveURL(docURL)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", err)), nil
+	}
+
+	token := h.resolveToken(host)
+	result, err := h.client.Fetch(host, path, token)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("fetch failed: %v", err)), nil
+	}
+	if result.Response.Status != protocol.StatusOK {
+		return mcp.NewToolResultText(formatResult(result, "version", "modified", "etag")), nil
+	}
+	body := result.Response.Body
+
+	var b strings.Builder
+
+	b.WriteString("## Outline\n")
+	if tree := mdoutline.Outline(body); tree != "" {
+		writeCapped(&b, strings.Split(strings.TrimRight(tree, "\n"), "\n"), "headings")
+	} else {
+		b.WriteString("(no headings)\n")
+	}
+	if para := mdoutline.OpeningParagraph(body); para != "" {
+		b.WriteString("\n## Opening\n")
+		b.WriteString(para)
+		b.WriteString("\n")
+	}
+
+	out := outboundLinkLines(body)
+	fmt.Fprintf(&b, "\n## Outbound links (%d)\n", len(out))
+	if len(out) == 0 {
+		b.WriteString("(none)\n")
+	} else {
+		writeCapped(&b, out, "links")
+	}
+
+	h.writeBacklinksSection(&b, docURL)
+	h.writeSiblingsSection(&b, host, path, token)
+
+	fmt.Fprintf(&b, "\nfetch %s#<anchor> for a section; mark_fetch force=true for the full body\n", docURL)
+
+	extra := map[string]string{
+		"size": fmt.Sprintf("%d bytes, %d lines", len(body), strings.Count(body, "\n")+1),
+	}
+	return mcp.NewToolResultText(formatResultWith(result, b.String(), extra, "version", "modified", "etag")), nil
+}
+
+// writeBacklinksSection appends the backlinks card section from the local
+// graph store. An empty or missing store degrades to a note, never an error.
+func (h *handler) writeBacklinksSection(b *strings.Builder, docURL string) {
+	fullURL := docURL
+	if strings.HasPrefix(docURL, "/") {
+		fullURL = h.defaultHost + docURL
+	}
+	if h.graphStore == nil {
+		b.WriteString("\n## Backlinks\n(graph store unavailable)\n")
+		return
+	}
+	backlinks := h.graphStore.BacklinksEnriched(fullURL)
+	fmt.Fprintf(b, "\n## Backlinks (%d)\n", len(backlinks))
+	if len(backlinks) == 0 {
+		b.WriteString("(none recorded — run mark_graph to populate)\n")
+		return
+	}
+	lines := make([]string, len(backlinks))
+	for i, bl := range backlinks {
+		if bl.Title != "" {
+			lines[i] = fmt.Sprintf("- [%s](%s)", bl.Title, bl.URL)
+		} else {
+			lines[i] = "- " + bl.URL
+		}
+	}
+	writeCapped(b, lines, "backlinks")
+}
+
+// writeSiblingsSection appends the sibling listing of the document's parent
+// directory. A failed LIST degrades to a note, never an error.
+func (h *handler) writeSiblingsSection(b *strings.Builder, host, path, token string) {
+	dir := path[:strings.LastIndex(path, "/")+1]
+	self := path[strings.LastIndex(path, "/")+1:]
+
+	fmt.Fprintf(b, "\n## Siblings in %s", dir)
+	listing, err := h.client.List(host, dir, token)
+	if err != nil || listing.Response.Status != protocol.StatusOK {
+		b.WriteString("\n(listing unavailable)\n")
+		return
+	}
+	var lines []string
+	for _, entry := range links.Extract(listing.Response.Body) {
+		if entry == self {
+			continue
+		}
+		lines = append(lines, "- "+entry)
+	}
+	fmt.Fprintf(b, " (%d)\n", len(lines))
+	if len(lines) == 0 {
+		b.WriteString("(none)\n")
+		return
+	}
+	writeCapped(b, lines, "siblings")
+}
+
+// outboundLinkLines extracts the document's links as one-line entries with
+// titles, deduplicated by destination in document order.
+func outboundLinkLines(body string) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, l := range links.ExtractWithPositions(body) {
+		if seen[l.Dest] {
+			continue
+		}
+		seen[l.Dest] = true
+		if l.Text != "" {
+			out = append(out, fmt.Sprintf("- [%s](%s)", l.Text, l.Dest))
+		} else {
+			out = append(out, "- "+l.Dest)
+		}
+	}
+	return out
+}
+
+// writeCapped writes at most exploreSectionCap pre-formatted lines and an
+// honest "+N more <noun>" marker for the overflow.
+func writeCapped(b *strings.Builder, lines []string, noun string) {
+	for i, line := range lines {
+		if i == exploreSectionCap {
+			break
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	if n := len(lines) - exploreSectionCap; n > 0 {
+		fmt.Fprintf(b, "+%d more %s\n", n, noun)
+	}
+}

--- a/client/cmd/demarkus-mcp/explore_test.go
+++ b/client/cmd/demarkus-mcp/explore_test.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/client/graph"
+	"github.com/latebit-io/demarkus/client/graphstore"
+	"github.com/latebit-io/demarkus/protocol"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+const exploreDoc = `# Hub
+
+The hub links everything together.
+
+## Sections
+
+- [Alpha](/alpha.md)
+- [Beta](/docs/beta.md)
+
+## More
+
+See [Alpha](/alpha.md) again (deduped).
+`
+
+const exploreListing = `- [hub.md](hub.md)
+- [alpha.md](alpha.md)
+- [notes.md](notes.md)
+- [docs/](docs/)
+`
+
+func exploreStub() *stubClient {
+	return &stubClient{
+		fetchFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusOK,
+				Metadata: map[string]string{"version": "2", "modified": "2026-07-04T00:00:00Z", "etag": "xyz"},
+				Body:     exploreDoc,
+			}}, nil
+		},
+		listFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status: protocol.StatusOK,
+				Body:   exploreListing,
+			}}, nil
+		},
+	}
+}
+
+func exploreText(t *testing.T, h *handler, url string) string {
+	t.Helper()
+	result, err := h.markExplore(context.Background(), newCallToolRequest(map[string]any{"url": url}))
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	return result.Content[0].(mcp.TextContent).Text
+}
+
+func TestHandlerMarkExplore_Card(t *testing.T) {
+	h := &handler{client: exploreStub()}
+	text := exploreText(t, h, "mark://host:6309/hub.md")
+
+	wants := []string{
+		"status: ok",
+		"version: 2",
+		"size: ",
+		"## Outline",
+		"- Hub (#hub,",
+		"  - Sections (#sections,",
+		"## Opening",
+		"The hub links everything together.",
+		"## Outbound links (2)",
+		"- [Alpha](/alpha.md)",
+		"- [Beta](/docs/beta.md)",
+		"## Backlinks",
+		"(graph store unavailable)",
+		"## Siblings in / (3)",
+		"- alpha.md",
+		"- notes.md",
+		"- docs/",
+		"fetch mark://host:6309/hub.md#<anchor> for a section",
+	}
+	for _, want := range wants {
+		if !strings.Contains(text, want) {
+			t.Errorf("card missing %q in:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "- hub.md") {
+		t.Error("siblings must exclude the document itself")
+	}
+	// /alpha.md is linked twice in the doc; outbound dedup lists it once.
+	if strings.Count(text, "(/alpha.md)") != 1 {
+		t.Errorf("outbound links should be deduplicated:\n%s", text)
+	}
+}
+
+func TestHandlerMarkExplore_BacklinksFromStore(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.json")
+	gs, err := graphstore.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	g := graph.New()
+	g.AddNode(&graph.Node{URL: "mark://host:6309/a.md", Title: "Page A", Status: "ok"})
+	g.AddNode(&graph.Node{URL: "mark://host:6309/hub.md", Title: "Hub", Status: "ok"})
+	g.AddEdge("mark://host:6309/a.md", "mark://host:6309/hub.md")
+	gs.Merge(g, nil)
+
+	h := &handler{client: exploreStub(), graphStore: gs}
+	text := exploreText(t, h, "mark://host:6309/hub.md")
+
+	if !strings.Contains(text, "## Backlinks (1)") || !strings.Contains(text, "[Page A](mark://host:6309/a.md)") {
+		t.Errorf("expected enriched backlink in card:\n%s", text)
+	}
+}
+
+func TestHandlerMarkExplore_SectionCaps(t *testing.T) {
+	var body strings.Builder
+	body.WriteString("# Big hub\n\n")
+	for i := range 15 {
+		fmt.Fprintf(&body, "## Section %d\n\n", i)
+		fmt.Fprintf(&body, "- [Doc %d](/doc-%d.md)\n\n", i, i)
+	}
+	sc := &stubClient{
+		fetchFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusOK,
+				Metadata: map[string]string{"version": "1"},
+				Body:     body.String(),
+			}}, nil
+		},
+		listFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: ""}}, nil
+		},
+	}
+	h := &handler{client: sc}
+	text := exploreText(t, h, "mark://host:6309/hub.md")
+
+	if !strings.Contains(text, "+6 more headings") {
+		t.Errorf("expected heading overflow marker (16 headings, cap 10):\n%s", text)
+	}
+	if !strings.Contains(text, "+5 more links") {
+		t.Errorf("expected link overflow marker (15 links, cap 10):\n%s", text)
+	}
+	if strings.Contains(text, "Section 12") && strings.Contains(text, "#section-12") {
+		t.Error("headings past the cap should not be listed")
+	}
+}
+
+func TestHandlerMarkExplore_ListFailureDegrades(t *testing.T) {
+	sc := exploreStub()
+	sc.listFn = func(_, _, _ string) (fetch.Result, error) {
+		return fetch.Result{}, fmt.Errorf("boom")
+	}
+	h := &handler{client: sc}
+	text := exploreText(t, h, "mark://host:6309/hub.md")
+	if !strings.Contains(text, "(listing unavailable)") {
+		t.Errorf("LIST failure should degrade to a note:\n%s", text)
+	}
+	if !strings.Contains(text, "## Outline") {
+		t.Error("card should still render the rest")
+	}
+}
+
+func TestHandlerMarkExplore_NonOKPassthrough(t *testing.T) {
+	sc := &stubClient{
+		fetchFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusNotFound,
+				Metadata: map[string]string{},
+			}}, nil
+		},
+	}
+	h := &handler{client: sc}
+	text := exploreText(t, h, "mark://host:6309/missing.md")
+	if !strings.Contains(text, "status: not-found") {
+		t.Errorf("non-ok fetch should pass through, got:\n%s", text)
+	}
+}
+
+func TestHandlerMarkExplore_InvalidURL(t *testing.T) {
+	h := &handler{client: &stubClient{}}
+	result, err := h.markExplore(context.Background(), newCallToolRequest(map[string]any{"url": "/bare"}))
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	assertIsToolError(t, result, "requires -host flag")
+}

--- a/client/cmd/demarkus-mcp/fetchmode_test.go
+++ b/client/cmd/demarkus-mcp/fetchmode_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/protocol"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// fetchStub returns a stubClient serving one document body with version/etag
+// metadata, counting fetches.
+func fetchStub(body, version, etag string, calls *int) *stubClient {
+	return &stubClient{
+		fetchFn: func(_, _, _ string) (fetch.Result, error) {
+			if calls != nil {
+				*calls++
+			}
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusOK,
+				Metadata: map[string]string{"version": version, "modified": "2026-07-04T00:00:00Z", "etag": etag},
+				Body:     body,
+			}}, nil
+		},
+	}
+}
+
+func fetchText(t *testing.T, h *handler, args map[string]any) string {
+	t.Helper()
+	result, err := h.markFetch(context.Background(), newCallToolRequest(args))
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	return result.Content[0].(mcp.TextContent).Text
+}
+
+const smallDoc = "# Doc\n\nIntro paragraph.\n\n## Setup\n\nSetup body.\n\n## Usage\n\nUsage body.\n"
+
+// bigDoc is a document over the outline threshold with the same structure.
+func bigDoc() string {
+	filler := strings.Repeat("filler line for section body padding\n", 150)
+	return "# Big\n\nIntro paragraph.\n\n## Setup\n\n" + filler + "\n## Usage\n\n" + filler
+}
+
+func TestHandlerMarkFetch_SmallDocFullBody(t *testing.T) {
+	h := &handler{client: fetchStub(smallDoc, "3", "abc", nil)}
+	text := fetchText(t, h, map[string]any{"url": "mark://example.com/doc.md"})
+	if !strings.Contains(text, "Setup body.") || !strings.Contains(text, "Usage body.") {
+		t.Errorf("small doc should return full body, got:\n%s", text)
+	}
+	if strings.Contains(text, "mode: outline") {
+		t.Error("small doc should not be outlined")
+	}
+}
+
+func TestHandlerMarkFetch_LargeDocOutline(t *testing.T) {
+	h := &handler{client: fetchStub(bigDoc(), "3", "abc", nil)}
+	text := fetchText(t, h, map[string]any{"url": "mark://example.com/big.md"})
+
+	if !strings.Contains(text, "mode: outline") {
+		t.Fatalf("large doc should return outline, got:\n%s", text[:200])
+	}
+	if strings.Contains(text, "filler line") {
+		t.Error("outline should not include section bodies")
+	}
+	for _, want := range []string{"#setup", "#usage", "Intro paragraph.", "fetch mark://example.com/big.md#<anchor> for a section", "size: "} {
+		if !strings.Contains(text, want) {
+			t.Errorf("outline missing %q in:\n%s", want, text)
+		}
+	}
+}
+
+func TestHandlerMarkFetch_LargeDocForceFullBody(t *testing.T) {
+	h := &handler{client: fetchStub(bigDoc(), "3", "abc", nil)}
+	text := fetchText(t, h, map[string]any{"url": "mark://example.com/big.md", "force": true})
+	if strings.Contains(text, "mode: outline") {
+		t.Error("force=true should bypass outline mode")
+	}
+	if !strings.Contains(text, "filler line") {
+		t.Error("force=true should return the full body")
+	}
+}
+
+func TestHandlerMarkFetch_SectionSlice(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		wantIn []string
+		notIn  []string
+	}{
+		{
+			"section of small doc",
+			"mark://example.com/doc.md#setup",
+			[]string{"section: #setup", "## Setup", "Setup body."},
+			[]string{"Usage body."},
+		},
+		{
+			"section works on large doc too",
+			"mark://example.com/doc.md#usage",
+			[]string{"## Usage"},
+			[]string{"## Setup", "mode: outline"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := smallDoc
+			if strings.Contains(tt.name, "large") {
+				body = bigDoc()
+			}
+			h := &handler{client: fetchStub(body, "3", "abc", nil)}
+			text := fetchText(t, h, map[string]any{"url": tt.url})
+			for _, want := range tt.wantIn {
+				if !strings.Contains(text, want) {
+					t.Errorf("missing %q in:\n%s", want, text)
+				}
+			}
+			for _, not := range tt.notIn {
+				if strings.Contains(text, not) {
+					t.Errorf("unexpected %q in:\n%s", not, text)
+				}
+			}
+		})
+	}
+}
+
+func TestHandlerMarkFetch_SectionNotFound(t *testing.T) {
+	h := &handler{client: fetchStub(smallDoc, "3", "abc", nil)}
+	result, err := h.markFetch(context.Background(), newCallToolRequest(map[string]any{
+		"url": "mark://example.com/doc.md#nope",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected tool error for missing section")
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, "available anchors") || !strings.Contains(text, "setup") {
+		t.Errorf("error should list available anchors, got: %s", text)
+	}
+}
+
+func TestHandlerMarkFetch_SessionDedup(t *testing.T) {
+	calls := 0
+	h := &handler{client: fetchStub(smallDoc, "3", "abc", &calls)}
+	url := map[string]any{"url": "mark://example.com/doc.md"}
+
+	first := fetchText(t, h, url)
+	if !strings.Contains(first, "Setup body.") {
+		t.Fatal("first fetch should return full body")
+	}
+
+	second := fetchText(t, h, url)
+	if !strings.Contains(second, "status: unchanged") {
+		t.Fatalf("second fetch should dedup, got:\n%s", second)
+	}
+	if !strings.Contains(second, "unchanged since v3") || !strings.Contains(second, "force=true") {
+		t.Errorf("dedup notice should name the version and the override, got:\n%s", second)
+	}
+	if strings.Contains(second, "Setup body.") {
+		t.Error("dedup response should not carry the body")
+	}
+
+	forced := fetchText(t, h, map[string]any{"url": "mark://example.com/doc.md", "force": true})
+	if !strings.Contains(forced, "Setup body.") {
+		t.Error("force=true should bust the dedup and return the body")
+	}
+}
+
+func TestHandlerMarkFetch_SectionFetchBypassesDedup(t *testing.T) {
+	h := &handler{client: fetchStub(smallDoc, "3", "abc", nil)}
+	_ = fetchText(t, h, map[string]any{"url": "mark://example.com/doc.md"})
+	text := fetchText(t, h, map[string]any{"url": "mark://example.com/doc.md#setup"})
+	if !strings.Contains(text, "Setup body.") {
+		t.Errorf("section fetch after full fetch must return content, got:\n%s", text)
+	}
+}
+
+func TestHandlerMarkFetch_ChangedDocNoted(t *testing.T) {
+	version, etag := "3", "abc"
+	sc := &stubClient{
+		fetchFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusOK,
+				Metadata: map[string]string{"version": version, "etag": etag},
+				Body:     smallDoc,
+			}}, nil
+		},
+	}
+	h := &handler{client: sc}
+	url := map[string]any{"url": "mark://example.com/doc.md"}
+
+	_ = fetchText(t, h, url)
+	version, etag = "5", "def"
+	text := fetchText(t, h, url)
+	if !strings.Contains(text, "note: changed since this session's earlier fetch (v3 -> v5)") {
+		t.Errorf("changed doc should carry a version delta note, got:\n%s", text)
+	}
+	if !strings.Contains(text, "Setup body.") {
+		t.Error("changed doc should return the body")
+	}
+
+	// The new version is now the recorded one.
+	third := fetchText(t, h, url)
+	if !strings.Contains(third, "unchanged since v5") {
+		t.Errorf("third fetch should dedup at the new version, got:\n%s", third)
+	}
+}
+
+func TestHandlerMarkFetch_OutlineDoesNotRecordSeen(t *testing.T) {
+	h := &handler{client: fetchStub(bigDoc(), "3", "abc", nil)}
+	url := map[string]any{"url": "mark://example.com/big.md"}
+
+	first := fetchText(t, h, url)
+	if !strings.Contains(first, "mode: outline") {
+		t.Fatal("expected outline")
+	}
+	// A repeat fetch returns the outline again, never "unchanged" — the
+	// agent has not seen the full body yet.
+	second := fetchText(t, h, url)
+	if strings.Contains(second, "status: unchanged") {
+		t.Error("outline-only fetch must not arm the dedup")
+	}
+	if !strings.Contains(second, "mode: outline") {
+		t.Error("repeat fetch of a large doc should outline again")
+	}
+}
+
+func TestHandlerMarkFetch_NonOKStatusPassthrough(t *testing.T) {
+	sc := &stubClient{
+		fetchFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusNotFound,
+				Metadata: map[string]string{},
+			}}, nil
+		},
+	}
+	h := &handler{client: sc}
+	text := fetchText(t, h, map[string]any{"url": "mark://example.com/missing.md#setup"})
+	if !strings.Contains(text, "status: not-found") {
+		t.Errorf("non-ok status should pass through, got:\n%s", text)
+	}
+}

--- a/client/cmd/demarkus-mcp/fetchmode_test.go
+++ b/client/cmd/demarkus-mcp/fetchmode_test.go
@@ -212,6 +212,51 @@ func TestHandlerMarkFetch_ChangedDocNoted(t *testing.T) {
 	}
 }
 
+func TestHandlerMarkFetch_NoIdentityNoDedup(t *testing.T) {
+	// A server that omits both version and etag gives dedup nothing to
+	// compare — every fetch must return the body, never "unchanged".
+	h := &handler{client: fetchStub(smallDoc, "", "", nil)}
+	url := map[string]any{"url": "mark://example.com/doc.md"}
+
+	for range 2 {
+		text := fetchText(t, h, url)
+		if strings.Contains(text, "status: unchanged") {
+			t.Fatalf("fetch without version/etag must not dedup, got:\n%s", text)
+		}
+		if !strings.Contains(text, "Setup body.") {
+			t.Errorf("fetch should return the body, got:\n%s", text)
+		}
+	}
+}
+
+func TestHandlerMarkFetch_EtagOnlyChangeNoted(t *testing.T) {
+	etag := "abc"
+	sc := &stubClient{
+		fetchFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusOK,
+				Metadata: map[string]string{"version": "3", "etag": etag},
+				Body:     smallDoc,
+			}}, nil
+		},
+	}
+	h := &handler{client: sc}
+	url := map[string]any{"url": "mark://example.com/doc.md"}
+
+	_ = fetchText(t, h, url)
+	etag = "def"
+	text := fetchText(t, h, url)
+	if strings.Contains(text, "status: unchanged") {
+		t.Fatal("etag change must bypass the dedup")
+	}
+	if !strings.Contains(text, "note: content changed since this session's earlier fetch (still v3, etag differs)") {
+		t.Errorf("etag-only change should carry a note, got:\n%s", text)
+	}
+	if !strings.Contains(text, "Setup body.") {
+		t.Error("etag-only change should return the body")
+	}
+}
+
 func TestHandlerMarkFetch_OutlineDoesNotRecordSeen(t *testing.T) {
 	h := &handler{client: fetchStub(bigDoc(), "3", "abc", nil)}
 	url := map[string]any{"url": "mark://example.com/big.md"}

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -9,9 +9,11 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"maps"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/latebit-io/demarkus/client/fetch"
@@ -21,6 +23,7 @@ import (
 	"github.com/latebit-io/demarkus/client/internal/cache"
 	"github.com/latebit-io/demarkus/client/internal/tokens"
 	"github.com/latebit-io/demarkus/client/links"
+	"github.com/latebit-io/demarkus/client/mdoutline"
 	"github.com/latebit-io/demarkus/client/merge"
 	"github.com/latebit-io/demarkus/protocol"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -59,6 +62,7 @@ func main() {
 	}
 	h := &handler{client: client, defaultHost: *defaultHost, token: *token, graphStore: gs}
 	s.AddTool(markFetchTool(*defaultHost), h.markFetch)
+	s.AddTool(markExploreTool(*defaultHost), h.markExplore)
 	s.AddTool(markListTool(*defaultHost), h.markList)
 	s.AddTool(markGraphTool(*defaultHost), h.markGraph)
 	s.AddTool(markVersionsTool(*defaultHost), h.markVersions)
@@ -95,6 +99,37 @@ type handler struct {
 	defaultHost string
 	token       string
 	graphStore  *graphstore.Store
+
+	// seenMu guards seen, the per-session fetch dedup state: host+path →
+	// identity of the document version whose full body was already returned
+	// to the agent this session. Process-lifetime only, never persisted —
+	// cross-session staleness risk outweighs the token saving.
+	seenMu sync.Mutex
+	seen   map[string]seenDoc
+}
+
+// seenDoc identifies a document version already returned in full this session.
+type seenDoc struct {
+	version string
+	etag    string
+}
+
+// seenLookup returns the recorded identity for key, if any.
+func (h *handler) seenLookup(key string) (seenDoc, bool) {
+	h.seenMu.Lock()
+	defer h.seenMu.Unlock()
+	d, ok := h.seen[key]
+	return d, ok
+}
+
+// seenRecord remembers that the full body of key's document was returned.
+func (h *handler) seenRecord(key string, d seenDoc) {
+	h.seenMu.Lock()
+	defer h.seenMu.Unlock()
+	if h.seen == nil {
+		h.seen = make(map[string]seenDoc)
+	}
+	h.seen[key] = d
 }
 
 // resolveToken returns the auth token for a host using the shared cascade:
@@ -140,20 +175,37 @@ func markFetchTool(host string) mcp.Tool {
 		mcp.WithDescription(
 			"Fetch a document from a Mark Protocol server. "+
 				"Returns the document status, version, modified timestamp, etag, and markdown body. "+
+				"Documents under 8KB return the full body. Larger documents return an outline "+
+				"instead — the heading tree with #anchors and per-section line counts plus the "+
+				"opening paragraph — so you can pull just the section you need by appending "+
+				"#<anchor> to the url (anchors are GitHub-style slugs; #section fetches work at "+
+				"any size). Re-fetching a document whose full body was already returned this "+
+				"session returns a short 'unchanged' notice when it has not changed. "+
+				"Set force=true for the full body regardless of size or session history. "+
 				urlHint(host),
 		),
 		mcp.WithString("url",
 			mcp.Required(),
-			mcp.Description(urlDesc(host)),
+			mcp.Description(urlDesc(host)+"; append #<anchor> to fetch a single section"),
+		),
+		mcp.WithBoolean("force",
+			mcp.Description("return the full body even if the document is large or unchanged since an earlier fetch this session (default false)"),
 		),
 	)
 }
+
+// outlineThreshold is the body size (bytes) above which mark_fetch returns
+// an outline instead of the full body, unless force=true or a #section is
+// requested.
+const outlineThreshold = 8 * 1024
 
 func markListTool(host string) mcp.Tool {
 	return mcp.NewTool("mark_list",
 		mcp.WithDescription(
 			"List documents and subdirectories on a Mark Protocol server. "+
-				"Use this to discover what documents exist. Archived documents are "+
+				"Use this to discover what documents exist. To orient around one "+
+				"specific document, prefer mark_explore — it bundles the sibling "+
+				"listing with the outline, links, and backlinks. Archived documents are "+
 				"hidden by default, along with directories that contain only archived "+
 				"documents; set include_archived to true for a recovery/audit view. "+
 				urlHint(host),
@@ -212,6 +264,9 @@ func markLookupTool(host string) mcp.Tool {
 				"— not document bodies; FETCH the ones you want. This is a catalog lookup, not "+
 				"full-text search: a subject that was never tagged or titled will not be found. "+
 				"Optionally narrow with a comma-separated key=value filter and cap results with limit. "+
+				"Start here when hunting a subject: lookup to find candidate documents, "+
+				"mark_explore the best match to orient, then mark_fetch url#<anchor> for the "+
+				"sections you actually need — full bodies of large documents are rarely necessary. "+
 				urlHint(host),
 		),
 		mcp.WithString("url",
@@ -410,6 +465,20 @@ func formatResult(r fetch.Result, keys ...string) string {
 	return b.String()
 }
 
+// formatResultWith renders r via formatResult with a replacement body and
+// extra metadata entries. The metadata map is cloned first — r may hold a
+// cached response whose map must never be mutated.
+func formatResultWith(r fetch.Result, body string, extra map[string]string, keys ...string) string {
+	meta := maps.Clone(r.Response.Metadata)
+	if meta == nil {
+		meta = make(map[string]string, len(extra))
+	}
+	maps.Copy(meta, extra)
+	r.Response.Metadata = meta
+	r.Response.Body = body
+	return formatResult(r, keys...)
+}
+
 // agentMeta returns publisher metadata with the "agent" key set to the MCP
 // client name from the session context. If the client name is unavailable,
 // it falls back to "unknown".
@@ -453,8 +522,10 @@ func (h *handler) markFetch(_ context.Context, req mcp.CallToolRequest) (*mcp.Ca
 	if err != nil {
 		return mcp.NewToolResultError("url is required"), nil
 	}
+	docURL, anchor, _ := strings.Cut(rawURL, "#")
+	force := req.GetBool("force", false)
 
-	host, path, err := h.resolveURL(rawURL)
+	host, path, err := h.resolveURL(docURL)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", err)), nil
 	}
@@ -463,8 +534,79 @@ func (h *handler) markFetch(_ context.Context, req mcp.CallToolRequest) (*mcp.Ca
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("fetch failed: %v", err)), nil
 	}
+	if result.Response.Status != protocol.StatusOK {
+		return mcp.NewToolResultText(formatResult(result, "version", "modified", "etag")), nil
+	}
 
-	return mcp.NewToolResultText(formatResult(result, "version", "modified", "etag")), nil
+	body := result.Response.Body
+	version := result.Response.Metadata["version"]
+	etag := result.Response.Metadata["etag"]
+	key := host + path
+
+	// #section slice: works at any size and bypasses dedup — the agent is
+	// asking for content it has not necessarily seen.
+	if anchor != "" {
+		section, ok := mdoutline.Section(body, anchor)
+		if !ok {
+			available := strings.Join(mdoutline.Anchors(body), ", ")
+			if available == "" {
+				available = "(document has no headings)"
+			}
+			return mcp.NewToolResultError(fmt.Sprintf("section #%s not found in %s; available anchors: %s", anchor, docURL, available)), nil
+		}
+		return mcp.NewToolResultText(formatResultWith(result, section,
+			map[string]string{"section": "#" + anchor}, "version", "modified", "etag")), nil
+	}
+
+	prev, seenBefore := h.seenLookup(key)
+	if seenBefore && !force && prev.version == version && prev.etag == etag {
+		var b strings.Builder
+		b.WriteString("status: unchanged\n")
+		fmt.Fprintf(&b, "version: %s\n", version)
+		if etag != "" {
+			fmt.Fprintf(&b, "etag: %s\n", etag)
+		}
+		fmt.Fprintf(&b, "\nunchanged since v%s — the full body was returned earlier this session; pass force=true to re-read it\n", version)
+		return mcp.NewToolResultText(b.String()), nil
+	}
+
+	extra := map[string]string{}
+	if seenBefore && prev.version != version {
+		extra["note"] = fmt.Sprintf("changed since this session's earlier fetch (v%s -> v%s)", prev.version, version)
+	}
+
+	// Size gate: large documents return an outline unless forced.
+	if !force && len(body) >= outlineThreshold {
+		extra["mode"] = "outline"
+		extra["size"] = fmt.Sprintf("%d bytes, %d lines", len(body), strings.Count(body, "\n")+1)
+		return mcp.NewToolResultText(formatResultWith(result, outlineBody(docURL, body),
+			extra, "version", "modified", "etag")), nil
+	}
+
+	h.seenRecord(key, seenDoc{version: version, etag: etag})
+	if len(extra) == 0 {
+		return mcp.NewToolResultText(formatResult(result, "version", "modified", "etag")), nil
+	}
+	return mcp.NewToolResultText(formatResultWith(result, body, extra, "version", "modified", "etag")), nil
+}
+
+// outlineBody builds the outline-mode body for a large document: heading
+// tree with anchors and line counts, the opening paragraph, and the hint
+// telling the agent how to get more.
+func outlineBody(docURL, body string) string {
+	var b strings.Builder
+	if tree := mdoutline.Outline(body); tree != "" {
+		b.WriteString(tree)
+	} else {
+		b.WriteString("(document has no headings)\n")
+	}
+	if para := mdoutline.OpeningParagraph(body); para != "" {
+		b.WriteString("\n")
+		b.WriteString(para)
+		b.WriteString("\n")
+	}
+	fmt.Fprintf(&b, "\nfetch %s#<anchor> for a section; force=true for the full body\n", docURL)
+	return b.String()
 }
 
 func (h *handler) markList(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go
@@ -1136,6 +1278,8 @@ func markBacklinksTool(host string) mcp.Tool {
 		mcp.WithDescription(
 			"Look up which documents link to a given URL, using the local graph store. "+
 				"Returns results from previous crawls — run mark_graph first to populate. "+
+				"mark_explore includes this same backlink list alongside the document's "+
+				"outline, outbound links, and siblings; prefer it for general orientation. "+
 				urlHint(host),
 		),
 		mcp.WithString("url",

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -558,21 +558,35 @@ func (h *handler) markFetch(_ context.Context, req mcp.CallToolRequest) (*mcp.Ca
 			map[string]string{"section": "#" + anchor}, "version", "modified", "etag")), nil
 	}
 
+	// Dedup needs at least one identity field: with version and etag both
+	// absent, two different bodies would compare equal and a changed
+	// document would be silently reported as unchanged.
+	hasIdentity := version != "" || etag != ""
 	prev, seenBefore := h.seenLookup(key)
-	if seenBefore && !force && prev.version == version && prev.etag == etag {
+	if seenBefore && !force && hasIdentity && prev.version == version && prev.etag == etag {
 		var b strings.Builder
 		b.WriteString("status: unchanged\n")
-		fmt.Fprintf(&b, "version: %s\n", version)
+		if version != "" {
+			fmt.Fprintf(&b, "version: %s\n", version)
+		}
 		if etag != "" {
 			fmt.Fprintf(&b, "etag: %s\n", etag)
 		}
-		fmt.Fprintf(&b, "\nunchanged since v%s — the full body was returned earlier this session; pass force=true to re-read it\n", version)
+		since := "since this session's earlier fetch (etag match)"
+		if version != "" {
+			since = "since v" + version
+		}
+		fmt.Fprintf(&b, "\nunchanged %s — the full body was returned earlier this session; pass force=true to re-read it\n", since)
 		return mcp.NewToolResultText(b.String()), nil
 	}
 
 	extra := map[string]string{}
-	if seenBefore && prev.version != version {
-		extra["note"] = fmt.Sprintf("changed since this session's earlier fetch (v%s -> v%s)", prev.version, version)
+	if seenBefore && (prev.version != version || prev.etag != etag) {
+		if prev.version != version {
+			extra["note"] = fmt.Sprintf("changed since this session's earlier fetch (v%s -> v%s)", prev.version, version)
+		} else {
+			extra["note"] = fmt.Sprintf("content changed since this session's earlier fetch (still v%s, etag differs)", version)
+		}
 	}
 
 	// Size gate: large documents return an outline unless forced.
@@ -583,7 +597,9 @@ func (h *handler) markFetch(_ context.Context, req mcp.CallToolRequest) (*mcp.Ca
 			extra, "version", "modified", "etag")), nil
 	}
 
-	h.seenRecord(key, seenDoc{version: version, etag: etag})
+	if hasIdentity {
+		h.seenRecord(key, seenDoc{version: version, etag: etag})
+	}
 	if len(extra) == 0 {
 		return mcp.NewToolResultText(formatResult(result, "version", "modified", "etag")), nil
 	}

--- a/client/mdoutline/mdoutline.go
+++ b/client/mdoutline/mdoutline.go
@@ -1,0 +1,205 @@
+// Package mdoutline provides pure functions over markdown bodies for
+// heading-tree outlines and #section slicing. It is the shared slicing
+// convention for MCP fetch surfaces: anchors match GitHub-style slugs so a
+// url#section reference means the same thing across every consumer.
+package mdoutline
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+)
+
+// Heading describes one heading in a markdown body and the section it opens.
+type Heading struct {
+	Level  int    // 1-6
+	Text   string // rendered heading text (inline markup stripped)
+	Anchor string // GitHub-style slug, deduplicated with -1, -2, ... suffixes
+	Start  int    // byte offset of the heading's line start
+	End    int    // byte offset where the section ends (next heading of level <= Level, or len(body))
+	Lines  int    // line count of the section span [Start, End)
+}
+
+// Headings parses body as markdown and returns all headings in document
+// order. Setext headings are included; # lines inside code fences and
+// indented code blocks are not headings and are excluded. Anchors follow
+// the GitHub slug convention with duplicate suffixing.
+func Headings(body string) []Heading {
+	src := []byte(body)
+	doc := goldmark.DefaultParser().Parse(text.NewReader(src))
+
+	var hs []Heading
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		h, ok := n.(*ast.Heading)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		lines := h.Lines()
+		if lines.Len() == 0 {
+			// Empty heading ("#" with no text) — nothing to slice or anchor.
+			return ast.WalkContinue, nil
+		}
+		start := lines.At(0).Start
+		for start > 0 && src[start-1] != '\n' {
+			start--
+		}
+		hs = append(hs, Heading{
+			Level: h.Level,
+			Text:  headingText(h, src),
+			Start: start,
+		})
+		return ast.WalkContinue, nil
+	})
+
+	// Deduplicate against every anchor already taken — generated suffixes
+	// count, so "Notes", "Notes", "Notes-1" yields notes, notes-1, notes-1-1
+	// (matching GitHub's slugger).
+	used := make(map[string]bool, len(hs))
+	for i := range hs {
+		s := Slug(hs[i].Text)
+		a := s
+		for n := 1; used[a]; n++ {
+			a = s + "-" + strconv.Itoa(n)
+		}
+		used[a] = true
+		hs[i].Anchor = a
+	}
+
+	for i := range hs {
+		end := len(src)
+		for j := i + 1; j < len(hs); j++ {
+			if hs[j].Level <= hs[i].Level {
+				end = hs[j].Start
+				break
+			}
+		}
+		hs[i].End = end
+		hs[i].Lines = countLines(src[hs[i].Start:end])
+	}
+	return hs
+}
+
+// headingText collects the text content of a heading node, descending into
+// inline children (code spans, emphasis) the way GitHub does when slugging.
+func headingText(h *ast.Heading, src []byte) string {
+	var b strings.Builder
+	_ = ast.Walk(h, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		if t, ok := n.(*ast.Text); ok {
+			b.Write(t.Segment.Value(src))
+		}
+		return ast.WalkContinue, nil
+	})
+	return b.String()
+}
+
+// Slug converts heading text to a GitHub-style anchor: lowercase, spaces
+// become hyphens, and everything that is not a letter, number, underscore,
+// or hyphen is removed. It does not apply duplicate suffixes — Headings
+// handles that across a whole document.
+func Slug(heading string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(heading) {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsNumber(r) || r == '_' || r == '-':
+			b.WriteRune(r)
+		case unicode.IsSpace(r):
+			b.WriteByte('-')
+		}
+	}
+	return b.String()
+}
+
+// Section returns the slice of body opened by the heading whose anchor
+// matches anchor (leading '#' optional, matched case-insensitively). The
+// slice runs from the heading line through the end of its subtree — up to
+// the next heading of the same or shallower level. When no anchor matches
+// exactly, the anchor is re-slugged so agents can pass raw heading text
+// ("Problem Statement") instead of the slug. Returns false if nothing
+// matches.
+func Section(body, anchor string) (string, bool) {
+	want := strings.TrimPrefix(strings.TrimSpace(anchor), "#")
+	hs := Headings(body)
+	for _, h := range hs {
+		if strings.EqualFold(h.Anchor, want) {
+			return body[h.Start:h.End], true
+		}
+	}
+	slugged := Slug(want)
+	for _, h := range hs {
+		if h.Anchor == slugged {
+			return body[h.Start:h.End], true
+		}
+	}
+	return "", false
+}
+
+// Outline renders the heading tree as an indented list, one heading per
+// line with its anchor and section line count — the map an agent needs to
+// pick a #section to fetch. Returns "" for a body with no headings.
+func Outline(body string) string {
+	hs := Headings(body)
+	if len(hs) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, h := range hs {
+		fmt.Fprintf(&b, "%s- %s (#%s, %d lines)\n", strings.Repeat("  ", h.Level-1), h.Text, h.Anchor, h.Lines)
+	}
+	return b.String()
+}
+
+// OpeningParagraph returns the first top-level paragraph of body as raw
+// markdown, or "" when the document has none.
+func OpeningParagraph(body string) string {
+	src := []byte(body)
+	doc := goldmark.DefaultParser().Parse(text.NewReader(src))
+	for n := doc.FirstChild(); n != nil; n = n.NextSibling() {
+		p, ok := n.(*ast.Paragraph)
+		if !ok {
+			continue
+		}
+		lines := p.Lines()
+		if lines.Len() == 0 {
+			return ""
+		}
+		start := lines.At(0).Start
+		stop := lines.At(lines.Len() - 1).Stop
+		return strings.TrimSpace(string(src[start:stop]))
+	}
+	return ""
+}
+
+// Anchors returns just the anchor strings of every heading in body, in
+// document order — for "section not found" hints.
+func Anchors(body string) []string {
+	hs := Headings(body)
+	out := make([]string, len(hs))
+	for i, h := range hs {
+		out[i] = h.Anchor
+	}
+	return out
+}
+
+// countLines counts the lines covered by span, treating a trailing partial
+// line as a line.
+func countLines(span []byte) int {
+	if len(span) == 0 {
+		return 0
+	}
+	n := strings.Count(string(span), "\n")
+	if span[len(span)-1] != '\n' {
+		n++
+	}
+	return n
+}

--- a/client/mdoutline/mdoutline.go
+++ b/client/mdoutline/mdoutline.go
@@ -29,6 +29,12 @@ type Heading struct {
 // order. Setext headings are included; # lines inside code fences and
 // indented code blocks are not headings and are excluded. Anchors follow
 // the GitHub slug convention with duplicate suffixing.
+//
+// Each exported helper reparses body independently, and the End/Lines pass
+// below is O(n²) in heading count. Both are deliberate: bodies are capped
+// by document size (tens of KB, dozens of headings), where a goldmark parse
+// is sub-millisecond, so sharing parsed state across calls would buy
+// nothing measurable at the cost of a stateful API.
 func Headings(body string) []Heading {
 	src := []byte(body)
 	doc := goldmark.DefaultParser().Parse(text.NewReader(src))

--- a/client/mdoutline/mdoutline_test.go
+++ b/client/mdoutline/mdoutline_test.go
@@ -1,0 +1,288 @@
+package mdoutline
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const sampleDoc = `# Title
+
+Opening paragraph spanning
+two lines.
+
+## Setup
+
+Setup body.
+
+### Details
+
+Detail body.
+
+## Usage
+
+Usage body.
+`
+
+func TestHeadings(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		levels  []int
+		anchors []string
+	}{
+		{
+			"atx tree",
+			sampleDoc,
+			[]int{1, 2, 3, 2},
+			[]string{"title", "setup", "details", "usage"},
+		},
+		{
+			"setext headings",
+			"Title\n=====\n\nbody\n\nSection\n-------\n\nmore\n",
+			[]int{1, 2},
+			[]string{"title", "section"},
+		},
+		{
+			"hash inside code fence is not a heading",
+			"# Real\n\n```\n# not a heading\n## also not\n```\n\n## After\n",
+			[]int{1, 2},
+			[]string{"real", "after"},
+		},
+		{
+			"hash inside tilde fence is not a heading",
+			"# Real\n\n~~~sh\n# comment\n~~~\n",
+			[]int{1},
+			[]string{"real"},
+		},
+		{
+			"hash in indented code block is not a heading",
+			"# Real\n\n    # indented code\n",
+			[]int{1},
+			[]string{"real"},
+		},
+		{
+			"duplicate headings get suffixed anchors",
+			"## Notes\n\n## Notes\n\n## Notes\n",
+			[]int{2, 2, 2},
+			[]string{"notes", "notes-1", "notes-2"},
+		},
+		{
+			"duplicate collides with explicit -1 heading",
+			"## Notes\n\n## Notes\n\n## Notes-1\n",
+			[]int{2, 2, 2},
+			[]string{"notes", "notes-1", "notes-1-1"},
+		},
+		{
+			"empty body",
+			"",
+			nil,
+			nil,
+		},
+		{
+			"no headings",
+			"just a paragraph\n",
+			nil,
+			nil,
+		},
+		{
+			"empty atx heading is skipped",
+			"#\n\n## Real\n",
+			[]int{2},
+			[]string{"real"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hs := Headings(tt.body)
+			var levels []int
+			var anchors []string
+			for _, h := range hs {
+				levels = append(levels, h.Level)
+				anchors = append(anchors, h.Anchor)
+			}
+			if !reflect.DeepEqual(levels, tt.levels) {
+				t.Errorf("levels = %v, want %v", levels, tt.levels)
+			}
+			if !reflect.DeepEqual(anchors, tt.anchors) {
+				t.Errorf("anchors = %v, want %v", anchors, tt.anchors)
+			}
+		})
+	}
+}
+
+func TestHeadingSpans(t *testing.T) {
+	hs := Headings(sampleDoc)
+	if len(hs) != 4 {
+		t.Fatalf("got %d headings, want 4", len(hs))
+	}
+
+	// Title (level 1) spans the whole document.
+	if hs[0].Start != 0 || hs[0].End != len(sampleDoc) {
+		t.Errorf("title span = [%d, %d), want [0, %d)", hs[0].Start, hs[0].End, len(sampleDoc))
+	}
+	// Setup (level 2) includes its Details subsection and ends at Usage.
+	setup := sampleDoc[hs[1].Start:hs[1].End]
+	if !strings.HasPrefix(setup, "## Setup") {
+		t.Errorf("setup span starts with %q", setup[:20])
+	}
+	if !strings.Contains(setup, "### Details") {
+		t.Error("setup span should include the Details subsection")
+	}
+	if strings.Contains(setup, "## Usage") {
+		t.Error("setup span should end before Usage")
+	}
+	// Usage (last section) runs to EOF.
+	if hs[3].End != len(sampleDoc) {
+		t.Errorf("usage End = %d, want %d", hs[3].End, len(sampleDoc))
+	}
+}
+
+func TestHeadingLines(t *testing.T) {
+	hs := Headings("## A\n\nline1\nline2\n\n## B\nno trailing newline")
+	if len(hs) != 2 {
+		t.Fatalf("got %d headings, want 2", len(hs))
+	}
+	if hs[0].Lines != 5 {
+		t.Errorf("section A lines = %d, want 5", hs[0].Lines)
+	}
+	if hs[1].Lines != 2 {
+		t.Errorf("section B lines = %d, want 2 (trailing partial line counts)", hs[1].Lines)
+	}
+}
+
+func TestSlug(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{"simple", "Problem", "problem"},
+		{"spaces to hyphens", "Problem Statement", "problem-statement"},
+		{"punctuation removed", "What's next?", "whats-next"},
+		{"em dash removed, double hyphen kept", "W1 — outline mode", "w1--outline-mode"},
+		{"slash removed", "outline/section mode", "outlinesection-mode"},
+		{"underscores kept", "mark_fetch tool", "mark_fetch-tool"},
+		{"hyphens kept", "size-adaptive", "size-adaptive"},
+		{"unicode letters kept", "Über uns", "über-uns"},
+		{"digits kept", "Phase 2 plan", "phase-2-plan"},
+		{"only punctuation", "!!!", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Slug(tt.text); got != tt.want {
+				t.Errorf("Slug(%q) = %q, want %q", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHeadingTextWithInlineCode(t *testing.T) {
+	hs := Headings("## The `mark_fetch` tool\n")
+	if len(hs) != 1 {
+		t.Fatalf("got %d headings, want 1", len(hs))
+	}
+	if hs[0].Text != "The mark_fetch tool" {
+		t.Errorf("text = %q, want backtick content without backticks", hs[0].Text)
+	}
+	if hs[0].Anchor != "the-mark_fetch-tool" {
+		t.Errorf("anchor = %q, want the-mark_fetch-tool", hs[0].Anchor)
+	}
+}
+
+func TestSection(t *testing.T) {
+	tests := []struct {
+		name         string
+		anchor       string
+		wantFound    bool
+		wantPrefix   string
+		wantContains string
+		wantExcludes string
+	}{
+		{"exact anchor", "setup", true, "## Setup", "### Details", "## Usage"},
+		{"leading hash stripped", "#setup", true, "## Setup", "", ""},
+		{"case insensitive", "SETUP", true, "## Setup", "", ""},
+		{"raw heading text re-slugged", "Opening paragraph", false, "", "", ""},
+		{"raw text matches heading", "Details", true, "### Details", "", ""},
+		{"last section runs to eof", "usage", true, "## Usage", "Usage body.", ""},
+		{"missing anchor", "nope", false, "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, found := Section(sampleDoc, tt.anchor)
+			if found != tt.wantFound {
+				t.Fatalf("found = %v, want %v", found, tt.wantFound)
+			}
+			if !found {
+				return
+			}
+			if !strings.HasPrefix(got, tt.wantPrefix) {
+				t.Errorf("section starts with %q, want prefix %q", got[:min(len(got), 30)], tt.wantPrefix)
+			}
+			if tt.wantContains != "" && !strings.Contains(got, tt.wantContains) {
+				t.Errorf("section should contain %q", tt.wantContains)
+			}
+			if tt.wantExcludes != "" && strings.Contains(got, tt.wantExcludes) {
+				t.Errorf("section should not contain %q", tt.wantExcludes)
+			}
+		})
+	}
+}
+
+func TestSectionDuplicateAnchors(t *testing.T) {
+	body := "## Notes\n\nfirst\n\n## Notes\n\nsecond\n"
+	got, found := Section(body, "notes-1")
+	if !found {
+		t.Fatal("notes-1 not found")
+	}
+	if !strings.Contains(got, "second") {
+		t.Errorf("notes-1 = %q, want the second Notes section", got)
+	}
+}
+
+func TestOutline(t *testing.T) {
+	t.Run("tree shape", func(t *testing.T) {
+		got := Outline(sampleDoc)
+		want := "- Title (#title, 16 lines)\n" +
+			"  - Setup (#setup, 8 lines)\n" +
+			"    - Details (#details, 4 lines)\n" +
+			"  - Usage (#usage, 3 lines)\n"
+		if got != want {
+			t.Errorf("outline =\n%q\nwant\n%q", got, want)
+		}
+	})
+	t.Run("no headings", func(t *testing.T) {
+		if got := Outline("plain text\n"); got != "" {
+			t.Errorf("outline = %q, want empty", got)
+		}
+	})
+}
+
+func TestOpeningParagraph(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"after h1", sampleDoc, "Opening paragraph spanning\ntwo lines."},
+		{"before any heading", "Intro text.\n\n# Title\n", "Intro text."},
+		{"no paragraph", "# Only headings\n\n## Nothing else\n", ""},
+		{"empty body", "", ""},
+		{"skips list to nothing", "# T\n\n- a list item\n", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := OpeningParagraph(tt.body); got != tt.want {
+				t.Errorf("OpeningParagraph = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAnchors(t *testing.T) {
+	got := Anchors(sampleDoc)
+	want := []string{"title", "setup", "details", "usage"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Anchors = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “explore” tool that returns a markdown neighborhood card with outline, opening paragraph, links, backlinks, and sibling pages.
  * Enhanced fetching to support `url#anchor` section requests and outline/section rendering guidance.

* **Bug Fixes**
  * Large documents now automatically use an outline view (unless forced).
  * Repeated full-document fetches in the same session can return an “unchanged” response, and identity changes are called out as “changed.”
  * Missing anchors and unavailable listings now degrade gracefully with clearer messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->