### PR TITLE
feat(client): seed graph tools from the published /graph.md

### DIFF
--- a/client/cmd/demarkus-mcp/explore.go
+++ b/client/cmd/demarkus-mcp/explore.go
@@ -79,6 +79,7 @@ func (h *handler) markExplore(_ context.Context, req mcp.CallToolRequest) (*mcp.
 		mdoutline.CappedList(&b, out, exploreSectionCap, "links")
 	}
 
+	h.seedGraph(host)
 	h.writeBacklinksSection(&b, "mark://"+host+path)
 	h.writeSiblingsSection(&b, host, path, token)
 
@@ -99,7 +100,6 @@ func (h *handler) writeBacklinksSection(b *strings.Builder, fullURL string) {
 		b.WriteString("\n## Backlinks\n(graph store unavailable)\n")
 		return
 	}
-	h.seedGraph(h.defaultHost)
 	backlinks := h.graphStore.BacklinksEnriched(fullURL)
 	fmt.Fprintf(b, "\n## Backlinks (%d)\n", len(backlinks))
 	if len(backlinks) == 0 {

--- a/client/cmd/demarkus-mcp/explore.go
+++ b/client/cmd/demarkus-mcp/explore.go
@@ -79,7 +79,7 @@ func (h *handler) markExplore(_ context.Context, req mcp.CallToolRequest) (*mcp.
 		mdoutline.CappedList(&b, out, exploreSectionCap, "links")
 	}
 
-	h.writeBacklinksSection(&b, docURL)
+	h.writeBacklinksSection(&b, "mark://"+host+path)
 	h.writeSiblingsSection(&b, host, path, token)
 
 	fmt.Fprintf(&b, "\nfetch %s#<anchor> for a section; mark_fetch force=true for the full body\n", docURL)
@@ -91,16 +91,15 @@ func (h *handler) markExplore(_ context.Context, req mcp.CallToolRequest) (*mcp.
 }
 
 // writeBacklinksSection appends the backlinks card section from the local
-// graph store. An empty or missing store degrades to a note, never an error.
-func (h *handler) writeBacklinksSection(b *strings.Builder, docURL string) {
-	fullURL := docURL
-	if strings.HasPrefix(docURL, "/") {
-		fullURL = h.defaultHost + docURL
-	}
+// graph store. fullURL must be canonical (mark://host:port/path) to match
+// crawled and seeded row keys. An empty or missing store degrades to a
+// note, never an error.
+func (h *handler) writeBacklinksSection(b *strings.Builder, fullURL string) {
 	if h.graphStore == nil {
 		b.WriteString("\n## Backlinks\n(graph store unavailable)\n")
 		return
 	}
+	h.seedGraph(h.defaultHost)
 	backlinks := h.graphStore.BacklinksEnriched(fullURL)
 	fmt.Fprintf(b, "\n## Backlinks (%d)\n", len(backlinks))
 	if len(backlinks) == 0 {

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -98,6 +98,7 @@ func main() {
 // markClient defines the fetch operations used by MCP tool handlers.
 type markClient interface {
 	Fetch(host, path, token string) (fetch.Result, error)
+	FetchConditional(host, path, token, etag string) (fetch.Result, error)
 	List(host, path, token string) (fetch.Result, error)
 	ListWithOptions(host, path, token string, opts fetch.ListOptions) (fetch.Result, error)
 	Versions(host, path, token string) (fetch.Result, error)
@@ -121,6 +122,11 @@ type handler struct {
 	// broker MCP gateway so the two surfaces answer identically.
 	seenMu sync.Mutex
 	seen   map[string]fetchdedup.Doc
+
+	// seedMu guards seedChecked: host → last /graph.md seed check, the
+	// per-process throttle for seedGraph. Process-scoped like seen.
+	seedMu      sync.Mutex
+	seedChecked map[string]time.Time
 }
 
 // seenLookup returns the recorded identity for key, if any.
@@ -139,6 +145,58 @@ func (h *handler) seenRecord(key string, d fetchdedup.Doc) {
 		h.seen = make(map[string]fetchdedup.Doc)
 	}
 	h.seen[key] = d
+}
+
+// seedCheckInterval caps /graph.md seed checks at one per host per interval;
+// the first graph-tool call in a session always checks.
+const seedCheckInterval = 5 * time.Minute
+
+// seedGraph refreshes the local graph store from the world's published
+// /graph.md aggregate so backlink queries answer before any local crawl.
+// Local crawls win (see graphstore.SeedFromExport). Never fatal: every
+// failure degrades silently to the unseeded store, warn-logging real errors.
+func (h *handler) seedGraph(base string) {
+	if h.graphStore == nil || base == "" {
+		return
+	}
+	host, path, err := fetch.ParseMarkURL(base + "/graph.md")
+	if err != nil {
+		return
+	}
+
+	h.seedMu.Lock()
+	if last, ok := h.seedChecked[host]; ok && time.Since(last) < seedCheckInterval {
+		h.seedMu.Unlock()
+		return
+	}
+	if h.seedChecked == nil {
+		h.seedChecked = make(map[string]time.Time)
+	}
+	h.seedChecked[host] = time.Now()
+	h.seedMu.Unlock()
+
+	result, err := h.client.FetchConditional(host, path, h.resolveToken(host), h.graphStore.SeedEtag(host))
+	if err != nil {
+		log.Printf("warning: graph seed fetch mark://%s%s: %v", host, path, err)
+		return
+	}
+	// not-modified means the stored seed is current; any other non-ok status
+	// (a world without /graph.md is normal) means nothing to seed.
+	if result.Response.Status != protocol.StatusOK {
+		return
+	}
+
+	nodes, edges := graphstore.ParseExport(result.Response.Body)
+	if len(nodes) == 0 && len(edges) == 0 {
+		return
+	}
+	h.graphStore.SeedFromExport(nodes, edges)
+	if etag := result.Response.Metadata["etag"]; etag != "" {
+		h.graphStore.SetSeedEtag(host, etag)
+	}
+	if err := h.graphStore.Save(); err != nil {
+		log.Printf("warning: graph seed save: %v", err)
+	}
 }
 
 // resolveToken returns the auth token for a host using the shared cascade:
@@ -238,7 +296,8 @@ func markGraphTool(host string) mcp.Tool {
 				"or find broken links. Edges carry provenance (link label, source section "+
 				"anchor, occurrence count) and typed relations ingested from rel-<predicate> "+
 				"publisher metadata. When a local graph store is available, results are "+
-				"persisted for backlink queries. "+
+				"persisted for backlink queries; the store is seeded from the world's "+
+				"published /graph.md when available, and local crawls take precedence. "+
 				urlHint(host),
 		),
 		mcp.WithString("url",
@@ -1205,18 +1264,20 @@ func (h *handler) markGraph(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 
 	depth := max(1, min(req.GetInt("depth", 2), 5))
 
-	if _, _, err := h.resolveURL(rawURL); err != nil {
+	host, path, err := h.resolveURL(rawURL)
+	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", err)), nil
 	}
-
-	startURL := rawURL
-	if strings.HasPrefix(rawURL, "/") {
-		startURL = h.defaultHost + rawURL
-	}
+	// Canonical start URL (default port included) so crawled rows share the
+	// key form of the hub's /graph.md aggregate and backlink lookups.
+	startURL := "mark://" + host + path
 
 	if h.graphStore == nil {
 		return mcp.NewToolResultError("graph store not available"), nil
 	}
+
+	// Seed before crawling so depth-limited crawls still benefit from hub context.
+	h.seedGraph(h.defaultHost)
 
 	g, err := h.graphStore.CrawlAndPersist(ctx, startURL, func(host, path string) (graph.FetchResult, error) {
 		r, fetchErr := h.client.Fetch(host, path, h.resolveToken(host))
@@ -1275,6 +1336,8 @@ func markBacklinksTool(host string) mcp.Tool {
 		mcp.WithDescription(
 			"Look up which documents link to a given URL, using the local graph store. "+
 				"Returns results from previous crawls; run mark_graph first to populate. "+
+				"The store is seeded from the world's published /graph.md when available, "+
+				"so backlinks answer even before any local crawl; local crawls take precedence. "+
 				"Each backlink shows its provenance (link label, source section anchor, "+
 				"occurrence count) and typed relations like [supersedes] when present. "+
 				"mark_explore includes this same backlink list alongside the document's "+
@@ -1294,17 +1357,20 @@ func (h *handler) markBacklinks(_ context.Context, req mcp.CallToolRequest) (*mc
 		return mcp.NewToolResultError("url is required"), nil
 	}
 
-	fullURL := rawURL
-	if strings.HasPrefix(rawURL, "/") {
-		if h.defaultHost == "" {
-			return mcp.NewToolResultError(fmt.Sprintf("bare path %q requires -host flag", rawURL)), nil
-		}
-		fullURL = h.defaultHost + rawURL
+	// Canonicalize (default port included) so the lookup key matches both
+	// crawled and seeded rows: the hub's /graph.md aggregate stores
+	// canonical mark://host:port URLs.
+	host, path, err := h.resolveURL(rawURL)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", err)), nil
 	}
+	fullURL := "mark://" + host + path
 
 	if h.graphStore == nil {
 		return mcp.NewToolResultError("graph store not available"), nil
 	}
+
+	h.seedGraph(h.defaultHost)
 
 	backlinks := h.graphStore.BacklinksEnriched(fullURL)
 	if len(backlinks) == 0 {

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -151,18 +151,16 @@ func (h *handler) seenRecord(key string, d fetchdedup.Doc) {
 // the first graph-tool call in a session always checks.
 const seedCheckInterval = 5 * time.Minute
 
-// seedGraph refreshes the local graph store from the world's published
-// /graph.md aggregate so backlink queries answer before any local crawl.
-// Local crawls win (see graphstore.SeedFromExport). Never fatal: every
-// failure degrades silently to the unseeded store, warn-logging real errors.
-func (h *handler) seedGraph(base string) {
-	if h.graphStore == nil || base == "" {
+// seedGraph refreshes the local graph store from the published /graph.md of
+// the world at host (canonical host:port, as returned by resolveURL) so
+// backlink queries answer before any local crawl. Local crawls win (see
+// graphstore.SeedFromExport). Never fatal: every failure degrades silently
+// to the unseeded store, warn-logging real errors.
+func (h *handler) seedGraph(host string) {
+	if h.graphStore == nil || h.client == nil || host == "" {
 		return
 	}
-	host, path, err := fetch.ParseMarkURL(base + "/graph.md")
-	if err != nil {
-		return
-	}
+	const path = "/graph.md"
 
 	h.seedMu.Lock()
 	if last, ok := h.seedChecked[host]; ok && time.Since(last) < seedCheckInterval {
@@ -1277,7 +1275,7 @@ func (h *handler) markGraph(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 	}
 
 	// Seed before crawling so depth-limited crawls still benefit from hub context.
-	h.seedGraph(h.defaultHost)
+	h.seedGraph(host)
 
 	g, err := h.graphStore.CrawlAndPersist(ctx, startURL, func(host, path string) (graph.FetchResult, error) {
 		r, fetchErr := h.client.Fetch(host, path, h.resolveToken(host))
@@ -1370,7 +1368,7 @@ func (h *handler) markBacklinks(_ context.Context, req mcp.CallToolRequest) (*mc
 		return mcp.NewToolResultError("graph store not available"), nil
 	}
 
-	h.seedGraph(h.defaultHost)
+	h.seedGraph(host)
 
 	backlinks := h.graphStore.BacklinksEnriched(fullURL)
 	if len(backlinks) == 0 {

--- a/client/cmd/demarkus-mcp/main_test.go
+++ b/client/cmd/demarkus-mcp/main_test.go
@@ -482,12 +482,13 @@ func TestHandlerMarkAppend_NoToken(t *testing.T) {
 
 // stubClient is a mock markClient for testing handler logic.
 type stubClient struct {
-	fetchFn    func(host, path, token string) (fetch.Result, error)
-	listFn     func(host, path, token string) (fetch.Result, error)
-	versionsFn func(host, path, token string) (fetch.Result, error)
-	publishFn  func(host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
-	appendFn   func(host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
-	lookupFn   func(host, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error)
+	fetchFn     func(host, path, token string) (fetch.Result, error)
+	fetchCondFn func(host, path, token, etag string) (fetch.Result, error)
+	listFn      func(host, path, token string) (fetch.Result, error)
+	versionsFn  func(host, path, token string) (fetch.Result, error)
+	publishFn   func(host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
+	appendFn    func(host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
+	lookupFn    func(host, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error)
 }
 
 func (s *stubClient) Fetch(host, path, token string) (fetch.Result, error) {
@@ -495,6 +496,14 @@ func (s *stubClient) Fetch(host, path, token string) (fetch.Result, error) {
 		return s.fetchFn(host, path, token)
 	}
 	return fetch.Result{}, nil
+}
+
+func (s *stubClient) FetchConditional(host, path, token, etag string) (fetch.Result, error) {
+	if s.fetchCondFn != nil {
+		return s.fetchCondFn(host, path, token, etag)
+	}
+	// Seed fetches against a stub with no graph.md behave like a missing doc.
+	return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
 }
 func (s *stubClient) List(host, path, token string) (fetch.Result, error) {
 	if s.listFn != nil {

--- a/client/cmd/demarkus-mcp/seed_test.go
+++ b/client/cmd/demarkus-mcp/seed_test.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/client/graph"
+	"github.com/latebit-io/demarkus/client/graphstore"
+	"github.com/latebit-io/demarkus/protocol"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// hubGraphBody renders a /graph.md aggregate where a.md links to b.md.
+func hubGraphBody() string {
+	src := graphstore.New()
+	g := graph.New()
+	g.AddNode(&graph.Node{URL: "mark://host:6309/a.md", Title: "Page A", Status: "ok", LinkCount: 1})
+	g.AddNode(&graph.Node{URL: "mark://host:6309/b.md", Title: "Page B", Status: "ok"})
+	g.AddEdgeInfo(graph.Edge{From: "mark://host:6309/a.md", To: "mark://host:6309/b.md", Label: "B", Count: 1})
+	src.Merge(g, nil)
+	return src.Export()
+}
+
+func emptyGraphStore(t *testing.T) *graphstore.Store {
+	t.Helper()
+	gs, err := graphstore.Load(filepath.Join(t.TempDir(), "graph.json"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return gs
+}
+
+func resultText(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	text, ok := res.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", res.Content[0])
+	}
+	return text.Text
+}
+
+func TestSeedGraph_ColdStoreAnswersBacklinks(t *testing.T) {
+	var gotPath string
+	sc := &stubClient{
+		fetchCondFn: func(_, path, _, _ string) (fetch.Result, error) {
+			gotPath = path
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusOK,
+				Metadata: map[string]string{"etag": "hub-etag-1"},
+				Body:     hubGraphBody(),
+			}}, nil
+		},
+	}
+	h := &handler{client: sc, defaultHost: "mark://host:6309", graphStore: emptyGraphStore(t)}
+
+	res, err := h.markBacklinks(context.Background(), newCallToolRequest(map[string]any{"url": "/b.md"}))
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %v", res.Content)
+	}
+	text := resultText(t, res)
+	if !strings.Contains(text, "Page A") || !strings.Contains(text, "mark://host:6309/a.md") {
+		t.Errorf("seeded backlink missing from output: %s", text)
+	}
+	if gotPath != "/graph.md" {
+		t.Errorf("seed fetched %q, want /graph.md", gotPath)
+	}
+	if got := h.graphStore.SeedEtag("host:6309"); got != "hub-etag-1" {
+		t.Errorf("SeedEtag = %q, want hub-etag-1", got)
+	}
+}
+
+// TestSeedGraph_DefaultHostWithoutPortCanonicalizes pins the live failure
+// mode this feature shipped against: the -host flag typically omits the
+// default port while the hub aggregate keys rows on mark://host:6309/...;
+// the backlinks lookup must canonicalize or seeded rows never match.
+func TestSeedGraph_DefaultHostWithoutPortCanonicalizes(t *testing.T) {
+	sc := &stubClient{
+		fetchCondFn: func(_, _, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: hubGraphBody()}}, nil
+		},
+	}
+	h := &handler{client: sc, defaultHost: "mark://host", graphStore: emptyGraphStore(t)}
+
+	res, err := h.markBacklinks(context.Background(), newCallToolRequest(map[string]any{"url": "/b.md"}))
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if !strings.Contains(resultText(t, res), "Page A") {
+		t.Errorf("portless -host missed seeded canonical rows: %s", resultText(t, res))
+	}
+}
+
+func TestSeedGraph_NotFoundDegrades(t *testing.T) {
+	sc := &stubClient{
+		fetchCondFn: func(_, _, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+		},
+	}
+	h := &handler{client: sc, defaultHost: "mark://host:6309", graphStore: emptyGraphStore(t)}
+
+	res, err := h.markBacklinks(context.Background(), newCallToolRequest(map[string]any{"url": "/b.md"}))
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if !strings.Contains(resultText(t, res), "No backlinks found") {
+		t.Errorf("expected empty-store hint, got: %s", resultText(t, res))
+	}
+}
+
+func TestSeedGraph_FetchErrorDegrades(t *testing.T) {
+	sc := &stubClient{
+		fetchCondFn: func(_, _, _, _ string) (fetch.Result, error) {
+			return fetch.Result{}, errors.New("dial refused")
+		},
+	}
+	h := &handler{client: sc, defaultHost: "mark://host:6309", graphStore: emptyGraphStore(t)}
+
+	res, err := h.markBacklinks(context.Background(), newCallToolRequest(map[string]any{"url": "/b.md"}))
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("seed failure must not fail the tool: %v", res.Content)
+	}
+	if !strings.Contains(resultText(t, res), "No backlinks found") {
+		t.Errorf("expected empty-store hint, got: %s", resultText(t, res))
+	}
+}
+
+func TestSeedGraph_LocalCrawlWins(t *testing.T) {
+	gs := emptyGraphStore(t)
+	// Local crawl observed a.md linking only to c.md.
+	g := graph.New()
+	g.AddNode(&graph.Node{URL: "mark://host:6309/a.md", Title: "Local A", Status: "ok", LinkCount: 1})
+	g.AddEdgeInfo(graph.Edge{From: "mark://host:6309/a.md", To: "mark://host:6309/c.md"})
+	gs.Merge(g, nil)
+
+	sc := &stubClient{
+		fetchCondFn: func(_, _, _, _ string) (fetch.Result, error) {
+			// Hub still claims a.md links to b.md.
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: hubGraphBody()}}, nil
+		},
+	}
+	h := &handler{client: sc, defaultHost: "mark://host:6309", graphStore: gs}
+
+	res, err := h.markBacklinks(context.Background(), newCallToolRequest(map[string]any{"url": "/b.md"}))
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if !strings.Contains(resultText(t, res), "No backlinks found") {
+		t.Errorf("seed row for authoritative source must not win: %s", resultText(t, res))
+	}
+
+	res, err = h.markBacklinks(context.Background(), newCallToolRequest(map[string]any{"url": "/c.md"}))
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if !strings.Contains(resultText(t, res), "Local A") {
+		t.Errorf("local edge lost after seeding: %s", resultText(t, res))
+	}
+}
+
+func TestSeedGraph_ThrottledWithinWindow(t *testing.T) {
+	calls := 0
+	sc := &stubClient{
+		fetchCondFn: func(_, _, _, _ string) (fetch.Result, error) {
+			calls++
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: hubGraphBody()}}, nil
+		},
+	}
+	h := &handler{client: sc, defaultHost: "mark://host:6309", graphStore: emptyGraphStore(t)}
+
+	for range 3 {
+		if _, err := h.markBacklinks(context.Background(), newCallToolRequest(map[string]any{"url": "/b.md"})); err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+	}
+	if calls != 1 {
+		t.Errorf("seed fetches = %d, want 1 (throttled)", calls)
+	}
+}
+
+func TestSeedGraph_EtagRoundTrip(t *testing.T) {
+	var gotEtags []string
+	sc := &stubClient{
+		fetchCondFn: func(_, _, _, etag string) (fetch.Result, error) {
+			gotEtags = append(gotEtags, etag)
+			if etag == "hub-etag-1" {
+				return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotModified}}, nil
+			}
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusOK,
+				Metadata: map[string]string{"etag": "hub-etag-1"},
+				Body:     hubGraphBody(),
+			}}, nil
+		},
+	}
+	h := &handler{client: sc, defaultHost: "mark://host:6309", graphStore: emptyGraphStore(t)}
+
+	if _, err := h.markBacklinks(context.Background(), newCallToolRequest(map[string]any{"url": "/b.md"})); err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+
+	// Expire the throttle so the second call re-checks with the stored etag.
+	h.seedMu.Lock()
+	h.seedChecked["host:6309"] = time.Now().Add(-2 * seedCheckInterval)
+	h.seedMu.Unlock()
+
+	res, err := h.markBacklinks(context.Background(), newCallToolRequest(map[string]any{"url": "/b.md"}))
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if len(gotEtags) != 2 || gotEtags[0] != "" || gotEtags[1] != "hub-etag-1" {
+		t.Errorf("etags sent = %v, want [\"\" hub-etag-1]", gotEtags)
+	}
+	// not-modified keeps the seeded rows.
+	if !strings.Contains(resultText(t, res), "Page A") {
+		t.Errorf("seeded backlink lost after not-modified refresh: %s", resultText(t, res))
+	}
+}
+
+func TestSeedGraph_ExploreBacklinksSeeded(t *testing.T) {
+	sc := &stubClient{
+		fetchFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: "# B\n\nBody.\n"}}, nil
+		},
+		fetchCondFn: func(_, _, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: hubGraphBody()}}, nil
+		},
+		listFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: ""}}, nil
+		},
+	}
+	h := &handler{client: sc, defaultHost: "mark://host:6309", graphStore: emptyGraphStore(t)}
+
+	res, err := h.markExplore(context.Background(), newCallToolRequest(map[string]any{"url": "/b.md"}))
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	text := resultText(t, res)
+	if !strings.Contains(text, "## Backlinks (1)") || !strings.Contains(text, "Page A") {
+		t.Errorf("explore backlinks not seeded: %s", text)
+	}
+}
+
+func TestSeedGraph_MarkGraphSeeds(t *testing.T) {
+	calls := 0
+	sc := &stubClient{
+		fetchFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: "# Doc\n"}}, nil
+		},
+		fetchCondFn: func(_, _, _, _ string) (fetch.Result, error) {
+			calls++
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: hubGraphBody()}}, nil
+		},
+	}
+	h := &handler{client: sc, defaultHost: "mark://host:6309", graphStore: emptyGraphStore(t)}
+
+	if _, err := h.markGraph(context.Background(), newCallToolRequest(map[string]any{"url": "/doc.md", "depth": float64(1)})); err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("seed fetches during mark_graph = %d, want 1", calls)
+	}
+	// Hub context is present alongside the crawl result.
+	if n := h.graphStore.GetNode("mark://host:6309/a.md"); n == nil {
+		t.Error("seeded hub node missing after mark_graph")
+	}
+}

