### PR TITLE
feat(server): multi-replica-safe LOOKUP for the postgres backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,9 @@ demarkus-memory plugin; this file carries only what's specific to demarkus.
   hold up — disagreement backed by reasoning is expected.
 - Never silently swallow errors. Every error is explicitly handled — logged or
   surfaced. No `_ = fn()` without a comment.
+- Code comments are terse: 1-3 lines stating only what the code can't show
+  (why, invariants, platform caveats). No narration, no essays. When touching
+  code that has verbose comments, tighten them in the same edit.
 - After each implementation, run tests and `bash pre-commit.sh`.
 
 ## Required preflight (every session, before writing code)

--- a/deploy/helm/demarkus-server/README.md
+++ b/deploy/helm/demarkus-server/README.md
@@ -95,7 +95,9 @@ On `helm upgrade`, the chart uses `lookup` to read the existing `-token-values` 
 
 ### Probes
 
-Liveness/readiness exec `demarkus -insecure -no-cache mark://localhost:<port>/.well-known/agent-manifest.md`. The manifest is always public per `/architecture.md`. Probe disabled root-fs writes via `-no-cache`. The image must include the `demarkus` CLI binary.
+Startup, liveness, and readiness all exec `demarkus -insecure -no-cache mark://localhost:<port>/.well-known/agent-manifest.md`. The manifest is always public per `/architecture.md`. Probe disabled root-fs writes via `-no-cache`. The image must include the `demarkus` CLI binary.
+
+The startup probe (default 30 × 10s, `probes.startup`) holds liveness off until the server answers its first request. The server serves nothing until store init completes — file mode walks the world for its hash index and catalog, postgres mode may backfill the LOOKUP catalog on first boot — so without the startup probe a slow first boot would eat into the liveness failure threshold and could be restart-looped.
 
 ### Security defaults
 

--- a/deploy/helm/demarkus-server/templates/statefulset.yaml
+++ b/deploy/helm/demarkus-server/templates/statefulset.yaml
@@ -73,9 +73,8 @@ spec:
               protocol: UDP
               containerPort: {{ .Values.server.udpPort }}
           {{- if .Values.probes.enabled }}
-          # Holds liveness off until the first successful response; covers
-          # startup work (hash index + catalog walk in file mode, catalog
-          # backfill in postgres mode) without inflating liveness thresholds.
+          # Holds liveness off during startup work (world walk / catalog
+          # backfill); see values.yaml.
           startupProbe:
             exec:
               command:

--- a/deploy/helm/demarkus-server/templates/statefulset.yaml
+++ b/deploy/helm/demarkus-server/templates/statefulset.yaml
@@ -73,6 +73,19 @@ spec:
               protocol: UDP
               containerPort: {{ .Values.server.udpPort }}
           {{- if .Values.probes.enabled }}
+          # Holds liveness off until the first successful response; covers
+          # startup work (hash index + catalog walk in file mode, catalog
+          # backfill in postgres mode) without inflating liveness thresholds.
+          startupProbe:
+            exec:
+              command:
+                - /demarkus
+                - -insecure
+                - -no-cache
+                - {{ printf "mark://localhost:%d/.well-known/agent-manifest.md" (int .Values.server.udpPort) | quote }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
           livenessProbe:
             exec:
               command:

--- a/deploy/helm/demarkus-server/tests/statefulset_test.yaml
+++ b/deploy/helm/demarkus-server/tests/statefulset_test.yaml
@@ -138,6 +138,8 @@ tests:
       probes.enabled: false
     asserts:
       - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+      - notExists:
           path: spec.template.spec.containers[0].livenessProbe
       - notExists:
           path: spec.template.spec.containers[0].readinessProbe
@@ -154,6 +156,21 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].livenessProbe.exec.command
           content: "mark://localhost:6309/.well-known/agent-manifest.md"
+
+  - it: startup probe gates liveness with a first-boot budget
+    template: statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].startupProbe.exec.command
+          content: "mark://localhost:6309/.well-known/agent-manifest.md"
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 30
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
 
   - it: container image is the demarkus-server repo and relies on ENTRYPOINT
     template: statefulset.yaml

--- a/deploy/helm/demarkus-server/values.yaml
+++ b/deploy/helm/demarkus-server/values.yaml
@@ -115,11 +115,24 @@ resources:
     cpu: 1000m
     memory: 512Mi
 
-# Liveness + readiness use the demarkus CLI fetching /.well-known/agent-manifest.md
-# (always public per /architecture.md). Cache disabled via -no-cache so probe
-# does not write to the read-only root filesystem.
+# Startup, liveness + readiness use the demarkus CLI fetching
+# /.well-known/agent-manifest.md (always public per /architecture.md). Cache
+# disabled via -no-cache so probe does not write to the read-only root
+# filesystem.
+#
+# The startup probe holds liveness off until the server answers its first
+# request. The server does startup work before it serves anything: file mode
+# walks the world for the hash index and LOOKUP catalog; postgres mode may
+# backfill the catalog table on first boot after an upgrade (bounded at 60s
+# in-process). The default budget (30 x 10s = 300s) comfortably covers both;
+# without it, a slow startup would eat into the liveness failure threshold
+# and a large world could be restart-looped before it ever came up.
 probes:
   enabled: true
+  startup:
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 30
   liveness:
     initialDelaySeconds: 10
     periodSeconds: 30

--- a/deploy/helm/demarkus-server/values.yaml
+++ b/deploy/helm/demarkus-server/values.yaml
@@ -115,12 +115,9 @@ resources:
     cpu: 1000m
     memory: 512Mi
 
-# All probes use the demarkus CLI fetching /.well-known/agent-manifest.md
-# (always public per /architecture.md); -no-cache keeps the read-only root
-# filesystem untouched. The startup probe (30 x 10s budget) holds liveness
-# off until the server answers: file mode walks the world at startup and
-# postgres mode may backfill the LOOKUP catalog (60s in-process bound), so
-# without it a large world could be restart-looped before ever coming up.
+# Probes exec the demarkus CLI against /.well-known/agent-manifest.md (always
+# public; -no-cache spares the read-only root fs). The startup probe covers
+# world walks and catalog backfill so a slow first boot is not restart-looped.
 probes:
   enabled: true
   startup:

--- a/deploy/helm/demarkus-server/values.yaml
+++ b/deploy/helm/demarkus-server/values.yaml
@@ -115,18 +115,12 @@ resources:
     cpu: 1000m
     memory: 512Mi
 
-# Startup, liveness + readiness use the demarkus CLI fetching
-# /.well-known/agent-manifest.md (always public per /architecture.md). Cache
-# disabled via -no-cache so probe does not write to the read-only root
-# filesystem.
-#
-# The startup probe holds liveness off until the server answers its first
-# request. The server does startup work before it serves anything: file mode
-# walks the world for the hash index and LOOKUP catalog; postgres mode may
-# backfill the catalog table on first boot after an upgrade (bounded at 60s
-# in-process). The default budget (30 x 10s = 300s) comfortably covers both;
-# without it, a slow startup would eat into the liveness failure threshold
-# and a large world could be restart-looped before it ever came up.
+# All probes use the demarkus CLI fetching /.well-known/agent-manifest.md
+# (always public per /architecture.md); -no-cache keeps the read-only root
+# filesystem untouched. The startup probe (30 x 10s budget) holds liveness
+# off until the server answers: file mode walks the world at startup and
+# postgres mode may backfill the LOOKUP catalog (60s in-process bound), so
+# without it a large world could be restart-looped before ever coming up.
 probes:
   enabled: true
   startup:

--- a/server/cmd/demarkus-server/main.go
+++ b/server/cmd/demarkus-server/main.go
@@ -32,12 +32,9 @@ type currentWalker interface {
 	WalkCurrent(fn func(store.CurrentDoc) error) error
 }
 
