### PR TITLE
feat(tools): plugin rentention gate

### DIFF
--- a/tools/demarkus-plugin/internal/config/config.go
+++ b/tools/demarkus-plugin/internal/config/config.go
@@ -137,6 +137,26 @@ func MemoryDestStrictness() (Strictness, error) {
 	return validStrictness(s, Block), nil
 }
 
+// RetentionStrictness is the enforcement level for the retention guard (a
+// publish/append whose metadata carries a prunable retention value permanently
+// deletes older versions). env override → plugin.retention-strictness → ask:
+// destructive-by-metadata warrants a human decision by default, on every
+// surface the gate covers (soul and knowledge alike).
+func RetentionStrictness() (Strictness, error) {
+	if v := os.Getenv("DEMARKUS_RETENTION_STRICTNESS"); v != "" {
+		return validStrictness(v, Ask), nil
+	}
+	p, err := path("plugin.retention-strictness")
+	if err != nil {
+		return Ask, err
+	}
+	s, err := readTrimmed(p)
+	if err != nil {
+		return Ask, err
+	}
+	return validStrictness(s, Ask), nil
+}
+
 // KnowledgeStrictness env override → plugin-knowledge.strictness.<slug> → warn.
 func KnowledgeStrictness(slug string) (Strictness, error) {
 	if v := os.Getenv("DEMARKUS_KNOWLEDGE_STRICTNESS"); v != "" {

--- a/tools/demarkus-plugin/internal/gate/gate.go
+++ b/tools/demarkus-plugin/internal/gate/gate.go
@@ -117,6 +117,17 @@ func prunableRetention(md map[string]any) (string, bool) {
 		if x == math.Trunc(x) && x >= 1 && x <= math.MaxInt32 {
 			return strconv.Itoa(int(x)), true
 		}
+	case int:
+		// Programmatic callers (not JSON decode) can hand the gate a native
+		// int; it reaches the server as its decimal string and prunes, so a
+		// missing case here would be a silent-allow hole, not a safe default.
+		if x >= 1 {
+			return strconv.Itoa(x), true
+		}
+	case int64:
+		if x >= 1 {
+			return strconv.FormatInt(x, 10), true
+		}
 	}
 	return "", false
 }

--- a/tools/demarkus-plugin/internal/gate/gate.go
+++ b/tools/demarkus-plugin/internal/gate/gate.go
@@ -8,9 +8,11 @@ package gate
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
+	"github.com/latebit-io/demarkus/protocol/store"
 	"github.com/latebit-io/demarkus/tools/demarkus-plugin/internal/config"
 )
 
@@ -85,6 +87,67 @@ func fieldPresent(md map[string]any, key string) bool {
 	default:
 		return true // numbers, bools, etc. count as present
 	}
+}
+
+// prunableRetention returns the normalized retention value when metadata
+// carries one the server will accept — a positive integer, the only form that
+// deletes versions (store.ParseRetention is the same predicate the server
+// enforces). Server-rejectable values (0, negative, fractional, non-numeric)
+// don't prompt: that write fails with bad-request and deletes nothing. JSON
+// numbers are accepted alongside strings because the gate sees the raw tool
+// input, before the MCP layer coerces metadata values to strings.
+func prunableRetention(md map[string]any) (string, bool) {
+	if md == nil {
+		return "", false
+	}
+	v, ok := md["retention"]
+	if !ok || v == nil {
+		return "", false
+	}
+	switch x := v.(type) {
+	case string:
+		if n, ok := store.ParseRetention(strings.TrimSpace(x)); ok {
+			return strconv.Itoa(n), true
+		}
+	case json.Number:
+		if n, ok := store.ParseRetention(x.String()); ok {
+			return strconv.Itoa(n), true
+		}
+	case float64:
+		if x == math.Trunc(x) && x >= 1 && x <= math.MaxInt32 {
+			return strconv.Itoa(int(x)), true
+		}
+	}
+	return "", false
+}
+
+// retentionDecision is the retention guard, independent of the tag and
+// destination gates: a publish or append whose metadata carries a prunable
+// retention value permanently deletes older versions, so the agent must
+// confirm with the user before the write goes through. mark_graph_publish is
+// exempt by construction — its verb parses as "graph_publish", and it sets
+// retention by design on a generated document.
+func retentionDecision(pt config.ParsedTool, args map[string]any) (*Decision, error) {
+	if pt.Verb != "publish" && pt.Verb != "append" {
+		return nil, nil
+	}
+	r, prunes := prunableRetention(metadataOf(args))
+	if !prunes {
+		return nil, nil
+	}
+	target := urlOr(args, "this document")
+	reason := fmt.Sprintf(
+		"demarkus write to %s sets metadata.retention=%s: the server will permanently delete all but the "+
+			"newest %s versions of this document — on this write and every later write carrying the key. "+
+			"This is intended for generated documents (graph exports, indexes). Confirm with the user before "+
+			"proceeding; if history matters, re-issue the write without the retention key. To relax this "+
+			"check, set DEMARKUS_RETENTION_STRICTNESS=warn.",
+		target, r, r)
+	s, err := config.RetentionStrictness()
+	if err != nil {
+		return nil, err
+	}
+	return &Decision{Decision: string(s), Reason: reason}, nil
 }
 
 // importanceOK: absent is fine; otherwise a number or non-blank numeric string in
