### PR TITLE
fix(client): fedcrawl falls back to H1 for node titles

### DIFF
--- a/client/internal/fedcrawl/contract_test.go
+++ b/client/internal/fedcrawl/contract_test.go
@@ -28,9 +28,11 @@ func TestGraphExportContract(t *testing.T) {
 	client.addDocWithMeta(host, "/index.md",
 		"# Team A hub\n\n## Services\n\n- [Applications](/a.md)\n",
 		"sha256-"+strings.Repeat("1", 64), map[string]string{"title": "Team A hub"})
+	// No metadata title: the node's title must come from the H1 fallback
+	// (the golden pins it, since the H1 text matches the old declared title).
 	client.addDocWithMeta(host, "/a.md",
 		"# Applications\n\n## Links\n\n- [B doc](/b.md)\n- [external](https://example.com/ext)\n- [dev](mark://localhost:6309/dev.md)\n",
-		"sha256-"+strings.Repeat("2", 64), map[string]string{"title": "Applications"})
+		"sha256-"+strings.Repeat("2", 64), nil)
 	client.addDocWithMeta(host, "/b.md",
 		"# B doc\n",
 		"sha256-"+strings.Repeat("3", 64), map[string]string{"title": "B doc", "rel-supersedes": "/a.md"})

--- a/client/internal/fedcrawl/crawl.go
+++ b/client/internal/fedcrawl/crawl.go
@@ -494,7 +494,14 @@ func (c *Crawler) recordEdges(host, path, body string, meta map[string]string) {
 		}
 		c.graph.AddEdgeInfo(graph.Edge{From: url, To: target, Rel: r.Rel, Count: 1})
 	}
-	c.graph.AddNode(&graph.Node{URL: url, Title: meta["title"], Status: "ok", LinkCount: linkCount})
+	// Declared metadata title first, H1 fallback like mark_graph's crawler:
+	// most docs carry their title as a heading, not metadata, and a blank
+	// title here propagates to every hub-graph consumer.
+	title := meta["title"]
+	if title == "" {
+		title = links.ExtractTitle(body)
+	}
+	c.graph.AddNode(&graph.Node{URL: url, Title: title, Status: "ok", LinkCount: linkCount})
 }
 
 // normalizeTarget keeps only mark:// targets with a port-stable host

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -774,3 +774,42 @@ func TestCrawlerRecordsTypedAndProvenancedEdges(t *testing.T) {
 		t.Errorf("loopback rel target leaked into export\n---\n%s", exp)
 	}
 }
+
+// TestRecordEdgesTitlePrecedence: declared metadata title wins; a doc with
+// only an H1 falls back to it (blank titles propagate to every hub-graph
+// consumer otherwise).
+func TestRecordEdgesTitlePrecedence(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Seeds = []string{"mark://example.com"}
+	cfg.Politeness.RequestDelay = 0
+
+	client := newMockClient()
+	client.addList("example.com:6309", "/", "- [declared.md](declared.md)\n- [heading.md](heading.md)\n- [bare.md](bare.md)\n")
+	client.addDocWithMeta("example.com:6309", "/declared.md", "# Heading Title\n", "sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", map[string]string{"title": "Declared Title"})
+	client.addDocWithMeta("example.com:6309", "/heading.md", "# Heading Only\n", "sha256-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", nil)
+	client.addDocWithMeta("example.com:6309", "/bare.md", "no heading at all\n", "sha256-cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", nil)
+
+	c := NewCrawler(cfg, client, nil, nil)
+	if _, err := c.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	want := map[string]string{
+		"mark://example.com:6309/declared.md": "Declared Title",
+		"mark://example.com:6309/heading.md":  "Heading Only",
+		"mark://example.com:6309/bare.md":     "",
+	}
+	for _, n := range c.graph.AllNodes() {
+		expect, ok := want[n.URL]
+		if !ok {
+			continue
+		}
+		if n.Title != expect {
+			t.Errorf("title of %s = %q, want %q", n.URL, n.Title, expect)
+		}
+		delete(want, n.URL)
+	}
+	if len(want) != 0 {
+		t.Errorf("nodes not crawled: %v", want)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph exports to derive document titles from the first H1 heading when no title metadata is provided.
  * Preserved metadata titles when available.
  * Documents without metadata or an H1 heading now export without a title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->