-// buildCatalog builds the in-memory LOOKUP catalog by walking the store's
-// current documents. File-backend only: the postgres backend serves LOOKUP
-// from its catalog table (maintained transactionally with each write, shared
-// by every replica), so it neither needs nor gets a per-process index. A
-// failed walk leaves an empty catalog (lookups return no matches) rather
-// than aborting startup.
+// buildCatalog builds the in-memory LOOKUP catalog by walking current
+// documents. File-backend only: postgres serves LOOKUP from its catalog
+// table. A failed walk leaves an empty catalog rather than aborting startup.
 func buildCatalog(s currentWalker, logger *slog.Logger) *catalog.Catalog {
 	cat := catalog.New()
 	if err := s.WalkCurrent(func(d store.CurrentDoc) error {
@@ -179,9 +176,7 @@ func main() {
 			}
 		}()
 		logger.Info("store: postgres backend ready")
-		// LOOKUP is served from the database (catalog rows maintained in the
-		// write transaction), so no per-process catalog build: with replicas
-		// sharing one database, an in-RAM index would diverge across pods.
+		// LOOKUP is DB-backed; a per-process index would diverge across pods.
 		docStore, cat = ps, ps
 	case "file":
 		s := store.New(cfg.ContentDir)

--- a/server/cmd/demarkus-server/main.go
+++ b/server/cmd/demarkus-server/main.go
@@ -27,15 +27,17 @@ import (
 	"github.com/quic-go/quic-go"
 )
 
-// currentWalker is the slice of a document store the catalog build needs;
-// both the file store and pgstore provide it.
+// currentWalker is the slice of a document store the catalog build needs.
 type currentWalker interface {
 	WalkCurrent(fn func(store.CurrentDoc) error) error
 }
 
-// buildCatalog builds the LOOKUP catalog by walking the store's current
-// documents. A failed walk leaves an empty catalog (lookups return no matches)
-// rather than aborting startup.
+// buildCatalog builds the in-memory LOOKUP catalog by walking the store's
+// current documents. File-backend only: the postgres backend serves LOOKUP
+// from its catalog table (maintained transactionally with each write, shared
+// by every replica), so it neither needs nor gets a per-process index. A
+// failed walk leaves an empty catalog (lookups return no matches) rather
+// than aborting startup.
 func buildCatalog(s currentWalker, logger *slog.Logger) *catalog.Catalog {
 	cat := catalog.New()
 	if err := s.WalkCurrent(func(d store.CurrentDoc) error {
@@ -163,7 +165,7 @@ func main() {
 	defer func() { _ = listener.Close() }()
 
 	var docStore handler.DocumentStore
-	var walker currentWalker
+	var cat handler.LookupCatalog
 	switch cfg.StoreBackend {
 	case "postgres":
 		ps, err := pgstore.Open(cfg.PostgresDSN, logger)
@@ -177,7 +179,10 @@ func main() {
 			}
 		}()
 		logger.Info("store: postgres backend ready")
-		docStore, walker = ps, ps
+		// LOOKUP is served from the database (catalog rows maintained in the
+		// write transaction), so no per-process catalog build: with replicas
+		// sharing one database, an in-RAM index would diverge across pods.
+		docStore, cat = ps, ps
 	case "file":
 		s := store.New(cfg.ContentDir)
 		// BuildHashIndex clears the index before walking; continuing after a
@@ -188,7 +193,7 @@ func main() {
 			os.Exit(1)
 		}
 		logger.Info("content hash index built", "entries", s.HashIndexSize())
-		docStore, walker = s, s
+		docStore, cat = s, buildCatalog(s, logger)
 	default:
 		// Unreachable: ValidateStoreBackend rejected unknown values above.
 		// Kept explicit so a backend added there but not here fails loudly
@@ -196,8 +201,6 @@ func main() {
 		logger.Error("unknown store backend reached store init", "store", cfg.StoreBackend)
 		os.Exit(1)
 	}
-
-	cat := buildCatalog(walker, logger)
 
 	if cfg.TokensFile != "" {
 		if err := loadTokenStore(cfg.TokensFile); err != nil {

--- a/server/internal/catalog/catalog.go
+++ b/server/internal/catalog/catalog.go
@@ -55,6 +55,13 @@ func (c *Catalog) Set(e *Entry) {
 	c.entries[e.Path] = e
 }
 
+// Put derives an entry from a written document and records it. It is the
+// in-memory implementation of the handler's LookupCatalog seam; body is the
+// document content with store frontmatter already stripped.
+func (c *Catalog) Put(docPath string, meta map[string]string, body []byte, modified time.Time) {
+	c.Set(FromDocument(docPath, meta, body, modified))
+}
+
 // Remove deletes the entry for the given path, if present.
 func (c *Catalog) Remove(docPath string) {
 	c.mu.Lock()
@@ -83,16 +90,18 @@ type Options struct {
 // Lookup returns documents whose tags or title match at least one query term,
 // satisfy every filter predicate, and fall under the scope, ordered by
 // descending match count, then importance, then modification time, then path.
+// The error is always nil; the signature carries it for the handler's
+// LookupCatalog seam, where database-backed implementations can fail.
 //
 // The query "*" matches every catalogued document under the scope (filters
 // still apply): with all match scores equal, the ordering reduces to
 // importance — "the most important documents here" without guessing a
 // subject. This is the whole-catalog view that universe browsers build on.
-func (c *Catalog) Lookup(query string, opts Options) []Result {
+func (c *Catalog) Lookup(query string, opts Options) ([]Result, error) {
 	matchAll := strings.TrimSpace(query) == "*"
-	terms := tokenize(query)
+	terms := Tokenize(query)
 	if !matchAll && len(terms) == 0 {
-		return nil
+		return nil, nil
 	}
 	scope := normalizeScope(opts.Scope)
 
@@ -102,7 +111,7 @@ func (c *Catalog) Lookup(query string, opts Options) []Result {
 		if !underScope(e.Path, scope) {
 			continue
 		}
-		if !matchesAll(e, opts.Filter) {
+		if !MatchesAll(e, opts.Filter) {
 			continue
 		}
 		if matchAll {
@@ -119,12 +128,13 @@ func (c *Catalog) Lookup(query string, opts Options) []Result {
 	if opts.Max > 0 && len(results) > opts.Max {
 		results = results[:opts.Max]
 	}
-	return results
+	return results, nil
 }
 
-// tokenize lowercases s and splits it into distinct whitespace-separated terms,
-// preserving first-seen order.
-func tokenize(s string) []string {
+// Tokenize lowercases s and splits it into distinct whitespace-separated terms,
+// preserving first-seen order. Exported so alternative LookupCatalog backends
+// tokenize queries identically to the in-memory catalog.
+func Tokenize(s string) []string {
 	seen := make(map[string]bool)
 	var out []string
 	for f := range strings.FieldsSeq(strings.ToLower(s)) {

--- a/server/internal/catalog/catalog.go
+++ b/server/internal/catalog/catalog.go
@@ -55,9 +55,8 @@ func (c *Catalog) Set(e *Entry) {
 	c.entries[e.Path] = e
 }
 
-// Put derives an entry from a written document and records it. It is the
-// in-memory implementation of the handler's LookupCatalog seam; body is the
-// document content with store frontmatter already stripped.
+// Put derives an entry from a written document and records it; body has
+// store frontmatter already stripped.
 func (c *Catalog) Put(docPath string, meta map[string]string, body []byte, modified time.Time) {
 	c.Set(FromDocument(docPath, meta, body, modified))
 }
@@ -90,8 +89,7 @@ type Options struct {
 // Lookup returns documents whose tags or title match at least one query term,
 // satisfy every filter predicate, and fall under the scope, ordered by
 // descending match count, then importance, then modification time, then path.
-// The error is always nil; the signature carries it for the handler's
-// LookupCatalog seam, where database-backed implementations can fail.
+// The error is always nil; the signature exists for the LookupCatalog seam.
 //
 // The query "*" matches every catalogued document under the scope (filters
 // still apply): with all match scores equal, the ordering reduces to
@@ -131,9 +129,9 @@ func (c *Catalog) Lookup(query string, opts Options) ([]Result, error) {
 	return results, nil
 }
 
-// Tokenize lowercases s and splits it into distinct whitespace-separated terms,
-// preserving first-seen order. Exported so alternative LookupCatalog backends
-// tokenize queries identically to the in-memory catalog.
+// Tokenize lowercases s and splits it into distinct whitespace-separated
+// terms, first-seen order. Exported so LookupCatalog backends tokenize
+// identically.
 func Tokenize(s string) []string {
 	seen := make(map[string]bool)
 	var out []string

--- a/server/internal/catalog/catalog_test.go
+++ b/server/internal/catalog/catalog_test.go
@@ -5,6 +5,17 @@ import (
 	"time"
 )
 
+// mustLookup runs a lookup and fails the test on error (the in-memory catalog
+// never returns one; the signature exists for the LookupCatalog seam).
+func mustLookup(t *testing.T, c *Catalog, query string, opts Options) []Result {
+	t.Helper()
+	rs, err := c.Lookup(query, opts)
+	if err != nil {
+		t.Fatalf("Lookup(%q): %v", query, err)
+	}
+	return rs
+}
+
 // paths returns the result paths in order, for concise assertions.
 func paths(rs []Result) []string {
 	out := make([]string, len(rs))
@@ -70,7 +81,7 @@ func TestLookupMatching(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := paths(c.Lookup(tt.query, Options{}))
+			got := paths(mustLookup(t, c, tt.query, Options{}))
 			if !equalPaths(got, tt.want) {
 				t.Errorf("Lookup(%q) = %v, want %v", tt.query, got, tt.want)
 			}
@@ -89,7 +100,7 @@ func TestLookupRanking(t *testing.T) {
 	// Same score (1) as one-term but lower importance.
 	c.Set(&Entry{Path: "/also-one.md", Tags: []string{"middleware"}, Importance: 0.5, Modified: recent})
 
-	got := paths(c.Lookup("auth middleware", Options{}))
+	got := paths(mustLookup(t, c, "auth middleware", Options{}))
 	want := []string{"/two-terms.md", "/one-term.md", "/also-one.md"}
 	if !equalPaths(got, want) {
 		t.Errorf("ranking = %v, want %v", got, want)
@@ -105,7 +116,7 @@ func TestLookupRankingTiebreaks(t *testing.T) {
 	c.Set(&Entry{Path: "/a.md", Tags: []string{"go"}, Importance: 0.5, Modified: recent})
 	c.Set(&Entry{Path: "/c.md", Tags: []string{"go"}, Importance: 0.5, Modified: old})
 
-	got := paths(c.Lookup("go", Options{}))
+	got := paths(mustLookup(t, c, "go", Options{}))
 	want := []string{"/a.md", "/b.md", "/c.md"} // a,b newer (path tiebreak), c oldest last
 	if !equalPaths(got, want) {
 		t.Errorf("tiebreak = %v, want %v", got, want)
@@ -132,7 +143,7 @@ func TestLookupScope(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := paths(c.Lookup("go", Options{Scope: tt.scope}))
+			got := paths(mustLookup(t, c, "go", Options{Scope: tt.scope}))
 			if !equalPaths(got, tt.want) {
 				t.Errorf("scope %q = %v, want %v", tt.scope, got, tt.want)
 			}
@@ -145,12 +156,12 @@ func TestLookupMax(t *testing.T) {
 	for _, p := range []string{"/a.md", "/b.md", "/c.md", "/d.md"} {
 		c.Set(&Entry{Path: p, Tags: []string{"go"}, Importance: 0.5})
 	}
-	got := c.Lookup("go", Options{Max: 2})
+	got := mustLookup(t, c, "go", Options{Max: 2})
 	if len(got) != 2 {
 		t.Fatalf("Max=2 returned %d results", len(got))
 	}
 	// Max 0 means no cap.
-	if all := c.Lookup("go", Options{Max: 0}); len(all) != 4 {
+	if all := mustLookup(t, c, "go", Options{Max: 0}); len(all) != 4 {
 		t.Fatalf("Max=0 returned %d results, want 4", len(all))
 	}
 }
@@ -164,7 +175,7 @@ func TestLookupWithFilter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got := paths(c.Lookup("go", Options{Filter: preds}))
+	got := paths(mustLookup(t, c, "go", Options{Filter: preds}))
 	want := []string{"/broker.md"}
 	if !equalPaths(got, want) {
 		t.Errorf("filtered lookup = %v, want %v", got, want)
@@ -174,7 +185,7 @@ func TestLookupWithFilter(t *testing.T) {
 func TestLookupScorePopulated(t *testing.T) {
 	c := New()
 	c.Set(&Entry{Path: "/two.md", Tags: []string{"auth", "middleware"}})
-	got := c.Lookup("auth middleware", Options{})
+	got := mustLookup(t, c, "auth middleware", Options{})
 	if len(got) != 1 || got[0].Score != 2 {
 		t.Fatalf("expected one result with score 2, got %+v", got)
 	}
@@ -189,34 +200,34 @@ func TestLookupMatchAll(t *testing.T) {
 
 	// "*" returns every catalogued doc, importance-ranked (scores all zero,
 	// so the tiebreak chain starts at importance).
-	got := paths(c.Lookup("*", Options{}))
+	got := paths(mustLookup(t, c, "*", Options{}))
 	want := []string{"/hub.md", "/docs/deep.md", "/mid.md", "/low.md"}
 	if !equalPaths(got, want) {
 		t.Fatalf("match-all order = %v, want %v", got, want)
 	}
 
 	// Scope and filters still narrow the universe.
-	if got := paths(c.Lookup("*", Options{Scope: "/docs/"})); !equalPaths(got, []string{"/docs/deep.md"}) {
+	if got := paths(mustLookup(t, c, "*", Options{Scope: "/docs/"})); !equalPaths(got, []string{"/docs/deep.md"}) {
 		t.Errorf("scoped match-all = %v", got)
 	}
 	preds, perr := ParseFilter("tag=go")
 	if perr != nil {
 		t.Fatalf("ParseFilter: %v", perr)
 	}
-	if got := paths(c.Lookup("*", Options{Filter: preds})); !equalPaths(got, []string{"/docs/deep.md", "/low.md"}) {
+	if got := paths(mustLookup(t, c, "*", Options{Filter: preds})); !equalPaths(got, []string{"/docs/deep.md", "/low.md"}) {
 		t.Errorf("filtered match-all = %v", got)
 	}
 	// Max caps it like any lookup.
-	if got := paths(c.Lookup("*", Options{Max: 1})); !equalPaths(got, []string{"/hub.md"}) {
+	if got := paths(mustLookup(t, c, "*", Options{Max: 1})); !equalPaths(got, []string{"/hub.md"}) {
 		t.Errorf("capped match-all = %v", got)
 	}
 	// Whitespace-padded star still counts; a star mixed with other terms is
 	// a normal query (star becomes a literal term) — "go" matches its two
 	// docs, NOT the whole catalog.
-	if got := paths(c.Lookup("  *  ", Options{})); len(got) != 4 {
+	if got := paths(mustLookup(t, c, "  *  ", Options{})); len(got) != 4 {
 		t.Errorf("padded star = %v", got)
 	}
-	if got := paths(c.Lookup("* go", Options{})); len(got) != 2 {
+	if got := paths(mustLookup(t, c, "* go", Options{})); len(got) != 2 {
 		t.Errorf("star-with-terms must behave as a term query, got %v", got)
 	}
 }

--- a/server/internal/catalog/filter.go
+++ b/server/internal/catalog/filter.go
@@ -78,9 +78,9 @@ func parseFilterTime(s string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("invalid date %q (want RFC 3339 or YYYY-MM-DD)", s)
 }
 
-// MatchesAll reports whether the entry satisfies every predicate. Exported so
-// alternative LookupCatalog backends apply the exact same filter semantics as
-// the in-memory catalog; Predicate fields stay unexported on purpose.
+// MatchesAll reports whether the entry satisfies every predicate. Exported
+// so LookupCatalog backends apply identical filter semantics; Predicate
+// fields stay unexported on purpose.
 func MatchesAll(e *Entry, preds []Predicate) bool {
 	for _, p := range preds {
 		if !p.matches(e) {

--- a/server/internal/catalog/filter.go
+++ b/server/internal/catalog/filter.go
@@ -78,8 +78,10 @@ func parseFilterTime(s string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("invalid date %q (want RFC 3339 or YYYY-MM-DD)", s)
 }
 
-// matchesAll reports whether the entry satisfies every predicate.
-func matchesAll(e *Entry, preds []Predicate) bool {
+// MatchesAll reports whether the entry satisfies every predicate. Exported so
+// alternative LookupCatalog backends apply the exact same filter semantics as
+// the in-memory catalog; Predicate fields stay unexported on purpose.
+func MatchesAll(e *Entry, preds []Predicate) bool {
 	for _, p := range preds {
 		if !p.matches(e) {
 			return false

--- a/server/internal/catalog/filter_test.go
+++ b/server/internal/catalog/filter_test.go
@@ -64,7 +64,7 @@ func TestPredicateMatches(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ParseFilter(%q): %v", tt.filter, err)
 			}
-			if got := matchesAll(e, preds); got != tt.want {
+			if got := MatchesAll(e, preds); got != tt.want {
 				t.Errorf("matchesAll for %q = %v, want %v", tt.filter, got, tt.want)
 			}
 		})

--- a/server/internal/configwatch/watcher.go
+++ b/server/internal/configwatch/watcher.go
@@ -4,10 +4,9 @@
 // stable path. Events are coalesced through a debounce window so a burst of
 // writes triggers one reload.
 //
-// Platform caveat: macOS kqueue diffs directory entries by name, so an
-// atomic same-name symlink swap within one rescan window produces no event;
-// Linux inotify (production) reports renames explicitly. The mount-refresh
-// pattern still works on macOS because staging the new link fires an event.
+// Platform caveat: macOS kqueue diffs directory entries by name, so a
+// same-name atomic symlink swap within one rescan window emits no event;
+// Linux inotify (production) reports renames explicitly.
 package configwatch
 
 import (

--- a/server/internal/configwatch/watcher.go
+++ b/server/internal/configwatch/watcher.go
@@ -3,6 +3,11 @@
 // rename swaps and symlink retargets, where the target inode changes under a
 // stable path. Events are coalesced through a debounce window so a burst of
 // writes triggers one reload.
+//
+// Platform caveat: macOS kqueue diffs directory entries by name, so an
+// atomic same-name symlink swap within one rescan window produces no event;
+// Linux inotify (production) reports renames explicitly. The mount-refresh
+// pattern still works on macOS because staging the new link fires an event.
 package configwatch
 
 import (

--- a/server/internal/configwatch/watcher_test.go
+++ b/server/internal/configwatch/watcher_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -52,6 +53,31 @@ func waitForCount(counter *atomic.Int32, want int32, deadline time.Duration) int
 	return counter.Load()
 }
 
+// awaitWatchLive proves the watch is established before the change under
+// test: fsnotify only reports changes made after registration, so a flat
+// sleep flakes under load. It touches a sentinel until a reload is observed
+// (a single touch would lose the same race; pausing a debounce window per
+// touch lets a pending reload fire), then drains stragglers and resets the
+// counter.
+func awaitWatchLive(t *testing.T, dir string, calls *atomic.Int32, debounce time.Duration) {
+	t.Helper()
+	sentinel := filepath.Join(dir, "watch-live.sentinel")
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if err := os.WriteFile(sentinel, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if got := waitForCount(calls, 1, debounce+250*time.Millisecond); got >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("watch never became live: no reload after repeated sentinel writes")
+		}
+	}
+	time.Sleep(2*debounce + 100*time.Millisecond)
+	calls.Store(0)
+}
+
 func TestRunValidatesInputs(t *testing.T) {
 	tests := []struct {
 		name string
@@ -88,7 +114,7 @@ func TestInPlaceWriteTriggersReload(t *testing.T) {
 	}
 	runInBackground(t, &w)
 
-	time.Sleep(50 * time.Millisecond) // let watcher attach
+	awaitWatchLive(t, dir, &calls, w.Debounce)
 	if err := os.WriteFile(target, []byte("v2"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +140,7 @@ func TestAtomicRenameTriggersReload(t *testing.T) {
 	}
 	runInBackground(t, &w)
 
-	time.Sleep(50 * time.Millisecond)
+	awaitWatchLive(t, dir, &calls, w.Debounce)
 	tmp := filepath.Join(dir, "tokens.toml.tmp")
 	if err := os.WriteFile(tmp, []byte("v2"), 0o600); err != nil {
 		t.Fatal(err)
@@ -133,7 +159,17 @@ func TestAtomicRenameTriggersReload(t *testing.T) {
 // indirection (here "current") into one of several content directories.
 // Swapping the indirection atomically retargets every leaf symlink at once,
 // the same way a process refreshing a mounted config tree does.
+//
+// Skipped on darwin: fsnotify's kqueue backend diffs directory entries by
+// name, so an atomic same-name swap inside one rescan window emits nothing;
+// catching the staged link's brief existence is a scheduler race (the
+// historical flake here). Linux inotify reports renames explicitly, so CI
+// enforces the guarantee; macOS still works in practice because the staged
+// link's creation fires its own event.
 func TestSymlinkRetargetTriggersReload(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("kqueue cannot observe a same-name atomic symlink swap; see comment above")
+	}
 	dir := t.TempDir()
 
 	v1 := filepath.Join(dir, "v1")
@@ -168,7 +204,7 @@ func TestSymlinkRetargetTriggersReload(t *testing.T) {
 	}
 	runInBackground(t, &w)
 
-	time.Sleep(50 * time.Millisecond)
+	awaitWatchLive(t, dir, &calls, w.Debounce)
 	// Atomic swap of the indirection: stage a new symlink and rename it over
 	// the old one. os.Rename replaces the destination atomically on POSIX.
 	staged := filepath.Join(dir, "current.new")
@@ -195,24 +231,28 @@ func TestDebounceCoalescesBurst(t *testing.T) {
 	w := Watcher{
 		Target:   target,
 		Reload:   func() error { calls.Add(1); return nil },
-		Debounce: 80 * time.Millisecond,
+		Debounce: 400 * time.Millisecond,
 		Logger:   discardLogger(),
 	}
 	runInBackground(t, &w)
 
-	time.Sleep(50 * time.Millisecond)
-	// Fire several writes well within the debounce window.
+	awaitWatchLive(t, dir, &calls, w.Debounce)
+	// The window is wide relative to the write pacing: a scheduler stall
+	// outlasting the debounce would fire it mid-burst and flake exactly-one.
 	for i := range 10 {
 		if err := os.WriteFile(target, []byte{byte('a' + i)}, 0o600); err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(5 * time.Millisecond)
+		time.Sleep(2 * time.Millisecond)
 	}
 
-	// Let the debounce window elapse and the reload fire.
-	time.Sleep(200 * time.Millisecond)
-	if got := calls.Load(); got != 1 {
+	// One coalesced reload, then a full window proving no straggler.
+	if got := waitForCount(&calls, 1, 2*time.Second); got != 1 {
 		t.Fatalf("expected exactly 1 reload from coalesced burst, got %d", got)
+	}
+	time.Sleep(500 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected no further reloads after the burst, got %d", got)
 	}
 }
 

--- a/server/internal/configwatch/watcher_test.go
+++ b/server/internal/configwatch/watcher_test.go
@@ -53,12 +53,9 @@ func waitForCount(counter *atomic.Int32, want int32, deadline time.Duration) int
 	return counter.Load()
 }
 
-// awaitWatchLive proves the watch is established before the change under
-// test: fsnotify only reports changes made after registration, so a flat
-// sleep flakes under load. It touches a sentinel until a reload is observed
-// (a single touch would lose the same race; pausing a debounce window per
-// touch lets a pending reload fire), then drains stragglers and resets the
-// counter.
+// awaitWatchLive touches a sentinel until a reload proves the watch is
+// registered (fsnotify misses pre-registration events; a single touch would
+// lose that same race), then drains stragglers and resets the counter.
 func awaitWatchLive(t *testing.T, dir string, calls *atomic.Int32, debounce time.Duration) {
 	t.Helper()
 	sentinel := filepath.Join(dir, "watch-live.sentinel")
@@ -160,12 +157,9 @@ func TestAtomicRenameTriggersReload(t *testing.T) {
 // Swapping the indirection atomically retargets every leaf symlink at once,
 // the same way a process refreshing a mounted config tree does.
 //
-// Skipped on darwin: fsnotify's kqueue backend diffs directory entries by
-// name, so an atomic same-name swap inside one rescan window emits nothing;
-// catching the staged link's brief existence is a scheduler race (the
-// historical flake here). Linux inotify reports renames explicitly, so CI
-// enforces the guarantee; macOS still works in practice because the staged
-// link's creation fires its own event.
+// Skipped on darwin: kqueue diffs directory entries by name, so a same-name
+// atomic symlink swap inside one rescan window emits nothing; Linux inotify
+// reports renames explicitly, so CI enforces the guarantee.
 func TestSymlinkRetargetTriggersReload(t *testing.T) {
 	if runtime.GOOS == "darwin" {
 		t.Skip("kqueue cannot observe a same-name atomic symlink swap; see comment above")

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -82,11 +82,26 @@ type DocumentStore interface {
 	Archive(reqPath string, archived bool) error
 }
 
+// LookupCatalog is the handler's view of the LOOKUP index, the catalog seam
+// alternative store backends implement alongside DocumentStore. The in-memory
+// implementation is catalog.Catalog, which the handler keeps current through
+// Put and Remove after each successful write; a backend that maintains its
+// catalog transactionally with the write (pgstore) implements Put and Remove
+// as no-ops. Every implementation must replicate catalog.Catalog's Lookup
+// semantics exactly: match scoring over tags and title, importance-ranked
+// ordering, scope, and filter predicates. Divergence between implementations
+// is a protocol bug; the storetest LOOKUP conformance suite is the contract.
+type LookupCatalog interface {
+	Lookup(query string, opts catalog.Options) ([]catalog.Result, error)
+	Put(docPath string, meta map[string]string, body []byte, modified time.Time)
+	Remove(docPath string)
+}
+
 // Handler serves markdown files from a content directory.
 type Handler struct {
 	ContentDir    string
 	Store         DocumentStore
-	Catalog       *catalog.Catalog        // LOOKUP index; nil disables LOOKUP and catalog updates
+	Catalog       LookupCatalog           // LOOKUP index; nil disables LOOKUP and catalog updates
 	GetTokenStore func() *auth.TokenStore // nil callback or nil return means writes are denied
 	Logger        *slog.Logger
 	ReadOnly      bool // reject all write operations
@@ -612,7 +627,12 @@ func (h *Handler) handleLookup(w io.Writer, req protocol.Request) {
 		}
 	}
 
-	results := h.Catalog.Lookup(query, catalog.Options{Scope: req.Path, Filter: preds, Max: maxLookupResults})
+	results, err := h.Catalog.Lookup(query, catalog.Options{Scope: req.Path, Filter: preds, Max: maxLookupResults})
+	if err != nil {
+		h.logger().Error("lookup failed", "path", sanitize(req.Path), "error", err)
+		h.writeError(w, protocol.StatusServerError, "internal error")
+		return
+	}
 
 	// Filter by read authorization before truncating to limit, so protected
 	// documents the requester cannot see never displace authorized matches and
@@ -644,7 +664,7 @@ func (h *Handler) catalogPut(reqPath string, body []byte, meta map[string]string
 	if h.Catalog == nil {
 		return
 	}
-	h.Catalog.Set(catalog.FromDocument(reqPath, meta, body, modified))
+	h.Catalog.Put(reqPath, meta, body, modified)
 }
 
 // catalogRemove drops a document from the LOOKUP catalog. No-op when no catalog

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -83,14 +83,11 @@ type DocumentStore interface {
 }
 
 // LookupCatalog is the handler's view of the LOOKUP index, the catalog seam
-// alternative store backends implement alongside DocumentStore. The in-memory
-// implementation is catalog.Catalog, which the handler keeps current through
-// Put and Remove after each successful write; a backend that maintains its
-// catalog transactionally with the write (pgstore) implements Put and Remove
-// as no-ops. Every implementation must replicate catalog.Catalog's Lookup
-// semantics exactly: match scoring over tags and title, importance-ranked
-// ordering, scope, and filter predicates. Divergence between implementations
-// is a protocol bug; the storetest LOOKUP conformance suite is the contract.
+// beside DocumentStore. The handler calls Put/Remove after successful writes
+// to keep the in-memory catalog current; backends that maintain the catalog
+// in the write transaction (pgstore) no-op them. Implementations must match
+// catalog.Catalog's Lookup semantics exactly; the storetest LOOKUP
+// conformance suite is the contract.
 type LookupCatalog interface {
 	Lookup(query string, opts catalog.Options) ([]catalog.Result, error)
 	Put(docPath string, meta map[string]string, body []byte, modified time.Time)

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -82,12 +82,9 @@ type DocumentStore interface {
 	Archive(reqPath string, archived bool) error
 }
 
-// LookupCatalog is the handler's view of the LOOKUP index, the catalog seam
-// beside DocumentStore. The handler calls Put/Remove after successful writes
-// to keep the in-memory catalog current; backends that maintain the catalog
-// in the write transaction (pgstore) no-op them. Implementations must match
-// catalog.Catalog's Lookup semantics exactly; the storetest LOOKUP
-// conformance suite is the contract.
+// LookupCatalog is the LOOKUP-index seam beside DocumentStore. Backends that
+// maintain the catalog in the write transaction (pgstore) no-op Put/Remove;
+// the storetest LOOKUP conformance suite is the contract for Lookup parity.
 type LookupCatalog interface {
 	Lookup(query string, opts catalog.Options) ([]catalog.Result, error)
 	Put(docPath string, meta map[string]string, body []byte, modified time.Time)

--- a/server/internal/pgstore/catalog.go
+++ b/server/internal/pgstore/catalog.go
@@ -12,26 +12,16 @@ import (
 	"github.com/latebit-io/demarkus/server/internal/catalog"
 )
 
-// This file is the Postgres implementation of the handler's LookupCatalog
-// seam. Catalog rows are written inside the same transaction as the document
-// write (see upsertCatalogRow calls in write), so every replica sees a
-// LOOKUP catalog exactly as current as the store itself; there is no per-pod
-// in-RAM index to diverge.
-//
-// Parity with catalog.Catalog is split deliberately:
-//   - All lowercasing happens in Go at write time (tags_lower, title_lower),
-//     because Postgres lower() and Go strings.ToLower disagree on unicode
-//     edge cases. The SQL query only ever compares Go-lowered values against
-//     Go-lowered query terms (catalog.Tokenize).
-//   - Match scoring, archived exclusion, scope, and ordering run in SQL.
-//   - Filter predicates run in Go through catalog.MatchesAll, the same code
-//     the in-memory catalog uses, so filter semantics cannot diverge.
+// This file implements the handler's LookupCatalog seam. Catalog rows ride
+// the document write transaction, so every replica's LOOKUP is exactly as
+// current as the store. Parity split: lowercasing happens in Go at write
+// time (Postgres lower() diverges from strings.ToLower on unicode); SQL does
+// scope, scoring, ordering; filters and Max run through shared catalog code
+// so they cannot diverge.
 
-// upsertCatalogRow writes the catalog row for a document tip inside the
-// caller's write transaction. entry is derived via catalog.FromDocument, the
-// same derivation the handler performs for the in-memory catalog. Archived
-// state is not stored here: the lookup query joins documents.archived, so
-// archive/unarchive need no catalog writes and unarchive restores the entry.
+// upsertCatalogRow writes a document tip's catalog row inside the caller's
+// write transaction. Archived state is not stored: Lookup joins
+// documents.archived, so archive/unarchive need no catalog writes.
 func upsertCatalogRow(ctx context.Context, tx *sql.Tx, p string, entry *catalog.Entry) error {
 	args, err := catalogRowArgs(p, entry)
 	if err != nil {
@@ -51,9 +41,8 @@ func upsertCatalogRow(ctx context.Context, tx *sql.Tx, p string, entry *catalog.
 	return nil
 }
 
-// insertCatalogRowIfAbsent is the backfill variant of upsertCatalogRow: it
-// never overwrites, so a row created by a concurrent live write (which is
-// newer than the tip the backfill read) always wins.
+// insertCatalogRowIfAbsent is the backfill variant: it never overwrites, so
+// a concurrent live write's newer row always wins.
 func insertCatalogRowIfAbsent(ctx context.Context, tx *sql.Tx, p string, entry *catalog.Entry) error {
 	args, err := catalogRowArgs(p, entry)
 	if err != nil {
@@ -69,8 +58,8 @@ func insertCatalogRowIfAbsent(ctx context.Context, tx *sql.Tx, p string, entry *
 	return nil
 }
 
-// catalogRowArgs encodes an entry as the shared column values of the two
-// catalog INSERT statements. All lowercasing happens here, in Go.
+// catalogRowArgs encodes an entry as the column values shared by both
+// catalog INSERTs. All lowercasing happens here, in Go.
 func catalogRowArgs(p string, entry *catalog.Entry) ([]any, error) {
 	tagsJSON, err := jsonArray(entry.Tags)
 	if err != nil {
@@ -92,8 +81,8 @@ func catalogRowArgs(p string, entry *catalog.Entry) ([]any, error) {
 		entry.Title, strings.ToLower(entry.Title), metaJSON, entry.Modified}, nil
 }
 
-// jsonArray marshals a string slice as a jsonb array, never null: the lookup
-// query feeds the value to jsonb_array_elements_text, which rejects scalars.
+// jsonArray marshals as a jsonb array, never null:
+// jsonb_array_elements_text rejects scalars.
 func jsonArray(ss []string) ([]byte, error) {
 	if ss == nil {
 		ss = []string{}
@@ -109,24 +98,18 @@ func jsonObject(m map[string]string) ([]byte, error) {
 	return json.Marshal(m)
 }
 
-// backfillCatalog inserts catalog rows for document tips that have none. It
-// runs on every Init: the first start after this table was introduced
-// backfills the whole world (the additive migration), and later starts
-// reconcile stragglers, e.g. documents written by an old binary during a
-// rolling deploy, which upserted no catalog rows. In the steady state the
-// query matches nothing. Archived documents get rows too; their entries stay
-// invisible to Lookup (the query excludes archived) but must exist so a
-// later unarchive restores them. ON CONFLICT DO NOTHING makes concurrent
-// replica startups idempotent and never overwrites a row a live write
-// created in the meantime.
+// backfillCatalog inserts catalog rows for document tips that have none, on
+// every Init: first boot after the table's introduction backfills the world,
+// later boots reconcile stragglers (docs written by an old binary during a
+// rolling deploy). Archived docs get rows too, so unarchive can restore
+// them. ON CONFLICT DO NOTHING keeps concurrent startups idempotent.
 func (s *Store) backfillCatalog(ctx context.Context) error {
 	type tip struct {
 		path     string
 		stored   []byte
 		modified time.Time
 	}
-	// Materialize before writing: database/sql allows one active statement
-	// per transaction, so reading and inserting cannot interleave.
+	// Materialize first: database/sql allows one active statement per tx.
 	var tips []tip
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT d.path, v.stored, v.modified
@@ -172,19 +155,16 @@ func (s *Store) backfillCatalog(ctx context.Context) error {
 	return nil
 }
 
-// Lookup implements the handler's LookupCatalog seam against the catalog
-// table, replicating catalog.Catalog.Lookup exactly: score is the count of
-// distinct query terms matching a tag (case-insensitive, exact) or the
-// non-empty title (case-insensitive substring); ordering is score desc,
-// importance desc, modified desc, path asc; "*" matches everything under
-// the scope with score zero. Filter predicates and the Max cap are applied
-// in Go via the shared catalog code.
+// Lookup replicates catalog.Catalog.Lookup exactly: score counts distinct
+// query terms matching a tag (exact) or the title (substring), both
+// case-insensitive; ordered by score, importance, modified, path. "*"
+// matches all under scope at score zero. Filters and Max run in Go via
+// shared catalog code.
 func (s *Store) Lookup(query string, opts catalog.Options) ([]catalog.Result, error) {
 	matchAll := strings.TrimSpace(query) == "*"
 	terms := catalog.Tokenize(query)
 	if matchAll {
-		// Score must stay zero for every row so ordering reduces to
-		// importance, exactly like the in-memory match-all path.
+		// Zero terms keep every score zero: match-all ordering is importance.
 		terms = nil
 	} else if len(terms) == 0 {
 		return nil, nil
@@ -216,7 +196,7 @@ func (s *Store) Lookup(query string, opts catalog.Options) ([]catalog.Result, er
 	if !matchAll {
 		q += ` WHERE m.score > 0`
 	}
-	// C-collated path asc equals the in-memory Go byte-wise tiebreak.
+	// C-collated path asc equals the in-memory byte-wise tiebreak.
 	q += ` ORDER BY m.score DESC, m.importance DESC, m.modified DESC, m.path ASC`
 
 	ctx, cancel := opCtx()
@@ -270,14 +250,10 @@ func scanLookupRow(rows *sql.Rows) (catalog.Result, error) {
 	return r, nil
 }
 
-// Put implements the handler's LookupCatalog seam as a no-op: the catalog
-// row was already upserted inside the write transaction that produced the
-// document, which is the whole point of this backend. Doing it again here
-// would race other replicas' writes.
+// Put is a no-op: the write transaction already upserted the row; repeating
+// it here would race other replicas' writes.
 func (s *Store) Put(_ string, _ map[string]string, _ []byte, _ time.Time) {}
 
-// Remove implements the handler's LookupCatalog seam as a no-op: the row is
-// kept and Lookup excludes archived documents via the documents join, so the
-// archive transaction that flipped the flag already hid the entry (and a
-// later unarchive restores it) transactionally.
+// Remove is a no-op: Lookup excludes archived docs via the documents join,
+// so the archive transaction already hid the entry.
 func (s *Store) Remove(_ string) {}

--- a/server/internal/pgstore/catalog.go
+++ b/server/internal/pgstore/catalog.go
@@ -12,12 +12,10 @@ import (
 	"github.com/latebit-io/demarkus/server/internal/catalog"
 )
 
-// This file implements the handler's LookupCatalog seam. Catalog rows ride
-// the document write transaction, so every replica's LOOKUP is exactly as
-// current as the store. Parity split: lowercasing happens in Go at write
-// time (Postgres lower() diverges from strings.ToLower on unicode); SQL does
-// scope, scoring, ordering; filters and Max run through shared catalog code
-// so they cannot diverge.
+// Postgres LookupCatalog: rows ride the document write tx, so every
+// replica's LOOKUP is as current as the store. Lowercasing happens in Go at
+// write time (Postgres lower() diverges on unicode); filters reuse shared
+// catalog code so they cannot diverge.
 
 // upsertCatalogRow writes a document tip's catalog row inside the caller's
 // write transaction. Archived state is not stored: Lookup joins
@@ -98,12 +96,35 @@ func jsonObject(m map[string]string) ([]byte, error) {
 	return json.Marshal(m)
 }
 
-// backfillCatalog inserts catalog rows for document tips that have none, on
-// every Init: first boot after the table's introduction backfills the world,
-// later boots reconcile stragglers (docs written by an old binary during a
-// rolling deploy). Archived docs get rows too, so unarchive can restore
-// them. ON CONFLICT DO NOTHING keeps concurrent startups idempotent.
+// backfillBatchSize bounds tips (with full stored blobs) held in memory per
+// backfill round.
+const backfillBatchSize = 100
+
+// backfillCatalog inserts catalog rows for tips lacking them (pre-catalog
+// migration, rolling-deploy stragglers, archived docs included). Per-batch
+// commits let an interrupted startup resume where it left off.
 func (s *Store) backfillCatalog(ctx context.Context) error {
+	total := 0
+	for {
+		n, err := s.backfillBatch(ctx)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			break
+		}
+		total += n
+	}
+	if total > 0 {
+		s.logger.Info("lookup catalog backfilled", "entries", total)
+	}
+	return nil
+}
+
+// backfillBatch fills one batch of missing rows; the WHERE c.path IS NULL
+// predicate advances past committed batches, so no cursor is needed.
+// ON CONFLICT DO NOTHING keeps concurrent replica startups idempotent.
+func (s *Store) backfillBatch(ctx context.Context) (int, error) {
 	type tip struct {
 		path     string
 		stored   []byte
@@ -116,28 +137,30 @@ func (s *Store) backfillCatalog(ctx context.Context) error {
 		FROM documents d
 		JOIN versions v ON v.path = d.path AND v.version = d.current_version
 		LEFT JOIN catalog c ON c.path = d.path
-		WHERE c.path IS NULL`)
+		WHERE c.path IS NULL
+		ORDER BY d.path
+		LIMIT $1`, backfillBatchSize)
 	if err != nil {
-		return fmt.Errorf("catalog backfill read: %w", err)
+		return 0, fmt.Errorf("catalog backfill read: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var t tip
 		if err := rows.Scan(&t.path, &t.stored, &t.modified); err != nil {
-			return fmt.Errorf("catalog backfill read: %w", err)
+			return 0, fmt.Errorf("catalog backfill read: %w", err)
 		}
 		tips = append(tips, t)
 	}
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("catalog backfill read: %w", err)
+		return 0, fmt.Errorf("catalog backfill read: %w", err)
 	}
 	if len(tips) == 0 {
-		return nil
+		return 0, nil
 	}
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("catalog backfill: %w", err)
+		return 0, fmt.Errorf("catalog backfill: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 	for _, t := range tips {
@@ -145,21 +168,18 @@ func (s *Store) backfillCatalog(ctx context.Context) error {
 			store.ExtractMetadata(t.stored), store.ExtractBody(t.stored),
 			t.modified.UTC().Truncate(time.Second))
 		if err := insertCatalogRowIfAbsent(ctx, tx, t.path, entry); err != nil {
-			return fmt.Errorf("catalog backfill: %w", err)
+			return 0, fmt.Errorf("catalog backfill: %w", err)
 		}
 	}
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("catalog backfill: %w", err)
+		return 0, fmt.Errorf("catalog backfill: %w", err)
 	}
-	s.logger.Info("lookup catalog backfilled", "entries", len(tips))
-	return nil
+	return len(tips), nil
 }
 
-// Lookup replicates catalog.Catalog.Lookup exactly: score counts distinct
-// query terms matching a tag (exact) or the title (substring), both
-// case-insensitive; ordered by score, importance, modified, path. "*"
-// matches all under scope at score zero. Filters and Max run in Go via
-// shared catalog code.
+// Lookup replicates catalog.Catalog.Lookup's semantics exactly; the
+// storetest LOOKUP conformance suite is the contract. Filters and the Max
+// cap run in Go via shared catalog code.
 func (s *Store) Lookup(query string, opts catalog.Options) ([]catalog.Result, error) {
 	matchAll := strings.TrimSpace(query) == "*"
 	terms := catalog.Tokenize(query)
@@ -198,6 +218,11 @@ func (s *Store) Lookup(query string, opts catalog.Options) ([]catalog.Result, er
 	}
 	// C-collated path asc equals the in-memory byte-wise tiebreak.
 	q += ` ORDER BY m.score DESC, m.importance DESC, m.modified DESC, m.path ASC`
+	// Filters run in Go, so SQL may truncate only when none are present.
+	if len(opts.Filter) == 0 && opts.Max > 0 {
+		args = append(args, opts.Max)
+		q += fmt.Sprintf(` LIMIT $%d`, len(args))
+	}
 
 	ctx, cancel := opCtx()
 	defer cancel()

--- a/server/internal/pgstore/catalog.go
+++ b/server/internal/pgstore/catalog.go
@@ -1,0 +1,283 @@
+package pgstore
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/latebit-io/demarkus/protocol/store"
+	"github.com/latebit-io/demarkus/server/internal/catalog"
+)
+
+// This file is the Postgres implementation of the handler's LookupCatalog
+// seam. Catalog rows are written inside the same transaction as the document
+// write (see upsertCatalogRow calls in write), so every replica sees a
+// LOOKUP catalog exactly as current as the store itself; there is no per-pod
+// in-RAM index to diverge.
+//
+// Parity with catalog.Catalog is split deliberately:
+//   - All lowercasing happens in Go at write time (tags_lower, title_lower),
+//     because Postgres lower() and Go strings.ToLower disagree on unicode
+//     edge cases. The SQL query only ever compares Go-lowered values against
+//     Go-lowered query terms (catalog.Tokenize).
+//   - Match scoring, archived exclusion, scope, and ordering run in SQL.
+//   - Filter predicates run in Go through catalog.MatchesAll, the same code
+//     the in-memory catalog uses, so filter semantics cannot diverge.
+
+// upsertCatalogRow writes the catalog row for a document tip inside the
+// caller's write transaction. entry is derived via catalog.FromDocument, the
+// same derivation the handler performs for the in-memory catalog. Archived
+// state is not stored here: the lookup query joins documents.archived, so
+// archive/unarchive need no catalog writes and unarchive restores the entry.
+func upsertCatalogRow(ctx context.Context, tx *sql.Tx, p string, entry *catalog.Entry) error {
+	args, err := catalogRowArgs(p, entry)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO catalog (path, tags, tags_lower, importance, title, title_lower, meta, modified)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		ON CONFLICT (path) DO UPDATE SET
+			tags = EXCLUDED.tags, tags_lower = EXCLUDED.tags_lower,
+			importance = EXCLUDED.importance, title = EXCLUDED.title,
+			title_lower = EXCLUDED.title_lower, meta = EXCLUDED.meta,
+			modified = EXCLUDED.modified`, args...)
+	if err != nil {
+		return fmt.Errorf("catalog row %s: %w", p, err)
+	}
+	return nil
+}
+
+// insertCatalogRowIfAbsent is the backfill variant of upsertCatalogRow: it
+// never overwrites, so a row created by a concurrent live write (which is
+// newer than the tip the backfill read) always wins.
+func insertCatalogRowIfAbsent(ctx context.Context, tx *sql.Tx, p string, entry *catalog.Entry) error {
+	args, err := catalogRowArgs(p, entry)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO catalog (path, tags, tags_lower, importance, title, title_lower, meta, modified)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		ON CONFLICT (path) DO NOTHING`, args...)
+	if err != nil {
+		return fmt.Errorf("catalog row %s: %w", p, err)
+	}
+	return nil
+}
+
+// catalogRowArgs encodes an entry as the shared column values of the two
+// catalog INSERT statements. All lowercasing happens here, in Go.
+func catalogRowArgs(p string, entry *catalog.Entry) ([]any, error) {
+	tagsJSON, err := jsonArray(entry.Tags)
+	if err != nil {
+		return nil, fmt.Errorf("catalog row %s: %w", p, err)
+	}
+	lower := make([]string, len(entry.Tags))
+	for i, tag := range entry.Tags {
+		lower[i] = strings.ToLower(tag)
+	}
+	tagsLowerJSON, err := jsonArray(lower)
+	if err != nil {
+		return nil, fmt.Errorf("catalog row %s: %w", p, err)
+	}
+	metaJSON, err := jsonObject(entry.Metadata)
+	if err != nil {
+		return nil, fmt.Errorf("catalog row %s: %w", p, err)
+	}
+	return []any{p, tagsJSON, tagsLowerJSON, entry.Importance,
+		entry.Title, strings.ToLower(entry.Title), metaJSON, entry.Modified}, nil
+}
+
+// jsonArray marshals a string slice as a jsonb array, never null: the lookup
+// query feeds the value to jsonb_array_elements_text, which rejects scalars.
+func jsonArray(ss []string) ([]byte, error) {
+	if ss == nil {
+		ss = []string{}
+	}
+	return json.Marshal(ss)
+}
+
+// jsonObject marshals a metadata map as a jsonb object, never null.
+func jsonObject(m map[string]string) ([]byte, error) {
+	if m == nil {
+		m = map[string]string{}
+	}
+	return json.Marshal(m)
+}
+
+// backfillCatalog inserts catalog rows for document tips that have none. It
+// runs on every Init: the first start after this table was introduced
+// backfills the whole world (the additive migration), and later starts
+// reconcile stragglers, e.g. documents written by an old binary during a
+// rolling deploy, which upserted no catalog rows. In the steady state the
+// query matches nothing. Archived documents get rows too; their entries stay
+// invisible to Lookup (the query excludes archived) but must exist so a
+// later unarchive restores them. ON CONFLICT DO NOTHING makes concurrent
+// replica startups idempotent and never overwrites a row a live write
+// created in the meantime.
+func (s *Store) backfillCatalog(ctx context.Context) error {
+	type tip struct {
+		path     string
+		stored   []byte
+		modified time.Time
+	}
+	// Materialize before writing: database/sql allows one active statement
+	// per transaction, so reading and inserting cannot interleave.
+	var tips []tip
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT d.path, v.stored, v.modified
+		FROM documents d
+		JOIN versions v ON v.path = d.path AND v.version = d.current_version
+		LEFT JOIN catalog c ON c.path = d.path
+		WHERE c.path IS NULL`)
+	if err != nil {
+		return fmt.Errorf("catalog backfill read: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var t tip
+		if err := rows.Scan(&t.path, &t.stored, &t.modified); err != nil {
+			return fmt.Errorf("catalog backfill read: %w", err)
+		}
+		tips = append(tips, t)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("catalog backfill read: %w", err)
+	}
+	if len(tips) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("catalog backfill: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, t := range tips {
+		entry := catalog.FromDocument("/"+t.path,
+			store.ExtractMetadata(t.stored), store.ExtractBody(t.stored),
+			t.modified.UTC().Truncate(time.Second))
+		if err := insertCatalogRowIfAbsent(ctx, tx, t.path, entry); err != nil {
+			return fmt.Errorf("catalog backfill: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("catalog backfill: %w", err)
+	}
+	s.logger.Info("lookup catalog backfilled", "entries", len(tips))
+	return nil
+}
+
+// Lookup implements the handler's LookupCatalog seam against the catalog
+// table, replicating catalog.Catalog.Lookup exactly: score is the count of
+// distinct query terms matching a tag (case-insensitive, exact) or the
+// non-empty title (case-insensitive substring); ordering is score desc,
+// importance desc, modified desc, path asc; "*" matches everything under
+// the scope with score zero. Filter predicates and the Max cap are applied
+// in Go via the shared catalog code.
+func (s *Store) Lookup(query string, opts catalog.Options) ([]catalog.Result, error) {
+	matchAll := strings.TrimSpace(query) == "*"
+	terms := catalog.Tokenize(query)
+	if matchAll {
+		// Score must stay zero for every row so ordering reduces to
+		// importance, exactly like the in-memory match-all path.
+		terms = nil
+	} else if len(terms) == 0 {
+		return nil, nil
+	}
+	termsJSON, err := jsonArray(terms)
+	if err != nil {
+		return nil, fmt.Errorf("lookup terms: %w", err)
+	}
+
+	sel := `
+		SELECT c.path, c.tags, c.importance, c.title, c.meta, c.modified,
+			(SELECT count(*)
+			 FROM jsonb_array_elements_text($1::jsonb) AS q(term)
+			 WHERE EXISTS (
+				SELECT 1 FROM jsonb_array_elements_text(c.tags_lower) AS tg(tag)
+				WHERE tg.tag = q.term)
+			   OR (c.title_lower <> '' AND strpos(c.title_lower, q.term) > 0)
+			)::int AS score
+		FROM catalog c
+		JOIN documents d ON d.path = c.path
+		WHERE NOT d.archived`
+	args := []any{termsJSON}
+	if scope := canonical(opts.Scope); scope != "" {
+		prefix := scope + "/"
+		sel += ` AND (c.path = $2 OR (c.path >= $3 AND c.path < $4))`
+		args = append(args, scope, prefix, prefixUpperBound(prefix))
+	}
+	q := `SELECT * FROM (` + sel + `) m`
+	if !matchAll {
+		q += ` WHERE m.score > 0`
+	}
+	// C-collated path asc equals the in-memory Go byte-wise tiebreak.
+	q += ` ORDER BY m.score DESC, m.importance DESC, m.modified DESC, m.path ASC`
+
+	ctx, cancel := opCtx()
+	defer cancel()
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("lookup: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []catalog.Result
+	for rows.Next() {
+		r, err := scanLookupRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("lookup: %w", err)
+		}
+		if !catalog.MatchesAll(&r.Entry, opts.Filter) {
+			continue
+		}
+		results = append(results, r)
+		if opts.Max > 0 && len(results) >= opts.Max {
+			break
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("lookup: %w", err)
+	}
+	return results, nil
+}
+
+// scanLookupRow decodes one lookup result row into the catalog result shape.
+func scanLookupRow(rows *sql.Rows) (catalog.Result, error) {
+	var r catalog.Result
+	var p string
+	var tagsJSON, metaJSON []byte
+	var modified time.Time
+	if err := rows.Scan(&p, &tagsJSON, &r.Importance, &r.Title, &metaJSON, &modified, &r.Score); err != nil {
+		return r, err
+	}
+	if err := json.Unmarshal(tagsJSON, &r.Tags); err != nil {
+		return r, fmt.Errorf("decode tags for %s: %w", p, err)
+	}
+	if err := json.Unmarshal(metaJSON, &r.Metadata); err != nil {
+		return r, fmt.Errorf("decode meta for %s: %w", p, err)
+	}
+	if len(r.Tags) == 0 {
+		r.Tags = nil
+	}
+	r.Path = "/" + p
+	r.Modified = modified.UTC().Truncate(time.Second)
+	return r, nil
+}
+
+// Put implements the handler's LookupCatalog seam as a no-op: the catalog
+// row was already upserted inside the write transaction that produced the
+// document, which is the whole point of this backend. Doing it again here
+// would race other replicas' writes.
+func (s *Store) Put(_ string, _ map[string]string, _ []byte, _ time.Time) {}
+
+// Remove implements the handler's LookupCatalog seam as a no-op: the row is
+// kept and Lookup excludes archived documents via the documents join, so the
+// archive transaction that flipped the flag already hid the entry (and a
+// later unarchive restores it) transactionally.
+func (s *Store) Remove(_ string) {}

--- a/server/internal/pgstore/pgstore.go
+++ b/server/internal/pgstore/pgstore.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/latebit-io/demarkus/protocol"
 	"github.com/latebit-io/demarkus/protocol/store"
+	"github.com/latebit-io/demarkus/server/internal/catalog"
 )
 
 // schema is applied idempotently at startup. Paths are stored canonical:
@@ -52,12 +53,27 @@ CREATE TABLE IF NOT EXISTS versions (
 	PRIMARY KEY (path, version)
 );
 CREATE INDEX IF NOT EXISTS versions_body_hash_idx ON versions (body_hash);
+CREATE TABLE IF NOT EXISTS catalog (
+	path        text COLLATE "C" PRIMARY KEY,
+	tags        jsonb NOT NULL,
+	tags_lower  jsonb NOT NULL,
+	importance  double precision NOT NULL,
+	title       text NOT NULL,
+	title_lower text NOT NULL,
+	meta        jsonb NOT NULL,
+	modified    timestamptz NOT NULL
+);
 `
 
 // queryTimeout bounds every store call. The DocumentStore interface carries
 // no context, so the deadline is applied here: a stalled Postgres fails the
 // request instead of holding its goroutine indefinitely.
 const queryTimeout = 10 * time.Second
+
+// initTimeout bounds Open's startup work. Wider than queryTimeout because
+// Init may backfill the whole LOOKUP catalog on the first start after an
+// upgrade; per-request budgets would crash-loop a large world.
+const initTimeout = 60 * time.Second
 
 // Store implements the handler's DocumentStore contract against Postgres.
 type Store struct {
@@ -74,9 +90,9 @@ func Open(dsn string, logger *slog.Logger) (*Store, error) {
 		return nil, fmt.Errorf("open postgres: %w", err)
 	}
 	s := NewWithDB(db, logger)
-	// Bound startup like every other operation: a stalled ping or blocked
-	// DDL must fail fast instead of hanging the server indefinitely.
-	ctx, cancel := opCtx()
+	// Bound startup so a stalled ping, blocked DDL, or hung backfill fails
+	// instead of hanging the server indefinitely.
+	ctx, cancel := context.WithTimeout(context.Background(), initTimeout)
 	defer cancel()
 	if err := s.Init(ctx); err != nil {
 		// Best-effort cleanup of a pool that never became usable.
@@ -109,7 +125,9 @@ func prefixUpperBound(prefix string) string {
 	return prefix[:len(prefix)-1] + "0"
 }
 
-// Init verifies connectivity and applies the idempotent schema.
+// Init verifies connectivity, applies the idempotent schema, and backfills
+// the LOOKUP catalog table from document tips when it is empty (the additive
+// migration for worlds written before the catalog table existed).
 func (s *Store) Init(ctx context.Context) error {
 	if err := s.db.PingContext(ctx); err != nil {
 		return fmt.Errorf("ping postgres: %w", err)
@@ -117,7 +135,7 @@ func (s *Store) Init(ctx context.Context) error {
 	if _, err := s.db.ExecContext(ctx, schema); err != nil {
 		return fmt.Errorf("apply schema: %w", err)
 	}
-	return nil
+	return s.backfillCatalog(ctx)
 }
 
 // Close releases the connection pool.
@@ -126,7 +144,7 @@ func (s *Store) Close() error { return s.db.Close() }
 // Reset destroys every document and version. It exists for the conformance
 // suite, which needs a fresh store per run; never call it on live data.
 func (s *Store) Reset(ctx context.Context) error {
-	if _, err := s.db.ExecContext(ctx, `TRUNCATE documents, versions`); err != nil {
+	if _, err := s.db.ExecContext(ctx, `TRUNCATE documents, versions, catalog`); err != nil {
 		return fmt.Errorf("reset: %w", err)
 	}
 	return nil
@@ -531,6 +549,12 @@ func (s *Store) write(reqPath string, expectedVersion int, content []byte, meta 
 		return nil, fmt.Errorf("update current v%d: %w", next, err)
 	}
 
+	// The LOOKUP catalog row rides the write transaction: every replica's
+	// Lookup sees this document the instant the write commits.
+	if err := upsertCatalogRow(ctx, tx, p, catalog.FromDocument("/"+p, meta, content, now)); err != nil {
+		return nil, err
+	}
+
 	doc := &store.Document{
 		Content:  content,
 		Modified: now,
@@ -539,20 +563,33 @@ func (s *Store) write(reqPath string, expectedVersion int, content []byte, meta 
 		Metadata: meta,
 	}
 
-	if keep := store.RetentionValue(meta); keep > 0 {
-		if cutoff := next - keep; cutoff >= 1 {
-			prune, err := s.pruneVersions(ctx, tx, p, cutoff)
-			if err != nil {
-				return nil, err
-			}
-			doc.Prune = prune
-		}
+	if err := s.applyRetention(ctx, tx, p, next, meta, doc); err != nil {
+		return nil, err
 	}
 
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit v%d: %w", next, err)
 	}
 	return doc, nil
+}
+
+// applyRetention prunes versions per the write's retention metadata, inside
+// the write transaction, recording the result on doc.
+func (s *Store) applyRetention(ctx context.Context, tx *sql.Tx, p string, next int, meta map[string]string, doc *store.Document) error {
+	keep := store.RetentionValue(meta)
+	if keep <= 0 {
+		return nil
+	}
+	cutoff := next - keep
+	if cutoff < 1 {
+		return nil
+	}
+	prune, err := s.pruneVersions(ctx, tx, p, cutoff)
+	if err != nil {
+		return err
+	}
+	doc.Prune = prune
+	return nil
 }
 
 // readTipForWrite loads the current version's stored bytes for the hash

--- a/server/internal/pgstore/pgstore.go
+++ b/server/internal/pgstore/pgstore.go
@@ -70,9 +70,8 @@ CREATE TABLE IF NOT EXISTS catalog (
 // request instead of holding its goroutine indefinitely.
 const queryTimeout = 10 * time.Second
 
-// initTimeout bounds Open's startup work. Wider than queryTimeout because
-// Init may backfill the whole LOOKUP catalog on the first start after an
-// upgrade; per-request budgets would crash-loop a large world.
+// initTimeout bounds Open's startup work; Init may backfill the whole LOOKUP
+// catalog on first boot, which must not crash-loop under the query budget.
 const initTimeout = 60 * time.Second
 
 // Store implements the handler's DocumentStore contract against Postgres.
@@ -90,8 +89,7 @@ func Open(dsn string, logger *slog.Logger) (*Store, error) {
 		return nil, fmt.Errorf("open postgres: %w", err)
 	}
 	s := NewWithDB(db, logger)
-	// Bound startup so a stalled ping, blocked DDL, or hung backfill fails
-	// instead of hanging the server indefinitely.
+	// Bound startup so a stalled ping, DDL, or backfill fails fast.
 	ctx, cancel := context.WithTimeout(context.Background(), initTimeout)
 	defer cancel()
 	if err := s.Init(ctx); err != nil {
@@ -126,8 +124,7 @@ func prefixUpperBound(prefix string) string {
 }
 
 // Init verifies connectivity, applies the idempotent schema, and backfills
-// the LOOKUP catalog table from document tips when it is empty (the additive
-// migration for worlds written before the catalog table existed).
+// missing LOOKUP catalog rows (the additive migration for pre-catalog worlds).
 func (s *Store) Init(ctx context.Context) error {
 	if err := s.db.PingContext(ctx); err != nil {
 		return fmt.Errorf("ping postgres: %w", err)
@@ -549,8 +546,7 @@ func (s *Store) write(reqPath string, expectedVersion int, content []byte, meta 
 		return nil, fmt.Errorf("update current v%d: %w", next, err)
 	}
 
-	// The LOOKUP catalog row rides the write transaction: every replica's
-	// Lookup sees this document the instant the write commits.
+	// Catalog row rides the write tx: visible to every replica at commit.
 	if err := upsertCatalogRow(ctx, tx, p, catalog.FromDocument("/"+p, meta, content, now)); err != nil {
 		return nil, err
 	}

--- a/server/internal/pgstore/pgstore_test.go
+++ b/server/internal/pgstore/pgstore_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -200,6 +201,36 @@ func TestPostgresCatalogBackfill(t *testing.T) {
 		t.Fatalf("reconcile init: %v", err)
 	}
 	assertLookupCount(t, s, "go", 2)
+}
+
+// TestPostgresCatalogBackfillBatches forces the backfill past one batch
+// (batch size 100), proving the loop and its per-batch commits terminate.
+func TestPostgresCatalogBackfillBatches(t *testing.T) {
+	s := openStore(t)
+	ctx := context.Background()
+	if err := s.Reset(ctx); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	const docs = 120
+	for i := range docs {
+		path := fmt.Sprintf("/batch/doc-%03d.md", i)
+		if _, err := s.WriteVersion(path, 0, []byte("x"), map[string]string{"tags": "batch"}); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	db, err := sql.Open("pgx", testDSN(t))
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.ExecContext(ctx, `DELETE FROM catalog`); err != nil {
+		t.Fatalf("clear catalog: %v", err)
+	}
+	assertLookupCount(t, s, "batch", 0)
+	if err := s.Init(ctx); err != nil {
+		t.Fatalf("re-init: %v", err)
+	}
+	assertLookupCount(t, s, "batch", docs)
 }
 
 // assertLookupCount asserts how many documents a lookup matches.

--- a/server/internal/pgstore/pgstore_test.go
+++ b/server/internal/pgstore/pgstore_test.go
@@ -1,10 +1,22 @@
 package pgstore_test
 
 import (
+	"bytes"
 	"context"
+	"database/sql"
+	"io"
+	"log/slog"
 	"os"
+	"strings"
 	"testing"
 
+	// Register the pgx database/sql driver for the raw handle the backfill
+	// test uses to clear the catalog table out of band.
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/latebit-io/demarkus/protocol"
+	"github.com/latebit-io/demarkus/server/internal/auth"
+	"github.com/latebit-io/demarkus/server/internal/catalog"
 	"github.com/latebit-io/demarkus/server/internal/handler"
 	"github.com/latebit-io/demarkus/server/internal/pgstore"
 	"github.com/latebit-io/demarkus/server/internal/storetest"
@@ -16,20 +28,195 @@ import (
 //
 //	DEMARKUS_TEST_PG_DSN="postgres://postgres:postgres@localhost:5432/demarkus_test" go test ./internal/pgstore/
 func TestPostgresConformance(t *testing.T) {
-	dsn := os.Getenv("DEMARKUS_TEST_PG_DSN")
-	if dsn == "" {
-		t.Skip("DEMARKUS_TEST_PG_DSN not set; skipping Postgres conformance")
-	}
-	s, err := pgstore.Open(dsn, nil)
-	if err != nil {
-		t.Fatalf("open postgres: %v", err)
-	}
-	t.Cleanup(func() { _ = s.Close() })
-
+	s := openStore(t)
 	storetest.RunConformance(t, func(t *testing.T) handler.DocumentStore {
 		if err := s.Reset(context.Background()); err != nil {
 			t.Fatalf("reset: %v", err)
 		}
 		return s
 	})
+}
+
+// testDSN returns the conformance database DSN or skips the test.
+func testDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("DEMARKUS_TEST_PG_DSN")
+	if dsn == "" {
+		t.Skip("DEMARKUS_TEST_PG_DSN not set; skipping Postgres test")
+	}
+	return dsn
+}
+
+// openStore opens a pgstore against the test database with a quiet logger.
+func openStore(t *testing.T) *pgstore.Store {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s, err := pgstore.Open(testDSN(t), logger)
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// TestPostgresLookupConformance runs the LOOKUP conformance suite against
+// pgstore's transactional catalog. The store is both halves of the backend
+// pair: catalog rows are maintained by its write transactions, and the
+// suite's handler-mirroring Put/Remove calls are the same no-ops the real
+// handler makes.
+func TestPostgresLookupConformance(t *testing.T) {
+	s := openStore(t)
+	storetest.RunLookupConformance(t, func(t *testing.T) storetest.LookupBackend {
+		if err := s.Reset(context.Background()); err != nil {
+			t.Fatalf("reset: %v", err)
+		}
+		return storetest.LookupBackend{Store: s, Catalog: s}
+	})
+}
+
+// mockStream is the minimal handler.Stream for driving requests in tests.
+type mockStream struct {
+	io.Reader
+	output bytes.Buffer
+}
+
+func (m *mockStream) Write(p []byte) (int, error) { return m.output.Write(p) }
+func (m *mockStream) Close() error                { return nil }
+
+// send runs one raw request through a handler and returns the parsed response.
+func send(t *testing.T, h *handler.Handler, request string) protocol.Response {
+	t.Helper()
+	stream := &mockStream{Reader: strings.NewReader(request)}
+	h.HandleStream(stream)
+	resp, err := protocol.ParseResponse(&stream.output)
+	if err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	return resp
+}
+
+// replicaHandler wraps a store in a handler the way main.go wires postgres
+// mode: the store is both DocumentStore and LookupCatalog, no catalog build.
+func replicaHandler(t *testing.T, s *pgstore.Store, ts *auth.TokenStore) *handler.Handler {
+	t.Helper()
+	return &handler.Handler{
+		Store:         s,
+		Catalog:       s,
+		Logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		GetTokenStore: func() *auth.TokenStore { return ts },
+	}
+}
+
+// TestPostgresLookupMultiReplica is the multi-replica proof: two handler and
+// catalog instances over one database, with no shared process state. A write
+// handled by one replica must be visible to LOOKUP on the other immediately,
+// and an archive handled by the second must hide the document from the first.
+func TestPostgresLookupMultiReplica(t *testing.T) {
+	storeA, storeB := openStore(t), openStore(t)
+	if err := storeA.Reset(context.Background()); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	const secret = "replica-secret"
+	ts := auth.NewTokenStore(map[string]auth.Token{
+		protocol.HashToken(secret): {Paths: []string{"/**"}, Operations: []string{"publish"}},
+	})
+	replicaA, replicaB := replicaHandler(t, storeA, ts), replicaHandler(t, storeB, ts)
+
+	pub := send(t, replicaA, "PUBLISH /notes/auth.md\n---\nauth: "+secret+"\ntags: middleware,go\n---\n# Auth Middleware\n")
+	if pub.Status != protocol.StatusCreated {
+		t.Fatalf("publish via A: status = %q, want created", pub.Status)
+	}
+
+	look := send(t, replicaB, "LOOKUP /\n---\nquery: middleware\n---\n")
+	if look.Status != protocol.StatusOK || look.Metadata["matches"] != "1" {
+		t.Fatalf("lookup via B: status %q matches %q, want ok/1", look.Status, look.Metadata["matches"])
+	}
+	if !strings.Contains(look.Body, "/notes/auth.md") || !strings.Contains(look.Body, "Auth Middleware") {
+		t.Errorf("lookup via B missing the document A published:\n%s", look.Body)
+	}
+
+	arch := send(t, replicaB, "ARCHIVE /notes/auth.md\n---\nauth: "+secret+"\n---\n")
+	if arch.Status != protocol.StatusOK {
+		t.Fatalf("archive via B: status = %q, want ok", arch.Status)
+	}
+	look = send(t, replicaA, "LOOKUP /\n---\nquery: middleware\n---\n")
+	if look.Metadata["matches"] != "0" {
+		t.Errorf("lookup via A after archive via B: matches = %q, want 0", look.Metadata["matches"])
+	}
+}
+
+// TestPostgresCatalogBackfill covers the additive migration: a database with
+// documents but no catalog rows (a world written before the catalog table
+// existed) gets its catalog rebuilt from version tips on Init. Archived
+// documents get rows too, staying hidden until unarchived. Init also
+// reconciles partial gaps (documents that missed their catalog row, e.g.
+// written by an old binary during a rolling deploy) without touching rows
+// that already exist.
+func TestPostgresCatalogBackfill(t *testing.T) {
+	s := openStore(t)
+	ctx := context.Background()
+	if err := s.Reset(ctx); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	if _, err := s.WriteVersion("/live.md", 0, []byte("# Live\n"), map[string]string{"tags": "go"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := s.WriteVersion("/gone.md", 0, []byte("# Gone\n"), map[string]string{"tags": "go"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := s.Archive("/gone.md", true); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	// Simulate the pre-catalog world: rows exist for documents and versions
+	// but the catalog table is empty.
+	db, err := sql.Open("pgx", testDSN(t))
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.ExecContext(ctx, `DELETE FROM catalog`); err != nil {
+		t.Fatalf("clear catalog: %v", err)
+	}
+	assertLookupCount(t, s, "go", 0)
+
+	if err := s.Init(ctx); err != nil {
+		t.Fatalf("re-init: %v", err)
+	}
+	assertLookupCount(t, s, "go", 1)
+
+	// The archived document's row was backfilled too: unarchive restores it
+	// without any write.
+	if err := s.Archive("/gone.md", false); err != nil {
+		t.Fatalf("unarchive: %v", err)
+	}
+	assertLookupCount(t, s, "go", 2)
+
+	// A second Init on a populated catalog is a no-op, not a duplicate fill.
+	if err := s.Init(ctx); err != nil {
+		t.Fatalf("second init: %v", err)
+	}
+	assertLookupCount(t, s, "go", 2)
+
+	// A partial gap (one document missing its row) is reconciled too.
+	if _, err := db.ExecContext(ctx, `DELETE FROM catalog WHERE path = 'live.md'`); err != nil {
+		t.Fatalf("clear one row: %v", err)
+	}
+	assertLookupCount(t, s, "go", 1)
+	if err := s.Init(ctx); err != nil {
+		t.Fatalf("reconcile init: %v", err)
+	}
+	assertLookupCount(t, s, "go", 2)
+}
+
+// assertLookupCount asserts how many documents a lookup matches.
+func assertLookupCount(t *testing.T, s *pgstore.Store, query string, want int) {
+	t.Helper()
+	rs, err := s.Lookup(query, catalog.Options{})
+	if err != nil {
+		t.Fatalf("lookup %q: %v", query, err)
+	}
+	if len(rs) != want {
+		t.Errorf("lookup %q matched %d, want %d (results %+v)", query, len(rs), want, rs)
+	}
 }

--- a/server/internal/pgstore/pgstore_test.go
+++ b/server/internal/pgstore/pgstore_test.go
@@ -59,11 +59,8 @@ func openStore(t *testing.T) *pgstore.Store {
 	return s
 }
 
-// TestPostgresLookupConformance runs the LOOKUP conformance suite against
-// pgstore's transactional catalog. The store is both halves of the backend
-// pair: catalog rows are maintained by its write transactions, and the
-// suite's handler-mirroring Put/Remove calls are the same no-ops the real
-// handler makes.
+// TestPostgresLookupConformance runs the LOOKUP conformance suite; the store
+// is both halves of the backend pair (rows maintained by its write txs).
 func TestPostgresLookupConformance(t *testing.T) {
 	s := openStore(t)
 	storetest.RunLookupConformance(t, func(t *testing.T) storetest.LookupBackend {
@@ -107,10 +104,9 @@ func replicaHandler(t *testing.T, s *pgstore.Store, ts *auth.TokenStore) *handle
 	}
 }
 
-// TestPostgresLookupMultiReplica is the multi-replica proof: two handler and
-// catalog instances over one database, with no shared process state. A write
-// handled by one replica must be visible to LOOKUP on the other immediately,
-// and an archive handled by the second must hide the document from the first.
+// TestPostgresLookupMultiReplica: two handler+catalog instances over one
+// database, no shared process state. A write via one must be visible to
+// LOOKUP on the other immediately; an archive via B must hide it from A.
 func TestPostgresLookupMultiReplica(t *testing.T) {
 	storeA, storeB := openStore(t), openStore(t)
 	if err := storeA.Reset(context.Background()); err != nil {
@@ -145,13 +141,10 @@ func TestPostgresLookupMultiReplica(t *testing.T) {
 	}
 }
 
-// TestPostgresCatalogBackfill covers the additive migration: a database with
-// documents but no catalog rows (a world written before the catalog table
-// existed) gets its catalog rebuilt from version tips on Init. Archived
-// documents get rows too, staying hidden until unarchived. Init also
-// reconciles partial gaps (documents that missed their catalog row, e.g.
-// written by an old binary during a rolling deploy) without touching rows
-// that already exist.
+// TestPostgresCatalogBackfill covers the additive migration: Init rebuilds
+// missing catalog rows from version tips (full pre-catalog worlds and
+// partial rolling-deploy gaps), including archived docs, without touching
+// existing rows.
 func TestPostgresCatalogBackfill(t *testing.T) {
 	s := openStore(t)
 	ctx := context.Background()

--- a/server/internal/storetest/filestore_test.go
+++ b/server/internal/storetest/filestore_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/latebit-io/demarkus/protocol/store"
+	"github.com/latebit-io/demarkus/server/internal/catalog"
 	"github.com/latebit-io/demarkus/server/internal/handler"
 )
 
@@ -12,5 +13,14 @@ import (
 func TestFileStoreConformance(t *testing.T) {
 	RunConformance(t, func(t *testing.T) handler.DocumentStore {
 		return store.New(t.TempDir())
+	})
+}
+
+// TestFileStoreLookupConformance runs the LOOKUP conformance suite against
+// the file backend's pairing: file store plus in-memory catalog, kept in
+// sync by the handler-mirroring helpers.
+func TestFileStoreLookupConformance(t *testing.T) {
+	RunLookupConformance(t, func(t *testing.T) LookupBackend {
+		return LookupBackend{Store: store.New(t.TempDir()), Catalog: catalog.New()}
 	})
 }

--- a/server/internal/storetest/lookup.go
+++ b/server/internal/storetest/lookup.go
@@ -1,0 +1,296 @@
+package storetest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/latebit-io/demarkus/protocol/store"
+	"github.com/latebit-io/demarkus/server/internal/catalog"
+	"github.com/latebit-io/demarkus/server/internal/handler"
+)
+
+// LookupBackend pairs a DocumentStore with the LookupCatalog that observes
+// it, the two halves the handler wires together. For the file backend the
+// catalog is a fresh in-memory catalog.Catalog; for pgstore both fields are
+// the same store, since it maintains its catalog inside write transactions.
+type LookupBackend struct {
+	Store   handler.DocumentStore
+	Catalog handler.LookupCatalog
+}
+
+// LookupFactory returns a fresh, empty backend for one conformance subtest.
+type LookupFactory func(t *testing.T) LookupBackend
+
+// RunLookupConformance exercises the LookupCatalog contract: every backend
+// must rank, score, scope, and filter identically to the in-memory catalog.
+// The helpers drive the catalog exactly as the handler does (Put after each
+// successful write, Remove on archive, Put on unarchive), which for
+// transactional backends are no-ops layered over rows the store already
+// maintains — precisely the parity being proven.
+func RunLookupConformance(t *testing.T, factory LookupFactory) {
+	subtests := []struct {
+		name string
+		fn   func(t *testing.T, b LookupBackend)
+	}{
+		{"Matching", testLookupMatching},
+		{"Ranking", testLookupRanking},
+		{"Tiebreaks", testLookupTiebreaks},
+		{"TitleFallback", testLookupTitleFallback},
+		{"MatchAll", testLookupMatchAll},
+		{"Scope", testLookupScope},
+		{"Filters", testLookupFilters},
+		{"ArchiveLifecycle", testLookupArchiveLifecycle},
+		{"UpdateReplacesEntry", testLookupUpdateReplacesEntry},
+		{"MaxCap", testLookupMaxCap},
+	}
+	for _, st := range subtests {
+		t.Run(st.name, func(t *testing.T) {
+			st.fn(t, factory(t))
+		})
+	}
+}
+
+func testLookupMatching(t *testing.T, b LookupBackend) {
+	// Distinct importances make same-score orderings deterministic without
+	// depending on write timestamps.
+	catalogPublish(t, b, "/tagged.md", "body", map[string]string{"tags": "auth,Go", "title": "Unrelated", "importance": "0.6"})
+	catalogPublish(t, b, "/titled.md", "body", map[string]string{"tags": "misc", "title": "Auth Middleware Design"})
+	catalogPublish(t, b, "/substring-tag.md", "body", map[string]string{"tags": "golang", "title": "Nothing here"})
+
+	// Tag matches are exact (case-insensitive); title matches are substrings.
+	assertLookup(t, b, "auth", catalog.Options{}, "/tagged.md", "/titled.md")
+	assertLookup(t, b, "AUTH", catalog.Options{}, "/tagged.md", "/titled.md")
+	assertLookup(t, b, "middleware", catalog.Options{}, "/titled.md")
+	// "go" is not the tag "golang", and no title contains it.
+	assertLookup(t, b, "go", catalog.Options{}, "/tagged.md")
+	assertLookup(t, b, "kubernetes", catalog.Options{})
+	assertLookup(t, b, "", catalog.Options{})
+	assertLookup(t, b, "   ", catalog.Options{})
+
+	// Entry contents survive the round trip: original-case tags, title, score.
+	rs := mustLookup(t, b, "middleware", catalog.Options{})
+	if len(rs) != 1 || rs[0].Title != "Auth Middleware Design" || rs[0].Score != 1 {
+		t.Errorf("result = %+v, want title %q score 1", rs, "Auth Middleware Design")
+	}
+	rs = mustLookup(t, b, "auth", catalog.Options{})
+	if len(rs) == 0 || len(rs[0].Tags) != 2 || rs[0].Tags[0] != "auth" || rs[0].Tags[1] != "Go" {
+		t.Errorf("tags = %+v, want original-case [auth Go]", rs)
+	}
+}
+
+func testLookupRanking(t *testing.T, b LookupBackend) {
+	// Matches one term, high importance.
+	catalogPublish(t, b, "/one-term.md", "x", map[string]string{"tags": "auth", "importance": "0.99"})
+	// Matches both terms: score must beat importance.
+	catalogPublish(t, b, "/two-terms.md", "x", map[string]string{"tags": "auth,middleware", "importance": "0.1"})
+	// Same score as one-term, lower importance.
+	catalogPublish(t, b, "/also-one.md", "x", map[string]string{"tags": "middleware", "importance": "0.5"})
+
+	assertLookup(t, b, "auth middleware", catalog.Options{},
+		"/two-terms.md", "/one-term.md", "/also-one.md")
+
+	// Duplicate terms count once: score stays 2, not 3.
+	rs := mustLookup(t, b, "auth auth middleware", catalog.Options{})
+	if len(rs) == 0 || rs[0].Path != "/two-terms.md" || rs[0].Score != 2 {
+		t.Errorf("distinct-term score = %+v, want /two-terms.md with score 2", rs)
+	}
+}
+
+func testLookupTiebreaks(t *testing.T, b LookupBackend) {
+	// Same score, same importance: modification time breaks the tie, then
+	// path ascending. Writes stamp their own time, so derive the expected
+	// order from the stored documents instead of assuming same-second writes.
+	catalogPublish(t, b, "/tie/b.md", "x", map[string]string{"tags": "go", "importance": "0.5"})
+	catalogPublish(t, b, "/tie/a.md", "x", map[string]string{"tags": "go", "importance": "0.5"})
+
+	first, second := "/tie/a.md", "/tie/b.md" // equal times: path ascending
+	if modifiedOf(t, b, "/tie/a.md").Before(modifiedOf(t, b, "/tie/b.md")) {
+		first, second = "/tie/b.md", "/tie/a.md" // b is newer: newest first
+	}
+	assertLookup(t, b, "go", catalog.Options{}, first, second)
+}
+
+func testLookupTitleFallback(t *testing.T, b LookupBackend) {
+	catalogPublish(t, b, "/declared.md", "# Ignored Heading\n", map[string]string{"title": "Declared Winner"})
+	catalogPublish(t, b, "/heading.md", "# From The Heading\n\nbody\n", nil)
+	catalogPublish(t, b, "/basename.md", "no heading at all\n", nil)
+
+	assertLookup(t, b, "winner", catalog.Options{}, "/declared.md")
+	// The declared title replaced the H1, so the H1 must not match.
+	assertLookup(t, b, "ignored", catalog.Options{})
+	assertLookup(t, b, "heading", catalog.Options{}, "/heading.md")
+	assertLookup(t, b, "basename.md", catalog.Options{}, "/basename.md")
+}
+
+func testLookupMatchAll(t *testing.T, b LookupBackend) {
+	catalogPublish(t, b, "/low.md", "x", map[string]string{"tags": "go", "importance": "0.2"})
+	catalogPublish(t, b, "/hub.md", "x", map[string]string{"tags": "hub", "importance": "0.9"})
+	catalogPublish(t, b, "/docs/deep.md", "x", map[string]string{"tags": "go", "importance": "0.7"})
+
+	// "*" returns everything, importance-ranked, all scores zero.
+	assertLookup(t, b, "*", catalog.Options{}, "/hub.md", "/docs/deep.md", "/low.md")
+	rs := mustLookup(t, b, "*", catalog.Options{})
+	for _, r := range rs {
+		if r.Score != 0 {
+			t.Errorf("match-all score for %s = %d, want 0", r.Path, r.Score)
+		}
+	}
+	// Scope, filters, and Max still narrow the universe.
+	assertLookup(t, b, "*", catalog.Options{Scope: "/docs/"}, "/docs/deep.md")
+	preds := mustParseFilter(t, "tag=go")
+	assertLookup(t, b, "*", catalog.Options{Filter: preds}, "/docs/deep.md", "/low.md")
+	assertLookup(t, b, "*", catalog.Options{Max: 1}, "/hub.md")
+	// A star mixed with other terms is a normal term query, not match-all.
+	assertLookup(t, b, "* hub", catalog.Options{}, "/hub.md")
+}
+
+func testLookupScope(t *testing.T, b LookupBackend) {
+	catalogPublish(t, b, "/docs/a.md", "x", map[string]string{"tags": "go", "importance": "0.9"})
+	catalogPublish(t, b, "/docs/sub/b.md", "x", map[string]string{"tags": "go", "importance": "0.4"})
+	catalogPublish(t, b, "/other/c.md", "x", map[string]string{"tags": "go", "importance": "0.6"})
+
+	all := []string{"/docs/a.md", "/other/c.md", "/docs/sub/b.md"} // 0.9, 0.6, 0.4
+	assertLookup(t, b, "go", catalog.Options{Scope: "/"}, all...)
+	assertLookup(t, b, "go", catalog.Options{Scope: ""}, all...)
+	assertLookup(t, b, "go", catalog.Options{Scope: "/docs/"}, "/docs/a.md", "/docs/sub/b.md")
+	assertLookup(t, b, "go", catalog.Options{Scope: "/docs"}, "/docs/a.md", "/docs/sub/b.md")
+	assertLookup(t, b, "go", catalog.Options{Scope: "/docs/sub"}, "/docs/sub/b.md")
+	// A raw prefix must not leak across path segments.
+	assertLookup(t, b, "go", catalog.Options{Scope: "/oth"})
+}
+
+func testLookupFilters(t *testing.T, b LookupBackend) {
+	catalogPublish(t, b, "/broker.md", "x", map[string]string{"tags": "go", "project": "broker"})
+	catalogPublish(t, b, "/universe.md", "x", map[string]string{"tags": "go,Design", "project": "universe"})
+
+	assertLookup(t, b, "go", catalog.Options{Filter: mustParseFilter(t, "project=broker")}, "/broker.md")
+	// Tag membership filter is case-insensitive.
+	assertLookup(t, b, "go", catalog.Options{Filter: mustParseFilter(t, "tag=design")}, "/universe.md")
+	// Both documents were written after 2000 and before 2100.
+	assertLookup(t, b, "go", catalog.Options{Filter: mustParseFilter(t, "modified-after=2100-01-01")})
+	assertLookup(t, b, "go", catalog.Options{Filter: mustParseFilter(t, "modified-before=2000-01-01")})
+	got := mustLookup(t, b, "go", catalog.Options{Filter: mustParseFilter(t, "modified-after=2000-01-01,modified-before=2100-01-01")})
+	if len(got) != 2 {
+		t.Errorf("date-window filter matched %d docs, want 2", len(got))
+	}
+}
+
+func testLookupArchiveLifecycle(t *testing.T, b LookupBackend) {
+	catalogPublish(t, b, "/keep.md", "x", map[string]string{"tags": "go"})
+	catalogPublish(t, b, "/hide.md", "x", map[string]string{"tags": "go", "importance": "0.4"})
+
+	assertLookup(t, b, "go", catalog.Options{}, "/keep.md", "/hide.md")
+	catalogArchive(t, b, "/hide.md")
+	assertLookup(t, b, "go", catalog.Options{}, "/keep.md")
+	// Archived documents are invisible to match-all too.
+	assertLookup(t, b, "*", catalog.Options{}, "/keep.md")
+	catalogUnarchive(t, b, "/hide.md")
+	assertLookup(t, b, "go", catalog.Options{}, "/keep.md", "/hide.md")
+}
+
+func testLookupUpdateReplacesEntry(t *testing.T, b LookupBackend) {
+	catalogPublish(t, b, "/doc.md", "x", map[string]string{"tags": "alpha", "importance": "0.3"})
+	catalogPublish(t, b, "/doc.md", "y", map[string]string{"tags": "beta", "importance": "0.8"})
+
+	assertLookup(t, b, "alpha", catalog.Options{})
+	assertLookup(t, b, "beta", catalog.Options{}, "/doc.md")
+	rs := mustLookup(t, b, "beta", catalog.Options{})
+	if len(rs) != 1 || rs[0].Importance != 0.8 {
+		t.Errorf("updated entry = %+v, want importance 0.8", rs)
+	}
+}
+
+func testLookupMaxCap(t *testing.T, b LookupBackend) {
+	catalogPublish(t, b, "/m1.md", "x", map[string]string{"tags": "go", "importance": "0.9"})
+	catalogPublish(t, b, "/m2.md", "x", map[string]string{"tags": "go", "importance": "0.7"})
+	catalogPublish(t, b, "/m3.md", "x", map[string]string{"tags": "go", "importance": "0.5"})
+
+	assertLookup(t, b, "go", catalog.Options{Max: 2}, "/m1.md", "/m2.md")
+	assertLookup(t, b, "go", catalog.Options{Max: 0}, "/m1.md", "/m2.md", "/m3.md")
+}
+
+// catalogPublish writes a version and updates the catalog the way the
+// handler's PUBLISH path does. Meta is passed through unvalidated; keep it
+// within store.ValidateMeta bounds.
+func catalogPublish(t *testing.T, b LookupBackend, path, body string, meta map[string]string) {
+	t.Helper()
+	doc, err := b.Store.WriteVersion(path, -1, []byte(body), meta)
+	if err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	b.Catalog.Put(path, doc.Metadata, doc.Content, doc.Modified)
+}
+
+// catalogArchive archives a document and updates the catalog the way the
+// handler's ARCHIVE path does.
+func catalogArchive(t *testing.T, b LookupBackend, path string) {
+	t.Helper()
+	if err := b.Store.Archive(path, true); err != nil {
+		t.Fatalf("archive %s: %v", path, err)
+	}
+	b.Catalog.Remove(path)
+}
+
+// catalogUnarchive unarchives a document and re-registers it the way the
+// handler's empty-body PUBLISH path does.
+func catalogUnarchive(t *testing.T, b LookupBackend, path string) {
+	t.Helper()
+	if err := b.Store.Archive(path, false); err != nil {
+		t.Fatalf("unarchive %s: %v", path, err)
+	}
+	doc, err := b.Store.Get(path, 0)
+	if err != nil {
+		t.Fatalf("get after unarchive %s: %v", path, err)
+	}
+	b.Catalog.Put(path, doc.Metadata, store.ExtractBody(doc.Content), doc.Modified)
+}
+
+// mustLookup runs a lookup, failing the test on error.
+func mustLookup(t *testing.T, b LookupBackend, query string, opts catalog.Options) []catalog.Result {
+	t.Helper()
+	rs, err := b.Catalog.Lookup(query, opts)
+	if err != nil {
+		t.Fatalf("lookup %q: %v", query, err)
+	}
+	return rs
+}
+
+// assertLookup asserts the exact ordered result paths of a lookup.
+func assertLookup(t *testing.T, b LookupBackend, query string, opts catalog.Options, want ...string) {
+	t.Helper()
+	rs := mustLookup(t, b, query, opts)
+	got := make([]string, len(rs))
+	for i, r := range rs {
+		got[i] = r.Path
+	}
+	if len(got) != len(want) {
+		t.Errorf("lookup %q = %v, want %v", query, got, want)
+		return
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("lookup %q = %v, want %v", query, got, want)
+			return
+		}
+	}
+}
+
+// mustParseFilter parses a filter expression, failing the test on error.
+func mustParseFilter(t *testing.T, s string) []catalog.Predicate {
+	t.Helper()
+	preds, err := catalog.ParseFilter(s)
+	if err != nil {
+		t.Fatalf("parse filter %q: %v", s, err)
+	}
+	return preds
+}
+
+// modifiedOf returns a document's current modification time.
+func modifiedOf(t *testing.T, b LookupBackend, path string) time.Time {
+	t.Helper()
+	doc, err := b.Store.Get(path, 0)
+	if err != nil {
+		t.Fatalf("get %s: %v", path, err)
+	}
+	return doc.Modified
+}

--- a/server/internal/storetest/lookup.go
+++ b/server/internal/storetest/lookup.go
@@ -9,10 +9,8 @@ import (
 	"github.com/latebit-io/demarkus/server/internal/handler"
 )
 
-// LookupBackend pairs a DocumentStore with the LookupCatalog that observes
-// it, the two halves the handler wires together. For the file backend the
-// catalog is a fresh in-memory catalog.Catalog; for pgstore both fields are
-// the same store, since it maintains its catalog inside write transactions.
+// LookupBackend pairs a DocumentStore with the LookupCatalog observing it:
+// file store + in-memory catalog, or pgstore as both.
 type LookupBackend struct {
 	Store   handler.DocumentStore
 	Catalog handler.LookupCatalog
@@ -22,11 +20,8 @@ type LookupBackend struct {
 type LookupFactory func(t *testing.T) LookupBackend
 
 // RunLookupConformance exercises the LookupCatalog contract: every backend
-// must rank, score, scope, and filter identically to the in-memory catalog.
-// The helpers drive the catalog exactly as the handler does (Put after each
-// successful write, Remove on archive, Put on unarchive), which for
-// transactional backends are no-ops layered over rows the store already
-// maintains — precisely the parity being proven.
+// must rank, score, scope, and filter identically. Helpers drive the catalog
+// exactly as the handler's write paths do.
 func RunLookupConformance(t *testing.T, factory LookupFactory) {
 	subtests := []struct {
 		name string
@@ -51,8 +46,7 @@ func RunLookupConformance(t *testing.T, factory LookupFactory) {
 }
 
 func testLookupMatching(t *testing.T, b LookupBackend) {
-	// Distinct importances make same-score orderings deterministic without
-	// depending on write timestamps.
+	// Distinct importances keep same-score orderings timestamp-independent.
 	catalogPublish(t, b, "/tagged.md", "body", map[string]string{"tags": "auth,Go", "title": "Unrelated", "importance": "0.6"})
 	catalogPublish(t, b, "/titled.md", "body", map[string]string{"tags": "misc", "title": "Auth Middleware Design"})
 	catalogPublish(t, b, "/substring-tag.md", "body", map[string]string{"tags": "golang", "title": "Nothing here"})
@@ -97,9 +91,9 @@ func testLookupRanking(t *testing.T, b LookupBackend) {
 }
 
 func testLookupTiebreaks(t *testing.T, b LookupBackend) {
-	// Same score, same importance: modification time breaks the tie, then
-	// path ascending. Writes stamp their own time, so derive the expected
-	// order from the stored documents instead of assuming same-second writes.
+	// Same score and importance: modified breaks the tie, then path asc.
+	// Derive the expected order from stored timestamps; writes may straddle
+	// a second boundary.
 	catalogPublish(t, b, "/tie/b.md", "x", map[string]string{"tags": "go", "importance": "0.5"})
 	catalogPublish(t, b, "/tie/a.md", "x", map[string]string{"tags": "go", "importance": "0.5"})
 
@@ -209,9 +203,8 @@ func testLookupMaxCap(t *testing.T, b LookupBackend) {
 	assertLookup(t, b, "go", catalog.Options{Max: 0}, "/m1.md", "/m2.md", "/m3.md")
 }
 
-// catalogPublish writes a version and updates the catalog the way the
-// handler's PUBLISH path does. Meta is passed through unvalidated; keep it
-// within store.ValidateMeta bounds.
+// catalogPublish writes a version and updates the catalog like the handler's
+// PUBLISH path.
 func catalogPublish(t *testing.T, b LookupBackend, path, body string, meta map[string]string) {
 	t.Helper()
 	doc, err := b.Store.WriteVersion(path, -1, []byte(body), meta)
@@ -221,8 +214,8 @@ func catalogPublish(t *testing.T, b LookupBackend, path, body string, meta map[s
 	b.Catalog.Put(path, doc.Metadata, doc.Content, doc.Modified)
 }
 
-// catalogArchive archives a document and updates the catalog the way the
-// handler's ARCHIVE path does.
+// catalogArchive archives a document and updates the catalog like the
+// handler's ARCHIVE path.
 func catalogArchive(t *testing.T, b LookupBackend, path string) {
 	t.Helper()
 	if err := b.Store.Archive(path, true); err != nil {
@@ -231,8 +224,8 @@ func catalogArchive(t *testing.T, b LookupBackend, path string) {
 	b.Catalog.Remove(path)
 }
 
-// catalogUnarchive unarchives a document and re-registers it the way the
-// handler's empty-body PUBLISH path does.
+// catalogUnarchive unarchives and re-registers a document like the handler's
+// empty-body PUBLISH path.
 func catalogUnarchive(t *testing.T, b LookupBackend, path string) {
 	t.Helper()
 	if err := b.Store.Archive(path, false); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Helm-configurable startup probe that confirms the agent manifest is reachable before liveness/readiness checks begin.
  * Expanded LOOKUP with a Postgres-backed catalog, including catalog backfill and multi-replica visibility behavior.
  * File-backed LOOKUP now uses the same catalog semantics via the shared conformance suite.
* **Bug Fixes**
  * LOOKUP request handling now returns a server error when LOOKUP fails.
* **Tests**
  * Strengthened Helm probe tests (including ensuring the startup probe is absent when disabled).
  * Added/expanded Postgres and file-store LOOKUP conformance, backfill, and multi-replica tests.
  * Reduced config-watcher test flakiness with more deterministic timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->