@@ -186,6 +249,15 @@ func evalMemory(_ string, pt config.ParsedTool, args map[string]any, cwd, soulID
 		}
 	}
 
+	// Retention guard (publish + append): destructive version pruning.
+	rd, err := retentionDecision(pt, args)
+	if err != nil {
+		return Decision{}, err
+	}
+	if rd != nil {
+		decisions = append(decisions, *rd)
+	}
+
 	// Publish tag-gate (publish only): missing tags or out-of-range importance.
 	if pt.Verb == "publish" {
 		md := metadataOf(args)
@@ -240,8 +312,18 @@ func combine(ds []Decision) Decision {
 }
 
 func evalKnowledge(pt config.ParsedTool, args map[string]any, slug string) (Decision, error) {
+	// Retention guard applies to publish and append; the tag/axis gate below is
+	// publish-only. Both are independent — combine to the most severe outcome.
+	var decisions []Decision
+	rd, err := retentionDecision(pt, args)
+	if err != nil {
+		return Decision{}, err
+	}
+	if rd != nil {
+		decisions = append(decisions, *rd)
+	}
 	if pt.Verb != "publish" {
-		return allow(), nil
+		return combine(decisions), nil
 	}
 	md := metadataOf(args)
 	tags := strings.TrimSpace(tagsString(md))
@@ -286,7 +368,7 @@ func evalKnowledge(pt config.ParsedTool, args map[string]any, slug string) (Deci
 	}
 
 	if tagsOK && impOK && len(missingAxes) == 0 && len(missingFields) == 0 {
-		return allow(), nil
+		return combine(decisions), nil
 	}
 
 	var problems []string
@@ -319,7 +401,8 @@ func evalKnowledge(pt config.ParsedTool, args map[string]any, slug string) (Deci
 	if err != nil {
 		return Decision{}, err
 	}
-	return Decision{Decision: string(s), Reason: reason}, nil
+	decisions = append(decisions, Decision{Decision: string(s), Reason: reason})
+	return combine(decisions), nil
 }
 
 func urlOr(args map[string]any, fallback string) string {

--- a/tools/demarkus-plugin/internal/gate/gate_test.go
+++ b/tools/demarkus-plugin/internal/gate/gate_test.go
@@ -241,3 +241,134 @@ func TestUnrelatedServerAllowed(t *testing.T) {
 		t.Fatalf("unrelated server: want allow, got %q", d.Decision)
 	}
 }
+
+func TestRetentionGate(t *testing.T) {
+	setupHome(t, map[string]string{"plugin-memory.conf": "SOUL_DIR=/x\nPORT=6310\nMODE=default\n"})
+
+	withRetention := func(tool string, retention any) Input {
+		return Input{Tool: tool, Input: map[string]any{
+			"url": "/x.md", "metadata": map[string]any{"tags": "a,b", "retention": retention},
+		}}
+	}
+
+	t.Run("memory publish asks by default", func(t *testing.T) {
+		d := mustEval(t, withRetention("demarkus_memory_mark_publish", "20"))
+		if d.Decision != "ask" {
+			t.Fatalf("want ask, got %q (%s)", d.Decision, d.Reason)
+		}
+		if !strings.Contains(d.Reason, "retention=20") || !strings.Contains(d.Reason, "permanently delete") {
+			t.Fatalf("reason should explain the deletion: %s", d.Reason)
+		}
+	})
+
+	t.Run("memory append asks too", func(t *testing.T) {
+		if d := mustEval(t, withRetention("demarkus_memory_mark_append", "5")); d.Decision != "ask" {
+			t.Fatalf("want ask, got %q (%s)", d.Decision, d.Reason)
+		}
+	})
+
+	t.Run("json number retention asks", func(t *testing.T) {
+		if d := mustEval(t, withRetention("demarkus_memory_mark_publish", 20.0)); d.Decision != "ask" {
+			t.Fatalf("want ask, got %q (%s)", d.Decision, d.Reason)
+		}
+	})
+
+	t.Run("server-rejectable values pass through", func(t *testing.T) {
+		// None of these can prune — the server rejects them with bad-request,
+		// so a destructive prompt would be misleading.
+		for _, v := range []any{"0", "-1", "abc", "", 0.0, -3.0, 20.5, true, nil} {
+			if d := mustEval(t, withRetention("demarkus_memory_mark_publish", v)); d.Decision != "allow" {
+				t.Errorf("retention=%v: want allow, got %q (%s)", v, d.Decision, d.Reason)
+			}
+		}
+	})
+
+	t.Run("absent retention allows", func(t *testing.T) {
+		d := mustEval(t, Input{Tool: "demarkus_memory_mark_publish", Input: map[string]any{
+			"url": "/x.md", "metadata": map[string]any{"tags": "a,b"},
+		}})
+		if d.Decision != "allow" {
+			t.Fatalf("want allow, got %q (%s)", d.Decision, d.Reason)
+		}
+	})
+
+	t.Run("graph publish is exempt", func(t *testing.T) {
+		// mark_graph_publish sets retention by design on a generated document;
+		// its verb parses as "graph_publish" so neither write gate fires.
+		d := mustEval(t, withRetention("demarkus_memory_mark_graph_publish", "20"))
+		if d.Decision != "allow" {
+			t.Fatalf("want allow, got %q (%s)", d.Decision, d.Reason)
+		}
+	})
+
+	t.Run("strictness env override", func(t *testing.T) {
+		t.Setenv("DEMARKUS_RETENTION_STRICTNESS", "warn")
+		if d := mustEval(t, withRetention("demarkus_memory_mark_publish", "20")); d.Decision != "warn" {
+			t.Fatalf("want warn, got %q (%s)", d.Decision, d.Reason)
+		}
+	})
+
+	t.Run("block-level tag gate outranks retention ask", func(t *testing.T) {
+		t.Setenv("DEMARKUS_MEMORY_STRICTNESS", "block")
+		d := mustEval(t, Input{Tool: "demarkus_memory_mark_publish", Input: map[string]any{
+			"url": "/x.md", "metadata": map[string]any{"retention": "20"},
+		}})
+		if d.Decision != "block" {
+			t.Fatalf("want block, got %q (%s)", d.Decision, d.Reason)
+		}
+	})
+
+	t.Run("retention ask outranks warn-level tag gate", func(t *testing.T) {
+		t.Setenv("DEMARKUS_MEMORY_STRICTNESS", "warn")
+		d := mustEval(t, Input{Tool: "demarkus_memory_mark_publish", Input: map[string]any{
+			"url": "/x.md", "metadata": map[string]any{"retention": "20"},
+		}})
+		if d.Decision != "ask" {
+			t.Fatalf("want ask, got %q (%s)", d.Decision, d.Reason)
+		}
+		if !strings.Contains(d.Reason, "retention") {
+			t.Fatalf("expected retention reason at winning severity, got: %s", d.Reason)
+		}
+	})
+}
+
+func TestRetentionGateKnowledge(t *testing.T) {
+	setupHome(t, map[string]string{"knowledge-systems": "knowledge\n"})
+
+	t.Run("compliant publish with retention asks", func(t *testing.T) {
+		d := mustEval(t, Input{Tool: "knowledge_mark_publish", Input: map[string]any{
+			"url": "/k.md", "metadata": map[string]any{"tags": "a,b", "retention": "10"},
+		}})
+		if d.Decision != "ask" {
+			t.Fatalf("want ask, got %q (%s)", d.Decision, d.Reason)
+		}
+	})
+
+	t.Run("append with retention asks", func(t *testing.T) {
+		d := mustEval(t, Input{Tool: "knowledge_mark_append", Input: map[string]any{
+			"url": "/k.md", "metadata": map[string]any{"retention": "10"},
+		}})
+		if d.Decision != "ask" {
+			t.Fatalf("want ask, got %q (%s)", d.Decision, d.Reason)
+		}
+	})
+
+	t.Run("append without retention allows", func(t *testing.T) {
+		d := mustEval(t, Input{Tool: "knowledge_mark_append", Input: map[string]any{
+			"url": "/k.md", "body": "more",
+		}})
+		if d.Decision != "allow" {
+			t.Fatalf("want allow, got %q (%s)", d.Decision, d.Reason)
+		}
+	})
+}
+
+func TestPrunableRetentionJSONNumber(t *testing.T) {
+	// Adapters that decode with json.Number must be recognized too.
+	if v, ok := prunableRetention(map[string]any{"retention": json.Number("15")}); !ok || v != "15" {
+		t.Errorf("json.Number 15: got (%q, %v), want (15, true)", v, ok)
+	}
+	if _, ok := prunableRetention(map[string]any{"retention": json.Number("0")}); ok {
+		t.Error("json.Number 0 should not be prunable")
+	}
+}

--- a/tools/demarkus-plugin/internal/gate/gate_test.go
+++ b/tools/demarkus-plugin/internal/gate/gate_test.go
@@ -267,16 +267,35 @@ func TestRetentionGate(t *testing.T) {
 		}
 	})
 
