### PR TITLE
fix(tools): pin provisioned demarkus-mcp to client v0.15.0

### DIFF
--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -42,7 +42,7 @@ import (
 // cadence; the bump workflow tracks their latest existing releases).
 const (
 	serverVersion = "0.18.0"
-	clientVersion = "0.13.2"
+	clientVersion = "0.15.0"
 	// fallbackToolsVersion is used ONLY by dev builds (Version == "dev"), where
 	// there's no real release to derive the tools version from. A real release
 	// uses its own ldflags Version — see toolsRef.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Demarkus client to version `0.15.0`, so installations now download and use the newer client release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->