--- a/client/cmd/demarkus-mcp/seed_test.go
+++ b/client/cmd/demarkus-mcp/seed_test.go
@@ -98,6 +98,30 @@ func TestSeedGraph_DefaultHostWithoutPortCanonicalizes(t *testing.T) {
 	}
 }
 
+// TestSeedGraph_SeedsResolvedHostNotDefault: a full mark:// URL against a
+// non-default host must seed that host's /graph.md (PR 253 review).
+func TestSeedGraph_SeedsResolvedHostNotDefault(t *testing.T) {
+	var gotHosts []string
+	sc := &stubClient{
+		fetchCondFn: func(host, _, _, _ string) (fetch.Result, error) {
+			gotHosts = append(gotHosts, host)
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: hubGraphBody()}}, nil
+		},
+	}
+	h := &handler{client: sc, defaultHost: "mark://elsewhere:6309", graphStore: emptyGraphStore(t)}
+
+	res, err := h.markBacklinks(context.Background(), newCallToolRequest(map[string]any{"url": "mark://host:6309/b.md"}))
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if len(gotHosts) != 1 || gotHosts[0] != "host:6309" {
+		t.Errorf("seeded hosts = %v, want [host:6309] (the URL's host, not the default)", gotHosts)
+	}
+	if !strings.Contains(resultText(t, res), "Page A") {
+		t.Errorf("backlinks missing from resolved-host seed: %s", resultText(t, res))
+	}
+}
+
 func TestSeedGraph_NotFoundDegrades(t *testing.T) {
 	sc := &stubClient{
 		fetchCondFn: func(_, _, _, _ string) (fetch.Result, error) {

--- a/client/fetch/conditional_test.go
+++ b/client/fetch/conditional_test.go
@@ -1,0 +1,128 @@
+package fetch
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/latebit-io/demarkus/protocol"
+	"github.com/quic-go/quic-go"
+)
+
+// startTestServer runs a minimal in-process QUIC server whose handler maps a
+// parsed request to a response. Returns the host:port to dial.
+func startTestServer(t *testing.T, handle func(protocol.Request) protocol.Response) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsConf := &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key}},
+		NextProtos:   []string{protocol.ALPN},
+	}
+
+	ln, err := quic.ListenAddr("127.0.0.1:0", tlsConf, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept(context.Background())
+			if err != nil {
+				return
+			}
+			go func() {
+				for {
+					stream, err := conn.AcceptStream(context.Background())
+					if err != nil {
+						return
+					}
+					go func() {
+						defer func() { _ = stream.Close() }()
+						req, err := protocol.ParseRequest(stream)
+						if err != nil {
+							return
+						}
+						resp := handle(req)
+						// Ignore write errors; the client side of the test
+						// fails on the missing response.
+						_, _ = resp.WriteTo(stream)
+					}()
+				}
+			}()
+		}
+	}()
+
+	return ln.Addr().String()
+}
+
+func TestFetchConditional(t *testing.T) {
+	const etag = "etag-1"
+	host := startTestServer(t, func(req protocol.Request) protocol.Response {
+		if req.Verb != protocol.VerbFetch {
+			return protocol.Response{Status: protocol.StatusBadRequest}
+		}
+		if req.Metadata["if-none-match"] == etag {
+			return protocol.Response{Status: protocol.StatusNotModified, Metadata: map[string]string{"etag": etag}}
+		}
+		return protocol.Response{Status: protocol.StatusOK, Metadata: map[string]string{"etag": etag}, Body: "# Graph\n"}
+	})
+
+	c := NewClient(Options{Insecure: true})
+	defer c.Close()
+
+	// No etag: plain fetch, full body.
+	r, err := c.FetchConditional(host, "/graph.md", "", "")
+	if err != nil {
+		t.Fatalf("FetchConditional without etag: %v", err)
+	}
+	if r.Response.Status != protocol.StatusOK || r.Response.Body != "# Graph\n" {
+		t.Fatalf("status = %q body = %q, want ok with body", r.Response.Status, r.Response.Body)
+	}
+	if r.Response.Metadata["etag"] != etag {
+		t.Fatalf("etag = %q, want %q", r.Response.Metadata["etag"], etag)
+	}
+
+	// Matching etag: not-modified passthrough with empty body.
+	r, err = c.FetchConditional(host, "/graph.md", "", etag)
+	if err != nil {
+		t.Fatalf("FetchConditional with etag: %v", err)
+	}
+	if r.Response.Status != protocol.StatusNotModified {
+		t.Fatalf("status = %q, want not-modified", r.Response.Status)
+	}
+	if r.Response.Body != "" {
+		t.Fatalf("body = %q, want empty on not-modified", r.Response.Body)
+	}
+
+	// Stale etag: full body again.
+	r, err = c.FetchConditional(host, "/graph.md", "", "stale")
+	if err != nil {
+		t.Fatalf("FetchConditional with stale etag: %v", err)
+	}
+	if r.Response.Status != protocol.StatusOK || r.Response.Body == "" {
+		t.Fatalf("status = %q body = %q, want ok with body", r.Response.Status, r.Response.Body)
+	}
+}

