### PR TITLE
feat(mcp): mcp gateway ergonomics parity

### DIFF
--- a/client/cmd/demarkus-mcp/explore.go
+++ b/client/cmd/demarkus-mcp/explore.go
@@ -60,7 +60,7 @@ func (h *handler) markExplore(_ context.Context, req mcp.CallToolRequest) (*mcp.
 
 	b.WriteString("## Outline\n")
 	if tree := mdoutline.Outline(body); tree != "" {
-		writeCapped(&b, strings.Split(strings.TrimRight(tree, "\n"), "\n"), "headings")
+		mdoutline.CappedList(&b, strings.Split(strings.TrimRight(tree, "\n"), "\n"), exploreSectionCap, "headings")
 	} else {
 		b.WriteString("(no headings)\n")
 	}
@@ -70,12 +70,12 @@ func (h *handler) markExplore(_ context.Context, req mcp.CallToolRequest) (*mcp.
 		b.WriteString("\n")
 	}
 
-	out := outboundLinkLines(body)
+	out := mdoutline.LinkLines(body)
 	fmt.Fprintf(&b, "\n## Outbound links (%d)\n", len(out))
 	if len(out) == 0 {
 		b.WriteString("(none)\n")
 	} else {
-		writeCapped(&b, out, "links")
+		mdoutline.CappedList(&b, out, exploreSectionCap, "links")
 	}
 
 	h.writeBacklinksSection(&b, docURL)
@@ -114,7 +114,7 @@ func (h *handler) writeBacklinksSection(b *strings.Builder, docURL string) {
 			lines[i] = "- " + bl.URL
 		}
 	}
-	writeCapped(b, lines, "backlinks")
+	mdoutline.CappedList(b, lines, exploreSectionCap, "backlinks")
 }
 
 // writeSiblingsSection appends the sibling listing of the document's parent
@@ -141,39 +141,5 @@ func (h *handler) writeSiblingsSection(b *strings.Builder, host, path, token str
 		b.WriteString("(none)\n")
 		return
 	}
-	writeCapped(b, lines, "siblings")
-}
-
-// outboundLinkLines extracts the document's links as one-line entries with
-// titles, deduplicated by destination in document order.
-func outboundLinkLines(body string) []string {
-	seen := make(map[string]bool)
-	var out []string
-	for _, l := range links.ExtractWithPositions(body) {
-		if seen[l.Dest] {
-			continue
-		}
-		seen[l.Dest] = true
-		if l.Text != "" {
-			out = append(out, fmt.Sprintf("- [%s](%s)", l.Text, l.Dest))
-		} else {
-			out = append(out, "- "+l.Dest)
-		}
-	}
-	return out
-}
-
-// writeCapped writes at most exploreSectionCap pre-formatted lines and an
-// honest "+N more <noun>" marker for the overflow.
-func writeCapped(b *strings.Builder, lines []string, noun string) {
-	for i, line := range lines {
-		if i == exploreSectionCap {
-			break
-		}
-		b.WriteString(line)
-		b.WriteString("\n")
-	}
-	if n := len(lines) - exploreSectionCap; n > 0 {
-		fmt.Fprintf(b, "+%d more %s\n", n, noun)
-	}
+	mdoutline.CappedList(b, lines, exploreSectionCap, "siblings")
 }

--- a/client/cmd/demarkus-mcp/fetchmode_test.go
+++ b/client/cmd/demarkus-mcp/fetchmode_test.go
@@ -268,6 +268,8 @@ func TestChangedNote(t *testing.T) {
 		want    string
 	}{
 		{"version bump", seenDoc{version: "3"}, "5", "changed since this session's earlier fetch (v3 -> v5)"},
+		{"was etag-only, now versioned", seenDoc{etag: "a"}, "5", "changed since this session's earlier fetch (was etag-only, now v5)"},
+		{"was versioned, now etag-only", seenDoc{version: "3"}, "", "changed since this session's earlier fetch (was v3, now etag-only)"},
 		{"etag rotated, version steady", seenDoc{version: "3", etag: "a"}, "3", "content changed since this session's earlier fetch (still v3, etag differs)"},
 		{"etag-only identity", seenDoc{etag: "a"}, "", "content changed since this session's earlier fetch (etag differs)"},
 	}

--- a/client/cmd/demarkus-mcp/fetchmode_test.go
+++ b/client/cmd/demarkus-mcp/fetchmode_test.go
@@ -257,6 +257,29 @@ func TestHandlerMarkFetch_EtagOnlyChangeNoted(t *testing.T) {
 	}
 }
 
