### PR TITLE
fix(ci): pin-bump no longer loops through tools releases

### DIFF
--- a/.github/scripts/bump-plugin-pins.sh
+++ b/.github/scripts/bump-plugin-pins.sh
@@ -137,7 +137,15 @@ fi
 
 cur_server=$(goconst serverVersion)
 cur_client=$(goconst clientVersion)
-cur_tools=$(goconst fallbackToolsVersion)
+# The bootstrap TOOLS_VERSION is the real pin (see header); fallbackToolsVersion
+# is dev-only and deliberately NOT the currency signal: using it here would
+# force a provision.go edit on every tools release, which cuts another tools
+# release, which reopens this PR, forever.
+cur_tools=$(sed -nE 's/^TOOLS_VERSION="([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' plugins/claude-code/scripts/bootstrap.sh)
+[[ "$cur_tools" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "error: missing or invalid TOOLS_VERSION in plugins/claude-code/scripts/bootstrap.sh" >&2
+  exit 1
+}
 
 emit server "$new_server"
 emit client "$new_client"
@@ -149,10 +157,15 @@ if [[ "$new_server" == "$cur_server" && "$new_client" == "$cur_client" && "$new_
   exit 0
 fi
 
-# Update the Go consts (source of truth) and every bootstrap's TOOLS_VERSION.
+# Update the Go consts and every bootstrap's TOOLS_VERSION. fallbackToolsVersion
+# rides along only when provision.go is already changing for a real pin: it is
+# read only by dev builds, and letting it be the sole tools/ change would cut a
+# junk tools release and loop this workflow (release -> bump PR -> release).
 set_goconst serverVersion "$new_server"
 set_goconst clientVersion "$new_client"
-set_goconst fallbackToolsVersion "$new_tools"
+if [[ "$new_server" != "$cur_server" || "$new_client" != "$cur_client" ]]; then
+  set_goconst fallbackToolsVersion "$new_tools"
+fi
 [[ "$new_tools" != "$cur_tools" ]] && set_bootstrap_tools "$new_tools"
 
 # Patch-bump the affected lineages.

--- a/.github/scripts/bump-plugin-pins.sh
+++ b/.github/scripts/bump-plugin-pins.sh
@@ -140,12 +140,24 @@ cur_client=$(goconst clientVersion)
 # The bootstrap TOOLS_VERSION is the real pin (see header); fallbackToolsVersion
 # is dev-only and deliberately NOT the currency signal: using it here would
 # force a provision.go edit on every tools release, which cuts another tools
-# release, which reopens this PR, forever.
-cur_tools=$(sed -nE 's/^TOOLS_VERSION="([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' plugins/claude-code/scripts/bootstrap.sh)
-[[ "$cur_tools" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-  echo "error: missing or invalid TOOLS_VERSION in plugins/claude-code/scripts/bootstrap.sh" >&2
+# release, which reopens this PR, forever. Sample EVERY bootstrap and use the
+# lowest pin, so a partially-bumped tree reads as changed and self-heals (the
+# update path rewrites all bootstraps to the same value) instead of hiding
+# behind changed=false.
+bootstrap_pins=()
+for b in plugins/*/scripts/bootstrap.sh; do
+  v=$(sed -nE 's/^TOOLS_VERSION="([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' "$b")
+  [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+    echo "error: missing or invalid TOOLS_VERSION in $b" >&2
+    exit 1
+  }
+  bootstrap_pins+=("$v")
+done
+[[ ${#bootstrap_pins[@]} -gt 0 ]] || {
+  echo "error: no plugin bootstrap.sh files found" >&2
   exit 1
 }
+cur_tools=$(printf '%s\n' "${bootstrap_pins[@]}" | sort -V | head -1)
 
 emit server "$new_server"
 emit client "$new_client"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved version pinning for plugin setup by using the bootstrap tools version as the primary source of truth.
  * Added semver validation to ensure only valid tool version values are applied; aborts on missing or invalid values.
  * Made tool version fallback updates more selective, updating related version settings only when server/client versions change.
  * Continued keeping bootstrap tools version in sync when the latest resolved tools release changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->