### PR TITLE
fix(client): Merge preserves resolved nodes on failed re-crawl (#222)

### DIFF
--- a/client/graphstore/store.go
+++ b/client/graphstore/store.go
@@ -194,8 +194,11 @@ func (s *Store) Save() error {
 	return os.Rename(tmp, s.path)
 }
 
-// Merge integrates a crawled graph into the store. Nodes are upserted with
-// fresh timestamps. For every source the crawl actually fetched, the stored
+// Merge integrates a crawled graph into the store. Nodes the crawl actually
+// read are upserted with fresh timestamps; a node the crawl failed to read
+// (error/external/blank status) never clobbers a stored one, so last-known-
+// good title/status survive transient fetch failures instead of regressing
+// (issue #222). For every source the crawl actually fetched, the stored
 // outgoing edge set is replaced by the crawl's, so deleted links and dropped
 // rel- predicates do not linger in backlink queries. The etags map provides
 // etag values keyed by URL. Returns the number of nodes upserted.
@@ -212,6 +215,22 @@ func (s *Store) Merge(g *graph.Graph, etags map[string]string) int {
 	refreshed := make(map[string]bool)
 
 	for _, n := range g.AllNodes() {
+		if !observedStatus(n.Status) {
+			// Failed fetch: we learned nothing about this node. Keep the
+			// stored copy untouched (its CrawledAt keeps it authoritative
+			// against seeds); only record nodes we have never seen.
+			if s.nodes[n.URL] == nil {
+				s.nodes[n.URL] = &StoredNode{
+					URL:       n.URL,
+					Title:     n.Title,
+					Status:    n.Status,
+					LinkCount: n.LinkCount,
+					CrawledAt: now,
+				}
+				count++
+			}
+			continue
+		}
 		sn := &StoredNode{
 			URL:       n.URL,
 			Title:     n.Title,
@@ -224,9 +243,7 @@ func (s *Store) Merge(g *graph.Graph, etags map[string]string) int {
 		}
 		s.nodes[n.URL] = sn
 		count++
-		if observedStatus(n.Status) {
-			refreshed[n.URL] = true
-		}
+		refreshed[n.URL] = true
 	}
 
 	s.dropEdgesFromLocked(refreshed)

--- a/client/graphstore/store.go
+++ b/client/graphstore/store.go
@@ -194,14 +194,10 @@ func (s *Store) Save() error {
 	return os.Rename(tmp, s.path)
 }
 
-// Merge integrates a crawled graph into the store. Nodes the crawl actually
-// read are upserted with fresh timestamps; a node the crawl failed to read
-// (error/external/blank status) never clobbers a stored one, so last-known-
-// good title/status survive transient fetch failures instead of regressing
-// (issue #222). For every source the crawl actually fetched, the stored
-// outgoing edge set is replaced by the crawl's, so deleted links and dropped
-// rel- predicates do not linger in backlink queries. The etags map provides
-// etag values keyed by URL. Returns the number of nodes upserted.
+// Merge integrates a crawled graph into the store; returns nodes upserted.
+// Only nodes the crawl actually read are upserted, and only their stored
+// outgoing edge sets replaced: an unread node (error/external/blank) must
+// not regress last-known-good data or drop edges it knows nothing about.
 func (s *Store) Merge(g *graph.Graph, etags map[string]string) int {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/client/graphstore/store.go
+++ b/client/graphstore/store.go
@@ -195,9 +195,10 @@ func (s *Store) Save() error {
 }
 
 // Merge integrates a crawled graph into the store; returns nodes upserted.
-// Only nodes the crawl actually read are upserted, and only their stored
-// outgoing edge sets replaced: an unread node (error/external/blank) must
-// not regress last-known-good data or drop edges it knows nothing about.
+// Stored nodes and their outgoing edge sets are replaced only for sources
+// the crawl actually read: an unread node (error/external/blank) never
+// regresses last-known-good data or drops edges it knows nothing about,
+// though never-seen unread nodes are still recorded.
 func (s *Store) Merge(g *graph.Graph, etags map[string]string) int {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/client/graphstore/store_test.go
+++ b/client/graphstore/store_test.go
@@ -248,6 +248,9 @@ func TestMergeRecordsNewUnfetchedNodes(t *testing.T) {
 	if n := s.GetNode("https://example.com/page"); n == nil || n.Status != "external" {
 		t.Errorf("external node not recorded: %+v", n)
 	}
+	if n := s.GetNode("mark://a:6309/down.md"); n == nil || n.Status != "error" {
+		t.Errorf("error node not recorded: %+v", n)
+	}
 }
 
 func TestMergeKeepsDistinctRels(t *testing.T) {

--- a/client/graphstore/store_test.go
+++ b/client/graphstore/store_test.go
@@ -207,6 +207,49 @@ func TestMergeKeepsEdgesOfUnfetchedSources(t *testing.T) {
 	}
 }
 
+// TestMergePreservesResolvedNodeOnFailedRecrawl pins issue #222: a crawl
+// that fails to fetch a node must not clobber the stored last-known-good
+// title/status, so repeated crawls converge instead of regressing.
+func TestMergePreservesResolvedNodeOnFailedRecrawl(t *testing.T) {
+	s := New()
+
+	g1 := graph.New()
+	g1.AddNode(&graph.Node{URL: "mark://a:6309/doc.md", Title: "Doc", Status: "ok", LinkCount: 2})
+	s.Merge(g1, map[string]string{"mark://a:6309/doc.md": "etag-1"})
+
+	g2 := graph.New()
+	g2.AddNode(&graph.Node{URL: "mark://a:6309/doc.md", Status: "error"})
+	s.Merge(g2, nil)
+
+	n := s.GetNode("mark://a:6309/doc.md")
+	if n.Title != "Doc" || n.Status != "ok" || n.LinkCount != 2 || n.Etag != "etag-1" {
+		t.Errorf("failed re-crawl clobbered resolved node: %+v", n)
+	}
+	if n.CrawledAt.IsZero() {
+		t.Error("preserved node lost its CrawledAt")
+	}
+
+	// Still authoritative: a subsequent seed must not overwrite it either.
+	s.SeedFromExport([]StoredNode{{URL: "mark://a:6309/doc.md", Title: "Hub Doc", Status: "ok"}}, nil)
+	if n := s.GetNode("mark://a:6309/doc.md"); n.Title != "Doc" {
+		t.Errorf("seed overwrote node preserved through a failed re-crawl: %+v", n)
+	}
+}
+
+func TestMergeRecordsNewUnfetchedNodes(t *testing.T) {
+	s := New()
+
+	g := graph.New()
+	g.AddNode(&graph.Node{URL: "https://example.com/page", Status: "external"})
+	g.AddNode(&graph.Node{URL: "mark://a:6309/down.md", Status: "error"})
+	if count := s.Merge(g, nil); count != 2 {
+		t.Errorf("Merge count = %d, want 2 (never-seen nodes still recorded)", count)
+	}
+	if n := s.GetNode("https://example.com/page"); n == nil || n.Status != "external" {
+		t.Errorf("external node not recorded: %+v", n)
+	}
+}
+
 func TestMergeKeepsDistinctRels(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "graph.json")
 	s, err := Load(path)

--- a/client/graphstore/store_test.go
+++ b/client/graphstore/store_test.go
@@ -216,6 +216,7 @@ func TestMergePreservesResolvedNodeOnFailedRecrawl(t *testing.T) {
 	g1 := graph.New()
 	g1.AddNode(&graph.Node{URL: "mark://a:6309/doc.md", Title: "Doc", Status: "ok", LinkCount: 2})
 	s.Merge(g1, map[string]string{"mark://a:6309/doc.md": "etag-1"})
+	firstCrawledAt := s.GetNode("mark://a:6309/doc.md").CrawledAt
 
 	g2 := graph.New()
 	g2.AddNode(&graph.Node{URL: "mark://a:6309/doc.md", Status: "error"})
@@ -225,8 +226,8 @@ func TestMergePreservesResolvedNodeOnFailedRecrawl(t *testing.T) {
 	if n.Title != "Doc" || n.Status != "ok" || n.LinkCount != 2 || n.Etag != "etag-1" {
 		t.Errorf("failed re-crawl clobbered resolved node: %+v", n)
 	}
-	if n.CrawledAt.IsZero() {
-		t.Error("preserved node lost its CrawledAt")
+	if !n.CrawledAt.Equal(firstCrawledAt) {
+		t.Errorf("CrawledAt changed on failed re-crawl: got %v, want %v", n.CrawledAt, firstCrawledAt)
 	}
 
 	// Still authoritative: a subsequent seed must not overwrite it either.


### PR DESCRIPTION
Fixes #222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved previously stored node details (including last-known-good timestamps) when a recrawl temporarily fails.
  * Prevented non-authoritative/unread crawl results from overwriting existing stored node and edge information.
  * Ensured newly discovered nodes are recorded and retrievable even on first arrival with external/error statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->