--- a/client/fetch/fetch.go
+++ b/client/fetch/fetch.go
@@ -121,6 +121,18 @@ func (c *Client) Fetch(host, path, token string) (Result, error) {
 	return c.cachedRequest(host, path, token, protocol.VerbFetch)
 }
 
+// FetchConditional is Fetch with an explicit if-none-match etag, for callers
+// that track document freshness themselves (e.g. the graph seeder, whose
+// authenticated fetches skip the disk cache so the built-in conditional path
+// never fires). A not-modified status returns with an empty body. An empty
+// etag degrades to a plain Fetch.
+func (c *Client) FetchConditional(host, path, token, etag string) (Result, error) {
+	if etag == "" {
+		return c.Fetch(host, path, token)
+	}
+	return c.cachedRequestMeta(host, path, token, protocol.VerbFetch, map[string]string{"if-none-match": etag})
+}
+
 // ListOptions carries optional parameters for a LIST request.
 type ListOptions struct {
 	// IncludeArchived asks the server to include archived documents (and

--- a/client/graphstore/store.go
+++ b/client/graphstore/store.go
@@ -55,20 +55,23 @@ func (e *StoredEdge) key() edgeKey {
 	return edgeKey{from: e.From, to: e.To, rel: e.Rel}
 }
 
-// document is the on-disk JSON envelope.
+// document is the on-disk JSON envelope. SeedEtags is additive (omitted when
+// empty) so pre-seed graph.json files round-trip unchanged; schema stays v1.
 type document struct {
-	Version int          `json:"version"`
-	Nodes   []StoredNode `json:"nodes"`
-	Edges   []StoredEdge `json:"edges"`
+	Version   int               `json:"version"`
+	Nodes     []StoredNode      `json:"nodes"`
+	Edges     []StoredEdge      `json:"edges"`
+	SeedEtags map[string]string `json:"seed_etags,omitempty"`
 }
 
 // Store is the persistent graph state.
 type Store struct {
-	path    string
-	mu      sync.RWMutex
-	nodes   map[string]*StoredNode
-	edges   []StoredEdge
-	edgeIdx map[edgeKey]int
+	path      string
+	mu        sync.RWMutex
+	nodes     map[string]*StoredNode
+	edges     []StoredEdge
+	edgeIdx   map[edgeKey]int
+	seedEtags map[string]string // host -> last seen /graph.md etag
 }
 
 // DefaultPath returns the default graph store location (~/.mark/graph.json).
@@ -88,8 +91,9 @@ func DefaultPath() string {
 // wants the disk-backing.
 func New() *Store {
 	return &Store{
-		nodes:   make(map[string]*StoredNode),
-		edgeIdx: make(map[edgeKey]int),
+		nodes:     make(map[string]*StoredNode),
+		edgeIdx:   make(map[edgeKey]int),
+		seedEtags: make(map[string]string),
 	}
 }
 
@@ -102,9 +106,10 @@ func Load(path string) (*Store, error) {
 	}
 
 	s := &Store{
-		path:    path,
-		nodes:   make(map[string]*StoredNode),
-		edgeIdx: make(map[edgeKey]int),
+		path:      path,
+		nodes:     make(map[string]*StoredNode),
+		edgeIdx:   make(map[edgeKey]int),
+		seedEtags: make(map[string]string),
 	}
 
 	data, err := os.ReadFile(path)
@@ -136,6 +141,7 @@ func Load(path string) (*Store, error) {
 			s.edges = append(s.edges, e)
 		}
 	}
+	maps.Copy(s.seedEtags, doc.SeedEtags)
 
 	return s, nil
 }