-	t.Run("json number retention asks", func(t *testing.T) {
+	t.Run("float64 retention asks", func(t *testing.T) {
+		// The default JSON decode yields float64 for numbers.
 		if d := mustEval(t, withRetention("demarkus_memory_mark_publish", 20.0)); d.Decision != "ask" {
 			t.Fatalf("want ask, got %q (%s)", d.Decision, d.Reason)
+		}
+	})
+
+	t.Run("json.Number retention asks", func(t *testing.T) {
+		// Adapters decoding with UseNumber hand the gate a json.Number.
+		if d := mustEval(t, withRetention("demarkus_memory_mark_publish", json.Number("20"))); d.Decision != "ask" {
+			t.Fatalf("want ask, got %q (%s)", d.Decision, d.Reason)
+		}
+	})
+
+	t.Run("native int retention asks", func(t *testing.T) {
+		// Programmatic callers can build the metadata map with a Go int; it
+		// reaches the server as "20" and prunes, so the gate must catch it.
+		if d := mustEval(t, withRetention("demarkus_memory_mark_publish", 20)); d.Decision != "ask" {
+			t.Fatalf("want ask, got %q (%s)", d.Decision, d.Reason)
+		}
+		if d := mustEval(t, withRetention("demarkus_memory_mark_publish", int64(20))); d.Decision != "ask" {
+			t.Fatalf("int64: want ask, got %q (%s)", d.Decision, d.Reason)
 		}
 	})
 
 	t.Run("server-rejectable values pass through", func(t *testing.T) {
 		// None of these can prune — the server rejects them with bad-request,
 		// so a destructive prompt would be misleading.
-		for _, v := range []any{"0", "-1", "abc", "", 0.0, -3.0, 20.5, true, nil} {
+		for _, v := range []any{"0", "-1", "abc", "", 0.0, -3.0, 20.5, true, nil, 0, -2, int64(0)} {
 			if d := mustEval(t, withRetention("demarkus_memory_mark_publish", v)); d.Decision != "allow" {
 				t.Errorf("retention=%v: want allow, got %q (%s)", v, d.Decision, d.Reason)
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a retention guard for publish/append operations, producing ask/warn/block/allow outcomes with clear reasons when `metadata.retention` is present.
  * Retention strictness is configurable via environment override, with a safe default when unset/invalid.
* **Bug Fixes**
  * Improved parsing of prunable retention values across input types (including integer/whole-number floats and `json.Number`), and reject invalid/fractional/zero/negative values.
  * Combined retention decisions with existing write/knowledge gating so the strictest result wins.
* **Tests**
  * Added coverage for retention gating behavior across memory and knowledge verbs and value types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->