### PR TITLE
feat(client): retention on published artifacts

### DIFF
--- a/client/cmd/demarkus-agent/main.go
+++ b/client/cmd/demarkus-agent/main.go
@@ -80,6 +80,7 @@ func crawlMain(args []string) {
 	publish := fs.Bool("publish", false, "publish indexes to hubs after crawl")
 	perServer := fs.Bool("per-server", false, "publish per-server indexes instead of aggregated")
 	publishGraph := fs.Bool("publish-graph", false, "publish a link-graph export (/graph.md) to hubs after crawl")
+	publishRetention := fs.Int("publish-retention", -1, "cap published artifacts (/graph.md, hash indexes) to their newest N versions — the server prunes older ones on write; 0 keeps every version; -1 uses the config value (default 20)")
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: demarkus-agent crawl [options]\n\n")
 		fmt.Fprintf(os.Stderr, "Runs a single federation crawl.\n\n")
@@ -102,6 +103,11 @@ func crawlMain(args []string) {
 	cfg, err := fedcrawl.Load(*configPath, seedList)
 	if err != nil {
 		fatal("load config", "err", err)
+	}
+
+	// CLI retention overrides config when set (-1 keeps the config value).
+	if *publishRetention >= 0 {
+		cfg.Publish.Retention = *publishRetention
 	}
 
 	// Validate.
@@ -191,6 +197,7 @@ func daemonMain(args []string) {
 	publish := fs.Bool("publish", false, "publish indexes to hubs after each crawl")
 	perServer := fs.Bool("per-server", false, "publish per-server indexes instead of aggregated")
 	publishGraph := fs.Bool("publish-graph", false, "publish a link-graph export (/graph.md) to hubs after each crawl")
+	publishRetention := fs.Int("publish-retention", -1, "cap published artifacts (/graph.md, hash indexes) to their newest N versions — the server prunes older ones on write; 0 keeps every version; -1 uses the config value (default 20)")
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: demarkus-agent daemon [options]\n\n")
 		fmt.Fprintf(os.Stderr, "Runs federation crawl as a daemon on a schedule.\n\n")
@@ -218,6 +225,11 @@ func daemonMain(args []string) {
 	cfg, err := fedcrawl.Load(*configPath, seedList)
 	if err != nil {
 		fatal("load config", "err", err)
+	}
+
+	// CLI retention overrides config when set (-1 keeps the config value).
+	if *publishRetention >= 0 {
+		cfg.Publish.Retention = *publishRetention
 	}
 
 	// Validate.

--- a/client/cmd/demarkus-agent/main.go
+++ b/client/cmd/demarkus-agent/main.go
@@ -80,7 +80,7 @@ func crawlMain(args []string) {
 	publish := fs.Bool("publish", false, "publish indexes to hubs after crawl")
 	perServer := fs.Bool("per-server", false, "publish per-server indexes instead of aggregated")
 	publishGraph := fs.Bool("publish-graph", false, "publish a link-graph export (/graph.md) to hubs after crawl")
-	publishRetention := fs.Int("publish-retention", -1, "cap published artifacts (/graph.md, hash indexes) to their newest N versions — the server prunes older ones on write; 0 keeps every version; -1 uses the config value (default 20)")
+	publishRetention := fs.Int("publish-retention", -1, "cap published artifacts (/graph.md, hash indexes) to their newest N versions; the server prunes older ones on write; 0 keeps every version; -1 uses the config value (default 20)")
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: demarkus-agent crawl [options]\n\n")
 		fmt.Fprintf(os.Stderr, "Runs a single federation crawl.\n\n")
@@ -197,7 +197,7 @@ func daemonMain(args []string) {
 	publish := fs.Bool("publish", false, "publish indexes to hubs after each crawl")
 	perServer := fs.Bool("per-server", false, "publish per-server indexes instead of aggregated")
 	publishGraph := fs.Bool("publish-graph", false, "publish a link-graph export (/graph.md) to hubs after each crawl")
-	publishRetention := fs.Int("publish-retention", -1, "cap published artifacts (/graph.md, hash indexes) to their newest N versions — the server prunes older ones on write; 0 keeps every version; -1 uses the config value (default 20)")
+	publishRetention := fs.Int("publish-retention", -1, "cap published artifacts (/graph.md, hash indexes) to their newest N versions; the server prunes older ones on write; 0 keeps every version; -1 uses the config value (default 20)")
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: demarkus-agent daemon [options]\n\n")
 		fmt.Fprintf(os.Stderr, "Runs federation crawl as a daemon on a schedule.\n\n")

--- a/client/cmd/demarkus-agent/main.go
+++ b/client/cmd/demarkus-agent/main.go
@@ -106,6 +106,11 @@ func crawlMain(args []string) {
 	}
 
 	// CLI retention overrides config when set (-1 keeps the config value).
+	// Anything else negative is a mistake; fail loudly instead of silently
+	// falling back to the config value.
+	if *publishRetention < -1 {
+		fatal("invalid -publish-retention (want -1, 0, or a positive count)", "value", *publishRetention)
+	}
 	if *publishRetention >= 0 {
 		cfg.Publish.Retention = *publishRetention
 	}
@@ -228,6 +233,11 @@ func daemonMain(args []string) {
 	}
 
 	// CLI retention overrides config when set (-1 keeps the config value).
+	// Anything else negative is a mistake; fail loudly instead of silently
+	// falling back to the config value.
+	if *publishRetention < -1 {
+		fatal("invalid -publish-retention (want -1, 0, or a positive count)", "value", *publishRetention)
+	}
 	if *publishRetention >= 0 {
 		cfg.Publish.Retention = *publishRetention
 	}

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -331,7 +331,7 @@ func markPublishTool(host string) mcp.Tool {
 			mcp.Description("conflict behavior: \"merge\" (default) returns a merge-candidate body; the agent reviews it (resolving any conflict markers) and calls mark_publish again with expected_version set to the returned publish-at-version. \"fail\" opts out and returns the raw conflict status."),
 		),
 		mcp.WithObject("metadata",
-			mcp.Description("optional publisher metadata stored with the document, as string values. The server interprets `tags` (comma-separated subject labels) and `importance` (0-1) for mark_lookup ranking; other keys are stored opaquely. Reserved keys are rejected. `retention` (positive integer) caps version history: this write and every later write carrying the key permanently delete versions older than the newest N. Destructive and irreversible — confirm with the user before setting it on a document whose history matters; intended for generated documents."),
+			mcp.Description("optional publisher metadata stored with the document, as string values. The server interprets `tags` (comma-separated subject labels) and `importance` (0-1) for mark_lookup ranking; other keys are stored opaquely. Reserved keys are rejected. `retention` (positive integer) caps version history: this write and every later write carrying the key permanently delete versions older than the newest N. Destructive and irreversible: confirm with the user before setting it on a document whose history matters; intended for generated documents."),
 		),
 	)
 }

--- a/client/internal/fedcrawl/config.go
+++ b/client/internal/fedcrawl/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Crawl      CrawlConfig      `toml:"crawl"`
 	Schedule   ScheduleConfig   `toml:"schedule"`
 	Politeness PolitenessConfig `toml:"politeness"`
+	Publish    PublishConfig    `toml:"publish"`
 }
 
 // CrawlConfig controls the scope and depth of crawling.
@@ -40,6 +41,17 @@ type PolitenessConfig struct {
 	PerServerConcurrency int           `toml:"per_server_concurrency"` // Max concurrent requests per server (default: 2)
 }
 
+// PublishConfig controls hub publications (hash indexes and /graph.md).
+type PublishConfig struct {
+	// Retention caps each published artifact's version history to its newest
+	// N versions — the server prunes older versions on write (retention
+	// publish metadata, SPEC §9.9). Everything the agent publishes is
+	// regenerated wholesale on every run, so old versions are pure growth
+	// (one live graph document reached 545 versions before this existed).
+	// 0 keeps every version. (default: 20)
+	Retention int `toml:"retention"`
+}
+
 // DefaultConfig returns a Config with sensible defaults.
 func DefaultConfig() Config {
 	return Config{
@@ -55,6 +67,9 @@ func DefaultConfig() Config {
 		Politeness: PolitenessConfig{
 			RequestDelay:         100 * time.Millisecond,
 			PerServerConcurrency: 2,
+		},
+		Publish: PublishConfig{
+			Retention: 20,
 		},
 	}
 }
@@ -130,6 +145,9 @@ func (c *Config) Validate() error {
 	}
 	if c.Politeness.PerServerConcurrency < 1 {
 		return fmt.Errorf("politeness.per_server_concurrency must be at least 1")
+	}
+	if c.Publish.Retention < 0 {
+		return fmt.Errorf("publish.retention must be non-negative (0 keeps every version)")
 	}
 	return nil
 }

--- a/client/internal/fedcrawl/crawl.go
+++ b/client/internal/fedcrawl/crawl.go
@@ -7,6 +7,7 @@ import (
 	"net"
 
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -585,9 +586,14 @@ func (c *Crawler) publishIndex(ctx context.Context, client PublishClient, host, 
 		return ctx.Err()
 	}
 
-	result, err := client.Publish(host, path, body, token, -1, map[string]string{
-		"agent": "demarkus-agent",
-	})
+	meta := map[string]string{"agent": "demarkus-agent"}
+	// Everything published here (hash indexes, /graph.md) is a generated
+	// artifact regenerated wholesale each run — retention keeps its version
+	// history bounded (the server prunes older versions on write, SPEC §9.9).
+	if c.cfg.Publish.Retention > 0 {
+		meta["retention"] = strconv.Itoa(c.cfg.Publish.Retention)
+	}
+	result, err := client.Publish(host, path, body, token, -1, meta)
 	if err != nil {
 		return err
 	}

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -36,6 +36,7 @@ type publishCall struct {
 	Body            string
 	Token           string
 	ExpectedVersion int
+	Meta            map[string]string
 }
 
 func newMockClient() *mockClient {
@@ -46,7 +47,7 @@ func newMockClient() *mockClient {
 	}
 }
 
-func (m *mockClient) Publish(host, path, body, token string, expectedVersion int, _ map[string]string) (fetch.Result, error) {
+func (m *mockClient) Publish(host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.calls = append(m.calls, "PUBLISH "+host+path)
@@ -56,6 +57,7 @@ func (m *mockClient) Publish(host, path, body, token string, expectedVersion int
 		Body:            body,
 		Token:           token,
 		ExpectedVersion: expectedVersion,
+		Meta:            meta,
 	})
 	status := protocol.StatusCreated
 	if s, ok := m.publishStatuses[host+path]; ok {
@@ -658,4 +660,74 @@ func containsMiddle(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestPublishRetentionMeta(t *testing.T) {
+	setup := func(retention int) (*Crawler, *mockClient) {
+		cfg := DefaultConfig()
+		cfg.Seeds = []string{"mark://a.example.com"}
+		cfg.Hubs = []string{"mark://hub.example.com"}
+		cfg.Publish.Retention = retention
+		client := newMockClient()
+		client.addList("a.example.com:6309", "/", "- [index.md](index.md)\n")
+		client.addDoc("a.example.com:6309", "/index.md", "# A",
+			"sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+		crawler := NewCrawler(cfg, client, nil, nil)
+		if _, err := crawler.Run(context.Background()); err != nil {
+			t.Fatalf("Run() error: %v", err)
+		}
+		return crawler, client
+	}
+
+	t.Run("default caps published artifacts at 20", func(t *testing.T) {
+		if got := DefaultConfig().Publish.Retention; got != 20 {
+			t.Fatalf("default publish.retention = %d, want 20", got)
+		}
+		crawler, client := setup(DefaultConfig().Publish.Retention)
+		if _, err := crawler.PublishGraphToHubs(context.Background(), client); err != nil {
+			t.Fatalf("PublishGraphToHubs() error: %v", err)
+		}
+		if _, err := crawler.PublishToHubs(context.Background(), client, false); err != nil {
+			t.Fatalf("PublishToHubs() error: %v", err)
+		}
+		if len(client.publishes) == 0 {
+			t.Fatal("expected publishes")
+		}
+		for _, call := range client.publishes {
+			if call.Meta["retention"] != "20" {
+				t.Errorf("publish %s%s meta.retention = %q, want %q", call.Host, call.Path, call.Meta["retention"], "20")
+			}
+			if call.Meta["agent"] != "demarkus-agent" {
+				t.Errorf("publish %s%s lost agent meta: %v", call.Host, call.Path, call.Meta)
+			}
+		}
+	})
+
+	t.Run("zero keeps every version", func(t *testing.T) {
+		crawler, client := setup(0)
+		if _, err := crawler.PublishGraphToHubs(context.Background(), client); err != nil {
+			t.Fatalf("PublishGraphToHubs() error: %v", err)
+		}
+		if len(client.publishes) == 0 {
+			t.Fatal("expected publishes")
+		}
+		for _, call := range client.publishes {
+			if _, ok := call.Meta["retention"]; ok {
+				t.Errorf("publish %s%s should carry no retention meta: %v", call.Host, call.Path, call.Meta)
+			}
+		}
+	})
+}
+
+func TestConfigValidate_PublishRetention(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Seeds = []string{"mark://a.example.com"}
+	cfg.Publish.Retention = -1
+	if err := cfg.Validate(); err == nil {
+		t.Error("negative publish.retention should fail validation")
+	}
+	cfg.Publish.Retention = 0
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("zero publish.retention should validate: %v", err)
+	}
 }

--- a/tools/demarkus-broker/internal/broker/mcp_tools_list.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_list.go
@@ -216,7 +216,7 @@ func markPublishTool() mcp.Tool {
 			mcp.Description("conflict behavior: \"merge\" (default) returns a merge-candidate body; the agent reviews it (resolving any conflict markers) and calls mark_publish again with expected_version set to the returned publish-at-version. \"fail\" opts out and returns the raw conflict status."),
 		),
 		mcp.WithObject("metadata",
-			mcp.Description("optional publisher metadata stored with the document, as string values. The server interprets `tags` (comma-separated subject labels) and `importance` (0-1) for mark_lookup ranking; other keys are stored opaquely. Reserved keys are rejected. `retention` (positive integer) caps version history: this write and every later write carrying the key permanently delete versions older than the newest N. Destructive and irreversible — confirm with the user before setting it on a document whose history matters; intended for generated documents."),
+			mcp.Description("optional publisher metadata stored with the document, as string values. The server interprets `tags` (comma-separated subject labels) and `importance` (0-1) for mark_lookup ranking; other keys are stored opaquely. Reserved keys are rejected. `retention` (positive integer) caps version history: this write and every later write carrying the key permanently delete versions older than the newest N. Destructive and irreversible: confirm with the user before setting it on a document whose history matters; intended for generated documents."),
 		),
 	)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `publish-retention` integer option for crawl and daemon runs to control hub publish retention. It defaults to using the config value (default is 20) and can be overridden from the command line.

* **Bug Fixes**
  * Improved validation to reject negative `publish.retention` (with `0` meaning keep all versions).
  * Published artifacts now carry retention-related metadata when retention is set, along with agent metadata; retention `0` omits the retention metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->