### PR TITLE
feat(store): version retention keep last N versions per document

### DIFF
--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -331,7 +331,7 @@ func markPublishTool(host string) mcp.Tool {
 			mcp.Description("conflict behavior: \"merge\" (default) returns a merge-candidate body; the agent reviews it (resolving any conflict markers) and calls mark_publish again with expected_version set to the returned publish-at-version. \"fail\" opts out and returns the raw conflict status."),
 		),
 		mcp.WithObject("metadata",
-			mcp.Description("optional publisher metadata stored with the document, as string values. The server interprets `tags` (comma-separated subject labels) and `importance` (0-1) for mark_lookup ranking; other keys are stored opaquely. Reserved keys are rejected."),
+			mcp.Description("optional publisher metadata stored with the document, as string values. The server interprets `tags` (comma-separated subject labels) and `importance` (0-1) for mark_lookup ranking; other keys are stored opaquely. Reserved keys are rejected. `retention` (positive integer) caps version history: this write and every later write carrying the key permanently delete versions older than the newest N. Destructive and irreversible — confirm with the user before setting it on a document whose history matters; intended for generated documents."),
 		),
 	)
 }
@@ -1327,6 +1327,12 @@ func markGraphExportTool() mcp.Tool {
 	)
 }
 
+// defaultGraphRetention bounds the published graph document's version history.
+// The graph is a generated artifact republished wholesale on every run, so
+// unbounded history is pure growth (one live document reached 545 versions);
+// 20 versions is enough to debug a bad crawl.
+const defaultGraphRetention = 20
+
 func markGraphPublishTool(host string) mcp.Tool {
 	return mcp.NewTool("mark_graph_publish",
 		mcp.WithDescription(
@@ -1345,6 +1351,9 @@ func markGraphPublishTool(host string) mcp.Tool {
 		mcp.WithNumber("expected_version",
 			mcp.Required(),
 			mcp.Description("version number from a prior fetch for conflict detection; use 0 when creating a new document"),
+		),
+		mcp.WithNumber("retention",
+			mcp.Description("how many versions of the graph document to keep (default 20). The graph is regenerated on every publish, so older versions are permanently pruned. Pass 0 to keep every version."),
 		),
 	)
 }
@@ -1386,9 +1395,18 @@ func (h *handler) markGraphPublish(ctx context.Context, req mcp.CallToolRequest)
 		return mcp.NewToolResultError("expected_version must be >= 0"), nil
 	}
 
+	retention := req.GetInt("retention", defaultGraphRetention)
+	if retention < 0 {
+		return mcp.NewToolResultError("retention must be >= 0 (0 keeps every version)"), nil
+	}
+
 	md := h.graphStore.Export()
 
-	result, err := h.client.Publish(host, path, md, token, expectedVersion, agentMeta(ctx))
+	meta := agentMeta(ctx)
+	if retention > 0 {
+		meta["retention"] = strconv.Itoa(retention)
+	}
+	result, err := h.client.Publish(host, path, md, token, expectedVersion, meta)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("publish failed: %v", err)), nil
 	}

--- a/client/cmd/demarkus-mcp/main_test.go
+++ b/client/cmd/demarkus-mcp/main_test.go
@@ -1764,3 +1764,75 @@ func assertIsToolError(t *testing.T, result *mcp.CallToolResult, substr string) 
 		t.Errorf("error text %q does not contain %q", text.Text, substr)
 	}
 }