@@ -166,6 +172,9 @@ func (s *Store) Save() error {
 		Version: schemaVersion,
 		Nodes:   nodes,
 		Edges:   s.edges,
+	}
+	if len(s.seedEtags) > 0 {
+		doc.SeedEtags = s.seedEtags
 	}
 
 	data, err := json.MarshalIndent(doc, "", "  ")
@@ -220,35 +229,118 @@ func (s *Store) Merge(g *graph.Graph, etags map[string]string) int {
 		}
 	}
 
-	if len(refreshed) > 0 {
-		kept := make([]StoredEdge, 0, len(s.edges))
-		for _, e := range s.edges {
-			if !refreshed[e.From] {
-				kept = append(kept, e)
-			}
-		}
-		if len(kept) != len(s.edges) {
-			s.edges = kept
-			s.edgeIdx = make(map[edgeKey]int, len(kept))
-			for i := range kept {
-				s.edgeIdx[kept[i].key()] = i
-			}
-		}
-	}
+	s.dropEdgesFromLocked(refreshed)
 
 	for _, e := range g.GetEdges() {
 		se := StoredEdge{From: e.From, To: e.To, Rel: e.Rel, Label: e.Label, Anchor: e.Anchor, Count: max(e.Count, 1)}
-		if i, exists := s.edgeIdx[se.key()]; exists {
-			// Last-crawl-wins, mirroring node upserts: re-merging the same
-			// crawl is idempotent and counts never inflate.
-			s.edges[i] = se
-		} else {
-			s.edgeIdx[se.key()] = len(s.edges)
-			s.edges = append(s.edges, se)
-		}
+		s.upsertEdgeLocked(&se)
 	}
 
 	return count
+}
+
+// dropEdgesFromLocked removes every stored edge whose From is in sources and
+// rebuilds the index. Caller must hold s.mu.
+func (s *Store) dropEdgesFromLocked(sources map[string]bool) {
+	if len(sources) == 0 {
+		return
+	}
+	kept := make([]StoredEdge, 0, len(s.edges))
+	for _, e := range s.edges {
+		if !sources[e.From] {
+			kept = append(kept, e)
+		}
+	}
+	if len(kept) != len(s.edges) {
+		s.edges = kept
+		s.edgeIdx = make(map[edgeKey]int, len(kept))
+		for i := range kept {
+			s.edgeIdx[kept[i].key()] = i
+		}
+	}
+}
+
+// upsertEdgeLocked inserts or replaces an edge by identity. Last write wins,
+// mirroring node upserts: re-merging the same crawl is idempotent and counts
+// never inflate. Caller must hold s.mu.
+func (s *Store) upsertEdgeLocked(se *StoredEdge) {
+	if i, exists := s.edgeIdx[se.key()]; exists {
+		s.edges[i] = *se
+	} else {
+		s.edgeIdx[se.key()] = len(s.edges)
+		s.edges = append(s.edges, *se)
+	}
+}
+
+// authoritativeLocked reports whether the stored node for url reflects a real
+// local crawl: a genuinely fetched status and a non-zero CrawledAt. Seeded
+// nodes carry zero CrawledAt, the durable "not locally observed" marker.
+// Caller must hold s.mu.
+func (s *Store) authoritativeLocked(url string) bool {
+	n := s.nodes[url]
+	if n == nil {
+		return false
+	}
+	if n.Status == "" || n.Status == "external" || n.Status == "error" {
+		return false
+	}
+	return !n.CrawledAt.IsZero()
+}
+
+// SeedFromExport merges a published /graph.md aggregate (as parsed by
+// ParseExport) into the store. Local wins: nodes and edges of a locally
+// authoritative source are never touched. Seeded nodes get zero CrawledAt so
+// a later local crawl flips them authoritative through Merge. For every
+// non-authoritative source in the seed, the stored outgoing edge set is
+// replaced, so stale rows from an earlier seed do not linger. Returns the
+// number of nodes seeded.
+func (s *Store) SeedFromExport(nodes []StoredNode, edges []StoredEdge) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	added := 0
+	for _, n := range nodes {
+		if s.authoritativeLocked(n.URL) {
+			continue
+		}
+		sn := n
+		sn.CrawledAt = time.Time{}
+		sn.Etag = "" // the hub export carries no per-node etags
+		s.nodes[sn.URL] = &sn
+		added++
+	}
+
+	seeded := make(map[string]bool)
+	for _, e := range edges {
+		if !s.authoritativeLocked(e.From) {
+			seeded[e.From] = true
+		}
+	}
+	s.dropEdgesFromLocked(seeded)
+
+	for _, e := range edges {
+		if !seeded[e.From] {
+			continue
+		}
+		e.Count = max(e.Count, 1)
+		s.upsertEdgeLocked(&e)
+	}
+
+	return added
+}
+
+// SeedEtag returns the last recorded /graph.md etag for host ("" if none).
+func (s *Store) SeedEtag(host string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.seedEtags[host]
+}
+
+// SetSeedEtag records the /graph.md etag for host, persisted by Save.
+func (s *Store) SetSeedEtag(host, etag string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.seedEtags[host] = etag
 }
 
 // Backlinks returns all URLs that link to the given URL, sorted alphabetically.

