### PR TITLE
fix(tools): translate seed URLs from world addresses to world names

### DIFF
--- a/tools/demarkus-broker/MCP-API.md
+++ b/tools/demarkus-broker/MCP-API.md
@@ -236,9 +236,11 @@ hub manifest unless `force: true`.
 > world fetches its `/graph.md` aggregate (conditional on the last
 > seen etag, throttled to one check per world per 5 minutes) and
 > merges it into the store, so cold pods answer backlinks without a
-> crawl. Locally crawled data always takes precedence over seeded
-> rows, and a world without `/graph.md` degrades to the unseeded
-> behavior.
+> crawl. Seed rows keyed by a configured world's internal dial address
+> (the form the federation agent publishes) are translated to
+> `mark://{worldName}/...` so they answer world-name queries. Locally
+> crawled data always takes precedence over seeded rows, and a world
+> without `/graph.md` degrades to the unseeded behavior.
 
 #### `mark_backlinks`
 

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
@@ -139,12 +139,9 @@ func (g *mcpGateway) seedWorldGraph(ctx context.Context, claims *Claims, worldNa
 	}
 }
 
-// translateSeedURLs rewrites node and edge URLs whose host is a configured
-// world's internal dial address into the gateway's mark://{worldName}/{path}
-// form. The hub aggregate is crawled over cluster-internal DNS, but every
-// gateway query and crawl keys on world names (and the tool URL grammar
-// rejects port-carrying hosts), so untranslated rows would be unreachable.
-// Unknown hosts stay as-is: they are labels, not lookup keys.
+// translateSeedURLs rewrites URLs on configured world dial addresses to
+// mark://{worldName}/... form; gateway queries key on world names, so
+// untranslated rows are unreachable. Unknown hosts are labels, kept as-is.
 func (g *mcpGateway) translateSeedURLs(nodes []graphstore.StoredNode, edges []graphstore.StoredEdge) {
 	worlds := g.srv.cfg.Worlds
 	byAddr := make(map[string]string, len(worlds))

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
@@ -132,9 +132,39 @@ func (g *mcpGateway) seedWorldGraph(ctx context.Context, claims *Claims, worldNa
 	if len(nodes) == 0 && len(edges) == 0 {
 		return
 	}
+	g.translateSeedURLs(nodes, edges)
 	g.graphStore.SeedFromExport(nodes, edges)
 	if e := result.Response.Metadata["etag"]; e != "" {
 		g.graphStore.SetSeedEtag(worldName, e)
+	}
+}
+
+// translateSeedURLs rewrites node and edge URLs whose host is a configured
+// world's internal dial address into the gateway's mark://{worldName}/{path}
+// form. The hub aggregate is crawled over cluster-internal DNS, but every
+// gateway query and crawl keys on world names (and the tool URL grammar
+// rejects port-carrying hosts), so untranslated rows would be unreachable.
+// Unknown hosts stay as-is: they are labels, not lookup keys.
+func (g *mcpGateway) translateSeedURLs(nodes []graphstore.StoredNode, edges []graphstore.StoredEdge) {
+	worlds := g.srv.cfg.Worlds
+	byAddr := make(map[string]string, len(worlds))
+	for i := range worlds {
+		byAddr["mark://"+resolveWorldAddress(&worlds[i])] = "mark://" + worlds[i].Name
+	}
+	translate := func(rawURL string) string {
+		for prefix, world := range byAddr {
+			if rest, ok := strings.CutPrefix(rawURL, prefix); ok && (rest == "" || rest[0] == '/') {
+				return world + rest
+			}
+		}
+		return rawURL
+	}
+	for i := range nodes {
+		nodes[i].URL = translate(nodes[i].URL)
+	}
+	for i := range edges {
+		edges[i].From = translate(edges[i].From)
+		edges[i].To = translate(edges[i].To)
 	}
 }
 

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph_seed_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph_seed_test.go
@@ -43,6 +43,54 @@ func seedingDispatcher(etag string) *fakeDispatcher {
 	}
 }
 