+
+func TestHandlerMarkGraphPublish_Retention(t *testing.T) {
+	newGraphHandler := func(t *testing.T, capture *map[string]string) *handler {
+		t.Helper()
+		gs, err := graphstore.Load(filepath.Join(t.TempDir(), "graph.json"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		sc := &stubClient{
+			publishFn: func(_, _, _, _ string, _ int, meta map[string]string) (fetch.Result, error) {
+				*capture = meta
+				return fetch.Result{Response: protocol.Response{
+					Status:   "created",
+					Metadata: map[string]string{"version": "1", "modified": "2026-03-08T12:00:00Z"},
+				}}, nil
+			},
+		}
+		return &handler{client: sc, graphStore: gs, token: "test-token"}
+	}
+
+	tests := []struct {
+		name          string
+		args          map[string]any
+		wantRetention string
+	}{
+		{
+			name:          "defaults to 20",
+			args:          map[string]any{"url": "mark://target.com/graph.md", "expected_version": float64(0)},
+			wantRetention: "20",
+		},
+		{
+			name:          "explicit override",
+			args:          map[string]any{"url": "mark://target.com/graph.md", "expected_version": float64(0), "retention": float64(5)},
+			wantRetention: "5",
+		},
+		{
+			name:          "zero disables retention",
+			args:          map[string]any{"url": "mark://target.com/graph.md", "expected_version": float64(0), "retention": float64(0)},
+			wantRetention: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var meta map[string]string
+			h := newGraphHandler(t, &meta)
+			result, err := h.markGraphPublish(context.Background(), newCallToolRequest(tt.args))
+			if err != nil {
+				t.Fatalf("unexpected Go error: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("unexpected tool error: %v", result.Content)
+			}
+			if got := meta["retention"]; got != tt.wantRetention {
+				t.Errorf("retention meta = %q, want %q", got, tt.wantRetention)
+			}
+		})
+	}
+
+	t.Run("negative rejected", func(t *testing.T) {
+		var meta map[string]string
+		h := newGraphHandler(t, &meta)
+		result, err := h.markGraphPublish(context.Background(), newCallToolRequest(map[string]any{
+			"url":              "mark://target.com/graph.md",
+			"expected_version": float64(0),
+			"retention":        float64(-1),
+		}))
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		assertIsToolError(t, result, "retention must be >= 0")
+	})
+}

--- a/client/cmd/demarkus/main.go
+++ b/client/cmd/demarkus/main.go
@@ -727,6 +727,13 @@ func confirmRetention(meta map[string]string, yes bool, in *os.File, out io.Writ
 	if !ok || yes {
 		return nil
 	}
+	// Only a positive integer can prune; anything else (0, negative,
+	// non-numeric) is rejected by the server's validation, so a destructive
+	// warning here would be misleading — let the server report the precise
+	// bad-request error instead.
+	if n, err := strconv.Atoi(r); err != nil || n < 1 {
+		return nil
+	}
 	if !term.IsTerminal(int(in.Fd())) {
 		return fmt.Errorf("retention=%s permanently deletes older versions on this and every later write carrying it; pass -yes to confirm in non-interactive mode", r)
 	}

--- a/client/cmd/demarkus/main.go
+++ b/client/cmd/demarkus/main.go
@@ -103,8 +103,11 @@ func requestMain() {
 	token := tokens.Resolve(*authToken, host, ts)
 	// Confirm destructive metadata before resolveBody so the prompt runs while
 	// stdin is still untouched (resolveBody may consume stdin for the body).
-	if err := confirmRetention(metaMap(meta), *yes, os.Stdin, os.Stderr); err != nil {
-		log.Fatal(err)
+	// Only PUBLISH/APPEND transmit metadata, so only they can prune.
+	if *verb == protocol.VerbPublish || *verb == protocol.VerbAppend {
+		if err := confirmRetention(metaMap(meta), *yes, os.Stdin, os.Stderr); err != nil {
+			log.Fatal(err)
+		}
 	}
 	reqBody := resolveBody(*verb, *body)
 	if *verb == protocol.VerbAppend {

--- a/client/cmd/demarkus/main.go
+++ b/client/cmd/demarkus/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"flag"
 	"fmt"
@@ -11,6 +12,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"golang.org/x/term"
 
 	"github.com/latebit-io/demarkus/client/fetch"
 	"github.com/latebit-io/demarkus/client/graph"
@@ -58,6 +61,7 @@ func requestMain() {
 	expectedVersion := flag.Int("expected-version", -1, "version check: -1 skip (default), 0 create-only, >0 require match; required (>0) for APPEND")
 	meta := metaFlag{}
 	flag.Var(meta, "meta", "publisher metadata key=value for PUBLISH/APPEND (repeatable); e.g. -meta tags=go,auth -meta importance=0.9")
+	yes := flag.Bool("yes", false, "skip the confirmation prompt for destructive metadata (retention)")
 	includeArchived := flag.Bool("include-archived", false, "LIST only: include archived documents (and all-archived directories) in the listing")
 	verbose := flag.Bool("v", false, "show status and metadata header before body")
 	noCache := flag.Bool("no-cache", false, "disable caching")
@@ -97,6 +101,11 @@ func requestMain() {
 
 	ts := tokens.LoadDefault()
 	token := tokens.Resolve(*authToken, host, ts)
+	// Confirm destructive metadata before resolveBody so the prompt runs while
+	// stdin is still untouched (resolveBody may consume stdin for the body).
+	if err := confirmRetention(metaMap(meta), *yes, os.Stdin, os.Stderr); err != nil {
+		log.Fatal(err)
+	}
 	reqBody := resolveBody(*verb, *body)
 	if *verb == protocol.VerbAppend {
 		if reqBody == "" {
@@ -704,6 +713,33 @@ func metaMap(m metaFlag) map[string]string {
 		return nil
 	}
 	return m
+}
+
+// confirmRetention guards the destructive retention metadata key: the write
+// carrying it (and every later one) permanently deletes versions older than
+// the newest N. Interactive runs confirm on the prompt; non-interactive runs
+// (stdin is not a TTY) must pass -yes so scripts state the intent explicitly.
+func confirmRetention(meta map[string]string, yes bool, in *os.File, out io.Writer) error {
+	r, ok := meta["retention"]
+	if !ok || yes {
+		return nil
+	}
+	if !term.IsTerminal(int(in.Fd())) {
+		return fmt.Errorf("retention=%s permanently deletes older versions on this and every later write carrying it; pass -yes to confirm in non-interactive mode", r)
+	}
+	if _, err := fmt.Fprintf(out, "retention=%s permanently deletes all but the newest %s versions of this document, on this write and every later write carrying the key. Continue? [y/N] ", r, r); err != nil {
+		return fmt.Errorf("write confirmation prompt: %w", err)
+	}
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("read confirmation: %w", err)
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return nil
+	default:
+		return fmt.Errorf("aborted: retention not confirmed")
+	}
 }
 
 func validateVerb(verb string) error {

--- a/client/cmd/demarkus/main.go
+++ b/client/cmd/demarkus/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/latebit-io/demarkus/client/internal/tokens"
 	"github.com/latebit-io/demarkus/client/links"
 	"github.com/latebit-io/demarkus/protocol"
+	"github.com/latebit-io/demarkus/protocol/store"
 )
 
 func main() {
@@ -730,8 +731,9 @@ func confirmRetention(meta map[string]string, yes bool, in *os.File, out io.Writ
 	// Only a positive integer can prune; anything else (0, negative,
 	// non-numeric) is rejected by the server's validation, so a destructive
 	// warning here would be misleading — let the server report the precise
-	// bad-request error instead.
-	if n, err := strconv.Atoi(r); err != nil || n < 1 {
+	// bad-request error instead. store.ParseRetention is the same predicate
+	// the server enforces.
+	if _, ok := store.ParseRetention(r); !ok {
 		return nil
 	}
 	if !term.IsTerminal(int(in.Fd())) {

--- a/client/cmd/demarkus/main_test.go
+++ b/client/cmd/demarkus/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/latebit-io/demarkus/protocol"
@@ -130,6 +132,40 @@ func TestEditorCommand(t *testing.T) {
 				if args[i] != tt.wantArgs[i] {
 					t.Errorf("args[%d]: got %q, want %q", i, args[i], tt.wantArgs[i])
 				}
+			}
+		})
+	}
+}
+
+func TestConfirmRetention(t *testing.T) {
+	// A regular file stands in for non-TTY stdin (pipes and redirects).
+	nonTTY, err := os.CreateTemp(t.TempDir(), "stdin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := nonTTY.Close(); err != nil {
+			t.Errorf("close temp stdin: %v", err)
+		}
+	}()
+
+	tests := []struct {
+		name    string
+		meta    map[string]string
+		yes     bool
+		wantErr bool
+	}{
+		{"no retention key", map[string]string{"tags": "a,b"}, false, false},
+		{"nil meta", nil, false, false},
+		{"retention with -yes", map[string]string{"retention": "5"}, true, false},
+		{"retention non-interactive without -yes", map[string]string{"retention": "5"}, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out strings.Builder
+			err := confirmRetention(tt.meta, tt.yes, nonTTY, &out)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("confirmRetention() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/client/cmd/demarkus/main_test.go
+++ b/client/cmd/demarkus/main_test.go
@@ -159,6 +159,11 @@ func TestConfirmRetention(t *testing.T) {
 		{"nil meta", nil, false, false},
 		{"retention with -yes", map[string]string{"retention": "5"}, true, false},
 		{"retention non-interactive without -yes", map[string]string{"retention": "5"}, false, true},
+		// Values the server rejects cannot prune, so no confirmation is
+		// required — the server's bad-request error is the real feedback.
+		{"retention zero passes through", map[string]string{"retention": "0"}, false, false},
+		{"retention negative passes through", map[string]string{"retention": "-1"}, false, false},
+		{"retention non-numeric passes through", map[string]string{"retention": "abc"}, false, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -696,12 +696,14 @@ v1 (genesis)     v2                    v3
 
 To verify the integrity of a document's version history:
 
-1. Read all version files, sorted by version number (oldest first).
-2. For each version N > 1:
+1. Read all retained version files, sorted by version number (oldest first).
+2. For each version N after the oldest retained version:
    a. Compute `sha256(<raw bytes of version N-1 file>)`.
    b. Format as `sha256-<hex>`.
    c. Compare with the `previous-hash` value in version N's store frontmatter.
    d. If they do not match, the chain is broken at version N.
+
+The oldest retained version is the verification root: its own `previous-hash` (absent for version 1, referencing a pruned file otherwise) is not checked.
 
 If any version file has been modified after publication, the hash recorded in the next version will not match, and the tampering is detected.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -597,9 +597,9 @@ Beyond the interpreted fields above, a PUBLISH request MAY carry additional publ
 
 ### 9.1. Version Model
 
-The Mark Protocol uses an append-only version model. Every write to a document creates a new version. Published versions are permanent and MUST NOT be modified or deleted. Version history is an append-only log.
+The Mark Protocol uses an append-only version model. Every write to a document creates a new version. Published versions are permanent and MUST NOT be modified or deleted, with one exception: a publisher-declared retention policy prunes the oldest versions of a document (§9.9). Version history is otherwise an append-only log.
 
-Version numbers are positive integers starting at 1, monotonically increasing by 1 for each write.
+Version numbers are positive integers starting at 1, monotonically increasing by 1 for each write. Retention pruning never affects version numbering.
 
 ### 9.2. Path-Based Version Access
 
@@ -705,6 +705,8 @@ To verify the integrity of a document's version history:
 
 If any version file has been modified after publication, the hash recorded in the next version will not match, and the tampering is detected.
 
+When retention pruning (§9.9) has removed the oldest versions, verification applies to the retained contiguous suffix. The oldest retained version's `previous-hash` references a deleted file and cannot be verified; every later link remains verifiable.
+
 ### 9.7. Immutability Enforcement
 
 Servers MUST NOT overwrite existing version files. Before writing a new version file, the server MUST verify that no file exists at the target path. If the target file already exists, the write MUST fail.
@@ -717,6 +719,20 @@ When a PUBLISH is performed on a document that exists as a flat file (no version
 2. Migrate the flat file content to `versions/<filename>.v1` with store frontmatter (`version: 1`, no `previous-hash`).
 3. Create the new version as `versions/<filename>.v2` with a `previous-hash` referencing the hash of the migrated v1 file.
 4. Update the current file to a symlink pointing to the new version.
+
+### 9.9. Version Retention
+
+A publisher MAY bound a document's version history by declaring a `retention` metadata key on PUBLISH or APPEND. The value MUST be a positive integer; a server MUST reject a write whose `retention` value is not an integer or is less than 1.
+
+When the newly written version N carries `retention: R` and more than R versions exist, the server MUST delete the stored version files with version numbers less than or equal to N − R, in ascending version order, after the write has succeeded. Deletion MUST stop at the first failure so the retained versions always form a contiguous suffix of the history (§9.6). The current version is never deleted; R ≥ 1 guarantees at least one version remains.
+
+Retention is evaluated per write: a write that omits the key prunes nothing, regardless of what earlier versions declared. Absent retention, the default append-only model applies unchanged. Reads of a pruned version return not-found; VERSIONS lists only the retained versions.
+
+Retention is intended for generated documents that are republished wholesale (graph exports, indexes), where old versions carry no value. It is destructive: pruned versions are unrecoverable through the protocol. Clients SHOULD warn and require explicit confirmation before a write that sets `retention` on a document not known to be generated.
+
+Pruning requires no separate capability — it executes under the write authorization of the PUBLISH or APPEND that carries the key, the same trust level that can archive the document. A server MUST record version deletions in its audit log, attributing them to the authenticated writer (in the reference implementation: path, pruned version range, and token label).
+
+Because pruning is the store's only destructive filesystem operation, deletion paths MUST NOT be derived from request input: version numbers come from enumerating the document's own versions directory, and each deletion MUST be confined to the store root with symlink escapes rejected at delete time (the reference implementation resolves every removal inside an `os.Root` anchored at the store root, so a planted or raced symlink cannot redirect a delete outside the store, and a version file that is itself a symlink is unlinked, never followed).
 
 ## 10. Caching
 

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -46,6 +46,22 @@ type Document struct {
 	Version  int
 	Archived bool
 	Metadata map[string]string
+	// Prune reports retention pruning performed by the write that produced
+	// this document, or nil when no pruning ran. Callers on the network path
+	// audit-log it so version deletions are always attributable.
+	Prune *PruneResult
+}
+
+// PruneResult describes the contiguous range of oldest versions deleted by
+// retention pruning after a successful write. From/To are zero when a
+// deletion failure stopped pruning before anything was removed. Err is
+// non-nil when pruning stopped early; versions From..To were already deleted
+// and the rest remain a contiguous suffix, so the hash chain stays
+// verifiable.
+type PruneResult struct {
+	From int
+	To   int
+	Err  error
 }
 
 // VersionInfo describes a single version of a document.
@@ -98,6 +114,14 @@ var okfKeys = map[string]bool{
 	"tags":        true,
 	"timestamp":   true,
 }
+
+// retentionKey is the publisher metadata key that bounds a document's version
+// history. When the just-written version carries it, the write prunes the
+// oldest versions so at most that many remain (current included). It is
+// publisher metadata, not a reserved store field: any writer with publish
+// capability may set it, the same trust level that can archive the document.
+// Absent retention means keep every version — the default is unchanged.
+const retentionKey = "retention"
 
 // reservedMetaKeys are bare frontmatter fields owned by the store. Publishers
 // may not set them (validateMeta rejects them) and extractMetadata never
@@ -1043,13 +1067,89 @@ func (s *Store) Write(reqPath string, content []byte, meta map[string]string) (*
 
 	s.UpdateHashIndex(reqPath, content)
 
-	return &Document{
+	doc := &Document{
 		Content:  content,
 		Modified: info.ModTime().UTC().Truncate(time.Second),
 		Version:  next,
 		Archived: false,
 		Metadata: meta,
-	}, nil
+	}
+	if keep := retentionValue(meta); keep > 0 {
+		doc.Prune = s.pruneVersions(versionsDir, base, next, keep)
+	}
+	return doc, nil
+}
+
+// retentionValue returns the retention count declared in publisher metadata,
+// or 0 when absent. validateMeta has already rejected non-integer or < 1
+// values, so a parse failure here means the map bypassed validation — treat
+// it as no retention rather than pruning on a value that was never vetted.
+func retentionValue(meta map[string]string) int {
+	v, ok := meta[retentionKey]
+	if !ok {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 {
+		return 0
+	}
+	return n
+}
+
+// pruneVersions deletes the oldest versions of a document so at most keep
+// versions remain, the just-written current version included. Deletion runs
+// oldest-first and stops at the first failure so the surviving versions are
+// always a contiguous suffix — VerifyChain never sees a gap. It runs only
+// after a successful write, which has already migrated the document to the
+// per-doc layout, so only versions/{base}/v{N} files are ever touched.
+//
+// Deletion is the store's only destructive operation, so it takes no chances
+// with the filesystem: version numbers come from ReadDir (never from input),
+// filenames are reconstructed as v{N}, and every removal goes through an
+// os.Root anchored at the store root. os.Root resolves the whole path inside
+// the root at delete time, so a planted symlink (e.g. versions/{base}
+// pointing outside the store) or a directory swapped in mid-prune cannot
+// redirect a delete to a file outside the store, and a version file that is
+// itself a symlink is unlinked, never followed. Returns nil when there was
+// nothing to delete.
+func (s *Store) pruneVersions(versionsDir, base string, current, keep int) *PruneResult {
+	cutoff := current - keep // delete versions <= cutoff
+	if cutoff < 1 {
+		return nil
+	}
+	relDocDir, err := filepath.Rel(s.root, filepath.Join(versionsDir, base))
+	if err != nil || strings.HasPrefix(relDocDir, "..") {
+		return &PruneResult{Err: fmt.Errorf("prune: doc dir escapes store root: %q", relDocDir)}
+	}
+	rootFS, err := os.OpenRoot(s.root)
+	if err != nil {
+		return &PruneResult{Err: fmt.Errorf("prune: open store root: %w", err)}
+	}
+	// Read-only directory handle; nothing actionable on close failure.
+	defer func() { _ = rootFS.Close() }()
+
+	versions := s.findVersionsPerDoc(versionsDir, base)
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].Version < versions[j].Version
+	})
+	var res *PruneResult
+	for _, v := range versions {
+		if v.Version > cutoff {
+			break
+		}
+		if err := rootFS.Remove(filepath.Join(relDocDir, fmt.Sprintf("v%d", v.Version))); err != nil {
+			if res == nil {
+				res = &PruneResult{}
+			}
+			res.Err = fmt.Errorf("prune v%d: %w", v.Version, err)
+			break
+		}
+		if res == nil {
+			res = &PruneResult{From: v.Version}
+		}
+		res.To = v.Version
+	}
+	return res
 }
 
 // prepareExistingDoc handles pre-write checks for existing documents:
@@ -1142,9 +1242,11 @@ func (s *Store) WriteVersion(reqPath string, expectedVersion int, content []byte
 	// version beyond expectedVersion+1 (e.g. v3 instead of v2). Detect
 	// this and treat it as a conflict. The written version file is kept
 	// to avoid leaving a dangling symlink — it's a valid version with a
-	// correct hash chain, just created under stale assumptions.
+	// correct hash chain, just created under stale assumptions. The prune
+	// result is preserved: the write pruned regardless of the conflict,
+	// and callers must still be able to audit-log the deletion.
 	if doc.Version != expectedVersion+1 {
-		return &Document{Version: doc.Version}, ErrConflict
+		return &Document{Version: doc.Version, Prune: doc.Prune}, ErrConflict
 	}
 
 	return doc, nil
@@ -1407,6 +1509,11 @@ func validateMeta(meta map[string]string) error {
 		if !protocol.IsValidMetaValue(v) {
 			return fmt.Errorf("metadata value for key %q contains newlines", k)
 		}
+		if k == retentionKey {
+			if n, err := strconv.Atoi(v); err != nil || n < 1 {
+				return fmt.Errorf("metadata key %q must be a positive integer, got %q", retentionKey, v)
+			}
+		}
 		size += SerializedMetaSize(k, v)
 	}
 	if len(meta) > protocol.MaxMetaKeys {
@@ -1549,10 +1656,13 @@ func extractBody(data []byte) []byte {
 // If v1 already exists (concurrent write), it is a no-op.
 // TODO(v1): remove this function; flat files without version history won't exist.
 func (s *Store) migrateFlatFile(versionsDir, base, currentFile string) error {
-	// Check both layouts for an existing v1.
-	perDocV1 := newVersionFilePath(versionsDir, base, 1)
-	if _, err := os.Stat(perDocV1); !errors.Is(err, os.ErrNotExist) {
-		return nil // v1 already exists (new layout)
+	// A document with any per-doc version history is not a flat file. This
+	// must not check for v1 specifically: retention pruning deletes the
+	// oldest versions, and misclassifying a pruned document here would
+	// resurrect a bogus v1 from the current symlink's raw bytes (store
+	// frontmatter included) and break the hash chain.
+	if len(s.findVersionsPerDoc(versionsDir, base)) > 0 {
+		return nil
 	}
 	flatV1 := filepath.Join(versionsDir, fmt.Sprintf("%s.v1", base))
 	if _, err := os.Stat(flatV1); !errors.Is(err, os.ErrNotExist) {

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -1080,6 +1080,19 @@ func (s *Store) Write(reqPath string, content []byte, meta map[string]string) (*
 	return doc, nil
 }
 
+// ParseRetention parses a retention metadata value. ok is true only for a
+// positive integer — the only form that prunes; validateMeta rejects every
+// other value. Exported so clients gating destructive-confirmation UX (the
+// CLI prompt) share the exact predicate the server enforces instead of
+// re-implementing it and drifting.
+func ParseRetention(v string) (n int, ok bool) {
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 {
+		return 0, false
+	}
+	return n, true
+}
+
 // retentionValue returns the retention count declared in publisher metadata,
 // or 0 when absent. validateMeta has already rejected non-integer or < 1
 // values, so a parse failure here means the map bypassed validation — treat
@@ -1089,8 +1102,8 @@ func retentionValue(meta map[string]string) int {
 	if !ok {
 		return 0
 	}
-	n, err := strconv.Atoi(v)
-	if err != nil || n < 1 {
+	n, ok := ParseRetention(v)
+	if !ok {
 		return 0
 	}
 	return n
@@ -1515,7 +1528,7 @@ func validateMeta(meta map[string]string) error {
 			return fmt.Errorf("metadata value for key %q contains newlines", k)
 		}
 		if k == retentionKey {
-			if n, err := strconv.Atoi(v); err != nil || n < 1 {
+			if _, ok := ParseRetention(v); !ok {
 				return fmt.Errorf("metadata key %q must be a positive integer, got %q", retentionKey, v)
 			}
 		}

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -1112,6 +1112,11 @@ func retentionValue(meta map[string]string) int {
 // redirect a delete to a file outside the store, and a version file that is
 // itself a symlink is unlinked, never followed. Returns nil when there was
 // nothing to delete.
+//
+// Deletion is deliberately unbounded per write: the first retained write on a
+// long history prunes the whole backlog inline (that is the upgrade path for
+// documents that accumulated hundreds of versions before retention existed).
+// Steady state deletes one version per write.
 func (s *Store) pruneVersions(versionsDir, base string, current, keep int) *PruneResult {
 	cutoff := current - keep // delete versions <= cutoff
 	if cutoff < 1 {

--- a/protocol/store/store_test.go
+++ b/protocol/store/store_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 
@@ -1795,4 +1797,315 @@ func TestHashIndex(t *testing.T) {
 			t.Error("unarchived doc should be back in index")
 		}
 	})
+}
+
+func TestValidateMeta_Retention(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"positive integer", "20", false},
+		{"one", "1", false},
+		{"zero", "0", true},
+		{"negative", "-3", true},
+		{"non-integer", "abc", true},
+		{"float", "1.5", true},
+		{"empty", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateMeta(map[string]string{"retention": tt.value})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateMeta(retention=%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// writeSequence writes n versions of /doc.md, passing meta only on the final
+// write, and returns the final document.
+func writeSequence(t *testing.T, s *Store, n int, finalMeta map[string]string) *Document {
+	t.Helper()
+	var doc *Document
+	var err error
+	for i := range n {
+		var meta map[string]string
+		if i == n-1 {
+			meta = finalMeta
+		}
+		doc, err = s.Write("/doc.md", fmt.Appendf(nil, "# Version %d", i+1), meta)
+		if err != nil {
+			t.Fatalf("write %d: %v", i+1, err)
+		}
+	}
+	return doc
+}
+
+func remainingVersions(t *testing.T, s *Store) []int {
+	t.Helper()
+	infos, err := s.Versions("/doc.md")
+	if err != nil {
+		t.Fatalf("Versions: %v", err)
+	}
+	nums := make([]int, 0, len(infos))
+	for _, v := range infos {
+		nums = append(nums, v.Version)
+	}
+	sort.Ints(nums)
+	return nums
+}
+
+func TestWrite_RetentionPrunes(t *testing.T) {
+	s := New(t.TempDir())
+	doc := writeSequence(t, s, 10, map[string]string{"retention": "3"})
+
+	if got, want := remainingVersions(t, s), []int{8, 9, 10}; !slices.Equal(got, want) {
+		t.Fatalf("remaining versions = %v, want %v", got, want)
+	}
+	if doc.Prune == nil {
+		t.Fatal("expected prune result on document")
+	}
+	if doc.Prune.From != 1 || doc.Prune.To != 7 || doc.Prune.Err != nil {
+		t.Errorf("prune = {From:%d To:%d Err:%v}, want {From:1 To:7 Err:nil}", doc.Prune.From, doc.Prune.To, doc.Prune.Err)
+	}
+	if err := s.VerifyChain("/doc.md"); err != nil {
+		t.Errorf("VerifyChain after prune: %v", err)
+	}
+	if _, err := s.Get("/doc.md", 1); err == nil {
+		t.Error("pruned version 1 should not be readable")
+	}
+	if doc, err := s.Get("/doc.md", 0); err != nil || doc.Version != 10 {
+		t.Errorf("current version = %d (err %v), want 10", doc.Version, err)
+	}
+}
+
+func TestWrite_NoRetention_NoPrune(t *testing.T) {
+	s := New(t.TempDir())
+	doc := writeSequence(t, s, 5, nil)
+
+	if got := remainingVersions(t, s); len(got) != 5 {
+		t.Errorf("remaining versions = %v, want all 5", got)
+	}
+	if doc.Prune != nil {
+		t.Errorf("prune result = %+v, want nil", doc.Prune)
+	}
+}
+
+func TestWrite_RetentionKeepsCurrent(t *testing.T) {
+	s := New(t.TempDir())
+	writeSequence(t, s, 4, map[string]string{"retention": "1"})
+
+	if got, want := remainingVersions(t, s), []int{4}; !slices.Equal(got, want) {
+		t.Fatalf("remaining versions = %v, want %v", got, want)
+	}
+	// Numbering continues from the pruned history.
+	doc, err := s.Write("/doc.md", []byte("# Version 5"), map[string]string{"retention": "1"})
+	if err != nil {
+		t.Fatalf("write after prune: %v", err)
+	}
+	if doc.Version != 5 {
+		t.Errorf("next version = %d, want 5", doc.Version)
+	}
+	if got, want := remainingVersions(t, s), []int{5}; !slices.Equal(got, want) {
+		t.Errorf("remaining versions = %v, want %v", got, want)
+	}
+}
+
+func TestWrite_RetentionRemoved_StopsPruning(t *testing.T) {
+	s := New(t.TempDir())
+	writeSequence(t, s, 3, map[string]string{"retention": "2"})
+
+	doc, err := s.Write("/doc.md", []byte("# Version 4"), nil)
+	if err != nil {
+		t.Fatalf("write without retention: %v", err)
+	}
+	if doc.Prune != nil {
+		t.Errorf("prune result = %+v, want nil without retention", doc.Prune)
+	}
+	if got, want := remainingVersions(t, s), []int{2, 3, 4}; !slices.Equal(got, want) {
+		t.Errorf("remaining versions = %v, want %v", got, want)
+	}
+}
+
+func TestWrite_RetentionLargerThanHistory_NoPrune(t *testing.T) {
+	s := New(t.TempDir())
+	doc := writeSequence(t, s, 3, map[string]string{"retention": "10"})
+
+	if doc.Prune != nil {
+		t.Errorf("prune result = %+v, want nil", doc.Prune)
+	}
+	if got := remainingVersions(t, s); len(got) != 3 {
+		t.Errorf("remaining versions = %v, want all 3", got)
+	}
+}
+
+func TestPruneVersions_AbortsOnError(t *testing.T) {
+	s := New(t.TempDir())
+	writeSequence(t, s, 5, nil)
+
+	docDir := filepath.Join(s.Root(), "versions", "doc.md")
+	if err := os.Chmod(docDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(docDir, 0o755); err != nil {
+			t.Errorf("restore permissions: %v", err)
+		}
+	})
+
+	res := s.pruneVersions(filepath.Join(s.Root(), "versions"), "doc.md", 5, 2)
+	if res == nil || res.Err == nil {
+		t.Fatalf("prune result = %+v, want error", res)
+	}
+	if res.From != 0 || res.To != 0 {
+		t.Errorf("prune range = %d-%d, want 0-0 (nothing deleted)", res.From, res.To)
+	}
+	if err := os.Chmod(docDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := remainingVersions(t, s); len(got) != 5 {
+		t.Errorf("remaining versions = %v, want all 5 (no gap)", got)
+	}
+	if err := s.VerifyChain("/doc.md"); err != nil {
+		t.Errorf("VerifyChain after failed prune: %v", err)
+	}
+}
+
+func TestWrite_RetentionMigratesFlatLayoutThenPrunes(t *testing.T) {
+	root := t.TempDir()
+	versionsDir := filepath.Join(root, "versions")
+	if err := os.Mkdir(versionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= 2; i++ {
+		if err := os.WriteFile(filepath.Join(versionsDir, fmt.Sprintf("doc.md.v%d", i)), fmt.Appendf(nil, "# V%d", i), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(filepath.Join("versions", "doc.md.v2"), filepath.Join(root, "doc.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	s := New(root)
+	doc, err := s.Write("/doc.md", []byte("# V3"), map[string]string{"retention": "1"})
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if doc.Version != 3 {
+		t.Fatalf("version = %d, want 3", doc.Version)
+	}
+	if doc.Prune == nil || doc.Prune.From != 1 || doc.Prune.To != 2 {
+		t.Fatalf("prune result = %+v, want From:1 To:2", doc.Prune)
+	}
+	if got, want := remainingVersions(t, s), []int{3}; !slices.Equal(got, want) {
+		t.Errorf("remaining versions = %v, want %v", got, want)
+	}
+}
+
+func TestWriteVersion_RetentionPrunes(t *testing.T) {
+	s := New(t.TempDir())
+	writeSequence(t, s, 3, nil)
+
+	doc, err := s.WriteVersion("/doc.md", 3, []byte("# Version 4"), map[string]string{"retention": "2"})
+	if err != nil {
+		t.Fatalf("WriteVersion: %v", err)
+	}
+	if doc.Prune == nil || doc.Prune.From != 1 || doc.Prune.To != 2 {
+		t.Fatalf("prune result = %+v, want From:1 To:2", doc.Prune)
+	}
+	if got, want := remainingVersions(t, s), []int{3, 4}; !slices.Equal(got, want) {
+		t.Errorf("remaining versions = %v, want %v", got, want)
+	}
+}
+
+func TestPruneVersions_SymlinkedDocDirCannotEscape(t *testing.T) {
+	// A planted symlink at versions/{base} pointing outside the store must
+	// not let pruning delete files outside the root. Requires local disk
+	// access to set up (the protocol cannot create symlinks) — this guards
+	// the store as a public API and against confused-deputy reuse.
+	root := t.TempDir()
+	outside := t.TempDir()
+	for i := 1; i <= 3; i++ {
+		if err := os.WriteFile(filepath.Join(outside, fmt.Sprintf("v%d", i)), fmt.Appendf(nil, "victim %d", i), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	versionsDir := filepath.Join(root, "versions")
+	if err := os.Mkdir(versionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(versionsDir, "doc.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	s := New(root)
+	res := s.pruneVersions(versionsDir, "doc.md", 3, 1)
+	if res == nil || res.Err == nil {
+		t.Fatalf("prune result = %+v, want escape error", res)
+	}
+	if res.From != 0 || res.To != 0 {
+		t.Errorf("prune range = %d-%d, want 0-0 (nothing deleted)", res.From, res.To)
+	}
+	for i := 1; i <= 3; i++ {
+		if _, err := os.Stat(filepath.Join(outside, fmt.Sprintf("v%d", i))); err != nil {
+			t.Errorf("outside file v%d was deleted through the symlink: %v", i, err)
+		}
+	}
+}
+
+func TestPruneVersions_SymlinkVersionFileNotFollowed(t *testing.T) {
+	// A version file that is itself a symlink is unlinked, never followed:
+	// the link target outside the store must survive the prune.
+	root := t.TempDir()
+	outsideFile := filepath.Join(t.TempDir(), "victim.md")
+	if err := os.WriteFile(outsideFile, []byte("victim"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := New(root)
+	writeSequence(t, s, 3, nil)
+	v1 := filepath.Join(root, "versions", "doc.md", "v1")
+	if err := os.Remove(v1); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsideFile, v1); err != nil {
+		t.Fatal(err)
+	}
+
+	res := s.pruneVersions(filepath.Join(root, "versions"), "doc.md", 3, 1)
+	if res == nil || res.Err != nil {
+		t.Fatalf("prune result = %+v, want clean prune", res)
+	}
+	if res.From != 1 || res.To != 2 {
+		t.Errorf("prune range = %d-%d, want 1-2", res.From, res.To)
+	}
+	if _, err := os.Lstat(v1); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("v1 symlink should be removed, Lstat err = %v", err)
+	}
+	if data, err := os.ReadFile(outsideFile); err != nil || string(data) != "victim" {
+		t.Errorf("symlink target outside the store was touched: data=%q err=%v", data, err)
+	}
+}
+
+func TestPruneVersions_DocDirOutsideRootRejected(t *testing.T) {
+	// A versionsDir that resolves outside the store root is refused before
+	// any deletion is attempted, regardless of how the caller derived it.
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(outside, "versions", "doc.md"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "versions", "doc.md", "v1"), []byte("victim"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := New(root)
+	res := s.pruneVersions(filepath.Join(outside, "versions"), "doc.md", 3, 1)
+	if res == nil || res.Err == nil {
+		t.Fatalf("prune result = %+v, want escape error", res)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "versions", "doc.md", "v1")); err != nil {
+		t.Errorf("file outside the store root was deleted: %v", err)
+	}
 }

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -792,6 +792,7 @@ func (h *Handler) handlePublish(w io.Writer, req protocol.Request) {
 	}
 
 	doc, err := h.Store.WriteVersion(req.Path, expectedVersion, []byte(req.Body), pubMeta)
+	h.logPrune("PUBLISH", req.Path, tokenLabel, doc)
 	if err != nil {
 		if errors.Is(err, store.ErrConflict) {
 			h.logger().Info("publish conflict", "audit", true, "operation", "PUBLISH", "path", sanitize(req.Path), "expected_version", expectedVersion, "server_version", doc.Version, "token_label", sanitize(tokenLabel), "success", false)
@@ -916,6 +917,7 @@ func (h *Handler) handleAppend(w io.Writer, req protocol.Request) {
 	}
 
 	doc, err := h.Store.Append(req.Path, expectedVersion, []byte(req.Body), pubMeta)
+	h.logPrune("APPEND", req.Path, tokenLabel, doc)
 	if err != nil {
 		if errors.Is(err, store.ErrConflict) {
 			h.logger().Info("append conflict", "audit", true, "operation", "APPEND", "path", sanitize(req.Path), "expected_version", expectedVersion, "server_version", doc.Version, "token_label", sanitize(tokenLabel), "success", false)
@@ -1039,6 +1041,22 @@ func escapeMD(s string) string {
 
 func escapeURL(s string) string {
 	return url.PathEscape(s)
+}
+
+// logPrune audit-logs retention pruning performed by a write. Version
+// deletions must always be attributable, so this runs on every write outcome
+// that carries a prune result — including conflict paths, where the write
+// (and its prune) happened despite the conflict response.
+func (h *Handler) logPrune(operation, reqPath, tokenLabel string, doc *store.Document) {
+	if doc == nil || doc.Prune == nil {
+		return
+	}
+	p := doc.Prune
+	if p.Err != nil {
+		h.logger().Error("prune incomplete", "audit", true, "operation", operation, "path", sanitize(reqPath), "pruned_from", p.From, "pruned_to", p.To, "token_label", sanitize(tokenLabel), "success", false, "error", p.Err)
+		return
+	}
+	h.logger().Info("prune", "audit", true, "operation", operation, "path", sanitize(reqPath), "pruned_from", p.From, "pruned_to", p.To, "token_label", sanitize(tokenLabel), "success", true)
 }
 
 // extractPublisherMeta returns non-control metadata keys from a request.

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -2473,18 +2473,22 @@ func TestHandlePublish_Retention(t *testing.T) {
 	})
 
 	t.Run("invalid retention rejected", func(t *testing.T) {
-		dir := t.TempDir()
-		h := &Handler{ContentDir: dir, Store: store.New(dir), Logger: discardLogger, GetTokenStore: func() *auth.TokenStore { return tokenStore }}
+		for _, value := range []string{"zero", "0", "-1"} {
+			t.Run("retention="+value, func(t *testing.T) {
+				dir := t.TempDir()
+				h := &Handler{ContentDir: dir, Store: store.New(dir), Logger: discardLogger, GetTokenStore: func() *auth.TokenStore { return tokenStore }}
 
-		stream := newMockStream("PUBLISH /doc.md\n---\nauth: " + testSecret + "\nretention: zero\n---\n# Hello\n")
-		h.HandleStream(stream)
+				stream := newMockStream("PUBLISH /doc.md\n---\nauth: " + testSecret + "\nretention: " + value + "\n---\n# Hello\n")
+				h.HandleStream(stream)
 
-		resp, err := protocol.ParseResponse(&stream.output)
-		if err != nil {
-			t.Fatalf("parse response: %v", err)
-		}
-		if resp.Status != protocol.StatusBadRequest {
-			t.Errorf("status: got %q, want %q", resp.Status, protocol.StatusBadRequest)
+				resp, err := protocol.ParseResponse(&stream.output)
+				if err != nil {
+					t.Fatalf("parse response: %v", err)
+				}
+				if resp.Status != protocol.StatusBadRequest {
+					t.Errorf("status: got %q, want %q", resp.Status, protocol.StatusBadRequest)
+				}
+			})
 		}
 	})
 
@@ -2515,6 +2519,103 @@ func TestHandlePublish_Retention(t *testing.T) {
 		}
 		if len(versions) != 4 {
 			t.Errorf("remaining versions = %d, want 4", len(versions))
+		}
+		if strings.Contains(logBuf.String(), "msg=prune") {
+			t.Errorf("unexpected prune audit entry:\n%s", logBuf.String())
+		}
+	})
+}
+
+func TestHandleAppend_Retention(t *testing.T) {
+	const testSecret = "test-append-retention-secret"
+	// APPEND authorizes under the "publish" operation (see handleAppend).
+	tokenStore := auth.NewTokenStore(map[string]auth.Token{
+		protocol.HashToken(testSecret): {
+			Paths:      []string{"/*"},
+			Operations: []string{"publish"},
+		},
+	})
+
+	seedDoc := func(t *testing.T, dir string, n int) *store.Store {
+		t.Helper()
+		s := store.New(dir)
+		for i := range n {
+			if _, err := s.Write("/doc.md", []byte("# Version "+strconv.Itoa(i+1)), nil); err != nil {
+				t.Fatalf("write %d: %v", i+1, err)
+			}
+		}
+		return s
+	}
+
+	t.Run("prunes and audit-logs", func(t *testing.T) {
+		dir := t.TempDir()
+		s := seedDoc(t, dir, 5)
+		var logBuf bytes.Buffer
+		h := &Handler{ContentDir: dir, Store: s, Logger: slog.New(slog.NewTextHandler(&logBuf, nil)), GetTokenStore: func() *auth.TokenStore { return tokenStore }}
+
+		stream := newMockStream("APPEND /doc.md\n---\nauth: " + testSecret + "\nexpected-version: 5\nretention: 2\n---\nappended line\n")
+		h.HandleStream(stream)
+
+		resp, err := protocol.ParseResponse(&stream.output)
+		if err != nil {
+			t.Fatalf("parse response: %v", err)
+		}
+		if resp.Status != protocol.StatusCreated {
+			t.Fatalf("status: got %q, want %q", resp.Status, protocol.StatusCreated)
+		}
+		versions, err := s.Versions("/doc.md")
+		if err != nil {
+			t.Fatalf("Versions: %v", err)
+		}
+		if len(versions) != 2 {
+			t.Errorf("remaining versions = %d, want 2", len(versions))
+		}
+		log := logBuf.String()
+		for _, want := range []string{"msg=prune", "operation=APPEND", "pruned_from=1", "pruned_to=4", "path=/doc.md", "success=true"} {
+			if !strings.Contains(log, want) {
+				t.Errorf("audit log missing %q:\n%s", want, log)
+			}
+		}
+	})
+
+	t.Run("invalid retention rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		s := seedDoc(t, dir, 1)
+		h := &Handler{ContentDir: dir, Store: s, Logger: discardLogger, GetTokenStore: func() *auth.TokenStore { return tokenStore }}
+
+		stream := newMockStream("APPEND /doc.md\n---\nauth: " + testSecret + "\nexpected-version: 1\nretention: 0\n---\nappended line\n")
+		h.HandleStream(stream)
+
+		resp, err := protocol.ParseResponse(&stream.output)
+		if err != nil {
+			t.Fatalf("parse response: %v", err)
+		}
+		if resp.Status != protocol.StatusBadRequest {
+			t.Errorf("status: got %q, want %q", resp.Status, protocol.StatusBadRequest)
+		}
+		if versions, err := s.Versions("/doc.md"); err != nil || len(versions) != 1 {
+			t.Errorf("versions = %d (err %v), want 1 untouched", len(versions), err)
+		}
+	})
+
+	t.Run("no prune without retention", func(t *testing.T) {
+		dir := t.TempDir()
+		s := seedDoc(t, dir, 3)
+		var logBuf bytes.Buffer
+		h := &Handler{ContentDir: dir, Store: s, Logger: slog.New(slog.NewTextHandler(&logBuf, nil)), GetTokenStore: func() *auth.TokenStore { return tokenStore }}
+
+		stream := newMockStream("APPEND /doc.md\n---\nauth: " + testSecret + "\nexpected-version: 3\n---\nappended line\n")
+		h.HandleStream(stream)
+
+		resp, err := protocol.ParseResponse(&stream.output)
+		if err != nil {
+			t.Fatalf("parse response: %v", err)
+		}
+		if resp.Status != protocol.StatusCreated {
+			t.Fatalf("status: got %q, want %q", resp.Status, protocol.StatusCreated)
+		}
+		if versions, err := s.Versions("/doc.md"); err != nil || len(versions) != 4 {
+			t.Errorf("versions = %d (err %v), want all 4", len(versions), err)
 		}
 		if strings.Contains(logBuf.String(), "msg=prune") {
 			t.Errorf("unexpected prune audit entry:\n%s", logBuf.String())

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -2426,3 +2426,98 @@ func TestReadOnlyMode(t *testing.T) {
 		}
 	})
 }
+
+func TestHandlePublish_Retention(t *testing.T) {
+	const testSecret = "test-retention-secret"
+	tokenStore := auth.NewTokenStore(map[string]auth.Token{
+		protocol.HashToken(testSecret): {
+			Paths:      []string{"/*"},
+			Operations: []string{"publish"},
+		},
+	})
+
+	t.Run("prunes and audit-logs", func(t *testing.T) {
+		dir := t.TempDir()
+		s := store.New(dir)
+		for i := range 5 {
+			if _, err := s.Write("/doc.md", []byte("# Version "+strconv.Itoa(i+1)), nil); err != nil {
+				t.Fatalf("write %d: %v", i+1, err)
+			}
+		}
+		var logBuf bytes.Buffer
+		h := &Handler{ContentDir: dir, Store: s, Logger: slog.New(slog.NewTextHandler(&logBuf, nil)), GetTokenStore: func() *auth.TokenStore { return tokenStore }}
+
+		stream := newMockStream("PUBLISH /doc.md\n---\nauth: " + testSecret + "\nretention: 2\n---\n# Version 6\n")
+		h.HandleStream(stream)
+
+		resp, err := protocol.ParseResponse(&stream.output)
+		if err != nil {
+			t.Fatalf("parse response: %v", err)
+		}
+		if resp.Status != protocol.StatusCreated {
+			t.Fatalf("status: got %q, want %q", resp.Status, protocol.StatusCreated)
+		}
+		versions, err := s.Versions("/doc.md")
+		if err != nil {
+			t.Fatalf("Versions: %v", err)
+		}
+		if len(versions) != 2 {
+			t.Errorf("remaining versions = %d, want 2", len(versions))
+		}
+		log := logBuf.String()
+		for _, want := range []string{"msg=prune", "operation=PUBLISH", "pruned_from=1", "pruned_to=4", "path=/doc.md", "success=true"} {
+			if !strings.Contains(log, want) {
+				t.Errorf("audit log missing %q:\n%s", want, log)
+			}
+		}
+	})
+
+	t.Run("invalid retention rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		h := &Handler{ContentDir: dir, Store: store.New(dir), Logger: discardLogger, GetTokenStore: func() *auth.TokenStore { return tokenStore }}
+
+		stream := newMockStream("PUBLISH /doc.md\n---\nauth: " + testSecret + "\nretention: zero\n---\n# Hello\n")
+		h.HandleStream(stream)
+
+		resp, err := protocol.ParseResponse(&stream.output)
+		if err != nil {
+			t.Fatalf("parse response: %v", err)
+		}
+		if resp.Status != protocol.StatusBadRequest {
+			t.Errorf("status: got %q, want %q", resp.Status, protocol.StatusBadRequest)
+		}
+	})
+
+	t.Run("no prune without retention", func(t *testing.T) {
+		dir := t.TempDir()
+		s := store.New(dir)
+		for i := range 3 {
+			if _, err := s.Write("/doc.md", []byte("# Version "+strconv.Itoa(i+1)), nil); err != nil {
+				t.Fatalf("write %d: %v", i+1, err)
+			}
+		}
+		var logBuf bytes.Buffer
+		h := &Handler{ContentDir: dir, Store: s, Logger: slog.New(slog.NewTextHandler(&logBuf, nil)), GetTokenStore: func() *auth.TokenStore { return tokenStore }}
+
+		stream := newMockStream("PUBLISH /doc.md\n---\nauth: " + testSecret + "\n---\n# Version 4\n")
+		h.HandleStream(stream)
+
+		resp, err := protocol.ParseResponse(&stream.output)
+		if err != nil {
+			t.Fatalf("parse response: %v", err)
+		}
+		if resp.Status != protocol.StatusCreated {
+			t.Fatalf("status: got %q, want %q", resp.Status, protocol.StatusCreated)
+		}
+		versions, err := s.Versions("/doc.md")
+		if err != nil {
+			t.Fatalf("Versions: %v", err)
+		}
+		if len(versions) != 4 {
+			t.Errorf("remaining versions = %d, want 4", len(versions))
+		}
+		if strings.Contains(logBuf.String(), "msg=prune") {
+			t.Errorf("unexpected prune audit entry:\n%s", logBuf.String())
+		}
+	})
+}

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -205,6 +206,12 @@ func (g *mcpGateway) handleMarkGraphExport(_ context.Context, _ mcp.CallToolRequ
 	return mcp.NewToolResultText(g.graphStore.Export()), nil
 }
 
+// defaultGraphRetention bounds the published graph document's version
+// history — mirrors the local demarkus-mcp default. The graph is a generated
+// artifact republished wholesale on every run, so unbounded history is pure
+// growth; 20 versions is enough to debug a bad crawl.
+const defaultGraphRetention = 20
+
 // handleMarkGraphPublish exports the broker's ephemeral graph
 // store and PUBLISHes it to a target world. Same expected_version
 // + on_conflict semantics as mark_publish (Slice 3); on_conflict
@@ -228,12 +235,19 @@ func (g *mcpGateway) handleMarkGraphPublish(ctx context.Context, req mcp.CallToo
 	if expectedVersion < 0 {
 		return mcp.NewToolResultError("expected_version must be >= 0"), nil
 	}
+	retention := req.GetInt("retention", defaultGraphRetention)
+	if retention < 0 {
+		return mcp.NewToolResultError("retention must be >= 0 (0 keeps every version)"), nil
+	}
 	claims, ok := claimsFromCtx(ctx)
 	if !ok {
 		return mcp.NewToolResultError("internal: missing identity on tool-call context"), nil
 	}
 	body := g.graphStore.Export()
 	meta := agentMetaFromClaims(claims)
+	if retention > 0 {
+		meta["retention"] = strconv.Itoa(retention)
+	}
 	result, err := g.dispatchWithAuth(ctx, claims, worldName, func(token string) (fetch.Result, error) {
 		return g.dispatcher.Publish(worldName, urlPath, body, token, expectedVersion, meta)
 	})

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph_test.go
@@ -851,5 +851,8 @@ func TestHandleMarkGraphPublishRetention(t *testing.T) {
 		if !res.IsError {
 			t.Error("isError = false on negative retention, want true")
 		}
+		if text := toolResultText(t, res); !strings.Contains(text, "retention must be >= 0") {
+			t.Errorf("error text = %q, want it to mention 'retention must be >= 0'", text)
+		}
 	})
 }

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph_test.go
@@ -784,3 +784,72 @@ func TestBrokerCrawlParseURLRejectsNonMark(t *testing.T) {
 // silenceGraphTestNoise keeps go vet happy when the test
 // imports the graph package without obviously using it.
 var _ = graph.New
+
+func TestHandleMarkGraphPublishRetention(t *testing.T) {
+	newGateway := func(t *testing.T, capture *map[string]string) *mcpGateway {
+		t.Helper()
+		return newGatewayWithDispatcher(t, mcpTestConfig(), &fakeDispatcher{
+			publishFn: func(_, _, _, _ string, _ int, meta map[string]string) (fetch.Result, error) {
+				*capture = meta
+				return fetch.Result{Response: protocol.Response{
+					Status:   protocol.StatusOK,
+					Metadata: map[string]string{"version": "1", "modified": "2026-05-22T10:00:00Z"},
+				}}, nil
+			},
+		})
+	}
+
+	tests := []struct {
+		name          string
+		args          map[string]any
+		wantRetention string
+	}{
+		{
+			name:          "defaults to 20",
+			args:          map[string]any{"url": "mark://team-a/graph.md", "expected_version": float64(0)},
+			wantRetention: "20",
+		},
+		{
+			name:          "explicit override",
+			args:          map[string]any{"url": "mark://team-a/graph.md", "expected_version": float64(0), "retention": float64(5)},
+			wantRetention: "5",
+		},
+		{
+			name:          "zero disables retention",
+			args:          map[string]any{"url": "mark://team-a/graph.md", "expected_version": float64(0), "retention": float64(0)},
+			wantRetention: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var meta map[string]string
+			g := newGateway(t, &meta)
+			res, err := g.handleMarkGraphPublish(withAliceClaims(context.Background()), callToolReq("mark_graph_publish", tt.args))
+			if err != nil {
+				t.Fatalf("handleMarkGraphPublish: %v", err)
+			}
+			if res.IsError {
+				t.Fatalf("isError = true: %s", toolResultText(t, res))
+			}
+			if got := meta["retention"]; got != tt.wantRetention {
+				t.Errorf("retention meta = %q, want %q", got, tt.wantRetention)
+			}
+		})
+	}
+
+	t.Run("negative rejected", func(t *testing.T) {
+		var meta map[string]string
+		g := newGateway(t, &meta)
+		res, err := g.handleMarkGraphPublish(withAliceClaims(context.Background()), callToolReq("mark_graph_publish", map[string]any{
+			"url":              "mark://team-a/graph.md",
+			"expected_version": float64(0),
+			"retention":        float64(-1),
+		}))
+		if err != nil {
+			t.Fatalf("handleMarkGraphPublish: %v", err)
+		}
+		if !res.IsError {
+			t.Error("isError = false on negative retention, want true")
+		}
+	})
+}

--- a/tools/demarkus-broker/internal/broker/mcp_tools_list.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_list.go
@@ -216,7 +216,7 @@ func markPublishTool() mcp.Tool {
 			mcp.Description("conflict behavior: \"merge\" (default) returns a merge-candidate body; the agent reviews it (resolving any conflict markers) and calls mark_publish again with expected_version set to the returned publish-at-version. \"fail\" opts out and returns the raw conflict status."),
 		),
 		mcp.WithObject("metadata",
-			mcp.Description("optional publisher metadata stored with the document, as string values. The server interprets `tags` (comma-separated subject labels) and `importance` (0-1) for mark_lookup ranking; other keys are stored opaquely. Reserved keys are rejected."),
+			mcp.Description("optional publisher metadata stored with the document, as string values. The server interprets `tags` (comma-separated subject labels) and `importance` (0-1) for mark_lookup ranking; other keys are stored opaquely. Reserved keys are rejected. `retention` (positive integer) caps version history: this write and every later write carrying the key permanently delete versions older than the newest N. Destructive and irreversible — confirm with the user before setting it on a document whose history matters; intended for generated documents."),
 		),
 	)
 }
@@ -408,6 +408,9 @@ func markGraphPublishTool() mcp.Tool {
 		mcp.WithNumber("expected_version",
 			mcp.Required(),
 			mcp.Description("version number from a prior fetch for conflict detection; use 0 when creating a new document"),
+		),
+		mcp.WithNumber("retention",
+			mcp.Description("how many versions of the graph document to keep (default 20). The graph is regenerated on every publish, so older versions are permanently pruned. Pass 0 to keep every version."),
 		),
 	)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added publisher-controlled version retention for document publishing, pruning older versions beyond a configurable newest-N cap (`0` keeps all versions).
  * Added configurable retention for graph publishing (defaults to 20; `0` keeps all graph versions).
* **Bug Fixes**
  * Improved pruning and migration behavior to avoid inconsistent version histories after pruning.
  * Added prune-result audit logging for all publish/append outcomes, including partial/error cases.
* **Documentation**
  * Updated the Mark Protocol spec to define retention, pruning, and retention-aware verification/read/list behavior.
* **Tests**
  * Expanded coverage for retention validation, pruning outcomes, interactive confirmation, and graph publish/append handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->