--- a/client/graphstore/store.go
+++ b/client/graphstore/store.go
@@ -224,7 +224,7 @@ func (s *Store) Merge(g *graph.Graph, etags map[string]string) int {
 		}
 		s.nodes[n.URL] = sn
 		count++
-		if n.Status != "" && n.Status != "external" && n.Status != "error" {
+		if observedStatus(n.Status) {
 			refreshed[n.URL] = true
 		}
 	}
@@ -272,6 +272,13 @@ func (s *Store) upsertEdgeLocked(se *StoredEdge) {
 	}
 }
 
+// observedStatus reports whether status means the document was actually
+// read, so its recorded outgoing edge set is complete. "external" and
+// "error" nodes were not read; their edge sets carry no information.
+func observedStatus(status string) bool {
+	return status != "" && status != "external" && status != "error"
+}
+
 // authoritativeLocked reports whether the stored node for url reflects a real
 // local crawl: a genuinely fetched status and a non-zero CrawledAt. Seeded
 // nodes carry zero CrawledAt, the durable "not locally observed" marker.
@@ -281,10 +288,7 @@ func (s *Store) authoritativeLocked(url string) bool {
 	if n == nil {
 		return false
 	}
-	if n.Status == "" || n.Status == "external" || n.Status == "error" {
-		return false
-	}
-	return !n.CrawledAt.IsZero()
+	return observedStatus(n.Status) && !n.CrawledAt.IsZero()
 }
 
 // SeedFromExport merges a published /graph.md aggregate (as parsed by
@@ -310,7 +314,18 @@ func (s *Store) SeedFromExport(nodes []StoredNode, edges []StoredEdge) int {
 		added++
 	}
 
+	// Sources whose outgoing edge set this seed replaces: every source the
+	// aggregate actually observed (real status) plus every seed-edge From,
+	// excluding locally authoritative ones. Node-based inclusion matters
+	// when a source's outgoing set went to zero: no edge rows remain, yet
+	// its stale seeded edges must still drop (Merge's refreshed criterion,
+	// applied to the seed's view).
 	seeded := make(map[string]bool)
+	for _, n := range nodes {
+		if observedStatus(n.Status) && !s.authoritativeLocked(n.URL) {
+			seeded[n.URL] = true
+		}
+	}
 	for _, e := range edges {
 		if !s.authoritativeLocked(e.From) {
 			seeded[e.From] = true

--- a/client/graphstore/store_test.go
+++ b/client/graphstore/store_test.go
@@ -550,3 +550,207 @@ func TestCrawlAndPersist_NilStore(t *testing.T) {
 		t.Errorf("NodeCount = %d, want 1", g.NodeCount())
 	}
 }
+
+func TestSeedFromExportEmptyStore(t *testing.T) {
+	s := New()
+
+	nodes := []StoredNode{
+		{URL: "mark://a:6309/a.md", Title: "A", Status: "ok", LinkCount: 1},
+		{URL: "mark://a:6309/b.md", Title: "B", Status: "ok"},
+	}
+	edges := []StoredEdge{
+		{From: "mark://a:6309/a.md", To: "mark://a:6309/b.md", Rel: "", Label: "B", Anchor: "intro", Count: 2},
+	}
+
+	added := s.SeedFromExport(nodes, edges)
+	if added != 2 {
+		t.Errorf("added = %d, want 2", added)
+	}
+	if s.EdgeCount() != 1 {
+		t.Errorf("EdgeCount = %d, want 1", s.EdgeCount())
+	}
+	if bl := s.Backlinks("mark://a:6309/b.md"); len(bl) != 1 || bl[0] != "mark://a:6309/a.md" {
+		t.Errorf("Backlinks = %v, want [mark://a:6309/a.md]", bl)
+	}
+	n := s.GetNode("mark://a:6309/a.md")
+	if n == nil {
+		t.Fatal("seeded node missing")
+	}
+	if !n.CrawledAt.IsZero() {
+		t.Error("seeded node must have zero CrawledAt")
+	}
+}
+
+func TestSeedFromExportLocalWins(t *testing.T) {
+	s := New()
+
+	// Local crawl: a.md links to b.md.
+	g := graph.New()
+	g.AddNode(&graph.Node{URL: "mark://a:6309/a.md", Title: "Local A", Status: "ok", LinkCount: 1})
+	g.AddEdgeInfo(graph.Edge{From: "mark://a:6309/a.md", To: "mark://a:6309/b.md"})
+	s.Merge(g, nil)
+
+	// Seed claims a.md has a different title and links only to c.md.
+	nodes := []StoredNode{{URL: "mark://a:6309/a.md", Title: "Hub A", Status: "ok", LinkCount: 1}}
+	edges := []StoredEdge{{From: "mark://a:6309/a.md", To: "mark://a:6309/c.md", Count: 1}}
+	added := s.SeedFromExport(nodes, edges)
+
+	if added != 0 {
+		t.Errorf("added = %d, want 0 (authoritative node must not be seeded)", added)
+	}
+	n := s.GetNode("mark://a:6309/a.md")
+	if n.Title != "Local A" {
+		t.Errorf("Title = %q, want %q", n.Title, "Local A")
+	}
+	if n.CrawledAt.IsZero() {
+		t.Error("authoritative node lost its CrawledAt")
+	}
+	if bl := s.Backlinks("mark://a:6309/c.md"); len(bl) != 0 {
+		t.Errorf("seed edges leaked past authoritative source: %v", bl)
+	}
+	if bl := s.Backlinks("mark://a:6309/b.md"); len(bl) != 1 {
+		t.Errorf("local edge dropped by seed: %v", bl)
+	}
+}
+
+func TestSeedFromExportOverwritesNonAuthoritative(t *testing.T) {
+	s := New()
+
+	// A locally crawled "error" node is not authoritative; seed may replace it.
+	g := graph.New()
+	g.AddNode(&graph.Node{URL: "mark://a:6309/a.md", Status: "error"})
+	s.Merge(g, nil)
+
+	nodes := []StoredNode{{URL: "mark://a:6309/a.md", Title: "A", Status: "ok", LinkCount: 1}}
+	added := s.SeedFromExport(nodes, nil)
+	if added != 1 {
+		t.Errorf("added = %d, want 1", added)
+	}
+	n := s.GetNode("mark://a:6309/a.md")
+	if n.Status != "ok" || n.Title != "A" {
+		t.Errorf("node = %+v, want seeded ok/A", n)
+	}
+	if !n.CrawledAt.IsZero() {
+		t.Error("seeded copy must carry zero CrawledAt")
+	}
+}
+
+func TestSeedThenCrawlFlipsAuthoritative(t *testing.T) {
+	s := New()
+
+	nodes := []StoredNode{{URL: "mark://a:6309/a.md", Title: "A", Status: "ok", LinkCount: 1}}
+	edges := []StoredEdge{{From: "mark://a:6309/a.md", To: "mark://a:6309/hub-only.md", Count: 1}}
+	s.SeedFromExport(nodes, edges)
+
+	// Local crawl of a.md observes a different outgoing set; Merge's refresh
+	// logic must replace the seeded edges.
+	g := graph.New()
+	g.AddNode(&graph.Node{URL: "mark://a:6309/a.md", Title: "A", Status: "ok", LinkCount: 1})
+	g.AddEdgeInfo(graph.Edge{From: "mark://a:6309/a.md", To: "mark://a:6309/b.md"})
+	s.Merge(g, nil)
+
+	if bl := s.Backlinks("mark://a:6309/hub-only.md"); len(bl) != 0 {
+		t.Errorf("stale seeded edge survived local crawl: %v", bl)
+	}
+	if bl := s.Backlinks("mark://a:6309/b.md"); len(bl) != 1 {
+		t.Errorf("crawled edge missing: %v", bl)
+	}
+
+	// Now authoritative: a re-seed must not touch it.
+	s.SeedFromExport(nodes, edges)
+	if bl := s.Backlinks("mark://a:6309/hub-only.md"); len(bl) != 0 {
+		t.Errorf("re-seed overwrote authoritative source: %v", bl)
+	}
+}
+
+func TestSeedRefreshReplacesSeededEdges(t *testing.T) {
+	s := New()
+
+	first := []StoredEdge{{From: "mark://a:6309/a.md", To: "mark://a:6309/old.md", Count: 1}}
+	s.SeedFromExport([]StoredNode{{URL: "mark://a:6309/a.md", Status: "ok"}}, first)
+
+	// The hub aggregate no longer carries the old.md link.
+	second := []StoredEdge{{From: "mark://a:6309/a.md", To: "mark://a:6309/new.md", Count: 1}}
+	s.SeedFromExport([]StoredNode{{URL: "mark://a:6309/a.md", Status: "ok"}}, second)
+
+	if bl := s.Backlinks("mark://a:6309/old.md"); len(bl) != 0 {
+		t.Errorf("stale seeded backlink survived re-seed: %v", bl)
+	}
+	if bl := s.Backlinks("mark://a:6309/new.md"); len(bl) != 1 {
+		t.Errorf("refreshed seed edge missing: %v", bl)
+	}
+}
+
+func TestSeedEtagsRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.json")
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	s.SetSeedEtag("a:6309", "etag-1")
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	s2, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load after save: %v", err)
+	}
+	if got := s2.SeedEtag("a:6309"); got != "etag-1" {
+		t.Errorf("SeedEtag = %q, want %q", got, "etag-1")
+	}
+	if got := s2.SeedEtag("other:6309"); got != "" {
+		t.Errorf("SeedEtag unknown host = %q, want empty", got)
+	}
+}
+
+func TestLoadLegacyFileWithoutSeedEtags(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.json")
+	legacy := `{"version":1,"nodes":[],"edges":[]}`
+	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load legacy: %v", err)
+	}
+	if got := s.SeedEtag("a:6309"); got != "" {
+		t.Errorf("SeedEtag = %q, want empty", got)
+	}
+	s.SetSeedEtag("a:6309", "etag-1")
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save after legacy load: %v", err)
+	}
+}
+
+func TestSeedFromLegacyExport(t *testing.T) {
+	// A /graph.md still in the pre-enrichment two-column edge form must seed.
+	body := `# Document Graph
+
+> Exported: 2026-07-01T00:00:00Z
+> Nodes: 2
+> Edges: 1
+
+## Nodes
+
+| URL | Title | Status | Links |
+|-----|-------|--------|-------|
+| [mark://a:6309/a.md](mark://a:6309/a.md) | A | ok | 1 |
+| [mark://a:6309/b.md](mark://a:6309/b.md) | B | ok | 0 |
+
+## Edges
+
+| From | To |
+|------|----|
+| mark://a:6309/a.md | mark://a:6309/b.md |
+`
+	nodes, edges := ParseExport(body)
+	s := New()
+	if added := s.SeedFromExport(nodes, edges); added != 2 {
+		t.Errorf("added = %d, want 2", added)
+	}
+	if bl := s.Backlinks("mark://a:6309/b.md"); len(bl) != 1 || bl[0] != "mark://a:6309/a.md" {
+		t.Errorf("Backlinks = %v, want [mark://a:6309/a.md]", bl)
+	}
+}

