### PR TITLE
fix(tools): broker graph tools seed every configured world

### DIFF
--- a/client/internal/fedcrawl/contract_test.go
+++ b/client/internal/fedcrawl/contract_test.go
@@ -17,12 +17,9 @@ const contractGoldenPath = "testdata/graph-export-incluster.md"
 // exportedLineRe matches the volatile timestamp header of an export.
 var exportedLineRe = regexp.MustCompile(`(?m)^> Exported: .*$`)
 
-// TestGraphExportContract pins the exact /graph.md body the agent publishes
-// when crawling an in-cluster topology (worlds seeded by service DNS). The
-// golden file is the producer half of a cross-module contract: the broker's
-// seed path consumes the same file in its own suite, so a drift in either
-// the export shape or the URL forms fails a build instead of shipping.
-// Regenerate with: go test ./internal/fedcrawl -run TestGraphExportContract -update
+// TestGraphExportContract pins the exact /graph.md body published for an
+// in-cluster topology. The golden is the producer half of a cross-module
+// contract; the broker's seed suite consumes the same file (-update regenerates).
 func TestGraphExportContract(t *testing.T) {
 	const host = "team-a.team-a.svc.cluster.local:6309"
 

--- a/client/internal/fedcrawl/contract_test.go
+++ b/client/internal/fedcrawl/contract_test.go
@@ -1,0 +1,78 @@
+package fedcrawl
+
+import (
+	"context"
+	"flag"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var updateGolden = flag.Bool("update", false, "rewrite the graph-export contract golden file")
+
+const contractGoldenPath = "testdata/graph-export-incluster.md"
+
+// exportedLineRe matches the volatile timestamp header of an export.
+var exportedLineRe = regexp.MustCompile(`(?m)^> Exported: .*$`)
+
+// TestGraphExportContract pins the exact /graph.md body the agent publishes
+// when crawling an in-cluster topology (worlds seeded by service DNS). The
+// golden file is the producer half of a cross-module contract: the broker's
+// seed path consumes the same file in its own suite, so a drift in either
+// the export shape or the URL forms fails a build instead of shipping.
+// Regenerate with: go test ./internal/fedcrawl -run TestGraphExportContract -update
+func TestGraphExportContract(t *testing.T) {
+	const host = "team-a.team-a.svc.cluster.local:6309"
+
+	client := newMockClient()
+	client.addList(host, "/", "- [index.md](index.md)\n- [a.md](a.md)\n- [b.md](b.md)\n")
+	client.addDocWithMeta(host, "/index.md",
+		"# Team A hub\n\n## Services\n\n- [Applications](/a.md)\n",
+		"sha256-"+strings.Repeat("1", 64), map[string]string{"title": "Team A hub"})
+	client.addDocWithMeta(host, "/a.md",
+		"# Applications\n\n## Links\n\n- [B doc](/b.md)\n- [external](https://example.com/ext)\n- [dev](mark://localhost:6309/dev.md)\n",
+		"sha256-"+strings.Repeat("2", 64), map[string]string{"title": "Applications"})
+	client.addDocWithMeta(host, "/b.md",
+		"# B doc\n",
+		"sha256-"+strings.Repeat("3", 64), map[string]string{"title": "B doc", "rel-supersedes": "/a.md"})
+
+	cfg := DefaultConfig()
+	cfg.Seeds = []string{"mark://" + host}
+	cfg.Crawl.MaxDocuments = 100
+	cfg.Politeness.RequestDelay = 0
+
+	crawler := NewCrawler(cfg, client, nil, nil)
+	if _, err := crawler.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	got := exportedLineRe.ReplaceAllString(crawler.GraphExport(), "> Exported: GOLDEN")
+
+	if *updateGolden {
+		if err := os.MkdirAll(filepath.Dir(contractGoldenPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(contractGoldenPath, []byte(got), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	want, err := os.ReadFile(contractGoldenPath)
+	if err != nil {
+		t.Fatalf("read golden (regenerate with -update): %v", err)
+	}
+	if got != string(want) {
+		t.Errorf("agent /graph.md export drifted from the contract golden.\nIf intentional, regenerate with -update and re-run the broker suite (it consumes this file).\ngot:\n%s\nwant:\n%s", got, want)
+	}
+
+	// Contract facts the consumer relies on, pinned independently of bytes:
+	// rows key on the internal dial address, and non-mark targets never enter.
+	if !strings.Contains(got, "mark://"+host+"/a.md") {
+		t.Error("export lost the internal dial-address URL form")
+	}
+	if strings.Contains(got, "https://example.com/ext") || strings.Contains(got, "localhost") {
+		t.Error("external or loopback target leaked into the federation export")
+	}
+}

--- a/client/internal/fedcrawl/testdata/graph-export-incluster.md
+++ b/client/internal/fedcrawl/testdata/graph-export-incluster.md
@@ -1,0 +1,21 @@
+# Document Graph
+
+> Exported: GOLDEN
+> Nodes: 3
+> Edges: 3
+
+## Nodes
+
+| URL | Title | Status | Links |
+|-----|-------|--------|-------|
+| [mark://team-a.team-a.svc.cluster.local:6309/a.md](mark://team-a.team-a.svc.cluster.local:6309/a.md) | Applications | ok | 1 |
+| [mark://team-a.team-a.svc.cluster.local:6309/b.md](mark://team-a.team-a.svc.cluster.local:6309/b.md) | B doc | ok | 0 |
+| [mark://team-a.team-a.svc.cluster.local:6309/index.md](mark://team-a.team-a.svc.cluster.local:6309/index.md) | Team A hub | ok | 1 |
+
+## Edges
+
+| From | To | Rel | Label | Anchor | Count |
+|------|----|-----|-------|--------|-------|
+| mark://team-a.team-a.svc.cluster.local:6309/a.md | mark://team-a.team-a.svc.cluster.local:6309/b.md |  | B doc | links | 1 |
+| mark://team-a.team-a.svc.cluster.local:6309/b.md | mark://team-a.team-a.svc.cluster.local:6309/a.md | supersedes |  |  | 1 |
+| mark://team-a.team-a.svc.cluster.local:6309/index.md | mark://team-a.team-a.svc.cluster.local:6309/a.md |  | Applications | services | 1 |

--- a/tools/demarkus-broker/MCP-API.md
+++ b/tools/demarkus-broker/MCP-API.md
@@ -231,12 +231,12 @@ hub manifest unless `force: true`.
 > persistence is parked for the post-broker design window.
 >
 > To make restarts cheap (not durable), the store is **seeded on
-> demand from each world's published `/graph.md`**: the first
-> `mark_backlinks` / `mark_graph` / `mark_explore` call touching a
-> world fetches its `/graph.md` aggregate (conditional on the last
-> seen etag, throttled to one check per world per 5 minutes) and
-> merges it into the store, so cold pods answer backlinks without a
-> crawl. Seed rows keyed by a configured world's internal dial address
+> demand from the worlds' published `/graph.md`**: any
+> `mark_backlinks` / `mark_graph` / `mark_explore` call checks every
+> configured world for a `/graph.md` aggregate (the hub is the one
+> that has it; conditional on the last seen etag, throttled to one
+> check per world per 5 minutes) and merges it into the store, so
+> cold pods answer backlinks without a crawl. Seed rows keyed by a configured world's internal dial address
 > (the form the federation agent publishes) are translated to
 > `mark://{worldName}/...` so they answer world-name queries. Locally
 > crawled data always takes precedence over seeded rows, and a world

--- a/tools/demarkus-broker/internal/broker/mcp_tools_explore.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_explore.go
@@ -67,7 +67,7 @@ func (g *mcpGateway) handleMarkExplore(ctx context.Context, req mcp.CallToolRequ
 	}
 
 	if claims, ok := claimsFromCtx(ctx); ok {
-		g.seedWorldGraph(ctx, claims, worldName)
+		g.seedGraphStore(ctx, claims)
 	}
 	g.writeBacklinksSection(&b, docURL)
 	g.writeSiblingsSection(&b, worldName, path)

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
@@ -96,6 +96,16 @@ func (g *mcpGateway) crawlFetchFn(ctx context.Context, claims *Claims) graphstor
 // interval; the first graph-tool call after a pod restart always checks.
 const seedCheckInterval = 5 * time.Minute
 
+// seedGraphStore seeds from every configured world's /graph.md. The
+// aggregate lives only on hub worlds and the broker does not know which
+// world is the hub; a world without /graph.md not-founds instantly and the
+// per-world throttle bounds the cost.
+func (g *mcpGateway) seedGraphStore(ctx context.Context, claims *Claims) {
+	for i := range g.srv.cfg.Worlds {
+		g.seedWorldGraph(ctx, claims, g.srv.cfg.Worlds[i].Name)
+	}
+}
+
 // seedWorldGraph refreshes the broker's ephemeral graph store from the
 // world's published /graph.md aggregate, so a cold pod answers backlinks
 // without a crawl. Local crawls win (see graphstore.SeedFromExport).
@@ -177,12 +187,11 @@ func (g *mcpGateway) handleMarkBacklinks(ctx context.Context, req mcp.CallToolRe
 	}
 	// Validate the URL shape so an agent typo doesn't silently
 	// produce "no backlinks" against a malformed lookup key.
-	worldName, _, perr := parseToolURL(raw)
-	if perr != nil {
+	if _, _, perr := parseToolURL(raw); perr != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", perr)), nil
 	}
 	if claims, ok := claimsFromCtx(ctx); ok {
-		g.seedWorldGraph(ctx, claims, worldName)
+		g.seedGraphStore(ctx, claims)
 	}
 	backlinks := g.graphStore.BacklinksEnriched(raw)
 	if len(backlinks) == 0 {
@@ -218,8 +227,7 @@ func (g *mcpGateway) handleMarkGraph(ctx context.Context, req mcp.CallToolReques
 	if err != nil {
 		return mcp.NewToolResultError("url is required"), nil
 	}
-	worldName, _, perr := parseToolURL(raw)
-	if perr != nil {
+	if _, _, perr := parseToolURL(raw); perr != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", perr)), nil
 	}
 	depth := max(1, min(req.GetInt("depth", 2), 5))
@@ -230,7 +238,7 @@ func (g *mcpGateway) handleMarkGraph(ctx context.Context, req mcp.CallToolReques
 
 	// Seed before crawling so depth-limited crawls still benefit from
 	// hub context.
-	g.seedWorldGraph(ctx, claims, worldName)
+	g.seedGraphStore(ctx, claims)
 
 	crawled, crawlErr := g.graphStore.CrawlAndPersist(
 		ctx,

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
@@ -96,9 +96,8 @@ func (g *mcpGateway) crawlFetchFn(ctx context.Context, claims *Claims) graphstor
 // interval; the first graph-tool call after a pod restart always checks.
 const seedCheckInterval = 5 * time.Minute
 
-// seedGraphStore seeds from every configured world's /graph.md. The
-// aggregate lives only on hub worlds and the broker does not know which
-// world is the hub; a world without /graph.md not-founds instantly and the
+// seedGraphStore seeds from every configured world: only hubs publish
+// /graph.md and the broker does not know which world is the hub; the
 // per-world throttle bounds the cost.
 func (g *mcpGateway) seedGraphStore(ctx context.Context, claims *Claims) {
 	for i := range g.srv.cfg.Worlds {

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph_seed_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph_seed_test.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -40,6 +41,63 @@ func seedingDispatcher(etag string) *fakeDispatcher {
 				Body:     worldGraphBody(),
 			}}, nil
 		},
+	}
+}
+
+// agentContractGolden is the /graph.md body the REAL federation agent
+// produces for an in-cluster topology, generated and pinned by
+// client/internal/fedcrawl's TestGraphExportContract. Consuming it here is
+// the other half of the cross-module contract: producer drift regenerates
+// the golden, and this suite fails if the seed path stops handling it.
+const agentContractGoldenPath = "../../../../client/internal/fedcrawl/testdata/graph-export-incluster.md"
+
+func agentContractGolden(t *testing.T) string {
+	t.Helper()
+	body, err := os.ReadFile(agentContractGoldenPath)
+	if err != nil {
+		t.Fatalf("read agent export contract golden (regenerate with: go test ./internal/fedcrawl -run TestGraphExportContract -update, in client/): %v", err)
+	}
+	return string(body)
+}
+
+// TestSeedConsumesAgentExportContract: the real agent's export (the golden)
+// must seed a cold gateway into answering world-name backlink queries, with
+// every world-address row translated.
+func TestSeedConsumesAgentExportContract(t *testing.T) {
+	cfg := mcpTestConfig()
+	cfg.Worlds = append(cfg.Worlds, WorldConfig{Name: "hub", Namespace: "hub", TokensSecret: "hub-tokens"})
+	body := agentContractGolden(t)
+	d := &fakeDispatcher{
+		fetchCondFn: func(worldName, path, _, _ string) (fetch.Result, error) {
+			if worldName == "hub" && path == "/graph.md" {
+				return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: body}}, nil
+			}
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+		},
+	}
+	g := newGatewayWithDispatcher(t, cfg, d)
+
+	res, err := g.handleMarkBacklinks(withAliceClaims(context.Background()), callToolReq("mark_backlinks", map[string]any{
+		"url": "mark://team-a/a.md",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkBacklinks: %v", err)
+	}
+	text := toolResultText(t, res)
+	// index.md's plain link and b.md's typed rel edge, both translated,
+	// with enriched provenance intact.
+	for _, want := range []string{"mark://team-a/index.md", "mark://team-a/b.md", "[supersedes]"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("missing %q in backlinks from the agent's real export:\n%s", want, text)
+		}
+	}
+
+	// Addressability invariant: every seeded mark:// row on a configured
+	// world address must be translated; none may keep the dial-address form.
+	for _, n := range g.graphStore.AllNodes() {
+		if strings.Contains(n.URL, ".svc.cluster.local") {
+			t.Errorf("unaddressable seeded row survived translation: %s", n.URL)
+		}
 	}
 }
 

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph_seed_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph_seed_test.go
@@ -94,6 +94,38 @@ func TestSeedTranslatesInternalAddressesToWorldNames(t *testing.T) {
 	}
 }
 
+// TestSeedFindsAggregateOnAnotherWorld: the aggregate lives only on the hub
+// world, so a cold query against a different world must still seed it; every
+// configured world is checked, not just the one in the query URL.
+func TestSeedFindsAggregateOnAnotherWorld(t *testing.T) {
+	cfg := mcpTestConfig()
+	cfg.Worlds = append(cfg.Worlds, WorldConfig{Name: "hub", Namespace: "hub", TokensSecret: "hub-tokens"})
+	d := &fakeDispatcher{
+		fetchCondFn: func(worldName, path, _, _ string) (fetch.Result, error) {
+			if worldName == "hub" && path == "/graph.md" {
+				return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: internalAddrGraphBody()}}, nil
+			}
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+		},
+	}
+	g := newGatewayWithDispatcher(t, cfg, d)
+
+	res, err := g.handleMarkBacklinks(withAliceClaims(context.Background()), callToolReq("mark_backlinks", map[string]any{
+		"url": "mark://team-a/b.md",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkBacklinks: %v", err)
+	}
+	if text := toolResultText(t, res); !strings.Contains(text, "mark://team-a/a.md") {
+		t.Errorf("hub-world aggregate not found from a team-a query:\n%s", text)
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if len(d.fetchCondCalls) != 2 {
+		t.Errorf("seed checks = %d, want 2 (every configured world once)", len(d.fetchCondCalls))
+	}
+}
+
 // TestHandleMarkBacklinksColdPodSeedsFromWorldGraph is the headline
 // behavior: a cold gateway answers backlinks from the world's
 // published /graph.md with no prior crawl.

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph_seed_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph_seed_test.go
@@ -44,11 +44,9 @@ func seedingDispatcher(etag string) *fakeDispatcher {
 	}
 }
 
-// agentContractGolden is the /graph.md body the REAL federation agent
-// produces for an in-cluster topology, generated and pinned by
-// client/internal/fedcrawl's TestGraphExportContract. Consuming it here is
-// the other half of the cross-module contract: producer drift regenerates
-// the golden, and this suite fails if the seed path stops handling it.
+// agentContractGoldenPath is the real agent's in-cluster /graph.md, pinned
+// by fedcrawl's TestGraphExportContract; consuming it here is the other
+// half of the cross-module contract (producer drift regenerates it).
 const agentContractGoldenPath = "../../../../client/internal/fedcrawl/testdata/graph-export-incluster.md"
 
 func agentContractGolden(t *testing.T) string {
@@ -179,8 +177,15 @@ func TestSeedFindsAggregateOnAnotherWorld(t *testing.T) {
 	}
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if len(d.fetchCondCalls) != 2 {
-		t.Errorf("seed checks = %d, want 2 (every configured world once)", len(d.fetchCondCalls))
+	probed := map[string]int{}
+	for _, c := range d.fetchCondCalls {
+		if c.path != "/graph.md" {
+			t.Errorf("seed probed %q, want /graph.md", c.path)
+		}
+		probed[c.worldName]++
+	}
+	if probed["team-a"] != 1 || probed["hub"] != 1 || len(probed) != 2 {
+		t.Errorf("seed probes = %v, want each configured world exactly once", probed)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Graph and backlink operations now proactively seed from every configured world’s published `/graph.md`, improving cross-world backlink accuracy and coverage.
- **Bug Fixes**
  - Tool URL inputs are validated before graph/backlink processing, with continued graceful behavior for worlds that lack `/graph.md`.
- **Tests**
  - Added golden-file contract tests to verify `/graph.md` export stability and key addressability invariants.
- **Documentation**
  - Clarified graph discovery, hub behavior, caching/throttling, and seeding scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->