+// TestChangedNote pins the identity-delta wording, including the
+// etag-only-identity edge (no version at all) that must not render a
+// bare "still v". Mirrored by the broker gateway's copy.
+func TestChangedNote(t *testing.T) {
+	tests := []struct {
+		name    string
+		prev    seenDoc
+		version string
+		want    string
+	}{
+		{"version bump", seenDoc{version: "3"}, "5", "changed since this session's earlier fetch (v3 -> v5)"},
+		{"etag rotated, version steady", seenDoc{version: "3", etag: "a"}, "3", "content changed since this session's earlier fetch (still v3, etag differs)"},
+		{"etag-only identity", seenDoc{etag: "a"}, "", "content changed since this session's earlier fetch (etag differs)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := changedNote(tt.prev, tt.version); got != tt.want {
+				t.Errorf("changedNote = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHandlerMarkFetch_OutlineDoesNotRecordSeen(t *testing.T) {
 	h := &handler{client: fetchStub(bigDoc(), "3", "abc", nil)}
 	url := map[string]any{"url": "mark://example.com/big.md"}

--- a/client/cmd/demarkus-mcp/fetchmode_test.go
+++ b/client/cmd/demarkus-mcp/fetchmode_test.go
@@ -257,30 +257,9 @@ func TestHandlerMarkFetch_EtagOnlyChangeNoted(t *testing.T) {
 	}
 }
 
-// TestChangedNote pins the identity-delta wording, including the
-// etag-only-identity edge (no version at all) that must not render a
-// bare "still v". Mirrored by the broker gateway's copy.
-func TestChangedNote(t *testing.T) {
-	tests := []struct {
-		name    string
-		prev    seenDoc
-		version string
-		want    string
-	}{
-		{"version bump", seenDoc{version: "3"}, "5", "changed since this session's earlier fetch (v3 -> v5)"},
-		{"was etag-only, now versioned", seenDoc{etag: "a"}, "5", "changed since this session's earlier fetch (was etag-only, now v5)"},
-		{"was versioned, now etag-only", seenDoc{version: "3"}, "", "changed since this session's earlier fetch (was v3, now etag-only)"},
-		{"etag rotated, version steady", seenDoc{version: "3", etag: "a"}, "3", "content changed since this session's earlier fetch (still v3, etag differs)"},
-		{"etag-only identity", seenDoc{etag: "a"}, "", "content changed since this session's earlier fetch (etag differs)"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := changedNote(tt.prev, tt.version); got != tt.want {
-				t.Errorf("changedNote = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
+// Identity-delta wording (unchanged notice, changed note, asymmetric
+// identity flips) is pinned once in client/fetchdedup's tests — both this
+// binary and the broker gateway render through that package.
 
 func TestHandlerMarkFetch_OutlineDoesNotRecordSeen(t *testing.T) {
 	h := &handler{client: fetchStub(bigDoc(), "3", "abc", nil)}

--- a/client/cmd/demarkus-mcp/fetchmode_test.go
+++ b/client/cmd/demarkus-mcp/fetchmode_test.go
@@ -261,6 +261,34 @@ func TestHandlerMarkFetch_EtagOnlyChangeNoted(t *testing.T) {
 // identity flips) is pinned once in client/fetchdedup's tests — both this
 // binary and the broker gateway render through that package.
 
+func TestHandlerMarkFetch_IdentityLostNoNote(t *testing.T) {
+	// A response that loses BOTH identity fields after an identified
+	// fetch has nothing truthful to say about what changed — the body
+	// comes back with no note (and no dedup).
+	version, etag := "3", "abc"
+	sc := &stubClient{
+		fetchFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusOK,
+				Metadata: map[string]string{"version": version, "etag": etag},
+				Body:     smallDoc,
+			}}, nil
+		},
+	}
+	h := &handler{client: sc}
+	url := map[string]any{"url": "mark://example.com/doc.md"}
+
+	_ = fetchText(t, h, url)
+	version, etag = "", ""
+	text := fetchText(t, h, url)
+	if strings.Contains(text, "note:") {
+		t.Errorf("identity-less response must not carry a changed note, got:\n%s", text)
+	}
+	if !strings.Contains(text, "Setup body.") {
+		t.Error("identity-less response should return the body")
+	}
+}
+
 func TestHandlerMarkFetch_OutlineDoesNotRecordSeen(t *testing.T) {
 	h := &handler{client: fetchStub(bigDoc(), "3", "abc", nil)}
 	url := map[string]any{"url": "mark://example.com/big.md"}

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -126,12 +126,18 @@ func (h *handler) seenLookup(key string) (seenDoc, bool) {
 // session's earlier full-body fetch. Mirrored by the broker MCP
 // gateway's copy so the two surfaces answer identically.
 func changedNote(prev seenDoc, version string) string {
-	if prev.version != version {
+	// Either side of a version change can be empty (seenRecord only
+	// requires one identity field): spell out identity-type flips
+	// instead of rendering a bare "v" with no number.
+	switch {
+	case prev.version != version && prev.version == "":
+		return fmt.Sprintf("changed since this session's earlier fetch (was etag-only, now v%s)", version)
+	case prev.version != version && version == "":
+		return fmt.Sprintf("changed since this session's earlier fetch (was v%s, now etag-only)", prev.version)
+	case prev.version != version:
 		return fmt.Sprintf("changed since this session's earlier fetch (v%s -> v%s)", prev.version, version)
-	}
-	if version == "" {
-		// Etag-only identity (server sends no version): don't print a
-		// bare "still v".
+	case version == "":
+		// Etag-only identity throughout (server sends no version).
 		return "content changed since this session's earlier fetch (etag differs)"
 	}
 	return fmt.Sprintf("content changed since this session's earlier fetch (still v%s, etag differs)", version)

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -565,7 +565,9 @@ func (h *handler) markFetch(_ context.Context, req mcp.CallToolRequest) (*mcp.Ca
 	}
 
 	extra := map[string]string{}
-	if seenBefore && prev != cur {
+	// cur.Identified() also gates the note: a response that lost both
+	// identity fields has nothing truthful to say about what changed.
+	if seenBefore && cur.Identified() && prev != cur {
 		extra["note"] = fetchdedup.ChangedNote(prev, cur)
 	}
 

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -593,7 +593,7 @@ func (h *handler) markFetch(_ context.Context, req mcp.CallToolRequest) (*mcp.Ca
 	if !force && len(body) >= outlineThreshold {
 		extra["mode"] = "outline"
 		extra["size"] = fmt.Sprintf("%d bytes, %d lines", len(body), strings.Count(body, "\n")+1)
-		return mcp.NewToolResultText(formatResultWith(result, outlineBody(docURL, body),
+		return mcp.NewToolResultText(formatResultWith(result, mdoutline.OutlineBody(docURL, body),
 			extra, "version", "modified", "etag")), nil
 	}
 
@@ -604,25 +604,6 @@ func (h *handler) markFetch(_ context.Context, req mcp.CallToolRequest) (*mcp.Ca
 		return mcp.NewToolResultText(formatResult(result, "version", "modified", "etag")), nil
 	}
 	return mcp.NewToolResultText(formatResultWith(result, body, extra, "version", "modified", "etag")), nil
-}
-
-// outlineBody builds the outline-mode body for a large document: heading
-// tree with anchors and line counts, the opening paragraph, and the hint
-// telling the agent how to get more.
-func outlineBody(docURL, body string) string {
-	var b strings.Builder
-	if tree := mdoutline.Outline(body); tree != "" {
-		b.WriteString(tree)
-	} else {
-		b.WriteString("(document has no headings)\n")
-	}
-	if para := mdoutline.OpeningParagraph(body); para != "" {
-		b.WriteString("\n")
-		b.WriteString(para)
-		b.WriteString("\n")
-	}
-	fmt.Fprintf(&b, "\nfetch %s#<anchor> for a section; force=true for the full body\n", docURL)
-	return b.String()
 }
 
 func (h *handler) markList(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -122,6 +122,21 @@ func (h *handler) seenLookup(key string) (seenDoc, bool) {
 	return d, ok
 }
 
+// changedNote describes how the document identity moved since the
+// session's earlier full-body fetch. Mirrored by the broker MCP
+// gateway's copy so the two surfaces answer identically.
+func changedNote(prev seenDoc, version string) string {
+	if prev.version != version {
+		return fmt.Sprintf("changed since this session's earlier fetch (v%s -> v%s)", prev.version, version)
+	}
+	if version == "" {
+		// Etag-only identity (server sends no version): don't print a
+		// bare "still v".
+		return "content changed since this session's earlier fetch (etag differs)"
+	}
+	return fmt.Sprintf("content changed since this session's earlier fetch (still v%s, etag differs)", version)
+}
+
 // seenRecord remembers that the full body of key's document was returned.
 func (h *handler) seenRecord(key string, d seenDoc) {
 	h.seenMu.Lock()
@@ -582,11 +597,7 @@ func (h *handler) markFetch(_ context.Context, req mcp.CallToolRequest) (*mcp.Ca
 
 	extra := map[string]string{}
 	if seenBefore && (prev.version != version || prev.etag != etag) {
-		if prev.version != version {
-			extra["note"] = fmt.Sprintf("changed since this session's earlier fetch (v%s -> v%s)", prev.version, version)
-		} else {
-			extra["note"] = fmt.Sprintf("content changed since this session's earlier fetch (still v%s, etag differs)", version)
-		}
+		extra["note"] = changedNote(prev, version)
 	}
 
 	// Size gate: large documents return an outline unless forced.

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/client/fetchdedup"
 	"github.com/latebit-io/demarkus/client/graph"
 	"github.com/latebit-io/demarkus/client/graphstore"
 	"github.com/latebit-io/demarkus/client/index"
@@ -103,52 +104,27 @@ type handler struct {
 	// seenMu guards seen, the per-session fetch dedup state: host+path →
 	// identity of the document version whose full body was already returned
 	// to the agent this session. Process-lifetime only, never persisted —
-	// cross-session staleness risk outweighs the token saving.
+	// cross-session staleness risk outweighs the token saving. Identity
+	// semantics and notice texts live in client/fetchdedup, shared with the
+	// broker MCP gateway so the two surfaces answer identically.
 	seenMu sync.Mutex
-	seen   map[string]seenDoc
-}
-
-// seenDoc identifies a document version already returned in full this session.
-type seenDoc struct {
-	version string
-	etag    string
+	seen   map[string]fetchdedup.Doc
 }
 
 // seenLookup returns the recorded identity for key, if any.
-func (h *handler) seenLookup(key string) (seenDoc, bool) {
+func (h *handler) seenLookup(key string) (fetchdedup.Doc, bool) {
 	h.seenMu.Lock()
 	defer h.seenMu.Unlock()
 	d, ok := h.seen[key]
 	return d, ok
 }
 
-// changedNote describes how the document identity moved since the
-// session's earlier full-body fetch. Mirrored by the broker MCP
-// gateway's copy so the two surfaces answer identically.
-func changedNote(prev seenDoc, version string) string {
-	// Either side of a version change can be empty (seenRecord only
-	// requires one identity field): spell out identity-type flips
-	// instead of rendering a bare "v" with no number.
-	switch {
-	case prev.version != version && prev.version == "":
-		return fmt.Sprintf("changed since this session's earlier fetch (was etag-only, now v%s)", version)
-	case prev.version != version && version == "":
-		return fmt.Sprintf("changed since this session's earlier fetch (was v%s, now etag-only)", prev.version)
-	case prev.version != version:
-		return fmt.Sprintf("changed since this session's earlier fetch (v%s -> v%s)", prev.version, version)
-	case version == "":
-		// Etag-only identity throughout (server sends no version).
-		return "content changed since this session's earlier fetch (etag differs)"
-	}
-	return fmt.Sprintf("content changed since this session's earlier fetch (still v%s, etag differs)", version)
-}
-
 // seenRecord remembers that the full body of key's document was returned.
-func (h *handler) seenRecord(key string, d seenDoc) {
+func (h *handler) seenRecord(key string, d fetchdedup.Doc) {
 	h.seenMu.Lock()
 	defer h.seenMu.Unlock()
 	if h.seen == nil {
-		h.seen = make(map[string]seenDoc)
+		h.seen = make(map[string]fetchdedup.Doc)
 	}
 	h.seen[key] = d
 }
@@ -582,28 +558,15 @@ func (h *handler) markFetch(_ context.Context, req mcp.CallToolRequest) (*mcp.Ca
 	// Dedup needs at least one identity field: with version and etag both
 	// absent, two different bodies would compare equal and a changed
 	// document would be silently reported as unchanged.
-	hasIdentity := version != "" || etag != ""
+	cur := fetchdedup.Doc{Version: version, Etag: etag}
 	prev, seenBefore := h.seenLookup(key)
-	if seenBefore && !force && hasIdentity && prev.version == version && prev.etag == etag {
-		var b strings.Builder
-		b.WriteString("status: unchanged\n")
-		if version != "" {
-			fmt.Fprintf(&b, "version: %s\n", version)
-		}
-		if etag != "" {
-			fmt.Fprintf(&b, "etag: %s\n", etag)
-		}
-		since := "since this session's earlier fetch (etag match)"
-		if version != "" {
-			since = "since v" + version
-		}
-		fmt.Fprintf(&b, "\nunchanged %s — the full body was returned earlier this session; pass force=true to re-read it\n", since)
-		return mcp.NewToolResultText(b.String()), nil
+	if seenBefore && !force && cur.Identified() && prev == cur {
+		return mcp.NewToolResultText(fetchdedup.UnchangedNotice(cur)), nil
 	}
 
 	extra := map[string]string{}
-	if seenBefore && (prev.version != version || prev.etag != etag) {
-		extra["note"] = changedNote(prev, version)
+	if seenBefore && prev != cur {
+		extra["note"] = fetchdedup.ChangedNote(prev, cur)
 	}
 
 	// Size gate: large documents return an outline unless forced.
@@ -614,8 +577,8 @@ func (h *handler) markFetch(_ context.Context, req mcp.CallToolRequest) (*mcp.Ca
 			extra, "version", "modified", "etag")), nil
 	}
 
-	if hasIdentity {
-		h.seenRecord(key, seenDoc{version: version, etag: etag})
+	if cur.Identified() {
+		h.seenRecord(key, cur)
 	}
 	if len(extra) == 0 {
 		return mcp.NewToolResultText(formatResult(result, "version", "modified", "etag")), nil

--- a/client/fetchdedup/fetchdedup.go
+++ b/client/fetchdedup/fetchdedup.go
@@ -1,0 +1,66 @@
+// Package fetchdedup carries the session fetch-dedup identity shared by
+// the MCP fetch surfaces (client/cmd/demarkus-mcp and the broker MCP
+// gateway): what identifies a fetched document version, and the exact
+// notice texts for "unchanged" and "changed since you last read this".
+// Both surfaces render these byte-identically; keeping one copy here is
+// what guarantees it.
+package fetchdedup
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Doc identifies a fetched document version by the identity metadata a
+// Mark server returns. Either field may be empty; a Doc with both empty
+// carries no identity and must not drive dedup decisions.
+type Doc struct {
+	Version string
+	Etag    string
+}
+
+// Identified reports whether d carries at least one identity field.
+// With both absent, two different bodies would compare equal and a
+// changed document would be silently reported as unchanged.
+func (d Doc) Identified() bool {
+	return d.Version != "" || d.Etag != ""
+}
+
+// UnchangedNotice renders the dedup short-circuit response: the document
+// identity plus a pointer at force=true. Only call it for an Identified
+// Doc.
+func UnchangedNotice(d Doc) string {
+	var b strings.Builder
+	b.WriteString("status: unchanged\n")
+	if d.Version != "" {
+		fmt.Fprintf(&b, "version: %s\n", d.Version)
+	}
+	if d.Etag != "" {
+		fmt.Fprintf(&b, "etag: %s\n", d.Etag)
+	}
+	since := "since this session's earlier fetch (etag match)"
+	if d.Version != "" {
+		since = "since v" + d.Version
+	}
+	fmt.Fprintf(&b, "\nunchanged %s — the full body was returned earlier this session; pass force=true to re-read it\n", since)
+	return b.String()
+}
+
+// ChangedNote describes how the document identity moved since the
+// session's earlier full-body fetch. Either side of a version change can
+// be empty (recording requires only one identity field): identity-type
+// flips are spelled out instead of rendering a bare "v" with no number.
+func ChangedNote(prev, cur Doc) string {
+	switch {
+	case prev.Version != cur.Version && prev.Version == "":
+		return fmt.Sprintf("changed since this session's earlier fetch (was etag-only, now v%s)", cur.Version)
+	case prev.Version != cur.Version && cur.Version == "":
+		return fmt.Sprintf("changed since this session's earlier fetch (was v%s, now etag-only)", prev.Version)
+	case prev.Version != cur.Version:
+		return fmt.Sprintf("changed since this session's earlier fetch (v%s -> v%s)", prev.Version, cur.Version)
+	case cur.Version == "":
+		// Etag-only identity throughout (server sends no version).
+		return "content changed since this session's earlier fetch (etag differs)"
+	}
+	return fmt.Sprintf("content changed since this session's earlier fetch (still v%s, etag differs)", cur.Version)
+}

--- a/client/fetchdedup/fetchdedup_test.go
+++ b/client/fetchdedup/fetchdedup_test.go
@@ -1,0 +1,88 @@
+package fetchdedup
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIdentified(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  Doc
+		want bool
+	}{
+		{"both fields", Doc{Version: "3", Etag: "a"}, true},
+		{"version only", Doc{Version: "3"}, true},
+		{"etag only", Doc{Etag: "a"}, true},
+		{"neither", Doc{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.doc.Identified(); got != tt.want {
+				t.Errorf("Identified() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnchangedNotice(t *testing.T) {
+	tests := []struct {
+		name    string
+		doc     Doc
+		wantIn  []string
+		wantOut []string
+	}{
+		{
+			"versioned",
+			Doc{Version: "3", Etag: "abc"},
+			[]string{"status: unchanged\n", "version: 3\n", "etag: abc\n", "unchanged since v3", "force=true"},
+			nil,
+		},
+		{
+			"etag-only identity",
+			Doc{Etag: "abc"},
+			[]string{"status: unchanged\n", "etag: abc\n", "unchanged since this session's earlier fetch (etag match)"},
+			[]string{"version:", "since v"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := UnchangedNotice(tt.doc)
+			for _, want := range tt.wantIn {
+				if !strings.Contains(got, want) {
+					t.Errorf("notice missing %q in:\n%s", want, got)
+				}
+			}
+			for _, not := range tt.wantOut {
+				if strings.Contains(got, not) {
+					t.Errorf("notice should not contain %q:\n%s", not, got)
+				}
+			}
+		})
+	}
+}
+
+// TestChangedNote pins the identity-delta wording, including the
+// asymmetric versioned<->etag-only flips that must not render a bare
+// "v" with no number.
+func TestChangedNote(t *testing.T) {
+	tests := []struct {
+		name string
+		prev Doc
+		cur  Doc
+		want string
+	}{
+		{"version bump", Doc{Version: "3"}, Doc{Version: "5"}, "changed since this session's earlier fetch (v3 -> v5)"},
+		{"was etag-only, now versioned", Doc{Etag: "a"}, Doc{Version: "5"}, "changed since this session's earlier fetch (was etag-only, now v5)"},
+		{"was versioned, now etag-only", Doc{Version: "3"}, Doc{Etag: "b"}, "changed since this session's earlier fetch (was v3, now etag-only)"},
+		{"etag rotated, version steady", Doc{Version: "3", Etag: "a"}, Doc{Version: "3", Etag: "b"}, "content changed since this session's earlier fetch (still v3, etag differs)"},
+		{"etag-only identity", Doc{Etag: "a"}, Doc{Etag: "b"}, "content changed since this session's earlier fetch (etag differs)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ChangedNote(tt.prev, tt.cur); got != tt.want {
+				t.Errorf("ChangedNote = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/client/mdoutline/render.go
+++ b/client/mdoutline/render.go
@@ -1,0 +1,68 @@
+package mdoutline
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/latebit-io/demarkus/client/links"
+)
+
+// This file holds the shared rendering helpers for the MCP fetch/explore
+// surfaces. Both the local demarkus-mcp and the broker MCP gateway compose
+// their tool responses from these, so outline mode and the explore card
+// read identically regardless of transport.
+
+// OutlineBody builds the outline-mode body for a large document: heading
+// tree with anchors and line counts, the opening paragraph, and the hint
+// telling the agent how to get more. docURL is the URL shape the consumer
+// exposes (bare path, mark://host/path, or mark://world/path) — it is
+// echoed verbatim into the hint.
+func OutlineBody(docURL, body string) string {
+	var b strings.Builder
+	if tree := Outline(body); tree != "" {
+		b.WriteString(tree)
+	} else {
+		b.WriteString("(document has no headings)\n")
+	}
+	if para := OpeningParagraph(body); para != "" {
+		b.WriteString("\n")
+		b.WriteString(para)
+		b.WriteString("\n")
+	}
+	fmt.Fprintf(&b, "\nfetch %s#<anchor> for a section; force=true for the full body\n", docURL)
+	return b.String()
+}
+
+// LinkLines extracts the document's links as one-line entries with titles,
+// deduplicated by destination in document order.
+func LinkLines(body string) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, l := range links.ExtractWithPositions(body) {
+		if seen[l.Dest] {
+			continue
+		}
+		seen[l.Dest] = true
+		if l.Text != "" {
+			out = append(out, fmt.Sprintf("- [%s](%s)", l.Text, l.Dest))
+		} else {
+			out = append(out, "- "+l.Dest)
+		}
+	}
+	return out
+}
+
+// CappedList writes at most limit pre-formatted lines to b and an honest
+// "+N more <noun>" marker for the overflow.
+func CappedList(b *strings.Builder, lines []string, limit int, noun string) {
+	for i, line := range lines {
+		if i == limit {
+			break
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	if n := len(lines) - limit; n > 0 {
+		fmt.Fprintf(b, "+%d more %s\n", n, noun)
+	}
+}

--- a/tools/demarkus-broker/internal/broker/mcp_gateway.go
+++ b/tools/demarkus-broker/internal/broker/mcp_gateway.go
@@ -62,7 +62,7 @@ type mcpGateway struct {
 func newMCPGateway(s *Server, version string, dispatcher worldDispatcher) *mcpGateway {
 	// Session-end eviction for the fetch dedup state. The store is
 	// constructed before the MCPServer because the hook closes over it.
-	fetchSeen := newSessionSeen()
+	fetchSeen := newSessionSeen(s.log, s.clock)
 	hooks := &mcpserver.Hooks{}
 	hooks.AddOnUnregisterSession(func(_ context.Context, session mcpserver.ClientSession) {
 		if session != nil {

--- a/tools/demarkus-broker/internal/broker/mcp_gateway.go
+++ b/tools/demarkus-broker/internal/broker/mcp_gateway.go
@@ -16,7 +16,7 @@ import (
 // MCPServer and its Streamable HTTP transport, sharing auth +
 // rate-limit machinery with the parent broker Server.
 //
-// All 15 tools have real handlers. Reads dispatch with an empty bearer
+// All 16 tools have real handlers. Reads dispatch with an empty bearer
 // (the world's tokens.toml grants no read op, so the org SSO gate at
 // the broker is the only access control); writes provision a per-world
 // token through worldWriteTokens and dispatch through worldDispatcher.
@@ -36,9 +36,15 @@ type mcpGateway struct {
 	// post-broker design window (see /thoughts.md "On Bucket
 	// Stores").
 	graphStore *graphstore.Store
+	// fetchSeen is the per-MCP-session unchanged-fetch dedup state
+	// (mcp_tools_fetchmode.go). Session entries are evicted by the
+	// OnUnregisterSession hook wired in newMCPGateway; like graphStore
+	// it is ephemeral per-pod state, consistent with the wire-shape-
+	// adapter framing.
+	fetchSeen *sessionSeen
 }
 
-// newMCPGateway constructs a gateway, registers the 15 tool
+// newMCPGateway constructs a gateway, registers the 16 tool
 // definitions (real handlers for Slice 2's read verbs, placeholders
 // for the rest), and wraps the mcp-go MCPServer in a Streamable HTTP
 // transport. The transport is an http.Handler — the caller mounts
@@ -54,6 +60,15 @@ type mcpGateway struct {
 // dispatcher is the worldDispatcher backing the tool handlers.
 // Production wires *worldPool; tests inject a fake.
 func newMCPGateway(s *Server, version string, dispatcher worldDispatcher) *mcpGateway {
+	// Session-end eviction for the fetch dedup state. The store is
+	// constructed before the MCPServer because the hook closes over it.
+	fetchSeen := newSessionSeen()
+	hooks := &mcpserver.Hooks{}
+	hooks.AddOnUnregisterSession(func(_ context.Context, session mcpserver.ClientSession) {
+		if session != nil {
+			fetchSeen.drop(session.SessionID())
+		}
+	})
 	mcpSrv := mcpserver.NewMCPServer(
 		"demarkus-broker",
 		version,
@@ -62,6 +77,7 @@ func newMCPGateway(s *Server, version string, dispatcher worldDispatcher) *mcpGa
 		// notifications/tools/list_changed advertisement the client
 		// would otherwise expect us to wire up — we never send one.
 		mcpserver.WithToolCapabilities(false),
+		mcpserver.WithHooks(hooks),
 	)
 	g := &mcpGateway{
 		srv:        s,
@@ -72,13 +88,14 @@ func newMCPGateway(s *Server, version string, dispatcher worldDispatcher) *mcpGa
 		// construction, dies with the broker pod. See the
 		// graphStore field doc for the design framing.
 		graphStore: graphstore.New(),
+		fetchSeen:  fetchSeen,
 	}
 	g.registerTools()
 	g.transport = mcpserver.NewStreamableHTTPServer(mcpSrv)
 	return g
 }
 
-// registerTools wires the 15 tool definitions onto the MCP server.
+// registerTools wires the 16 tool definitions onto the MCP server.
 // Tools absent from the toolHandlers map fall through to
 // notImplementedHandler. The per-tool handler map lives in
 // toolHandlers so adding new implementations is a one-line edit and
@@ -100,12 +117,13 @@ func (g *mcpGateway) registerTools() {
 // package-level var) so the handlers carry the gateway receiver
 // without indirection through a global.
 //
-// All 15 tools are real handlers — every entry below points at a
+// All 16 tools are real handlers — every entry below points at a
 // concrete implementation, and notImplementedHandler should never
 // run in production.
 func (g *mcpGateway) toolHandlers() map[string]mcpserver.ToolHandlerFunc {
 	return map[string]mcpserver.ToolHandlerFunc{
 		"mark_fetch":         g.handleMarkFetch,
+		"mark_explore":       g.handleMarkExplore,
 		"mark_list":          g.handleMarkList,
 		"mark_lookup":        g.handleMarkLookup,
 		"mark_versions":      g.handleMarkVersions,

--- a/tools/demarkus-broker/internal/broker/mcp_gateway_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_gateway_test.go
@@ -168,7 +168,7 @@ func TestMCPGatewayInitializeHandshake(t *testing.T) {
 	}
 }
 
-func TestMCPGatewayToolsListReturnsExpected13(t *testing.T) {
+func TestMCPGatewayToolsListMatchesAdvertisedNames(t *testing.T) {
 	v := &fakeVerifier{claims: Claims{Subject: "google|alice", Email: "alice@example.com", EmailVerified: true}}
 	ts := newTestMCPGateway(t, mcpTestConfig(), v)
 

--- a/tools/demarkus-broker/internal/broker/mcp_tools_explore.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_explore.go
@@ -1,0 +1,126 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/client/links"
+	"github.com/latebit-io/demarkus/client/mdoutline"
+	"github.com/latebit-io/demarkus/protocol"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// exploreSectionCap bounds each section of the neighborhood card.
+// Overflow is reported honestly as "+N more". Matches the local
+// demarkus-mcp value.
+const exploreSectionCap = 10
+
+// handleMarkExplore implements the mark_explore tool: one call returns a
+// neighborhood card for a document — outline head (heading tree + opening
+// paragraph), outbound links, recorded backlinks, and the sibling listing
+// of its parent directory. Mirrors client/cmd/demarkus-mcp markExplore;
+// the broker differences are the world-name URL shape and that backlinks
+// come from the broker's ephemeral graph store.
+func (g *mcpGateway) handleMarkExplore(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
+	raw, err := req.RequireString("url")
+	if err != nil {
+		return mcp.NewToolResultError("url is required"), nil
+	}
+	docURL, _, _ := strings.Cut(raw, "#")
+
+	worldName, path, err := parseToolURL(docURL)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", err)), nil
+	}
+	result, err := g.dispatcher.Fetch(worldName, path, "")
+	if err != nil {
+		return g.toolErrorFor("explore", worldName, err), nil
+	}
+	if result.Response.Status != protocol.StatusOK {
+		return mcp.NewToolResultText(formatToolResult(result, "version", "modified", "etag")), nil
+	}
+	body := result.Response.Body
+
+	var b strings.Builder
+
+	b.WriteString("## Outline\n")
+	if tree := mdoutline.Outline(body); tree != "" {
+		mdoutline.CappedList(&b, strings.Split(strings.TrimRight(tree, "\n"), "\n"), exploreSectionCap, "headings")
+	} else {
+		b.WriteString("(no headings)\n")
+	}
+	if para := mdoutline.OpeningParagraph(body); para != "" {
+		b.WriteString("\n## Opening\n")
+		b.WriteString(para)
+		b.WriteString("\n")
+	}
+
+	out := mdoutline.LinkLines(body)
+	fmt.Fprintf(&b, "\n## Outbound links (%d)\n", len(out))
+	if len(out) == 0 {
+		b.WriteString("(none)\n")
+	} else {
+		mdoutline.CappedList(&b, out, exploreSectionCap, "links")
+	}
+
+	g.writeBacklinksSection(&b, docURL)
+	g.writeSiblingsSection(&b, worldName, path)
+
+	fmt.Fprintf(&b, "\nfetch %s#<anchor> for a section; mark_fetch force=true for the full body\n", docURL)
+
+	extra := map[string]string{
+		"size": fmt.Sprintf("%d bytes, %d lines", len(body), strings.Count(body, "\n")+1),
+	}
+	return mcp.NewToolResultText(formatToolResultWith(result, b.String(), extra, "version", "modified", "etag")), nil
+}
+
+// writeBacklinksSection appends the backlinks card section from the
+// broker's ephemeral graph store. An empty store degrades to a note,
+// never an error. The store is keyed by full mark://{worldName}/{path}
+// URLs — the same shape mark_graph crawls record.
+func (g *mcpGateway) writeBacklinksSection(b *strings.Builder, docURL string) {
+	backlinks := g.graphStore.BacklinksEnriched(docURL)
+	fmt.Fprintf(b, "\n## Backlinks (%d)\n", len(backlinks))
+	if len(backlinks) == 0 {
+		b.WriteString("(none recorded — run mark_graph to populate; the broker's graph store is per-pod and resets on restart)\n")
+		return
+	}
+	lines := make([]string, len(backlinks))
+	for i, bl := range backlinks {
+		if bl.Title != "" {
+			lines[i] = fmt.Sprintf("- [%s](%s)", bl.Title, bl.URL)
+		} else {
+			lines[i] = "- " + bl.URL
+		}
+	}
+	mdoutline.CappedList(b, lines, exploreSectionCap, "backlinks")
+}
+
+// writeSiblingsSection appends the sibling listing of the document's
+// parent directory. A failed LIST degrades to a note, never an error.
+func (g *mcpGateway) writeSiblingsSection(b *strings.Builder, worldName, path string) {
+	dir := path[:strings.LastIndex(path, "/")+1]
+	self := path[strings.LastIndex(path, "/")+1:]
+
+	fmt.Fprintf(b, "\n## Siblings in %s", dir)
+	listing, err := g.dispatcher.List(worldName, dir, "", fetch.ListOptions{})
+	if err != nil || listing.Response.Status != protocol.StatusOK {
+		b.WriteString("\n(listing unavailable)\n")
+		return
+	}
+	var lines []string
+	for _, entry := range links.Extract(listing.Response.Body) {
+		if entry == self {
+			continue
+		}
+		lines = append(lines, "- "+entry)
+	}
+	fmt.Fprintf(b, " (%d)\n", len(lines))
+	if len(lines) == 0 {
+		b.WriteString("(none)\n")
+		return
+	}
+	mdoutline.CappedList(b, lines, exploreSectionCap, "siblings")
+}

--- a/tools/demarkus-broker/internal/broker/mcp_tools_explore_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_explore_test.go
@@ -1,0 +1,170 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/client/graph"
+	"github.com/latebit-io/demarkus/protocol"
+)
+
+const exploreTestDoc = `# Hub
+
+The hub links everything together.
+
+## Sections
+
+- [Alpha](/alpha.md)
+- [Beta](/docs/beta.md)
+
+## More
+
+See [Alpha](/alpha.md) again (deduped).
+`
+
+const exploreTestListing = `- [hub.md](hub.md)
+- [alpha.md](alpha.md)
+- [notes.md](notes.md)
+- [docs/](docs/)
+`
+
+func exploreDispatcher() *fakeDispatcher {
+	return &fakeDispatcher{
+		fetchFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusOK,
+				Metadata: map[string]string{"version": "2", "modified": "2026-07-05T00:00:00Z", "etag": "xyz"},
+				Body:     exploreTestDoc,
+			}}, nil
+		},
+		listFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status: protocol.StatusOK,
+				Body:   exploreTestListing,
+			}}, nil
+		},
+	}
+}
+
+func exploreResultText(t *testing.T, g *mcpGateway, url string) string {
+	t.Helper()
+	res, err := g.handleMarkExplore(withAliceClaims(context.Background()), callToolReq("mark_explore", map[string]any{"url": url}))
+	if err != nil {
+		t.Fatalf("handleMarkExplore: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("isError = true: %+v", res.Content)
+	}
+	return toolResultText(t, res)
+}
+
+func TestHandleMarkExploreCard(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), exploreDispatcher())
+	text := exploreResultText(t, g, "mark://team-a/hub.md")
+
+	wants := []string{
+		"status: ok",
+		"version: 2",
+		"size: ",
+		"## Outline",
+		"- Hub (#hub,",
+		"  - Sections (#sections,",
+		"## Opening",
+		"The hub links everything together.",
+		"## Outbound links (2)",
+		"- [Alpha](/alpha.md)",
+		"## Backlinks (0)",
+		"(none recorded — run mark_graph to populate",
+		"## Siblings in / (3)",
+		"- alpha.md",
+		"- docs/",
+		"fetch mark://team-a/hub.md#<anchor> for a section",
+	}
+	for _, want := range wants {
+		if !strings.Contains(text, want) {
+			t.Errorf("card missing %q in:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "- hub.md") {
+		t.Error("siblings must exclude the document itself")
+	}
+	// /alpha.md is linked twice in the doc; outbound dedup lists it once.
+	if strings.Count(text, "(/alpha.md)") != 1 {
+		t.Errorf("outbound links should be deduplicated:\n%s", text)
+	}
+}
+
+func TestHandleMarkExploreBacklinksFromGraphStore(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), exploreDispatcher())
+	gr := graph.New()
+	gr.AddNode(&graph.Node{URL: "mark://team-a/a.md", Title: "Page A", Status: "ok"})
+	gr.AddNode(&graph.Node{URL: "mark://team-a/hub.md", Title: "Hub", Status: "ok"})
+	gr.AddEdge("mark://team-a/a.md", "mark://team-a/hub.md")
+	g.graphStore.Merge(gr, nil)
+
+	text := exploreResultText(t, g, "mark://team-a/hub.md")
+	if !strings.Contains(text, "## Backlinks (1)") || !strings.Contains(text, "[Page A](mark://team-a/a.md)") {
+		t.Errorf("expected enriched backlink in card:\n%s", text)
+	}
+}
+
+func TestHandleMarkExploreSectionCaps(t *testing.T) {
+	var body strings.Builder
+	body.WriteString("# Big hub\n\n")
+	for i := range 15 {
+		fmt.Fprintf(&body, "## Section %d\n\n", i)
+		fmt.Fprintf(&body, "- [Doc %d](/doc-%d.md)\n\n", i, i)
+	}
+	d := &fakeDispatcher{
+		fetchFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusOK,
+				Metadata: map[string]string{"version": "1"},
+				Body:     body.String(),
+			}}, nil
+		},
+		listFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: ""}}, nil
+		},
+	}
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), d)
+	text := exploreResultText(t, g, "mark://team-a/hub.md")
+
+	if !strings.Contains(text, "+6 more headings") {
+		t.Errorf("expected heading overflow marker (16 headings, cap 10):\n%s", text)
+	}
+	if !strings.Contains(text, "+5 more links") {
+		t.Errorf("expected link overflow marker (15 links, cap 10):\n%s", text)
+	}
+}
+
+func TestHandleMarkExploreListFailureDegrades(t *testing.T) {
+	d := exploreDispatcher()
+	d.listFn = func(_, _, _ string) (fetch.Result, error) {
+		return fetch.Result{}, fmt.Errorf("boom")
+	}
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), d)
+	text := exploreResultText(t, g, "mark://team-a/hub.md")
+	if !strings.Contains(text, "(listing unavailable)") {
+		t.Errorf("LIST failure should degrade to a note:\n%s", text)
+	}
+	if !strings.Contains(text, "## Outline") {
+		t.Error("card should still render the rest")
+	}
+}
+
+func TestHandleMarkExploreInvalidURL(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), &fakeDispatcher{})
+	res, err := g.handleMarkExplore(withAliceClaims(context.Background()), callToolReq("mark_explore", map[string]any{
+		"url": "mark:///no-world.md",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkExplore: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected tool error for missing world name")
+	}
+}

--- a/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode.go
@@ -258,6 +258,11 @@ func changedNote(prev seenDoc, version string) string {
 	if prev.version != version {
 		return fmt.Sprintf("changed since this session's earlier fetch (v%s -> v%s)", prev.version, version)
 	}
+	if version == "" {
+		// Etag-only identity (server sends no version): don't print a
+		// bare "still v".
+		return "content changed since this session's earlier fetch (etag differs)"
+	}
 	return fmt.Sprintf("content changed since this session's earlier fetch (still v%s, etag differs)", version)
 }
 

--- a/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode.go
@@ -1,0 +1,229 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strings"
+	"sync"
+
+	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/client/mdoutline"
+	"github.com/latebit-io/demarkus/protocol"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+// This file is the broker's port of the local demarkus-mcp fetch
+// ergonomics (client/cmd/demarkus-mcp markFetch): size-adaptive outline
+// mode, #section slicing, and unchanged-fetch dedup. The mode-selection
+// logic mirrors the local handler the same way formatToolResult mirrors
+// formatResult — deliberately, so the two surfaces answer identically.
+// The one structural difference is dedup scope: the local client is a
+// per-user process, so a process-lifetime map IS session scope; the
+// broker is multi-tenant, so dedup state is keyed by MCP session and a
+// caller without a session gets no dedup at all (never a cross-user
+// "unchanged" claim).
+
+// outlineThreshold is the body size (bytes) above which mark_fetch
+// returns an outline instead of the full body, unless force=true or a
+// #section is requested. Matches client/cmd/demarkus-mcp.
+const outlineThreshold = 8 * 1024
+
+// seenDoc identifies a document version already returned in full to one
+// MCP session.
+type seenDoc struct {
+	version string
+	etag    string
+}
+
+// sessionSeen is the per-session fetch dedup state: MCP session ID →
+// (world+path → identity of the version whose full body that session
+// already received). Sessions are evicted by the OnUnregisterSession
+// hook; the caps below bound memory if a transport never unregisters.
+type sessionSeen struct {
+	mu   sync.Mutex
+	byID map[string]map[string]seenDoc
+}
+
+const (
+	// maxSeenSessions bounds how many concurrent sessions carry dedup
+	// state. Beyond it, new sessions simply get no dedup (correct,
+	// just less token-efficient) rather than evicting someone else's.
+	maxSeenSessions = 4096
+	// maxSeenDocsPerSession bounds per-session growth; past it the
+	// session keeps its existing entries but records no new ones.
+	maxSeenDocsPerSession = 1024
+)
+
+func newSessionSeen() *sessionSeen {
+	return &sessionSeen{byID: make(map[string]map[string]seenDoc)}
+}
+
+func (s *sessionSeen) lookup(sessionID, key string) (seenDoc, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	d, ok := s.byID[sessionID][key]
+	return d, ok
+}
+
+func (s *sessionSeen) record(sessionID, key string, d seenDoc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	docs, ok := s.byID[sessionID]
+	if !ok {
+		if len(s.byID) >= maxSeenSessions {
+			return
+		}
+		docs = make(map[string]seenDoc)
+		s.byID[sessionID] = docs
+	}
+	if _, exists := docs[key]; !exists && len(docs) >= maxSeenDocsPerSession {
+		return
+	}
+	docs[key] = d
+}
+
+func (s *sessionSeen) drop(sessionID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.byID, sessionID)
+}
+
+// sessionIDFromContext returns the MCP session ID for the request, or ""
+// when the context carries no session (dedup is then skipped entirely).
+func sessionIDFromContext(ctx context.Context) string {
+	if session := mcpserver.ClientSessionFromContext(ctx); session != nil {
+		return session.SessionID()
+	}
+	return ""
+}
+
+// handleMarkFetch implements the mark_fetch tool against the brokered
+// world with the shared fetch ergonomics: full body under 8KB, outline
+// above, url#anchor section slicing at any size, force override, and
+// session-scoped unchanged dedup. Reads are open to any SSO-authenticated
+// caller; see the pre-ergonomics rationale on handleMarkList.
+func (g *mcpGateway) handleMarkFetch(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
+	raw, err := req.RequireString("url")
+	if err != nil {
+		return mcp.NewToolResultError("url is required"), nil
+	}
+	// The fragment is the section selector, cut before URL validation —
+	// parseToolURL rejects fragments because the other verbs would
+	// silently drop them; here it has defined meaning.
+	docURL, anchor, _ := strings.Cut(raw, "#")
+	force := req.GetBool("force", false)
+
+	worldName, path, err := parseToolURL(docURL)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", err)), nil
+	}
+	result, err := g.dispatcher.Fetch(worldName, path, "")
+	if err != nil {
+		return g.toolErrorFor("fetch", worldName, err), nil
+	}
+	if result.Response.Status != protocol.StatusOK {
+		return mcp.NewToolResultText(formatToolResult(result, "version", "modified", "etag")), nil
+	}
+
+	body := result.Response.Body
+	version := result.Response.Metadata["version"]
+	etag := result.Response.Metadata["etag"]
+	key := worldName + path
+
+	// #section slice: works at any size and bypasses dedup — the agent
+	// is asking for content it has not necessarily seen.
+	if anchor != "" {
+		section, ok := mdoutline.Section(body, anchor)
+		if !ok {
+			available := strings.Join(mdoutline.Anchors(body), ", ")
+			if available == "" {
+				available = "(document has no headings)"
+			}
+			return mcp.NewToolResultError(fmt.Sprintf("section #%s not found in %s; available anchors: %s", anchor, docURL, available)), nil
+		}
+		return mcp.NewToolResultText(formatToolResultWith(result, section,
+			map[string]string{"section": "#" + anchor}, "version", "modified", "etag")), nil
+	}
+
+	// Dedup needs at least one identity field: with version and etag
+	// both absent, two different bodies would compare equal and a
+	// changed document would be silently reported as unchanged.
+	hasIdentity := version != "" || etag != ""
+	sessionID := sessionIDFromContext(ctx)
+
+	var prev seenDoc
+	seenBefore := false
+	if sessionID != "" {
+		prev, seenBefore = g.fetchSeen.lookup(sessionID, key)
+	}
+	if seenBefore && !force && hasIdentity && prev.version == version && prev.etag == etag {
+		return mcp.NewToolResultText(unchangedNotice(version, etag)), nil
+	}
+
+	extra := map[string]string{}
+	if seenBefore && (prev.version != version || prev.etag != etag) {
+		extra["note"] = changedNote(prev, version)
+	}
+
+	// Size gate: large documents return an outline unless forced.
+	if !force && len(body) >= outlineThreshold {
+		extra["mode"] = "outline"
+		extra["size"] = fmt.Sprintf("%d bytes, %d lines", len(body), strings.Count(body, "\n")+1)
+		return mcp.NewToolResultText(formatToolResultWith(result, mdoutline.OutlineBody(docURL, body),
+			extra, "version", "modified", "etag")), nil
+	}
+
+	if sessionID != "" && hasIdentity {
+		g.fetchSeen.record(sessionID, key, seenDoc{version: version, etag: etag})
+	}
+	if len(extra) == 0 {
+		return mcp.NewToolResultText(formatToolResult(result, "version", "modified", "etag")), nil
+	}
+	return mcp.NewToolResultText(formatToolResultWith(result, body, extra, "version", "modified", "etag")), nil
+}
+
+// unchangedNotice renders the dedup short-circuit response: the document
+// identity plus a pointer at force=true. Only called when at least one of
+// version/etag is non-empty.
+func unchangedNotice(version, etag string) string {
+	var b strings.Builder
+	b.WriteString("status: unchanged\n")
+	if version != "" {
+		fmt.Fprintf(&b, "version: %s\n", version)
+	}
+	if etag != "" {
+		fmt.Fprintf(&b, "etag: %s\n", etag)
+	}
+	since := "since this session's earlier fetch (etag match)"
+	if version != "" {
+		since = "since v" + version
+	}
+	fmt.Fprintf(&b, "\nunchanged %s — the full body was returned earlier this session; pass force=true to re-read it\n", since)
+	return b.String()
+}
+
+// changedNote describes how the document identity moved since the
+// session's earlier full-body fetch.
+func changedNote(prev seenDoc, version string) string {
+	if prev.version != version {
+		return fmt.Sprintf("changed since this session's earlier fetch (v%s -> v%s)", prev.version, version)
+	}
+	return fmt.Sprintf("content changed since this session's earlier fetch (still v%s, etag differs)", version)
+}
+
+// formatToolResultWith renders r via formatToolResult with a replacement
+// body and extra metadata entries. The metadata map is cloned first — r
+// may hold a response whose map must never be mutated. Mirrors the local
+// client's formatResultWith.
+func formatToolResultWith(r fetch.Result, body string, extra map[string]string, keys ...string) string {
+	meta := maps.Clone(r.Response.Metadata)
+	if meta == nil {
+		meta = make(map[string]string, len(extra))
+	}
+	maps.Copy(meta, extra)
+	r.Response.Metadata = meta
+	r.Response.Body = body
+	return formatToolResult(r, keys...)
+}

--- a/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/client/fetchdedup"
 	"github.com/latebit-io/demarkus/client/mdoutline"
 	"github.com/latebit-io/demarkus/protocol"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -20,7 +21,9 @@ import (
 // ergonomics (client/cmd/demarkus-mcp markFetch): size-adaptive outline
 // mode, #section slicing, and unchanged-fetch dedup. The mode-selection
 // logic mirrors the local handler the same way formatToolResult mirrors
-// formatResult — deliberately, so the two surfaces answer identically.
+// formatResult — deliberately, so the two surfaces answer identically —
+// while the identity semantics and notice texts are genuinely shared via
+// client/fetchdedup (one copy, not a mirror).
 // The one structural difference is dedup scope: the local client is a
 // per-user process, so a process-lifetime map IS session scope; the
 // broker is multi-tenant, so dedup state is keyed by MCP session and a
@@ -31,13 +34,6 @@ import (
 // returns an outline instead of the full body, unless force=true or a
 // #section is requested. Matches client/cmd/demarkus-mcp.
 const outlineThreshold = 8 * 1024
-
-// seenDoc identifies a document version already returned in full to one
-// MCP session.
-type seenDoc struct {
-	version string
-	etag    string
-}
 
 // sessionSeen is the per-session fetch dedup state: MCP session ID →
 // (world+path → identity of the version whose full body that session
@@ -59,7 +55,7 @@ type sessionSeen struct {
 // sessionEntry carries one session's dedup state plus the LRU stamp the
 // session-cap eviction orders by.
 type sessionEntry struct {
-	docs       map[string]seenDoc
+	docs       map[string]fetchdedup.Doc
 	lastAccess time.Time
 	capLogged  bool
 }
@@ -78,19 +74,19 @@ func newSessionSeen(log *slog.Logger, now func() time.Time) *sessionSeen {
 	return &sessionSeen{byID: make(map[string]*sessionEntry), log: log, now: now}
 }
 
-func (s *sessionSeen) lookup(sessionID, key string) (seenDoc, bool) {
+func (s *sessionSeen) lookup(sessionID, key string) (fetchdedup.Doc, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	e, ok := s.byID[sessionID]
 	if !ok {
-		return seenDoc{}, false
+		return fetchdedup.Doc{}, false
 	}
 	e.lastAccess = s.now()
 	d, ok := e.docs[key]
 	return d, ok
 }
 
-func (s *sessionSeen) record(sessionID, key string, d seenDoc) {
+func (s *sessionSeen) record(sessionID, key string, d fetchdedup.Doc) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	e, ok := s.byID[sessionID]
@@ -98,7 +94,7 @@ func (s *sessionSeen) record(sessionID, key string, d seenDoc) {
 		if len(s.byID) >= maxSeenSessions {
 			s.evictOldestLocked()
 		}
-		e = &sessionEntry{docs: make(map[string]seenDoc)}
+		e = &sessionEntry{docs: make(map[string]fetchdedup.Doc)}
 		s.byID[sessionID] = e
 	}
 	e.lastAccess = s.now()
@@ -198,21 +194,21 @@ func (g *mcpGateway) handleMarkFetch(ctx context.Context, req mcp.CallToolReques
 	// Dedup needs at least one identity field: with version and etag
 	// both absent, two different bodies would compare equal and a
 	// changed document would be silently reported as unchanged.
-	hasIdentity := version != "" || etag != ""
+	cur := fetchdedup.Doc{Version: version, Etag: etag}
 	sessionID := sessionIDFromContext(ctx)
 
-	var prev seenDoc
+	var prev fetchdedup.Doc
 	seenBefore := false
 	if sessionID != "" {
 		prev, seenBefore = g.fetchSeen.lookup(sessionID, key)
 	}
-	if seenBefore && !force && hasIdentity && prev.version == version && prev.etag == etag {
-		return mcp.NewToolResultText(unchangedNotice(version, etag)), nil
+	if seenBefore && !force && cur.Identified() && prev == cur {
+		return mcp.NewToolResultText(fetchdedup.UnchangedNotice(cur)), nil
 	}
 
 	extra := map[string]string{}
-	if seenBefore && (prev.version != version || prev.etag != etag) {
-		extra["note"] = changedNote(prev, version)
+	if seenBefore && prev != cur {
+		extra["note"] = fetchdedup.ChangedNote(prev, cur)
 	}
 
 	// Size gate: large documents return an outline unless forced.
@@ -223,53 +219,13 @@ func (g *mcpGateway) handleMarkFetch(ctx context.Context, req mcp.CallToolReques
 			extra, "version", "modified", "etag")), nil
 	}
 
-	if sessionID != "" && hasIdentity {
-		g.fetchSeen.record(sessionID, key, seenDoc{version: version, etag: etag})
+	if sessionID != "" && cur.Identified() {
+		g.fetchSeen.record(sessionID, key, cur)
 	}
 	if len(extra) == 0 {
 		return mcp.NewToolResultText(formatToolResult(result, "version", "modified", "etag")), nil
 	}
 	return mcp.NewToolResultText(formatToolResultWith(result, body, extra, "version", "modified", "etag")), nil
-}
-
-// unchangedNotice renders the dedup short-circuit response: the document
-// identity plus a pointer at force=true. Only called when at least one of
-// version/etag is non-empty.
-func unchangedNotice(version, etag string) string {
-	var b strings.Builder
-	b.WriteString("status: unchanged\n")
-	if version != "" {
-		fmt.Fprintf(&b, "version: %s\n", version)
-	}
-	if etag != "" {
-		fmt.Fprintf(&b, "etag: %s\n", etag)
-	}
-	since := "since this session's earlier fetch (etag match)"
-	if version != "" {
-		since = "since v" + version
-	}
-	fmt.Fprintf(&b, "\nunchanged %s — the full body was returned earlier this session; pass force=true to re-read it\n", since)
-	return b.String()
-}
-
-// changedNote describes how the document identity moved since the
-// session's earlier full-body fetch.
-func changedNote(prev seenDoc, version string) string {
-	// Either side of a version change can be empty (record only
-	// requires one identity field): spell out identity-type flips
-	// instead of rendering a bare "v" with no number.
-	switch {
-	case prev.version != version && prev.version == "":
-		return fmt.Sprintf("changed since this session's earlier fetch (was etag-only, now v%s)", version)
-	case prev.version != version && version == "":
-		return fmt.Sprintf("changed since this session's earlier fetch (was v%s, now etag-only)", prev.version)
-	case prev.version != version:
-		return fmt.Sprintf("changed since this session's earlier fetch (v%s -> v%s)", prev.version, version)
-	case version == "":
-		// Etag-only identity throughout (server sends no version).
-		return "content changed since this session's earlier fetch (etag differs)"
-	}
-	return fmt.Sprintf("content changed since this session's earlier fetch (still v%s, etag differs)", version)
 }
 
 // formatToolResultWith renders r via formatToolResult with a replacement

--- a/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode.go
@@ -3,9 +3,11 @@ package broker
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"maps"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/latebit-io/demarkus/client/fetch"
 	"github.com/latebit-io/demarkus/client/mdoutline"
@@ -39,49 +41,95 @@ type seenDoc struct {
 
 // sessionSeen is the per-session fetch dedup state: MCP session ID →
 // (world+path → identity of the version whose full body that session
-// already received). Sessions are evicted by the OnUnregisterSession
-// hook; the caps below bound memory if a transport never unregisters.
+// already received). The OnUnregisterSession hook drops a session's
+// state, but mcp-go's Streamable HTTP transport only unregisters on an
+// explicit session DELETE — a client that just drops the connection
+// leaks its entry (mark3labs/mcp-go#723). The caps below therefore WILL
+// be reached on a long-lived pod: the session cap evicts the
+// least-recently-used session (benign — dedup is best-effort, the cost
+// is one extra full read for an evicted-but-live session) and logs so
+// the degradation is observable.
 type sessionSeen struct {
 	mu   sync.Mutex
-	byID map[string]map[string]seenDoc
+	byID map[string]*sessionEntry
+	log  *slog.Logger
+	now  func() time.Time
+}
+
+// sessionEntry carries one session's dedup state plus the LRU stamp the
+// session-cap eviction orders by.
+type sessionEntry struct {
+	docs       map[string]seenDoc
+	lastAccess time.Time
+	capLogged  bool
 }
 
 const (
-	// maxSeenSessions bounds how many concurrent sessions carry dedup
-	// state. Beyond it, new sessions simply get no dedup (correct,
-	// just less token-efficient) rather than evicting someone else's.
+	// maxSeenSessions bounds how many sessions carry dedup state. At
+	// the cap a new session evicts the least-recently-used one.
 	maxSeenSessions = 4096
 	// maxSeenDocsPerSession bounds per-session growth; past it the
-	// session keeps its existing entries but records no new ones.
+	// session keeps its existing entries but records no new ones
+	// (logged once per session).
 	maxSeenDocsPerSession = 1024
 )
 
-func newSessionSeen() *sessionSeen {
-	return &sessionSeen{byID: make(map[string]map[string]seenDoc)}
+func newSessionSeen(log *slog.Logger, now func() time.Time) *sessionSeen {
+	return &sessionSeen{byID: make(map[string]*sessionEntry), log: log, now: now}
 }
 
 func (s *sessionSeen) lookup(sessionID, key string) (seenDoc, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	d, ok := s.byID[sessionID][key]
+	e, ok := s.byID[sessionID]
+	if !ok {
+		return seenDoc{}, false
+	}
+	e.lastAccess = s.now()
+	d, ok := e.docs[key]
 	return d, ok
 }
 
 func (s *sessionSeen) record(sessionID, key string, d seenDoc) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	docs, ok := s.byID[sessionID]
+	e, ok := s.byID[sessionID]
 	if !ok {
 		if len(s.byID) >= maxSeenSessions {
-			return
+			s.evictOldestLocked()
 		}
-		docs = make(map[string]seenDoc)
-		s.byID[sessionID] = docs
+		e = &sessionEntry{docs: make(map[string]seenDoc)}
+		s.byID[sessionID] = e
 	}
-	if _, exists := docs[key]; !exists && len(docs) >= maxSeenDocsPerSession {
+	e.lastAccess = s.now()
+	if _, exists := e.docs[key]; !exists && len(e.docs) >= maxSeenDocsPerSession {
+		if !e.capLogged {
+			e.capLogged = true
+			s.log.Warn("mcp fetch dedup: per-session doc cap reached; further documents in this session will not dedup",
+				"cap", maxSeenDocsPerSession)
+		}
 		return
 	}
-	docs[key] = d
+	e.docs[key] = d
+}
+
+// evictOldestLocked removes the least-recently-used session's state to
+// make room for a new one. Caller holds s.mu. Session IDs are
+// deliberately not logged (they route Streamable HTTP traffic).
+func (s *sessionSeen) evictOldestLocked() {
+	var oldestID string
+	var oldest time.Time
+	for id, e := range s.byID {
+		if oldestID == "" || e.lastAccess.Before(oldest) {
+			oldestID, oldest = id, e.lastAccess
+		}
+	}
+	if oldestID == "" {
+		return
+	}
+	delete(s.byID, oldestID)
+	s.log.Warn("mcp fetch dedup: session cap reached; evicted least-recently-used session state (likely leaked sessions from clients that disconnected without a session DELETE)",
+		"cap", maxSeenSessions)
 }
 
 func (s *sessionSeen) drop(sessionID string) {

--- a/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode.go
@@ -255,12 +255,18 @@ func unchangedNotice(version, etag string) string {
 // changedNote describes how the document identity moved since the
 // session's earlier full-body fetch.
 func changedNote(prev seenDoc, version string) string {
-	if prev.version != version {
+	// Either side of a version change can be empty (record only
+	// requires one identity field): spell out identity-type flips
+	// instead of rendering a bare "v" with no number.
+	switch {
+	case prev.version != version && prev.version == "":
+		return fmt.Sprintf("changed since this session's earlier fetch (was etag-only, now v%s)", version)
+	case prev.version != version && version == "":
+		return fmt.Sprintf("changed since this session's earlier fetch (was v%s, now etag-only)", prev.version)
+	case prev.version != version:
 		return fmt.Sprintf("changed since this session's earlier fetch (v%s -> v%s)", prev.version, version)
-	}
-	if version == "" {
-		// Etag-only identity (server sends no version): don't print a
-		// bare "still v".
+	case version == "":
+		// Etag-only identity throughout (server sends no version).
 		return "content changed since this session's earlier fetch (etag differs)"
 	}
 	return fmt.Sprintf("content changed since this session's earlier fetch (still v%s, etag differs)", version)

--- a/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode.go
@@ -207,7 +207,9 @@ func (g *mcpGateway) handleMarkFetch(ctx context.Context, req mcp.CallToolReques
 	}
 
 	extra := map[string]string{}
-	if seenBefore && prev != cur {
+	// cur.Identified() also gates the note: a response that lost both
+	// identity fields has nothing truthful to say about what changed.
+	if seenBefore && cur.Identified() && prev != cur {
 		extra["note"] = fetchdedup.ChangedNote(prev, cur)
 	}
 

--- a/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode_test.go
@@ -1,0 +1,307 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/protocol"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const fetchModeDoc = "# Doc\n\nIntro paragraph.\n\n## Setup\n\nSetup body.\n\n## Usage\n\nUsage body.\n"
+
+// bigFetchModeDoc returns a body over the outline threshold.
+func bigFetchModeDoc() string {
+	filler := strings.Repeat("filler line for section body padding\n", 150)
+	return "# Big\n\nIntro paragraph.\n\n## Setup\n\n" + filler + "\n## Usage\n\n" + filler
+}
+
+// fetchModeDispatcher scripts one document with the given identity.
+func fetchModeDispatcher(body, version, etag string) *fakeDispatcher {
+	return &fakeDispatcher{
+		fetchFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusOK,
+				Metadata: map[string]string{"version": version, "modified": "2026-07-05T00:00:00Z", "etag": etag},
+				Body:     body,
+			}}, nil
+		},
+	}
+}
+
+// sessionCtx attaches an MCP client session with the given ID, matching
+// what the Streamable HTTP transport installs on real traffic.
+func sessionCtx(g *mcpGateway, sessionID string) context.Context {
+	session := mcpserver.NewInProcessSession(sessionID, nil)
+	return g.mcpServer.WithContext(withAliceClaims(context.Background()), session)
+}
+
+// fetchModeText runs mark_fetch through the gateway handler and returns
+// the tool result text, failing the test on any error envelope.
+func fetchModeText(ctx context.Context, t *testing.T, g *mcpGateway, args map[string]any) string {
+	t.Helper()
+	res, err := g.handleMarkFetch(ctx, callToolReq("mark_fetch", args))
+	if err != nil {
+		t.Fatalf("handleMarkFetch: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("isError = true: %+v", res.Content)
+	}
+	return toolResultText(t, res)
+}
+
+func TestHandleMarkFetchLargeDocOutline(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), fetchModeDispatcher(bigFetchModeDoc(), "3", "abc"))
+	text := fetchModeText(withAliceClaims(context.Background()), t, g, map[string]any{"url": "mark://team-a/big.md"})
+
+	if !strings.Contains(text, "mode: outline") {
+		t.Fatalf("large doc should return outline, got:\n%.200s", text)
+	}
+	if strings.Contains(text, "filler line") {
+		t.Error("outline should not include section bodies")
+	}
+	for _, want := range []string{"#setup", "#usage", "Intro paragraph.", "fetch mark://team-a/big.md#<anchor> for a section", "size: "} {
+		if !strings.Contains(text, want) {
+			t.Errorf("outline missing %q", want)
+		}
+	}
+}
+
+func TestHandleMarkFetchForceReturnsFullBody(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), fetchModeDispatcher(bigFetchModeDoc(), "3", "abc"))
+	text := fetchModeText(withAliceClaims(context.Background()), t, g, map[string]any{"url": "mark://team-a/big.md", "force": true})
+	if strings.Contains(text, "mode: outline") {
+		t.Error("force=true should bypass outline mode")
+	}
+	if !strings.Contains(text, "filler line") {
+		t.Error("force=true should return the full body")
+	}
+}
+
+func TestHandleMarkFetchSectionSlice(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), fetchModeDispatcher(fetchModeDoc, "3", "abc"))
+	text := fetchModeText(withAliceClaims(context.Background()), t, g, map[string]any{"url": "mark://team-a/doc.md#setup"})
+	for _, want := range []string{"section: #setup", "## Setup", "Setup body."} {
+		if !strings.Contains(text, want) {
+			t.Errorf("section slice missing %q in:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "Usage body.") {
+		t.Error("section slice should not include other sections")
+	}
+}
+
+func TestHandleMarkFetchSectionNotFoundListsAnchors(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), fetchModeDispatcher(fetchModeDoc, "3", "abc"))
+	res, err := g.handleMarkFetch(withAliceClaims(context.Background()), callToolReq("mark_fetch", map[string]any{
+		"url": "mark://team-a/doc.md#nope",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkFetch: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected tool error for missing section")
+	}
+	text := toolResultText(t, res)
+	if !strings.Contains(text, "available anchors") || !strings.Contains(text, "setup") {
+		t.Errorf("error should list available anchors, got: %s", text)
+	}
+}
+
+func TestHandleMarkFetchSessionDedup(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), fetchModeDispatcher(fetchModeDoc, "3", "abc"))
+	ctx := sessionCtx(g, "session-1")
+	url := map[string]any{"url": "mark://team-a/doc.md"}
+
+	first := fetchModeText(ctx, t, g, url)
+	if !strings.Contains(first, "Setup body.") {
+		t.Fatal("first fetch should return full body")
+	}
+
+	second := fetchModeText(ctx, t, g, url)
+	if !strings.Contains(second, "status: unchanged") || !strings.Contains(second, "unchanged since v3") {
+		t.Fatalf("second fetch in same session should dedup, got:\n%s", second)
+	}
+
+	forced := fetchModeText(ctx, t, g, map[string]any{"url": "mark://team-a/doc.md", "force": true})
+	if !strings.Contains(forced, "Setup body.") {
+		t.Error("force=true should bust the dedup")
+	}
+}
+
+func TestHandleMarkFetchDedupIsPerSession(t *testing.T) {
+	// The broker is multi-tenant: one session's full-body fetch must
+	// never produce an "unchanged" answer for a different session.
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), fetchModeDispatcher(fetchModeDoc, "3", "abc"))
+	url := map[string]any{"url": "mark://team-a/doc.md"}
+
+	_ = fetchModeText(sessionCtx(g, "alice-session"), t, g, url)
+	other := fetchModeText(sessionCtx(g, "bob-session"), t, g, url)
+	if strings.Contains(other, "status: unchanged") {
+		t.Fatal("dedup leaked across sessions")
+	}
+	if !strings.Contains(other, "Setup body.") {
+		t.Error("other session should get the full body")
+	}
+}
+
+func TestHandleMarkFetchNoSessionNoDedup(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), fetchModeDispatcher(fetchModeDoc, "3", "abc"))
+	ctx := withAliceClaims(context.Background()) // no MCP session attached
+	url := map[string]any{"url": "mark://team-a/doc.md"}
+
+	for range 2 {
+		text := fetchModeText(ctx, t, g, url)
+		if strings.Contains(text, "status: unchanged") {
+			t.Fatal("sessionless fetch must never dedup")
+		}
+		if !strings.Contains(text, "Setup body.") {
+			t.Error("sessionless fetch should return the body")
+		}
+	}
+}
+
+func TestHandleMarkFetchSessionEvictionDropsDedup(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), fetchModeDispatcher(fetchModeDoc, "3", "abc"))
+	ctx := sessionCtx(g, "ephemeral")
+	url := map[string]any{"url": "mark://team-a/doc.md"}
+
+	_ = fetchModeText(ctx, t, g, url)
+	if _, ok := g.fetchSeen.lookup("ephemeral", "team-a/doc.md"); !ok {
+		t.Fatal("full-body fetch should record dedup state")
+	}
+	g.fetchSeen.drop("ephemeral")
+	text := fetchModeText(ctx, t, g, url)
+	if strings.Contains(text, "status: unchanged") {
+		t.Fatal("dropped session must not dedup")
+	}
+}
+
+func TestSessionSeenCaps(t *testing.T) {
+	t.Run("per-session doc cap stops recording", func(t *testing.T) {
+		s := newSessionSeen()
+		for i := range maxSeenDocsPerSession + 10 {
+			s.record("s1", fmt.Sprintf("w/doc-%d.md", i), seenDoc{version: "1"})
+		}
+		s.mu.Lock()
+		n := len(s.byID["s1"])
+		s.mu.Unlock()
+		if n != maxSeenDocsPerSession {
+			t.Errorf("session doc count = %d, want cap %d", n, maxSeenDocsPerSession)
+		}
+		// Existing entries still update.
+		s.record("s1", "w/doc-0.md", seenDoc{version: "2"})
+		if d, _ := s.lookup("s1", "w/doc-0.md"); d.version != "2" {
+			t.Error("existing entry should still update at cap")
+		}
+	})
+	t.Run("session cap stops new sessions", func(t *testing.T) {
+		s := newSessionSeen()
+		s.byID = make(map[string]map[string]seenDoc, maxSeenSessions)
+		for i := range maxSeenSessions {
+			s.byID[fmt.Sprintf("s%d", i)] = map[string]seenDoc{}
+		}
+		s.record("one-too-many", "w/doc.md", seenDoc{version: "1"})
+		if _, ok := s.lookup("one-too-many", "w/doc.md"); ok {
+			t.Error("record beyond session cap should be a no-op")
+		}
+	})
+}
+
+// newTestMCPGatewayWith is newTestMCPGateway with an injected
+// dispatcher, for HTTP-level tests that need scripted world responses.
+func newTestMCPGatewayWith(t *testing.T, cfg *Config, verifier Verifier, d worldDispatcher) *httptest.Server {
+	t.Helper()
+	signer := newTestSigner(t)
+	k8s := fake.NewSimpleClientset()
+	brokerSrv := NewServer(cfg, signer, verifier, k8s, nil, nil, nil)
+	ts := httptest.NewServer(brokerSrv.MCPGatewayWith("test", d))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestMCPGatewayFetchDedupOverHTTP proves the session scoping works
+// through the real Streamable HTTP transport, not just with a session
+// hand-attached to the context: the Mcp-Session-Id issued at initialize
+// is what keys the dedup, and a second initialize (new session) starts
+// clean.
+func TestMCPGatewayFetchDedupOverHTTP(t *testing.T) {
+	v := &fakeVerifier{claims: Claims{Subject: "google|alice", Email: "alice@example.com", EmailVerified: true}}
+	ts := newTestMCPGatewayWith(t, mcpTestConfig(), v, fetchModeDispatcher(fetchModeDoc, "3", "abc"))
+
+	initSession := func(id int) string {
+		t.Helper()
+		resp := mcpRequest(t, ts.URL, "alice-token", "", initializeRequest(id))
+		if resp.HTTPStatus != http.StatusOK {
+			t.Fatalf("initialize: status = %d, body = %s", resp.HTTPStatus, resp.RawBody)
+		}
+		sessionID := resp.Headers[mcpSessionHeader]
+		if sessionID == "" {
+			t.Fatalf("initialize response missing %s header", mcpSessionHeader)
+		}
+		return sessionID
+	}
+	fetchVia := func(id int, sessionID string) string {
+		t.Helper()
+		resp := mcpRequest(t, ts.URL, "alice-token", sessionID, map[string]any{
+			"jsonrpc": "2.0",
+			"id":      id,
+			"method":  "tools/call",
+			"params": map[string]any{
+				"name":      "mark_fetch",
+				"arguments": map[string]any{"url": "mark://team-a/doc.md"},
+			},
+		})
+		if resp.HTTPStatus != http.StatusOK || resp.Error != nil {
+			t.Fatalf("tools/call: status = %d, error = %+v, body = %s", resp.HTTPStatus, resp.Error, resp.RawBody)
+		}
+		content, ok := resp.Result["content"].([]any)
+		if !ok || len(content) == 0 {
+			t.Fatalf("tools/call result missing content: %+v", resp.Result)
+		}
+		entry, ok := content[0].(map[string]any)
+		if !ok {
+			t.Fatalf("content[0] not an object: %+v", content[0])
+		}
+		text, _ := entry["text"].(string)
+		return text
+	}
+
+	session1 := initSession(1)
+	first := fetchVia(2, session1)
+	if !strings.Contains(first, "Setup body.") {
+		t.Fatalf("first fetch should return the body, got:\n%s", first)
+	}
+	second := fetchVia(3, session1)
+	if !strings.Contains(second, "status: unchanged") {
+		t.Fatalf("second fetch in the same HTTP session should dedup, got:\n%s", second)
+	}
+
+	session2 := initSession(4)
+	fresh := fetchVia(5, session2)
+	if strings.Contains(fresh, "status: unchanged") {
+		t.Fatal("dedup leaked across HTTP sessions")
+	}
+	if !strings.Contains(fresh, "Setup body.") {
+		t.Error("new session should get the full body")
+	}
+}
+
+func TestHandleMarkFetchNoIdentityNoDedup(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), fetchModeDispatcher(fetchModeDoc, "", ""))
+	ctx := sessionCtx(g, "session-1")
+	url := map[string]any{"url": "mark://team-a/doc.md"}
+
+	for range 2 {
+		text := fetchModeText(ctx, t, g, url)
+		if strings.Contains(text, "status: unchanged") {
+			t.Fatal("fetch without version/etag must not dedup")
+		}
+	}
+}

--- a/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode_test.go
@@ -3,10 +3,12 @@ package broker
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/latebit-io/demarkus/client/fetch"
 	"github.com/latebit-io/demarkus/protocol"
@@ -183,14 +185,25 @@ func TestHandleMarkFetchSessionEvictionDropsDedup(t *testing.T) {
 	}
 }
 
+// discardSessionSeen builds a sessionSeen with a discard logger and a
+// deterministic monotonic clock (each call to now advances one second).
+func discardSessionSeen() *sessionSeen {
+	tick := 0
+	base := time.Date(2026, 7, 5, 0, 0, 0, 0, time.UTC)
+	return newSessionSeen(slog.New(slog.DiscardHandler), func() time.Time {
+		tick++
+		return base.Add(time.Duration(tick) * time.Second)
+	})
+}
+
 func TestSessionSeenCaps(t *testing.T) {
 	t.Run("per-session doc cap stops recording", func(t *testing.T) {
-		s := newSessionSeen()
+		s := discardSessionSeen()
 		for i := range maxSeenDocsPerSession + 10 {
 			s.record("s1", fmt.Sprintf("w/doc-%d.md", i), seenDoc{version: "1"})
 		}
 		s.mu.Lock()
-		n := len(s.byID["s1"])
+		n := len(s.byID["s1"].docs)
 		s.mu.Unlock()
 		if n != maxSeenDocsPerSession {
 			t.Errorf("session doc count = %d, want cap %d", n, maxSeenDocsPerSession)
@@ -201,15 +214,30 @@ func TestSessionSeenCaps(t *testing.T) {
 			t.Error("existing entry should still update at cap")
 		}
 	})
-	t.Run("session cap stops new sessions", func(t *testing.T) {
-		s := newSessionSeen()
-		s.byID = make(map[string]map[string]seenDoc, maxSeenSessions)
+	t.Run("session cap evicts the least-recently-used session", func(t *testing.T) {
+		s := discardSessionSeen()
 		for i := range maxSeenSessions {
-			s.byID[fmt.Sprintf("s%d", i)] = map[string]seenDoc{}
+			s.record(fmt.Sprintf("s%d", i), "w/doc.md", seenDoc{version: "1"})
 		}
-		s.record("one-too-many", "w/doc.md", seenDoc{version: "1"})
-		if _, ok := s.lookup("one-too-many", "w/doc.md"); ok {
-			t.Error("record beyond session cap should be a no-op")
+		// Touch s0 so it is no longer the oldest; s1 becomes the LRU.
+		if _, ok := s.lookup("s0", "w/doc.md"); !ok {
+			t.Fatal("s0 should be recorded")
+		}
+		s.record("one-over-cap", "w/doc.md", seenDoc{version: "1"})
+		if _, ok := s.lookup("one-over-cap", "w/doc.md"); !ok {
+			t.Error("new session past the cap should be recorded (evicting the LRU)")
+		}
+		if _, ok := s.lookup("s1", "w/doc.md"); ok {
+			t.Error("least-recently-used session should have been evicted")
+		}
+		if _, ok := s.lookup("s0", "w/doc.md"); !ok {
+			t.Error("recently-touched session must survive the eviction")
+		}
+		s.mu.Lock()
+		n := len(s.byID)
+		s.mu.Unlock()
+		if n != maxSeenSessions {
+			t.Errorf("session count = %d, want cap %d", n, maxSeenSessions)
 		}
 	})
 }

--- a/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode_test.go
@@ -1,6 +1,7 @@
 package broker
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -185,20 +186,23 @@ func TestHandleMarkFetchSessionEvictionDropsDedup(t *testing.T) {
 	}
 }
 
-// discardSessionSeen builds a sessionSeen with a discard logger and a
-// deterministic monotonic clock (each call to now advances one second).
-func discardSessionSeen() *sessionSeen {
+// capturedSessionSeen builds a sessionSeen with a log-capturing handler
+// (so tests can assert the cap warnings fire) and a deterministic
+// monotonic clock (each call to now advances one second).
+func capturedSessionSeen() (*sessionSeen, *bytes.Buffer) {
+	var logs bytes.Buffer
 	tick := 0
 	base := time.Date(2026, 7, 5, 0, 0, 0, 0, time.UTC)
-	return newSessionSeen(slog.New(slog.DiscardHandler), func() time.Time {
+	s := newSessionSeen(slog.New(slog.NewTextHandler(&logs, nil)), func() time.Time {
 		tick++
 		return base.Add(time.Duration(tick) * time.Second)
 	})
+	return s, &logs
 }
 
 func TestSessionSeenCaps(t *testing.T) {
-	t.Run("per-session doc cap stops recording", func(t *testing.T) {
-		s := discardSessionSeen()
+	t.Run("per-session doc cap stops recording and warns once", func(t *testing.T) {
+		s, logs := capturedSessionSeen()
 		for i := range maxSeenDocsPerSession + 10 {
 			s.record("s1", fmt.Sprintf("w/doc-%d.md", i), seenDoc{version: "1"})
 		}
@@ -213,15 +217,22 @@ func TestSessionSeenCaps(t *testing.T) {
 		if d, _ := s.lookup("s1", "w/doc-0.md"); d.version != "2" {
 			t.Error("existing entry should still update at cap")
 		}
+		// 10 rejected records, but the degradation warns exactly once.
+		if got := strings.Count(logs.String(), "per-session doc cap reached"); got != 1 {
+			t.Errorf("doc-cap warning logged %d times, want exactly 1\nlogs:\n%s", got, logs.String())
+		}
 	})
-	t.Run("session cap evicts the least-recently-used session", func(t *testing.T) {
-		s := discardSessionSeen()
+	t.Run("session cap evicts the least-recently-used session and warns", func(t *testing.T) {
+		s, logs := capturedSessionSeen()
 		for i := range maxSeenSessions {
 			s.record(fmt.Sprintf("s%d", i), "w/doc.md", seenDoc{version: "1"})
 		}
 		// Touch s0 so it is no longer the oldest; s1 becomes the LRU.
 		if _, ok := s.lookup("s0", "w/doc.md"); !ok {
 			t.Fatal("s0 should be recorded")
+		}
+		if logs.Len() != 0 {
+			t.Fatalf("no warning expected before the cap is exceeded, got:\n%s", logs.String())
 		}
 		s.record("one-over-cap", "w/doc.md", seenDoc{version: "1"})
 		if _, ok := s.lookup("one-over-cap", "w/doc.md"); !ok {
@@ -239,7 +250,33 @@ func TestSessionSeenCaps(t *testing.T) {
 		if n != maxSeenSessions {
 			t.Errorf("session count = %d, want cap %d", n, maxSeenSessions)
 		}
+		if got := strings.Count(logs.String(), "session cap reached"); got != 1 {
+			t.Errorf("eviction warning logged %d times, want exactly 1\nlogs:\n%s", got, logs.String())
+		}
 	})
+}
+
+// TestChangedNote pins the identity-delta wording, including the
+// etag-only-identity edge (no version at all) that must not render a
+// bare "still v".
+func TestChangedNote(t *testing.T) {
+	tests := []struct {
+		name    string
+		prev    seenDoc
+		version string
+		want    string
+	}{
+		{"version bump", seenDoc{version: "3"}, "5", "changed since this session's earlier fetch (v3 -> v5)"},
+		{"etag rotated, version steady", seenDoc{version: "3", etag: "a"}, "3", "content changed since this session's earlier fetch (still v3, etag differs)"},
+		{"etag-only identity", seenDoc{etag: "a"}, "", "content changed since this session's earlier fetch (etag differs)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := changedNote(tt.prev, tt.version); got != tt.want {
+				t.Errorf("changedNote = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }
 
 // newTestMCPGatewayWith is newTestMCPGateway with an injected

--- a/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode_test.go
@@ -267,6 +267,8 @@ func TestChangedNote(t *testing.T) {
 		want    string
 	}{
 		{"version bump", seenDoc{version: "3"}, "5", "changed since this session's earlier fetch (v3 -> v5)"},
+		{"was etag-only, now versioned", seenDoc{etag: "a"}, "5", "changed since this session's earlier fetch (was etag-only, now v5)"},
+		{"was versioned, now etag-only", seenDoc{version: "3"}, "", "changed since this session's earlier fetch (was v3, now etag-only)"},
 		{"etag rotated, version steady", seenDoc{version: "3", etag: "a"}, "3", "content changed since this session's earlier fetch (still v3, etag differs)"},
 		{"etag-only identity", seenDoc{etag: "a"}, "", "content changed since this session's earlier fetch (etag differs)"},
 	}

--- a/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/client/fetchdedup"
 	"github.com/latebit-io/demarkus/protocol"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 	"k8s.io/client-go/kubernetes/fake"
@@ -204,7 +205,7 @@ func TestSessionSeenCaps(t *testing.T) {
 	t.Run("per-session doc cap stops recording and warns once", func(t *testing.T) {
 		s, logs := capturedSessionSeen()
 		for i := range maxSeenDocsPerSession + 10 {
-			s.record("s1", fmt.Sprintf("w/doc-%d.md", i), seenDoc{version: "1"})
+			s.record("s1", fmt.Sprintf("w/doc-%d.md", i), fetchdedup.Doc{Version: "1"})
 		}
 		s.mu.Lock()
 		n := len(s.byID["s1"].docs)
@@ -213,8 +214,8 @@ func TestSessionSeenCaps(t *testing.T) {
 			t.Errorf("session doc count = %d, want cap %d", n, maxSeenDocsPerSession)
 		}
 		// Existing entries still update.
-		s.record("s1", "w/doc-0.md", seenDoc{version: "2"})
-		if d, _ := s.lookup("s1", "w/doc-0.md"); d.version != "2" {
+		s.record("s1", "w/doc-0.md", fetchdedup.Doc{Version: "2"})
+		if d, _ := s.lookup("s1", "w/doc-0.md"); d.Version != "2" {
 			t.Error("existing entry should still update at cap")
 		}
 		// 10 rejected records, but the degradation warns exactly once.
@@ -225,7 +226,7 @@ func TestSessionSeenCaps(t *testing.T) {
 	t.Run("session cap evicts the least-recently-used session and warns", func(t *testing.T) {
 		s, logs := capturedSessionSeen()
 		for i := range maxSeenSessions {
-			s.record(fmt.Sprintf("s%d", i), "w/doc.md", seenDoc{version: "1"})
+			s.record(fmt.Sprintf("s%d", i), "w/doc.md", fetchdedup.Doc{Version: "1"})
 		}
 		// Touch s0 so it is no longer the oldest; s1 becomes the LRU.
 		if _, ok := s.lookup("s0", "w/doc.md"); !ok {
@@ -234,7 +235,7 @@ func TestSessionSeenCaps(t *testing.T) {
 		if logs.Len() != 0 {
 			t.Fatalf("no warning expected before the cap is exceeded, got:\n%s", logs.String())
 		}
-		s.record("one-over-cap", "w/doc.md", seenDoc{version: "1"})
+		s.record("one-over-cap", "w/doc.md", fetchdedup.Doc{Version: "1"})
 		if _, ok := s.lookup("one-over-cap", "w/doc.md"); !ok {
 			t.Error("new session past the cap should be recorded (evicting the LRU)")
 		}
@@ -256,30 +257,9 @@ func TestSessionSeenCaps(t *testing.T) {
 	})
 }
 
-// TestChangedNote pins the identity-delta wording, including the
-// etag-only-identity edge (no version at all) that must not render a
-// bare "still v".
-func TestChangedNote(t *testing.T) {
-	tests := []struct {
-		name    string
-		prev    seenDoc
-		version string
-		want    string
-	}{
-		{"version bump", seenDoc{version: "3"}, "5", "changed since this session's earlier fetch (v3 -> v5)"},
-		{"was etag-only, now versioned", seenDoc{etag: "a"}, "5", "changed since this session's earlier fetch (was etag-only, now v5)"},
-		{"was versioned, now etag-only", seenDoc{version: "3"}, "", "changed since this session's earlier fetch (was v3, now etag-only)"},
-		{"etag rotated, version steady", seenDoc{version: "3", etag: "a"}, "3", "content changed since this session's earlier fetch (still v3, etag differs)"},
-		{"etag-only identity", seenDoc{etag: "a"}, "", "content changed since this session's earlier fetch (etag differs)"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := changedNote(tt.prev, tt.version); got != tt.want {
-				t.Errorf("changedNote = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
+// Identity-delta wording (unchanged notice, changed note, asymmetric
+// identity flips) is pinned once in client/fetchdedup's tests — both the
+// broker gateway and the local demarkus-mcp render through that package.
 
 // newTestMCPGatewayWith is newTestMCPGateway with an injected
 // dispatcher, for HTTP-level tests that need scripted world responses.

--- a/tools/demarkus-broker/internal/broker/mcp_tools_list.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_list.go
@@ -24,6 +24,7 @@ const mcpURLDesc = "mark:// URL, e.g. mark://team-a/index.md"
 // description.
 var mcpToolNames = []string{
 	"mark_fetch",
+	"mark_explore",
 	"mark_list",
 	"mark_versions",
 	"mark_lookup",
@@ -40,8 +41,8 @@ var mcpToolNames = []string{
 	"mark_worlds",
 }
 
-// mcpTools returns the 15 tool definitions exposed by the broker MCP
-// gateway. The first 14 mirror client/cmd/demarkus-mcp's tool surface
+// mcpTools returns the 16 tool definitions exposed by the broker MCP
+// gateway. The first 15 mirror client/cmd/demarkus-mcp's tool surface
 // for parity (so the agent sees the same vocabulary regardless of
 // transport); only the URL-format description differs because the
 // broker addresses worlds by name rather than host:port. mark_worlds
@@ -51,6 +52,7 @@ var mcpToolNames = []string{
 func mcpTools() []mcp.Tool {
 	return []mcp.Tool{
 		markFetchTool(),
+		markExploreTool(),
 		markListTool(),
 		markVersionsTool(),
 		markLookupTool(),
@@ -73,6 +75,36 @@ func markFetchTool() mcp.Tool {
 		mcp.WithDescription(
 			"Fetch a document from a Mark Protocol server. "+
 				"Returns the document status, version, modified timestamp, etag, and markdown body. "+
+				"Documents under 8KB return the full body. Larger documents return an outline "+
+				"instead — the heading tree with #anchors and per-section line counts plus the "+
+				"opening paragraph — so you can pull just the section you need by appending "+
+				"#<anchor> to the url (anchors are GitHub-style slugs; #section fetches work at "+
+				"any size). Re-fetching a document whose full body was already returned this "+
+				"session returns a short 'unchanged' notice when it has not changed. "+
+				"Set force=true for the full body regardless of size or session history. "+
+				mcpURLHint,
+		),
+		mcp.WithString("url",
+			mcp.Required(),
+			mcp.Description(mcpURLDesc+"; append #<anchor> to fetch a single section"),
+		),
+		mcp.WithBoolean("force",
+			mcp.Description("return the full body even if the document is large or unchanged since an earlier fetch this session (default false)"),
+		),
+	)
+}
+
+func markExploreTool() mcp.Tool {
+	return mcp.NewTool("mark_explore",
+		mcp.WithDescription(
+			"Orient around one document in a single call: its outline head (heading "+
+				"tree with #anchors plus the opening paragraph), outbound links, recorded "+
+				"backlinks, and sibling documents in the same directory — each section "+
+				"capped at 10 entries. Use this instead of a fetch + backlinks + list "+
+				"chain when you need to understand what a document covers and what to "+
+				"read next; then mark_fetch url#<anchor> for the sections that matter. "+
+				"Backlinks come from the broker's graph store (mark_graph populates it; "+
+				"per-pod, resets on broker restart). "+
 				mcpURLHint,
 		),
 		mcp.WithString("url",
@@ -86,7 +118,9 @@ func markListTool() mcp.Tool {
 	return mcp.NewTool("mark_list",
 		mcp.WithDescription(
 			"List documents and subdirectories on a Mark Protocol server. "+
-				"Use this to discover what documents exist. Archived documents are "+
+				"Use this to discover what documents exist. To orient around one "+
+				"specific document, prefer mark_explore — it bundles the sibling "+
+				"listing with the outline, links, and backlinks. Archived documents are "+
 				"hidden by default, along with directories that contain only archived "+
 				"documents; set include_archived to true for a recovery/audit view. "+
 				mcpURLHint,
@@ -125,6 +159,9 @@ func markLookupTool() mcp.Tool {
 				"— not document bodies; FETCH the ones you want. This is a catalog lookup, not "+
 				"full-text search: a subject that was never tagged or titled will not be found. "+
 				"Optionally narrow with a comma-separated key=value filter and cap results with limit. "+
+				"Start here when hunting a subject: lookup to find candidate documents, "+
+				"mark_explore the best match to orient, then mark_fetch url#<anchor> for the "+
+				"sections you actually need — full bodies of large documents are rarely necessary. "+
 				mcpURLHint,
 		),
 		mcp.WithString("url",
@@ -295,6 +332,8 @@ func markBacklinksTool() mcp.Tool {
 				"Returns results from previous crawls — run mark_graph first to populate. "+
 				"NOTE: the broker's graph store is ephemeral (per-pod lifetime); a broker restart "+
 				"resets the store and you must re-crawl. "+
+				"mark_explore includes this same backlink list alongside the document's "+
+				"outline, outbound links, and siblings; prefer it for general orientation. "+
 				mcpURLHint,
 		),
 		mcp.WithString("url",

--- a/tools/demarkus-broker/internal/broker/mcp_tools_list_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_list_test.go
@@ -5,16 +5,16 @@ import (
 	"testing"
 )
 
-func TestMCPToolsExactly15(t *testing.T) {
+func TestMCPToolsExactly16(t *testing.T) {
 	tools := mcpTools()
 	if len(tools) != len(mcpToolNames) {
 		t.Fatalf("mcpTools() returned %d tools, mcpToolNames lists %d — names + builders out of sync", len(tools), len(mcpToolNames))
 	}
-	// 14 tools mirror client/cmd/demarkus-mcp for cross-transport parity;
+	// 15 tools mirror client/cmd/demarkus-mcp for cross-transport parity;
 	// mark_worlds is the one deliberate broker-only addition (enumerating
 	// worlds is a knowledge-system concept with no single-world analogue).
-	if len(tools) != 15 {
-		t.Fatalf("expected 15 tools (demarkus-mcp parity surface + mark_worlds), got %d", len(tools))
+	if len(tools) != 16 {
+		t.Fatalf("expected 16 tools (demarkus-mcp parity surface + mark_worlds), got %d", len(tools))
 	}
 	for i, tool := range tools {
 		if tool.Name != mcpToolNames[i] {
@@ -50,6 +50,11 @@ func TestMCPToolsExposeRequiredArguments(t *testing.T) {
 	}{
 		{
 			tool:         "mark_fetch",
+			wantRequired: []string{"url"},
+			wantOptional: []string{"force"},
+		},
+		{
+			tool:         "mark_explore",
 			wantRequired: []string{"url"},
 		},
 		{

--- a/tools/demarkus-broker/internal/broker/mcp_tools_read.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_read.go
@@ -157,30 +157,14 @@ func (g *mcpGateway) dispatchWithAuth(ctx context.Context, _ *Claims, worldName 
 	return fetch.Result{}, fmt.Errorf("broker: world %s rejected write token after %d attempts (token propagation lag exceeded broker deadline)", worldName, maxAttempts)
 }
 
-// handleMarkFetch implements the mark_fetch tool against the
-// brokered world. Reads are open to any SSO-authenticated caller:
-// the world's tokens.toml is write-only (no `read` operation is
-// granted to any token), so an empty bearer flows through and the
-// document is returned. No token, no mint, no propagation-race
-// retry — that machinery exists solely for writes.
-func (g *mcpGateway) handleMarkFetch(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
-	raw, err := req.RequireString("url")
-	if err != nil {
-		return mcp.NewToolResultError("url is required"), nil
-	}
-	worldName, path, err := parseToolURL(raw)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", err)), nil
-	}
-	result, err := g.dispatcher.Fetch(worldName, path, "")
-	if err != nil {
-		return g.toolErrorFor("fetch", worldName, err), nil
-	}
-	return mcp.NewToolResultText(formatToolResult(result, "version", "modified", "etag")), nil
-}
+// handleMarkFetch lives in mcp_tools_fetchmode.go together with the
+// outline/section/dedup ergonomics it carries.
 
 // handleMarkList implements the mark_list tool. Reads dispatch
-// unauthenticated; see handleMarkFetch for the rationale.
+// unauthenticated: the world's tokens.toml is write-only (no `read`
+// operation is granted to any token), so an empty bearer flows through
+// and the listing is returned. No token, no mint, no propagation-race
+// retry — that machinery exists solely for writes.
 func (g *mcpGateway) handleMarkList(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go
 	raw, err := req.RequireString("url")
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `mark_explore` tool that returns a capped “neighborhood card” with an outline, optional opening paragraph, outbound links, backlinks, sibling entries, and follow-up fetch hints (with graceful “none/unavailable” messaging).
* **Bug Fixes**
  * Improved `mark_fetch` for large documents (outline-by-default, `force=true` for full bodies) with more reliable `#anchor` section slicing, clearer “available anchors” errors, and more accurate session-scoped “unchanged” behavior when identity data changes or is missing.
* **Tests**
  * Added coverage for `mark_explore` card generation (including link/backlink caps and listing failure degradation) and for `mark_fetch` outline/anchor slicing and dedup semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->