### PR TITLE
feat(client): MCP resources + prompts for demarkus-mcp

### DIFF
--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -55,7 +55,12 @@ func main() {
 	client := fetch.NewClient(opts)
 	defer client.Close()
 
-	s := mcpserver.NewMCPServer("demarkus-mcp", version)
+	// listChanged on resources: the startup listing registers picker
+	// entries in the background after clients may have connected, and the
+	// notification is what makes them appear without a reconnect.
+	s := mcpserver.NewMCPServer("demarkus-mcp", version,
+		mcpserver.WithResourceCapabilities(false, true),
+	)
 
 	gs, gsErr := graphstore.Load(graphstore.DefaultPath())
 	if gsErr != nil {
@@ -77,6 +82,13 @@ func main() {
 	s.AddTool(markBacklinksTool(*defaultHost), h.markBacklinks)
 	s.AddTool(markGraphExportTool(), h.markGraphExport)
 	s.AddTool(markGraphPublishTool(*defaultHost), h.markGraphPublish)
+
+	registerResources(s, h, *defaultHost)
+	registerPrompts(s, *defaultHost)
+	if *defaultHost != "" {
+		// Best-effort picker population; never blocks or fails startup.
+		go registerListedResources(s, h, *defaultHost)
+	}
 
 	if err := mcpserver.ServeStdio(s); err != nil {
 		log.Fatal(err)

--- a/client/cmd/demarkus-mcp/prompts.go
+++ b/client/cmd/demarkus-mcp/prompts.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+// MCP prompts: the workflows the tool descriptions teach, vended as
+// first-class commands (Claude Code surfaces them as /mcp__<server>__<name>
+// slash commands; Desktop shows them in the prompt picker). The server
+// versions the workflow — every connected agent gets the same flow without
+// the model having to remember strategy prose.
+
+// registerPrompts wires the three v1 prompts: orient, recall, whats-new.
+func registerPrompts(s *mcpserver.MCPServer, defaultHost string) {
+	s.AddPrompt(mcp.NewPrompt("orient",
+		mcp.WithPromptDescription("Orient around a demarkus document: explore its neighborhood in one call, then read just the sections that matter."),
+		mcp.WithArgument("url",
+			mcp.RequiredArgument(),
+			mcp.ArgumentDescription(urlDesc(defaultHost)),
+		),
+	), orientPrompt)
+
+	s.AddPrompt(mcp.NewPrompt("recall",
+		mcp.WithPromptDescription("Recall what is known about a subject: catalog lookup first, then orient on the best match and read the relevant sections."),
+		mcp.WithArgument("subject",
+			mcp.RequiredArgument(),
+			mcp.ArgumentDescription("the subject to recall, e.g. \"broker auth\" or \"release process\""),
+		),
+	), recallPrompt)
+
+	s.AddPrompt(mcp.NewPrompt("whats-new",
+		mcp.WithPromptDescription("Digest of what changed on the server recently: catalog lookup filtered by modified date, newest first."),
+		mcp.WithArgument("since",
+			mcp.ArgumentDescription("start date as YYYY-MM-DD (default: 7 days ago)"),
+		),
+	), whatsNewPrompt)
+}
+
+// requiredArg returns the trimmed argument value or an error naming it —
+// prompt arguments arrive as strings and empties are the common client bug.
+func requiredArg(req *mcp.GetPromptRequest, name string) (string, error) {
+	v := strings.TrimSpace(req.Params.Arguments[name])
+	if v == "" {
+		return "", fmt.Errorf("%s argument is required", name)
+	}
+	return v, nil
+}
+
+func orientPrompt(_ context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) { //nolint:gocritic // signature required by mcp-go
+	url, err := requiredArg(&req, "url")
+	if err != nil {
+		return nil, err
+	}
+	text := fmt.Sprintf(`Orient around the demarkus document %s.
+
+1. Call mark_explore with url %q — one call returns its outline (heading tree with #anchors), opening paragraph, outbound links, backlinks, and siblings.
+2. From the outline, call mark_fetch with url "%s#<anchor>" for the one or two sections that matter to the current task. Do not fetch the full body of a large document unless a section fetch proves insufficient (then use force=true).
+3. Answer with: what this document is (one sentence), where it sits (key links/backlinks), and what its most relevant sections say — citing each as %s#<anchor>.`, url, url, url, url)
+	return mcp.NewGetPromptResult("Orient around "+url, []mcp.PromptMessage{
+		mcp.NewPromptMessage(mcp.RoleUser, mcp.NewTextContent(text)),
+	}), nil
+}
+
+func recallPrompt(_ context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) { //nolint:gocritic // signature required by mcp-go
+	subject, err := requiredArg(&req, "subject")
+	if err != nil {
+		return nil, err
+	}
+	text := fmt.Sprintf(`Recall what this demarkus server knows about: %s.
+
+1. Call mark_lookup with url "/" and query %q — the catalog returns an importance-ranked table of matching documents. If nothing matches, retry once with a broader or synonymous query before concluding.
+2. Call mark_explore on the best match to see its outline and neighborhood; explore a second candidate only if the first does not cover the subject.
+3. Call mark_fetch with url "<path>#<anchor>" for the sections that actually address the subject — avoid full bodies of large documents.
+4. Report what is known, citing every claim with its mark:// path (and #anchor where applicable). If the catalog has nothing on the subject, say so plainly — never invent memory.`, subject, subject)
+	return mcp.NewGetPromptResult("Recall: "+subject, []mcp.PromptMessage{
+		mcp.NewPromptMessage(mcp.RoleUser, mcp.NewTextContent(text)),
+	}), nil
+}
+
+func whatsNewPrompt(_ context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) { //nolint:gocritic // signature required by mcp-go
+	since := strings.TrimSpace(req.Params.Arguments["since"])
+	sinceLine := `Use the date 7 days before today, formatted YYYY-MM-DD.`
+	if since != "" {
+		sinceLine = fmt.Sprintf("Use the date %q.", since)
+	}
+	text := fmt.Sprintf(`Summarize what changed on this demarkus server recently.
+
+1. %s
+2. Call mark_lookup with url "/", query "*", and filter "modified-after=<that date>" — this returns every catalogued document modified since then, importance-ranked.
+3. For the handful of most important changed documents, call mark_fetch with a #<anchor> section or rely on the outline to see what changed — do not fetch full bodies of large documents.
+4. Report a short digest, newest and most important first: each entry is the document (as a mark:// path), what it covers, and why it likely changed. If nothing changed, say so.`, sinceLine)
+	title := "What's new"
+	if since != "" {
+		title = "What's new since " + since
+	}
+	return mcp.NewGetPromptResult(title, []mcp.PromptMessage{
+		mcp.NewPromptMessage(mcp.RoleUser, mcp.NewTextContent(text)),
+	}), nil
+}

--- a/client/cmd/demarkus-mcp/prompts_test.go
+++ b/client/cmd/demarkus-mcp/prompts_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+func promptText(t *testing.T, fn func(context.Context, mcp.GetPromptRequest) (*mcp.GetPromptResult, error), args map[string]string) string {
+	t.Helper()
+	res, err := fn(context.Background(), mcp.GetPromptRequest{
+		Params: mcp.GetPromptParams{Arguments: args},
+	})
+	if err != nil {
+		t.Fatalf("prompt handler: %v", err)
+	}
+	if len(res.Messages) != 1 {
+		t.Fatalf("got %d messages, want 1", len(res.Messages))
+	}
+	content, ok := res.Messages[0].Content.(mcp.TextContent)
+	if !ok {
+		t.Fatalf("content is %T, want TextContent", res.Messages[0].Content)
+	}
+	if res.Messages[0].Role != mcp.RoleUser {
+		t.Errorf("role = %q, want user", res.Messages[0].Role)
+	}
+	return content.Text
+}
+
+func TestOrientPrompt(t *testing.T) {
+	text := promptText(t, orientPrompt, map[string]string{"url": "/plans/foo.md"})
+	for _, want := range []string{"mark_explore", `"/plans/foo.md"`, "#<anchor>", "mark_fetch"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("orient prompt missing %q in:\n%s", want, text)
+		}
+	}
+}
+
+func TestRecallPrompt(t *testing.T) {
+	text := promptText(t, recallPrompt, map[string]string{"subject": "broker auth"})
+	for _, want := range []string{"mark_lookup", `"broker auth"`, "mark_explore", "never invent memory"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("recall prompt missing %q in:\n%s", want, text)
+		}
+	}
+}
+
+func TestWhatsNewPrompt(t *testing.T) {
+	t.Run("default window", func(t *testing.T) {
+		text := promptText(t, whatsNewPrompt, nil)
+		for _, want := range []string{"7 days before today", `query "*"`, "modified-after="} {
+			if !strings.Contains(text, want) {
+				t.Errorf("whats-new prompt missing %q in:\n%s", want, text)
+			}
+		}
+	})
+	t.Run("explicit since", func(t *testing.T) {
+		text := promptText(t, whatsNewPrompt, map[string]string{"since": "2026-07-01"})
+		if !strings.Contains(text, `"2026-07-01"`) {
+			t.Errorf("whats-new prompt should carry the given date:\n%s", text)
+		}
+		if strings.Contains(text, "7 days before today") {
+			t.Error("explicit since should replace the default window")
+		}
+	})
+}
+
+func TestPromptsRequireArguments(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(context.Context, mcp.GetPromptRequest) (*mcp.GetPromptResult, error)
+		arg  string
+	}{
+		{"orient", orientPrompt, "url"},
+		{"recall", recallPrompt, "subject"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.fn(context.Background(), mcp.GetPromptRequest{
+				Params: mcp.GetPromptParams{Arguments: map[string]string{tt.arg: "  "}},
+			})
+			if err == nil || !strings.Contains(err.Error(), tt.arg) {
+				t.Errorf("expected error naming %q, got %v", tt.arg, err)
+			}
+		})
+	}
+}
+
+func TestRegisterPromptsListsAll(t *testing.T) {
+	s := mcpserverForPrompts(t)
+	resp := s.HandleMessage(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"prompts/list"}`))
+	result, ok := resp.(mcp.JSONRPCResponse)
+	if !ok {
+		t.Fatalf("prompts/list returned %T", resp)
+	}
+	list, ok := result.Result.(mcp.ListPromptsResult)
+	if !ok {
+		t.Fatalf("result is %T, want ListPromptsResult", result.Result)
+	}
+	got := make(map[string]bool, len(list.Prompts))
+	for _, p := range list.Prompts {
+		got[p.Name] = true
+	}
+	for _, want := range []string{"orient", "recall", "whats-new"} {
+		if !got[want] {
+			t.Errorf("prompts/list missing %q; got %v", want, got)
+		}
+	}
+}
+
+// mcpserverForPrompts builds a server with the prompts registered.
+func mcpserverForPrompts(t *testing.T) *mcpserver.MCPServer {
+	t.Helper()
+	s := mcpserver.NewMCPServer("test", "0")
+	registerPrompts(s, "mark://example.com")
+	return s
+}

--- a/client/cmd/demarkus-mcp/resources.go
+++ b/client/cmd/demarkus-mcp/resources.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/latebit-io/demarkus/client/links"
+	"github.com/latebit-io/demarkus/client/mdoutline"
+	"github.com/latebit-io/demarkus/protocol"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+// MCP resources: demarkus documents as client-attachable context. A
+// resource read puts a document (or one #section of it) into the
+// conversation without the model spending a tool turn — the Desktop
+// picker / Claude Code @-mention path into demarkus.
+//
+// Resource reads deliberately bypass the mark_fetch ergonomics (no
+// outline gate, no unchanged dedup): attaching is an explicit act by the
+// user, and an outline or a notice where a document was requested would
+// be the wrong surprise. #anchor URIs are the section-sized attach.
+
+// maxListedResources caps how many documents the startup listing
+// registers as concrete picker entries.
+const maxListedResources = 50
+
+// registerResources wires the resources surface: a URI template covering
+// every document (with #anchor section support), plus the two well-known
+// entry points every demarkus server has, so the picker is never empty.
+func registerResources(s *mcpserver.MCPServer, h *handler, defaultHost string) {
+	if defaultHost == "" {
+		s.AddResourceTemplate(mcp.NewResourceTemplate(
+			"mark://{host}/{+path}",
+			"demarkus document",
+			mcp.WithTemplateDescription("Any document on a Mark Protocol server, by host and path; append #<anchor> to attach a single section (anchors are GitHub-style heading slugs)."),
+			mcp.WithTemplateMIMEType("text/markdown"),
+		), h.readResource)
+		return
+	}
+
+	s.AddResourceTemplate(mcp.NewResourceTemplate(
+		defaultHost+"/{+path}",
+		"demarkus document",
+		mcp.WithTemplateDescription("Any document on "+defaultHost+", by path; append #<anchor> to attach a single section (anchors are GitHub-style heading slugs)."),
+		mcp.WithTemplateMIMEType("text/markdown"),
+	), h.readResource)
+
+	s.AddResource(mcp.NewResource(
+		defaultHost+"/index.md",
+		"Index hub",
+		mcp.WithResourceDescription("The server's index hub — the map of everything it holds."),
+		mcp.WithMIMEType("text/markdown"),
+	), h.readResource)
+	s.AddResource(mcp.NewResource(
+		defaultHost+protocol.WellKnownManifestPath,
+		"Agent manifest",
+		mcp.WithResourceDescription("The server's agent manifest: purpose, key paths, auth requirements, usage guidelines."),
+		mcp.WithMIMEType("text/markdown"),
+	), h.readResource)
+}
+
+// registerListedResources fetches the host's top-level listing and
+// registers each document as a concrete resource so client pickers show
+// real content, not just the two well-known entries. Best-effort by
+// design: it runs in a goroutine after the server starts serving, and a
+// down or slow host only costs the extra picker entries — never startup.
+// Late additions notify connected clients via listChanged.
+func registerListedResources(s *mcpserver.MCPServer, h *handler, defaultHost string) {
+	host, path, err := h.resolveURL("/")
+	if err != nil {
+		return
+	}
+	listing, err := h.client.List(host, path, h.resolveToken(host))
+	if err != nil || listing.Response.Status != protocol.StatusOK {
+		log.Printf("resource listing skipped (host %s unavailable): picker shows well-known entries only", host)
+		return
+	}
+
+	var resources []mcpserver.ServerResource
+	for _, entry := range links.Extract(listing.Response.Body) {
+		if len(resources) == maxListedResources {
+			log.Printf("resource listing capped at %d entries", maxListedResources)
+			break
+		}
+		// Top-level documents only; directories and the already-registered
+		// index stay out (re-registering index.md would clobber its entry).
+		if strings.HasSuffix(entry, "/") || !strings.HasSuffix(entry, ".md") || entry == "index.md" {
+			continue
+		}
+		resources = append(resources, mcpserver.ServerResource{
+			Resource: mcp.NewResource(
+				defaultHost+"/"+entry,
+				entry,
+				mcp.WithResourceDescription("Document on "+defaultHost+"."),
+				mcp.WithMIMEType("text/markdown"),
+			),
+			Handler: h.readResource,
+		})
+	}
+	if len(resources) > 0 {
+		s.AddResources(resources...)
+	}
+}
+
+// readResource serves every resource read: whole documents and #anchor
+// sections, for both the concrete resources and the URI template.
+func (h *handler) readResource(_ context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	raw := req.Params.URI
+	docURL, anchor, _ := strings.Cut(raw, "#")
+
+	host, path, err := h.resolveURL(docURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid resource URI %q: %w", raw, err)
+	}
+	result, err := h.client.Fetch(host, path, h.resolveToken(host))
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s: %w", docURL, err)
+	}
+	if result.Response.Status != protocol.StatusOK {
+		return nil, fmt.Errorf("%s: %s", docURL, result.Response.Status)
+	}
+
+	body := result.Response.Body
+	if anchor != "" {
+		section, ok := mdoutline.Section(body, anchor)
+		if !ok {
+			available := strings.Join(mdoutline.Anchors(body), ", ")
+			if available == "" {
+				available = "(document has no headings)"
+			}
+			return nil, fmt.Errorf("section #%s not found in %s; available anchors: %s", anchor, docURL, available)
+		}
+		body = section
+	}
+
+	return []mcp.ResourceContents{mcp.TextResourceContents{
+		URI:      raw,
+		MIMEType: "text/markdown",
+		Text:     body,
+	}}, nil
+}

--- a/client/cmd/demarkus-mcp/resources.go
+++ b/client/cmd/demarkus-mcp/resources.go
@@ -71,6 +71,9 @@ func registerResources(s *mcpserver.MCPServer, h *handler, defaultHost string) {
 func registerListedResources(s *mcpserver.MCPServer, h *handler, defaultHost string) {
 	host, path, err := h.resolveURL("/")
 	if err != nil {
+		// Unreachable in practice (callers gate on -host being set), but a
+		// silent return would make any future regression undiagnosable.
+		log.Printf("resource listing skipped (%v): picker shows well-known entries only", err)
 		return
 	}
 	listing, err := h.client.List(host, path, h.resolveToken(host))

--- a/client/cmd/demarkus-mcp/resources_test.go
+++ b/client/cmd/demarkus-mcp/resources_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/protocol"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+func readResourceText(t *testing.T, h *handler, uri string) string {
+	t.Helper()
+	contents, err := h.readResource(context.Background(), mcp.ReadResourceRequest{
+		Params: mcp.ReadResourceParams{URI: uri},
+	})
+	if err != nil {
+		t.Fatalf("readResource(%s): %v", uri, err)
+	}
+	if len(contents) != 1 {
+		t.Fatalf("got %d contents, want 1", len(contents))
+	}
+	text, ok := contents[0].(mcp.TextResourceContents)
+	if !ok {
+		t.Fatalf("contents[0] is %T, want TextResourceContents", contents[0])
+	}
+	if text.MIMEType != "text/markdown" {
+		t.Errorf("MIMEType = %q, want text/markdown", text.MIMEType)
+	}
+	if text.URI != uri {
+		t.Errorf("URI = %q, want %q (echoed verbatim)", text.URI, uri)
+	}
+	return text.Text
+}
+
+func TestReadResource_WholeDocument(t *testing.T) {
+	h := &handler{client: fetchStub(smallDoc, "3", "abc", nil)}
+	text := readResourceText(t, h, "mark://example.com/doc.md")
+	if text != smallDoc {
+		t.Errorf("resource read should return the exact body, got:\n%s", text)
+	}
+}
+
+func TestReadResource_Section(t *testing.T) {
+	h := &handler{client: fetchStub(smallDoc, "3", "abc", nil)}
+	text := readResourceText(t, h, "mark://example.com/doc.md#setup")
+	if !strings.HasPrefix(text, "## Setup") || !strings.Contains(text, "Setup body.") {
+		t.Errorf("section resource should return the section, got:\n%s", text)
+	}
+	if strings.Contains(text, "Usage body.") {
+		t.Error("section resource should not include other sections")
+	}
+}
+
+func TestReadResource_LargeDocIsNotOutlined(t *testing.T) {
+	// Attaching is deliberate: resource reads never outline-gate and never
+	// hit the unchanged dedup, regardless of size or fetch history.
+	h := &handler{client: fetchStub(bigDoc(), "3", "abc", nil)}
+	first := readResourceText(t, h, "mark://example.com/big.md")
+	if !strings.Contains(first, "filler line") {
+		t.Fatal("resource read of a large doc must return the full body")
+	}
+	second := readResourceText(t, h, "mark://example.com/big.md")
+	if second != first {
+		t.Error("repeat resource read must return the same full body (no dedup)")
+	}
+}
+
+func TestReadResource_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		client  markClient
+		uri     string
+		wantErr string
+	}{
+		{
+			"section not found lists anchors",
+			fetchStub(smallDoc, "3", "abc", nil),
+			"mark://example.com/doc.md#nope",
+			"available anchors",
+		},
+		{
+			"non-ok status surfaces",
+			&stubClient{fetchFn: func(_, _, _ string) (fetch.Result, error) {
+				return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+			}},
+			"mark://example.com/missing.md",
+			"not-found",
+		},
+		{
+			"transport error surfaces",
+			&stubClient{fetchFn: func(_, _, _ string) (fetch.Result, error) {
+				return fetch.Result{}, fmt.Errorf("boom")
+			}},
+			"mark://example.com/doc.md",
+			"boom",
+		},
+		{
+			"bare path without host",
+			&stubClient{},
+			"/doc.md",
+			"requires -host",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &handler{client: tt.client}
+			_, err := h.readResource(context.Background(), mcp.ReadResourceRequest{
+				Params: mcp.ReadResourceParams{URI: tt.uri},
+			})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRegisterListedResources(t *testing.T) {
+	listing := "- [index.md](index.md)\n- [patterns.md](patterns.md)\n- [journal/](journal/)\n- [notes.md](notes.md)\n- [image.png](image.png)\n"
+	sc := &stubClient{
+		listFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: listing}}, nil
+		},
+	}
+	h := &handler{client: sc, defaultHost: "mark://example.com"}
+	s := mcpserver.NewMCPServer("test", "0", mcpserver.WithResourceCapabilities(false, true))
+
+	registerListedResources(s, h, "mark://example.com")
+
+	// The registered resources are observable through a resources/list
+	// round-trip on the server.
+	got := listResourceURIs(t, s)
+	for _, want := range []string{"mark://example.com/patterns.md", "mark://example.com/notes.md"} {
+		if !got[want] {
+			t.Errorf("listing should register %s; got %v", want, got)
+		}
+	}
+	for _, not := range []string{"mark://example.com/index.md", "mark://example.com/journal/", "mark://example.com/image.png"} {
+		if got[not] {
+			t.Errorf("listing must not register %s (index dedup / dirs / non-markdown)", not)
+		}
+	}
+}
+
+func TestRegisterListedResources_HostDownIsQuiet(t *testing.T) {
+	sc := &stubClient{
+		listFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{}, fmt.Errorf("dial: connection refused")
+		},
+	}
+	h := &handler{client: sc, defaultHost: "mark://example.com"}
+	s := mcpserver.NewMCPServer("test", "0", mcpserver.WithResourceCapabilities(false, true))
+
+	registerListedResources(s, h, "mark://example.com") // must not panic or register anything
+	if got := listResourceURIs(t, s); len(got) != 0 {
+		t.Errorf("down host should register nothing, got %v", got)
+	}
+}
+
+// listResourceURIs drives a real resources/list request through the
+// server and returns the URIs as a set.
+func listResourceURIs(t *testing.T, s *mcpserver.MCPServer) map[string]bool {
+	t.Helper()
+	resp := s.HandleMessage(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"resources/list"}`))
+	result, ok := resp.(mcp.JSONRPCResponse)
+	if !ok {
+		t.Fatalf("resources/list returned %T", resp)
+	}
+	list, ok := result.Result.(mcp.ListResourcesResult)
+	if !ok {
+		t.Fatalf("result is %T, want ListResourcesResult", result.Result)
+	}
+	got := make(map[string]bool, len(list.Resources))
+	for _, r := range list.Resources {
+		got[r.URI] = true
+	}
+	return got
+}
+
+func TestRegisterResources_WellKnownAndTemplate(t *testing.T) {
+	h := &handler{client: &stubClient{}, defaultHost: "mark://example.com"}
+	s := mcpserver.NewMCPServer("test", "0")
+	registerResources(s, h, "mark://example.com")
+
+	got := listResourceURIs(t, s)
+	for _, want := range []string{"mark://example.com/index.md", "mark://example.com" + protocol.WellKnownManifestPath} {
+		if !got[want] {
+			t.Errorf("well-known resource %s missing; got %v", want, got)
+		}
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP support for browsing document resources (full reads and anchor-specific section reads).
  * Introduced new MCP prompts for orientation, recall, and “what’s new” workflows.
  * Enabled dynamic resource discovery and a template-based URI scheme for document access.
* **Bug Fixes**
  * Improved missing-anchor and resource retrieval errors with clearer guidance.
  * Startup now proceeds even if background resource discovery cannot complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->