+// internalAddrGraphBody renders a /graph.md the way the federation agent
+// publishes it in-cluster: rows keyed by internal dial addresses
+// (name.namespace.svc.cluster.local:6309), not world names.
+func internalAddrGraphBody() string {
+	src := graphstore.New()
+	g := graph.New()
+	const base = "mark://team-a.team-a.svc.cluster.local:6309"
+	g.AddNode(&graph.Node{URL: base + "/a.md", Title: "Page A", Status: "ok", LinkCount: 2})
+	g.AddNode(&graph.Node{URL: base + "/b.md", Title: "Page B", Status: "ok"})
+	g.AddNode(&graph.Node{URL: "https://example.com/ext", Status: "external"})
+	g.AddEdgeInfo(graph.Edge{From: base + "/a.md", To: base + "/b.md", Label: "B", Count: 1})
+	g.AddEdgeInfo(graph.Edge{From: base + "/a.md", To: "https://example.com/ext", Count: 1})
+	src.Merge(g, nil)
+	return src.Export()
+}
+
+// TestSeedTranslatesInternalAddressesToWorldNames pins the production
+// topology: the hub aggregate keys rows by cluster-internal DNS, which no
+// legal tool URL can address (world host must not carry a port). Seeding
+// must translate configured world addresses to world names so backlinks
+// answer; unknown hosts stay untouched.
+func TestSeedTranslatesInternalAddressesToWorldNames(t *testing.T) {
+	d := &fakeDispatcher{
+		fetchCondFn: func(_, path, _, _ string) (fetch.Result, error) {
+			if path != "/graph.md" {
+				return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+			}
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: internalAddrGraphBody()}}, nil
+		},
+	}
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), d)
+
+	res, err := g.handleMarkBacklinks(withAliceClaims(context.Background()), callToolReq("mark_backlinks", map[string]any{
+		"url": "mark://team-a/b.md",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkBacklinks: %v", err)
+	}
+	text := toolResultText(t, res)
+	if !strings.Contains(text, "Page A") || !strings.Contains(text, "mark://team-a/a.md") {
+		t.Errorf("internal-address seed rows not translated to world names:\n%s", text)
+	}
+	// The external node's URL is not a world address and must stay as-is.
+	if n := g.graphStore.GetNode("https://example.com/ext"); n == nil {
+		t.Error("external node URL was rewritten or dropped")
+	}
+}
+
 // TestHandleMarkBacklinksColdPodSeedsFromWorldGraph is the headline
 // behavior: a cold gateway answers backlinks from the world's
 // published /graph.md with no prior crawl.

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph_seed_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph_seed_test.go
@@ -59,11 +59,9 @@ func internalAddrGraphBody() string {
 	return src.Export()
 }
 
-// TestSeedTranslatesInternalAddressesToWorldNames pins the production
-// topology: the hub aggregate keys rows by cluster-internal DNS, which no
-// legal tool URL can address (world host must not carry a port). Seeding
-// must translate configured world addresses to world names so backlinks
-// answer; unknown hosts stay untouched.
+// TestSeedTranslatesInternalAddressesToWorldNames: the hub aggregate keys
+// rows by cluster-internal DNS, which no legal tool URL can address; seeding
+// must translate world addresses to world names and leave unknown hosts alone.
 func TestSeedTranslatesInternalAddressesToWorldNames(t *testing.T) {
 	d := &fakeDispatcher{
 		fetchCondFn: func(_, path, _, _ string) (fetch.Result, error) {
@@ -85,9 +83,14 @@ func TestSeedTranslatesInternalAddressesToWorldNames(t *testing.T) {
 	if !strings.Contains(text, "Page A") || !strings.Contains(text, "mark://team-a/a.md") {
 		t.Errorf("internal-address seed rows not translated to world names:\n%s", text)
 	}
-	// The external node's URL is not a world address and must stay as-is.
+	// The external URL is not a world address and must stay as-is, on the
+	// node and on the edge destination (asserted via the store; the tool
+	// URL grammar only admits mark:// URLs).
 	if n := g.graphStore.GetNode("https://example.com/ext"); n == nil {
 		t.Error("external node URL was rewritten or dropped")
+	}
+	if bl := g.graphStore.Backlinks("https://example.com/ext"); len(bl) != 1 || bl[0] != "mark://team-a/a.md" {
+		t.Errorf("external edge destination = %v, want [mark://team-a/a.md]", bl)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Seeded graph links now correctly translate when source URLs use internal world addresses.
  * Internal link destinations are converted to world-name URL form, while external destinations remain unchanged.
  * Local crawls still take precedence over seeded results.
* **Documentation**
  * Updated guidance for seeded URL translation behavior and crawl precedence.
* **Tests**
  * Added coverage verifying internal-to-world-name translation and preservation of external URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->