--- a/client/graphstore/store_test.go
+++ b/client/graphstore/store_test.go
@@ -681,6 +681,41 @@ func TestSeedRefreshReplacesSeededEdges(t *testing.T) {
 	}
 }
 
+func TestSeedRefreshDropsEdgesOfEmptiedSource(t *testing.T) {
+	s := New()
+
+	nodes := []StoredNode{{URL: "mark://a:6309/a.md", Status: "ok", LinkCount: 1}}
+	edges := []StoredEdge{{From: "mark://a:6309/a.md", To: "mark://a:6309/old.md", Count: 1}}
+	s.SeedFromExport(nodes, edges)
+
+	// The aggregate now says a.md has no outgoing links at all: the node row
+	// is present (observed) but no edge rows remain. The stale seeded edge
+	// must drop even with an empty edge set.
+	s.SeedFromExport([]StoredNode{{URL: "mark://a:6309/a.md", Status: "ok"}}, nil)
+
+	if bl := s.Backlinks("mark://a:6309/old.md"); len(bl) != 0 {
+		t.Errorf("stale seeded edge survived zero-edge re-seed: %v", bl)
+	}
+}
+
+func TestSeedKeepsEdgesOfUnobservedSeedNode(t *testing.T) {
+	s := New()
+
+	s.SeedFromExport(
+		[]StoredNode{{URL: "mark://a:6309/a.md", Status: "ok", LinkCount: 1}},
+		[]StoredEdge{{From: "mark://a:6309/a.md", To: "mark://a:6309/b.md", Count: 1}},
+	)
+
+	// A later seed carries a.md only as an error node with no edges: the
+	// aggregate did not read it, so its recorded edge set says nothing and
+	// the earlier seeded edges must survive.
+	s.SeedFromExport([]StoredNode{{URL: "mark://a:6309/a.md", Status: "error"}}, nil)
+
+	if bl := s.Backlinks("mark://a:6309/b.md"); len(bl) != 1 {
+		t.Errorf("unobserved seed node dropped edges it knew nothing about: %v", bl)
+	}
+}
+
 func TestSeedEtagsRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "graph.json")
 	s, err := Load(path)

--- a/docs/site/architecture/index.md
+++ b/docs/site/architecture/index.md
@@ -125,7 +125,7 @@ Markdown links form a natural **document graph**. The CLI, TUI, and MCP server i
 
 The client-side `graphstore` package persists crawled graph data at `~/.mark/graph.json`. All three tools share this store — a graph built by the CLI is visible in the TUI and queryable via MCP. Each crawl merges new nodes and edges into the existing graph, so knowledge accumulates across sessions.
 
-Backlinks ("what documents link here?") are derived from the stored graph with no server-side changes needed. The MCP `mark_backlinks` tool exposes this as a query for agents.
+Backlinks ("what documents link here?") are derived from the stored graph with no server-side changes needed. The MCP `mark_backlinks` tool exposes this as a query for agents. The store is seeded on demand from the world's published `/graph.md` aggregate, so a fresh client answers backlinks before its first crawl; local crawls take precedence over seeded rows.
 
 The graph itself is exportable as a publishable markdown document containing `mark://` links. `mark_graph_export` renders the graph; `mark_graph_publish` exports and publishes in one step. Other agents can crawl the published graph document to discover the topology without recrawling the original servers — enabling multi-agent discovery where agents share and merge knowledge maps.
 

--- a/docs/site/client/index.md
+++ b/docs/site/client/index.md
@@ -51,7 +51,7 @@ demarkus edit --insecure -auth $TOKEN mark://localhost:6309/new-doc.md
 demarkus graph --insecure -depth 3 mark://localhost:6309/index.md
 ```
 
-Graph results are persisted to `~/.mark/graph.json` and accumulate across sessions. Each crawl merges new nodes and edges into the existing graph, so your map of the `mark://` network grows over time.
+Graph results are persisted to `~/.mark/graph.json` and accumulate across sessions. Each crawl merges new nodes and edges into the existing graph, so your map of the `mark://` network grows over time. The MCP graph tools also seed the store from the connected world's published `/graph.md` aggregate, so backlinks answer even before your first crawl; locally crawled data always takes precedence.
 
 ### Open Knowledge Format codec
 

--- a/tools/demarkus-broker/MCP-API.md
+++ b/tools/demarkus-broker/MCP-API.md
@@ -229,12 +229,23 @@ hub manifest unless `force: true`.
 > re-populate. This is a deliberate trade-off documented under
 > "Ephemeral graph store" in the chart README — bucket-store-backed
 > persistence is parked for the post-broker design window.
+>
+> To make restarts cheap (not durable), the store is **seeded on
+> demand from each world's published `/graph.md`**: the first
+> `mark_backlinks` / `mark_graph` / `mark_explore` call touching a
+> world fetches its `/graph.md` aggregate (conditional on the last
+> seen etag, throttled to one check per world per 5 minutes) and
+> merges it into the store, so cold pods answer backlinks without a
+> crawl. Locally crawled data always takes precedence over seeded
+> rows, and a world without `/graph.md` degrades to the unseeded
+> behavior.
 
 #### `mark_backlinks`
 
 Look up which documents link to a given URL, using the broker's
-graph store. Returns results from previous `mark_graph` runs;
-returns an empty hint if no crawl has populated the relevant edges.
+graph store. Returns results from previous `mark_graph` runs and
+the world's published `/graph.md` seed; returns an empty hint if
+neither has populated the relevant edges.
 Each backlink carries its provenance (link label, source section
 anchor, occurrence count) and typed relations like `[supersedes]`.
 

--- a/tools/demarkus-broker/internal/broker/mcp_gateway.go
+++ b/tools/demarkus-broker/internal/broker/mcp_gateway.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sync"
+	"time"
 
 	"github.com/latebit-io/demarkus/client/fetch"
 	"github.com/latebit-io/demarkus/client/graphstore"
@@ -42,6 +44,11 @@ type mcpGateway struct {
 	// it is ephemeral per-pod state, consistent with the wire-shape-
 	// adapter framing.
 	fetchSeen *sessionSeen
+	// graphSeedMu guards graphSeedChecked: worldName → last /graph.md
+	// seed check, the per-pod throttle for seedWorldGraph. The seed
+	// etag itself lives in graphStore (SeedEtag), keyed by worldName.
+	graphSeedMu      sync.Mutex
+	graphSeedChecked map[string]time.Time
 }
 
 // newMCPGateway constructs a gateway, registers the 16 tool

--- a/tools/demarkus-broker/internal/broker/mcp_tools_explore.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_explore.go
@@ -24,7 +24,7 @@ const exploreSectionCap = 10
 // of its parent directory. Mirrors client/cmd/demarkus-mcp markExplore;
 // the broker differences are the world-name URL shape and that backlinks
 // come from the broker's ephemeral graph store.
-func (g *mcpGateway) handleMarkExplore(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
+func (g *mcpGateway) handleMarkExplore(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
 	raw, err := req.RequireString("url")
 	if err != nil {
 		return mcp.NewToolResultError("url is required"), nil
@@ -66,6 +66,9 @@ func (g *mcpGateway) handleMarkExplore(_ context.Context, req mcp.CallToolReques
 		mdoutline.CappedList(&b, out, exploreSectionCap, "links")
 	}
 
+	if claims, ok := claimsFromCtx(ctx); ok {
+		g.seedWorldGraph(ctx, claims, worldName)
+	}
 	g.writeBacklinksSection(&b, docURL)
 	g.writeSiblingsSection(&b, worldName, path)
 

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
@@ -92,21 +92,70 @@ func (g *mcpGateway) crawlFetchFn(ctx context.Context, claims *Claims) graphstor
 	}
 }
 
+// seedCheckInterval caps /graph.md seed checks at one per world per
+// interval; the first graph-tool call after a pod restart always checks.
+const seedCheckInterval = 5 * time.Minute
+
+// seedWorldGraph refreshes the broker's ephemeral graph store from the
+// world's published /graph.md aggregate, so a cold pod answers backlinks
+// without a crawl. Local crawls win (see graphstore.SeedFromExport).
+// Never fatal: every failure degrades silently to the unseeded store,
+// warn-logging real errors. Conditional on the stored seed etag; a
+// not-modified response keeps the previously seeded rows.
+func (g *mcpGateway) seedWorldGraph(ctx context.Context, claims *Claims, worldName string) {
+	g.graphSeedMu.Lock()
+	if last, ok := g.graphSeedChecked[worldName]; ok && time.Since(last) < seedCheckInterval {
+		g.graphSeedMu.Unlock()
+		return
+	}
+	if g.graphSeedChecked == nil {
+		g.graphSeedChecked = make(map[string]time.Time)
+	}
+	g.graphSeedChecked[worldName] = time.Now()
+	g.graphSeedMu.Unlock()
+
+	etag := g.graphStore.SeedEtag(worldName)
+	result, err := g.dispatchWithAuth(ctx, claims, worldName, func(token string) (fetch.Result, error) {
+		return g.dispatcher.FetchConditional(worldName, "/graph.md", token, etag)
+	})
+	if err != nil {
+		g.log.Warn("graph seed fetch failed", "world", worldName, "err", err)
+		return
+	}
+	// not-modified means the stored seed is current; any other non-ok
+	// status (a world without /graph.md is normal) means nothing to seed.
+	if result.Response.Status != protocol.StatusOK {
+		return
+	}
+
+	nodes, edges := graphstore.ParseExport(result.Response.Body)
+	if len(nodes) == 0 && len(edges) == 0 {
+		return
+	}
+	g.graphStore.SeedFromExport(nodes, edges)
+	if e := result.Response.Metadata["etag"]; e != "" {
+		g.graphStore.SetSeedEtag(worldName, e)
+	}
+}
+
 // handleMarkBacklinks queries the broker's ephemeral graph store
-// for documents linking to a given URL. Pure local read — no
-// dispatch — because the graph store is the index of "what we've
-// crawled" and that data already lives in the broker's process.
-// First-time callers see an empty result (and a hint to run
-// mark_graph first); broker-pod restarts reset to that state.
-func (g *mcpGateway) handleMarkBacklinks(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
+// for documents linking to a given URL, seeding the store from the
+// world's published /graph.md first so cold pods still answer.
+// First-time callers on a world with no /graph.md see an empty
+// result (and a hint to run mark_graph first).
+func (g *mcpGateway) handleMarkBacklinks(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
 	raw, err := req.RequireString("url")
 	if err != nil {
 		return mcp.NewToolResultError("url is required"), nil
 	}
 	// Validate the URL shape so an agent typo doesn't silently
 	// produce "no backlinks" against a malformed lookup key.
-	if _, _, perr := parseToolURL(raw); perr != nil {
+	worldName, _, perr := parseToolURL(raw)
+	if perr != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", perr)), nil
+	}
+	if claims, ok := claimsFromCtx(ctx); ok {
+		g.seedWorldGraph(ctx, claims, worldName)
 	}
 	backlinks := g.graphStore.BacklinksEnriched(raw)
 	if len(backlinks) == 0 {
@@ -142,7 +191,8 @@ func (g *mcpGateway) handleMarkGraph(ctx context.Context, req mcp.CallToolReques
 	if err != nil {
 		return mcp.NewToolResultError("url is required"), nil
 	}
-	if _, _, perr := parseToolURL(raw); perr != nil {
+	worldName, _, perr := parseToolURL(raw)
+	if perr != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", perr)), nil
 	}
 	depth := max(1, min(req.GetInt("depth", 2), 5))
@@ -150,6 +200,10 @@ func (g *mcpGateway) handleMarkGraph(ctx context.Context, req mcp.CallToolReques
 	if !ok {
 		return mcp.NewToolResultError("internal: missing identity on tool-call context"), nil
 	}
+
+	// Seed before crawling so depth-limited crawls still benefit from
+	// hub context.
+	g.seedWorldGraph(ctx, claims, worldName)
 
 	crawled, crawlErr := g.graphStore.CrawlAndPersist(
 		ctx,

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph_seed_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph_seed_test.go
@@ -1,0 +1,193 @@
+package broker
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/client/graph"
+	"github.com/latebit-io/demarkus/client/graphstore"
+	"github.com/latebit-io/demarkus/protocol"
+)
+
+// worldGraphBody renders a /graph.md aggregate for team-a where a.md
+// links to b.md.
+func worldGraphBody() string {
+	src := graphstore.New()
+	g := graph.New()
+	g.AddNode(&graph.Node{URL: "mark://team-a/a.md", Title: "Page A", Status: "ok", LinkCount: 1})
+	g.AddNode(&graph.Node{URL: "mark://team-a/b.md", Title: "Page B", Status: "ok"})
+	g.AddEdgeInfo(graph.Edge{From: "mark://team-a/a.md", To: "mark://team-a/b.md", Label: "B", Count: 1})
+	src.Merge(g, nil)
+	return src.Export()
+}
+
+// seedingDispatcher scripts /graph.md on team-a with the given etag.
+func seedingDispatcher(etag string) *fakeDispatcher {
+	return &fakeDispatcher{
+		fetchCondFn: func(_, path, _, sentEtag string) (fetch.Result, error) {
+			if path != "/graph.md" {
+				return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+			}
+			if sentEtag != "" && sentEtag == etag {
+				return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotModified}}, nil
+			}
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusOK,
+				Metadata: map[string]string{"etag": etag},
+				Body:     worldGraphBody(),
+			}}, nil
+		},
+	}
+}
+
+// TestHandleMarkBacklinksColdPodSeedsFromWorldGraph is the headline
+// behavior: a cold gateway answers backlinks from the world's
+// published /graph.md with no prior crawl.
+func TestHandleMarkBacklinksColdPodSeedsFromWorldGraph(t *testing.T) {
+	d := seedingDispatcher("hub-etag-1")
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), d)
+
+	res, err := g.handleMarkBacklinks(withAliceClaims(context.Background()), callToolReq("mark_backlinks", map[string]any{
+		"url": "mark://team-a/b.md",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkBacklinks: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("isError = true: %s", toolResultText(t, res))
+	}
+	text := toolResultText(t, res)
+	if !strings.Contains(text, "Page A") || !strings.Contains(text, "mark://team-a/a.md") {
+		t.Errorf("seeded backlink missing:\n%s", text)
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if len(d.fetchCalls) != 0 {
+		t.Errorf("plain fetches = %d, want 0 (no crawl needed)", len(d.fetchCalls))
+	}
+	if len(d.fetchCondCalls) != 1 || d.fetchCondCalls[0].path != "/graph.md" || d.fetchCondCalls[0].worldName != "team-a" {
+		t.Errorf("fetchCondCalls = %+v, want one /graph.md check on team-a", d.fetchCondCalls)
+	}
+}
+
+// TestHandleMarkGraphCrawlBeatsSeed: the seed runs before the crawl,
+// and the crawl's view of a source replaces the seeded edges.
+func TestHandleMarkGraphCrawlBeatsSeed(t *testing.T) {
+	d := seedingDispatcher("hub-etag-1")
+	d.fetchFn = func(_, path, _ string) (fetch.Result, error) {
+		if path == "/a.md" {
+			// Locally, a.md now links to c.md, not b.md.
+			return fetch.Result{Response: protocol.Response{
+				Status: protocol.StatusOK,
+				Body:   crawlBody("Page A", "/c.md"),
+			}}, nil
+		}
+		return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: crawlBody("Doc")}}, nil
+	}
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), d)
+	ctx := withAliceClaims(context.Background())
+
+	if res, err := g.handleMarkGraph(ctx, callToolReq("mark_graph", map[string]any{
+		"url": "mark://team-a/a.md",
+	})); err != nil || res.IsError {
+		t.Fatalf("mark_graph: err=%v text=%s", err, toolResultText(t, res))
+	}
+
+	res, err := g.handleMarkBacklinks(ctx, callToolReq("mark_backlinks", map[string]any{
+		"url": "mark://team-a/b.md",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkBacklinks: %v", err)
+	}
+	if text := toolResultText(t, res); !strings.Contains(text, "No backlinks") {
+		t.Errorf("stale seeded edge survived the crawl:\n%s", text)
+	}
+
+	res, err = g.handleMarkBacklinks(ctx, callToolReq("mark_backlinks", map[string]any{
+		"url": "mark://team-a/c.md",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkBacklinks: %v", err)
+	}
+	if text := toolResultText(t, res); !strings.Contains(text, "mark://team-a/a.md") {
+		t.Errorf("crawled edge missing:\n%s", text)
+	}
+}
+
+func TestSeedWorldGraphThrottledWithinWindow(t *testing.T) {
+	d := seedingDispatcher("hub-etag-1")
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), d)
+	ctx := withAliceClaims(context.Background())
+
+	for range 3 {
+		if _, err := g.handleMarkBacklinks(ctx, callToolReq("mark_backlinks", map[string]any{
+			"url": "mark://team-a/b.md",
+		})); err != nil {
+			t.Fatalf("handleMarkBacklinks: %v", err)
+		}
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if len(d.fetchCondCalls) != 1 {
+		t.Errorf("seed checks = %d, want 1 (throttled)", len(d.fetchCondCalls))
+	}
+}
+
+func TestSeedWorldGraphEtagRoundTrip(t *testing.T) {
+	d := seedingDispatcher("hub-etag-1")
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), d)
+	ctx := withAliceClaims(context.Background())
+
+	if _, err := g.handleMarkBacklinks(ctx, callToolReq("mark_backlinks", map[string]any{
+		"url": "mark://team-a/b.md",
+	})); err != nil {
+		t.Fatalf("handleMarkBacklinks: %v", err)
+	}
+
+	// Expire the throttle so the next call re-checks with the stored etag.
+	g.graphSeedMu.Lock()
+	g.graphSeedChecked["team-a"] = time.Now().Add(-2 * seedCheckInterval)
+	g.graphSeedMu.Unlock()
+
+	res, err := g.handleMarkBacklinks(ctx, callToolReq("mark_backlinks", map[string]any{
+		"url": "mark://team-a/b.md",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkBacklinks: %v", err)
+	}
+
+	d.mu.Lock()
+	calls := append([]condCall(nil), d.fetchCondCalls...)
+	d.mu.Unlock()
+	if len(calls) != 2 || calls[0].etag != "" || calls[1].etag != "hub-etag-1" {
+		t.Errorf("etags sent = %+v, want [\"\" hub-etag-1]", calls)
+	}
+	// not-modified keeps the seeded rows.
+	if text := toolResultText(t, res); !strings.Contains(text, "Page A") {
+		t.Errorf("seeded backlink lost after not-modified refresh:\n%s", text)
+	}
+}
+
+// TestHandleMarkExploreBacklinksSeeded: explore's backlinks section
+// benefits from the same per-world seed.
+func TestHandleMarkExploreBacklinksSeeded(t *testing.T) {
+	d := seedingDispatcher("hub-etag-1")
+	d.fetchFn = func(_, _, _ string) (fetch.Result, error) {
+		return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: "# B\n\nBody.\n"}}, nil
+	}
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), d)
+
+	res, err := g.handleMarkExplore(withAliceClaims(context.Background()), callToolReq("mark_explore", map[string]any{
+		"url": "mark://team-a/b.md",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkExplore: %v", err)
+	}
+	text := toolResultText(t, res)
+	if !strings.Contains(text, "## Backlinks (1)") || !strings.Contains(text, "Page A") {
+		t.Errorf("explore backlinks not seeded:\n%s", text)
+	}
+}

--- a/tools/demarkus-broker/internal/broker/mcp_tools_list.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_list.go
@@ -330,10 +330,12 @@ func markBacklinksTool() mcp.Tool {
 		mcp.WithDescription(
 			"Look up which documents link to a given URL, using the broker's graph store. "+
 				"Returns results from previous crawls; run mark_graph first to populate. "+
+				"The store is seeded from the world's published /graph.md when available, "+
+				"so backlinks answer even on a cold pod; local crawls take precedence. "+
 				"Each backlink shows its provenance (link label, source section anchor, "+
 				"occurrence count) and typed relations like [supersedes] when present. "+
 				"NOTE: the broker's graph store is ephemeral (per-pod lifetime); a broker restart "+
-				"resets the store and you must re-crawl. "+
+				"resets crawled data and re-seeds from /graph.md on the next call. "+
 				"mark_explore includes this same backlink list alongside the document's "+
 				"outline, outbound links, and siblings; prefer it for general orientation. "+
 				mcpURLHint,
@@ -354,7 +356,8 @@ func markGraphTool() mcp.Tool {
 				"or find broken links. Edges carry provenance (link label, source section "+
 				"anchor, occurrence count) and typed relations ingested from rel-<predicate> "+
 				"publisher metadata. When a graph store is available, results are "+
-				"persisted for backlink queries. "+
+				"persisted for backlink queries; the store is seeded from the world's "+
+				"published /graph.md when available, and local crawls take precedence. "+
 				mcpURLHint,
 		),
 		mcp.WithString("url",

--- a/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
@@ -24,21 +24,23 @@ import (
 type fakeDispatcher struct {
 	mu sync.Mutex
 
-	fetchFn    func(worldName, path, token string) (fetch.Result, error)
-	listFn     func(worldName, path, token string) (fetch.Result, error)
-	versionsFn func(worldName, path, token string) (fetch.Result, error)
-	lookupFn   func(worldName, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error)
-	publishFn  func(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
-	appendFn   func(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
-	archiveFn  func(worldName, path, token string) (fetch.Result, error)
+	fetchFn     func(worldName, path, token string) (fetch.Result, error)
+	fetchCondFn func(worldName, path, token, etag string) (fetch.Result, error)
+	listFn      func(worldName, path, token string) (fetch.Result, error)
+	versionsFn  func(worldName, path, token string) (fetch.Result, error)
+	lookupFn    func(worldName, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error)
+	publishFn   func(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
+	appendFn    func(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
+	archiveFn   func(worldName, path, token string) (fetch.Result, error)
 
-	fetchCalls    []dispatchCall
-	listCalls     []dispatchCall
-	versionsCalls []dispatchCall
-	lookupCalls   []lookupCall
-	publishCalls  []writeCall
-	appendCalls   []writeCall
-	archiveCalls  []dispatchCall
+	fetchCalls     []dispatchCall
+	fetchCondCalls []condCall
+	listCalls      []dispatchCall
+	versionsCalls  []dispatchCall
+	lookupCalls    []lookupCall
+	publishCalls   []writeCall
+	appendCalls    []writeCall
+	archiveCalls   []dispatchCall
 }
 
 // lookupCall records a LOOKUP dispatch for assertions.
@@ -54,6 +56,15 @@ type dispatchCall struct {
 	worldName string
 	path      string
 	token     string
+}
+
+// condCall records a FetchConditional dispatch (the graph seeder's
+// /graph.md checks) with the if-none-match etag it carried.
+type condCall struct {
+	worldName string
+	path      string
+	token     string
+	etag      string
 }
 
 // writeCall records a Publish/Append invocation. Captures the
@@ -77,6 +88,19 @@ func (f *fakeDispatcher) Fetch(worldName, path, token string) (fetch.Result, err
 		return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK}}, nil
 	}
 	return fn(worldName, path, token)
+}
+
+func (f *fakeDispatcher) FetchConditional(worldName, path, token, etag string) (fetch.Result, error) {
+	f.mu.Lock()
+	f.fetchCondCalls = append(f.fetchCondCalls, condCall{worldName, path, token, etag})
+	fn := f.fetchCondFn
+	f.mu.Unlock()
+	if fn == nil {
+		// Seed fetches against a fake with no /graph.md behave like a
+		// missing doc so graph tests stay unseeded unless they opt in.
+		return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+	}
+	return fn(worldName, path, token, etag)
 }
 
 func (f *fakeDispatcher) List(worldName, path, token string, _ fetch.ListOptions) (fetch.Result, error) {

--- a/tools/demarkus-broker/internal/broker/world_pool.go
+++ b/tools/demarkus-broker/internal/broker/world_pool.go
@@ -22,6 +22,7 @@ import (
 // tools land in Slices 4–5.
 type worldDispatcher interface {
 	Fetch(worldName, path, token string) (fetch.Result, error)
+	FetchConditional(worldName, path, token, etag string) (fetch.Result, error)
 	List(worldName, path, token string, opts fetch.ListOptions) (fetch.Result, error)
 	Versions(worldName, path, token string) (fetch.Result, error)
 	Lookup(worldName, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error)
@@ -107,6 +108,16 @@ func (p *worldPool) Fetch(worldName, path, token string) (fetch.Result, error) {
 		return fetch.Result{}, err
 	}
 	return c.Fetch(host, path, token)
+}
+
+// FetchConditional dispatches a FETCH with an explicit if-none-match etag
+// (the graph seeder tracks /graph.md freshness itself).
+func (p *worldPool) FetchConditional(worldName, path, token, etag string) (fetch.Result, error) {
+	c, host, err := p.clientFor(worldName)
+	if err != nil {
+		return fetch.Result{}, err
+	}
+	return c.FetchConditional(host, path, token, etag)
 }
 
 // List dispatches a LIST against worldName. Same proxy contract


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backlinks can now be available immediately from published graph data, even before a crawl.
  * Graph and explore operations automatically incorporate existing graph context; locally crawled results take precedence.
* **Bug Fixes**
  * Improved canonical URL handling for consistent graph/backlink matching.
  * Conditional graph refreshes reduce unnecessary network transfer, with graceful fallback on missing or failed data.
  * Seeding is throttled per world to avoid repeated refreshes.
* **Documentation**
  * Updated graph/backlinks docs to reflect on-demand seeding, precedence rules, and conditional refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->