### PR TITLE
feat(client): join URLs for one-paste remote joins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,8 +9,8 @@
     {
       "name": "demarkus-memory",
       "source": "./plugins/claude-code",
-      "description": "Zero-config local memory for Claude Code. Spawns a local demarkus-server and wires MCP tools for fetch/publish/append/graph/lookup over your own versioned markdown store, and self-documents sessions to it. /soul-join adds remote souls to a catalog with per-project binding and a destination gate. With a promote destination configured — a joined knowledge system or a registered plain remote demarkus server — /promote lifts ready notes up to it, /promote-scan sweeps for candidates, an ADR publish nudges promotion, and /soul-refresh pulls promoted docs back as they evolve.",
-      "version": "0.12.16",
+      "description": "Zero-config local memory for Claude Code. Spawns a local demarkus-server and wires MCP tools for fetch/publish/append/graph/lookup over your own versioned markdown store, and self-documents sessions to it. /soul-join adds remote souls to a catalog with per-project binding and a destination gate; a join URL (host and token in one paste-able string) joins a remote soul in one step. With a promote destination configured — a joined knowledge system or a registered plain remote demarkus server — /promote lifts ready notes up to it, /promote-scan sweeps for candidates, an ADR publish nudges promotion, and /soul-refresh pulls promoted docs back as they evolve.",
+      "version": "0.13.0",
       "category": "memory",
       "tags": ["memory", "demarkus", "mark-protocol", "local-first"],
       "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/claude-code"

--- a/client/cmd/demarkus/main.go
+++ b/client/cmd/demarkus/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/latebit-io/demarkus/client/internal/bookmarks"
 	"github.com/latebit-io/demarkus/client/internal/cache"
 	"github.com/latebit-io/demarkus/client/internal/tokens"
+	"github.com/latebit-io/demarkus/client/joinurl"
 	"github.com/latebit-io/demarkus/client/links"
 	"github.com/latebit-io/demarkus/protocol"
 	"github.com/latebit-io/demarkus/protocol/store"
@@ -40,6 +41,9 @@ func main() {
 			return
 		case "token":
 			tokenMain(os.Args[2:])
+			return
+		case "join":
+			joinMain(os.Args[2:])
 			return
 		case "bookmark":
 			bookmarkMain(os.Args[2:])
@@ -499,6 +503,36 @@ func tokenMain(args []string) {
 	default:
 		log.Fatalf("unknown token command: %s", args[0])
 	}
+}
+
+// joinMain stores the token carried by a join URL for the host, so
+// subsequent requests resolve it automatically.
+func joinMain(args []string) {
+	if len(args) != 1 {
+		fmt.Fprintf(os.Stderr, "usage: demarkus join 'mark://host[:port]#token=...'\n")
+		fmt.Fprintf(os.Stderr, "Stores the join URL's token for the host; quote the URL so the shell keeps the fragment.\n")
+		os.Exit(1)
+	}
+	j, err := joinurl.Parse(args[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+	if j.Token == "" {
+		log.Fatal("join URL carries no token; nothing to store (did the shell strip the #fragment? quote the URL)")
+	}
+	host, _, err := fetch.ParseMarkURL("mark://" + j.Host)
+	if err != nil {
+		log.Fatal(err)
+	}
+	ts, err := tokens.Load(tokens.DefaultPath())
+	if err != nil {
+		log.Fatalf("load tokens: %v", err)
+	}
+	if err := ts.Set(host, j.Token); err != nil {
+		log.Fatalf("save token: %v", err)
+	}
+	fmt.Fprintf(os.Stderr, "Joined %s: token stored.\n", host)
+	fmt.Fprintf(os.Stderr, "Try: demarkus mark://%s/index.md\n", host)
 }
 
 func bookmarkMain(args []string) {

--- a/client/fetch/fetch.go
+++ b/client/fetch/fetch.go
@@ -387,7 +387,6 @@ func (c *Client) getConn(host string) (*quic.Conn, error) {
 	} else {
 		tlsConf.ServerName = host
 	}
-
 	conn, err := quic.DialAddr(ctx, host, tlsConf, c.quicConf)
 	if err != nil {
 		return nil, fmt.Errorf("dial %s: %w", host, err)

--- a/client/joinurl/joinurl.go
+++ b/client/joinurl/joinurl.go
@@ -17,8 +17,8 @@ type Join struct {
 
 // Build renders a join URL. Host is required; token is optional.
 func Build(j Join) (string, error) {
-	if j.Host == "" {
-		return "", fmt.Errorf("join URL requires a host")
+	if j.Host == "" || strings.HasPrefix(j.Host, ":") {
+		return "", fmt.Errorf("join URL requires a hostname")
 	}
 	if strings.ContainsAny(j.Host, "/#?@[") {
 		return "", fmt.Errorf("join URL host must be host[:port], got %q", j.Host)
@@ -49,7 +49,7 @@ func Parse(raw string) (Join, error) {
 	if u.Scheme != "mark" {
 		return Join{}, fmt.Errorf("join URL must use mark:// (got %s://)", u.Scheme)
 	}
-	if u.Host == "" {
+	if u.Host == "" || u.Hostname() == "" {
 		return Join{}, fmt.Errorf("join URL has no host")
 	}
 	// Reject URL state Join cannot represent, so nothing is silently dropped.

--- a/client/joinurl/joinurl.go
+++ b/client/joinurl/joinurl.go
@@ -6,6 +6,7 @@ package joinurl
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -17,11 +18,11 @@ type Join struct {
 
 // Build renders a join URL. Host is required; token is optional.
 func Build(j Join) (string, error) {
-	if j.Host == "" || strings.HasPrefix(j.Host, ":") {
-		return "", fmt.Errorf("join URL requires a hostname")
-	}
 	if strings.ContainsAny(j.Host, "/#?@[") {
 		return "", fmt.Errorf("join URL host must be host[:port], got %q", j.Host)
+	}
+	if err := validateHostPort(j.Host); err != nil {
+		return "", err
 	}
 	s := "mark://" + j.Host
 	if j.Token != "" {
@@ -67,6 +68,9 @@ func Parse(raw string) (Join, error) {
 	if strings.HasPrefix(u.Host, "[") {
 		return Join{}, fmt.Errorf("IPv6 literal hosts are not supported in join URLs; use a DNS name")
 	}
+	if err := validateHostPort(u.Host); err != nil {
+		return Join{}, err
+	}
 	j := Join{Host: u.Host}
 	if u.Fragment == "" {
 		return j, nil
@@ -88,6 +92,30 @@ func Parse(raw string) (Join, error) {
 	}
 	j.Token = vals.Get("token")
 	return j, nil
+}
+
+// validateHostPort enforces the host[:port] contract shared by Build and
+// Parse: non-empty hostname, and any port numeric in 1-65535.
+func validateHostPort(host string) error {
+	hostname, port, hasPort := strings.Cut(host, ":")
+	if hostname == "" {
+		return fmt.Errorf("join URL requires a hostname")
+	}
+	if !hasPort {
+		return nil
+	}
+	if port == "" || len(port) > 5 {
+		return fmt.Errorf("join URL has invalid port %q", port)
+	}
+	for _, c := range port {
+		if c < '0' || c > '9' {
+			return fmt.Errorf("join URL has invalid port %q", port)
+		}
+	}
+	if n, _ := strconv.Atoi(port); n < 1 || n > 65535 {
+		return fmt.Errorf("join URL port %s is out of range (1-65535)", port)
+	}
+	return nil
 }
 
 // HasCredentials reports whether raw looks like a join URL fragment form

--- a/client/joinurl/joinurl.go
+++ b/client/joinurl/joinurl.go
@@ -1,11 +1,6 @@
-// Package joinurl builds and parses demarkus join URLs: a single string that
-// carries everything needed to join a server, of the form
-//
-//	mark://host[:port]#token=<raw>
-//
-// The credential rides in the URL fragment, which never appears in any
-// protocol request; the string exists only to be pasted into a join flow
-// (/soul-join, demarkus join) or rendered as a QR code.
+// Package joinurl builds and parses demarkus join URLs
+// (mark://host[:port]#token=<raw>). The credential rides in the URL
+// fragment, which never appears in any protocol request.
 package joinurl
 
 import (
@@ -25,7 +20,7 @@ func Build(j Join) (string, error) {
 	if j.Host == "" {
 		return "", fmt.Errorf("join URL requires a host")
 	}
-	if strings.ContainsAny(j.Host, "/#?") {
+	if strings.ContainsAny(j.Host, "/#?@[") {
 		return "", fmt.Errorf("join URL host must be host[:port], got %q", j.Host)
 	}
 	s := "mark://" + j.Host
@@ -57,8 +52,20 @@ func Parse(raw string) (Join, error) {
 	if u.Host == "" {
 		return Join{}, fmt.Errorf("join URL has no host")
 	}
+	// Reject URL state Join cannot represent, so nothing is silently dropped.
+	if u.User != nil {
+		return Join{}, fmt.Errorf("join URL must not carry userinfo")
+	}
+	if u.RawQuery != "" || u.ForceQuery {
+		return Join{}, fmt.Errorf("join URL must not carry a query (credentials go in the #fragment)")
+	}
 	if u.Path != "" && u.Path != "/" {
 		return Join{}, fmt.Errorf("join URL must not carry a path (got %q)", u.Path)
+	}
+	// Bracketed IPv6 would be misparsed by downstream host handling (slug
+	// derivation, default-port append); fail loudly until that is fixed.
+	if strings.HasPrefix(u.Host, "[") {
+		return Join{}, fmt.Errorf("IPv6 literal hosts are not supported in join URLs; use a DNS name")
 	}
 	j := Join{Host: u.Host}
 	if u.Fragment == "" {
@@ -71,9 +78,12 @@ func Parse(raw string) (Join, error) {
 	if err != nil {
 		return Join{}, fmt.Errorf("invalid join URL fragment: %w", err)
 	}
-	for k := range vals {
+	for k, v := range vals {
 		if k != "token" {
 			return Join{}, fmt.Errorf("join URL fragment has unknown key %q (expected token)", k)
+		}
+		if len(v) > 1 {
+			return Join{}, fmt.Errorf("join URL fragment repeats %q", k)
 		}
 	}
 	j.Token = vals.Get("token")

--- a/client/joinurl/joinurl.go
+++ b/client/joinurl/joinurl.go
@@ -18,9 +18,6 @@ type Join struct {
 
 // Build renders a join URL. Host is required; token is optional.
 func Build(j Join) (string, error) {
-	if strings.ContainsAny(j.Host, "/#?@[") {
-		return "", fmt.Errorf("join URL host must be host[:port], got %q", j.Host)
-	}
 	if err := validateHostPort(j.Host); err != nil {
 		return "", err
 	}
@@ -95,11 +92,18 @@ func Parse(raw string) (Join, error) {
 }
 
 // validateHostPort enforces the host[:port] contract shared by Build and
-// Parse: non-empty hostname, and any port numeric in 1-65535.
+// Parse: hostname restricted to the DNS charset, any port numeric in 1-65535.
 func validateHostPort(host string) error {
 	hostname, port, hasPort := strings.Cut(host, ":")
 	if hostname == "" {
 		return fmt.Errorf("join URL requires a hostname")
+	}
+	for _, c := range hostname {
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9', c == '.', c == '-', c == '_':
+		default:
+			return fmt.Errorf("join URL hostname has invalid character %q", c)
+		}
 	}
 	if !hasPort {
 		return nil

--- a/client/joinurl/joinurl.go
+++ b/client/joinurl/joinurl.go
@@ -1,0 +1,88 @@
+// Package joinurl builds and parses demarkus join URLs: a single string that
+// carries everything needed to join a server, of the form
+//
+//	mark://host[:port]#token=<raw>
+//
+// The credential rides in the URL fragment, which never appears in any
+// protocol request; the string exists only to be pasted into a join flow
+// (/soul-join, demarkus join) or rendered as a QR code.
+package joinurl
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Join is the parsed content of a join URL.
+type Join struct {
+	Host  string // host[:port] as written; no scheme
+	Token string // raw capability token, may be empty (read-only server)
+}
+
+// Build renders a join URL. Host is required; token is optional.
+func Build(j Join) (string, error) {
+	if j.Host == "" {
+		return "", fmt.Errorf("join URL requires a host")
+	}
+	if strings.ContainsAny(j.Host, "/#?") {
+		return "", fmt.Errorf("join URL host must be host[:port], got %q", j.Host)
+	}
+	s := "mark://" + j.Host
+	if j.Token != "" {
+		s += "#token=" + url.QueryEscape(j.Token)
+	}
+	return s, nil
+}
+
+// Parse decodes a join URL. Accepts a bare host, mark://host, or the full
+// fragment form; unknown fragment keys are rejected so a typo (or a URL from
+// a newer issuer with keys this build does not support) fails loudly instead
+// of silently dropping a credential.
+func Parse(raw string) (Join, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return Join{}, fmt.Errorf("empty join URL")
+	}
+	if !strings.Contains(s, "://") {
+		s = "mark://" + s
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return Join{}, fmt.Errorf("invalid join URL: %w", err)
+	}
+	if u.Scheme != "mark" {
+		return Join{}, fmt.Errorf("join URL must use mark:// (got %s://)", u.Scheme)
+	}
+	if u.Host == "" {
+		return Join{}, fmt.Errorf("join URL has no host")
+	}
+	if u.Path != "" && u.Path != "/" {
+		return Join{}, fmt.Errorf("join URL must not carry a path (got %q)", u.Path)
+	}
+	j := Join{Host: u.Host}
+	if u.Fragment == "" {
+		return j, nil
+	}
+	// EscapedFragment keeps percent-escapes intact so ParseQuery decodes them
+	// exactly once (u.Fragment is already decoded; parsing it would corrupt
+	// tokens containing '+' or '%').
+	vals, err := url.ParseQuery(u.EscapedFragment())
+	if err != nil {
+		return Join{}, fmt.Errorf("invalid join URL fragment: %w", err)
+	}
+	for k := range vals {
+		if k != "token" {
+			return Join{}, fmt.Errorf("join URL fragment has unknown key %q (expected token)", k)
+		}
+	}
+	j.Token = vals.Get("token")
+	return j, nil
+}
+
+// HasCredentials reports whether raw looks like a join URL fragment form
+// (carries a token) rather than a bare host.
+func HasCredentials(raw string) bool {
+	j, err := Parse(raw)
+	return err == nil && j.Token != ""
+}

--- a/client/joinurl/joinurl_test.go
+++ b/client/joinurl/joinurl_test.go
@@ -41,6 +41,7 @@ func TestBuildRejects(t *testing.T) {
 		{"host with fragment", Join{Host: "h#f"}},
 		{"host with userinfo", Join{Host: "u@h"}},
 		{"ipv6 literal host", Join{Host: "[::1]:6309"}},
+		{"port-only host", Join{Host: ":6309"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -72,6 +73,7 @@ func TestParseForms(t *testing.T) {
 		{"query rejected", "mark://h?x=1#token=t", Join{}, true},
 		{"duplicate token rejected", "h#token=a&token=b", Join{}, true},
 		{"ipv6 literal rejected", "mark://[2001:db8::1]:6309#token=t", Join{}, true},
+		{"port-only authority rejected", "mark://:6309#token=t", Join{}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/client/joinurl/joinurl_test.go
+++ b/client/joinurl/joinurl_test.go
@@ -43,6 +43,8 @@ func TestBuildRejects(t *testing.T) {
 		{"ipv6 literal host", Join{Host: "[::1]:6309"}},
 		{"port-only host", Join{Host: ":6309"}},
 		{"non-numeric port", Join{Host: "h:bad"}},
+		{"host with space", Join{Host: "h x"}},
+		{"host with bracket", Join{Host: "h]x"}},
 		{"out-of-range port", Join{Host: "h:65536"}},
 		{"zero port", Join{Host: "h:0"}},
 	}

--- a/client/joinurl/joinurl_test.go
+++ b/client/joinurl/joinurl_test.go
@@ -39,6 +39,8 @@ func TestBuildRejects(t *testing.T) {
 		{"empty host", Join{}},
 		{"host with path", Join{Host: "h/x"}},
 		{"host with fragment", Join{Host: "h#f"}},
+		{"host with userinfo", Join{Host: "u@h"}},
+		{"ipv6 literal host", Join{Host: "[::1]:6309"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -66,6 +68,10 @@ func TestParseForms(t *testing.T) {
 		{"with path", "mark://h/docs/x.md", Join{}, true},
 		{"unknown fragment key", "h#token=t&extra=1", Join{}, true},
 		{"future fp key fails loudly", "h#token=t&fp=sha256:ab", Join{}, true},
+		{"userinfo rejected", "mark://user@h#token=t", Join{}, true},
+		{"query rejected", "mark://h?x=1#token=t", Join{}, true},
+		{"duplicate token rejected", "h#token=a&token=b", Join{}, true},
+		{"ipv6 literal rejected", "mark://[2001:db8::1]:6309#token=t", Join{}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/client/joinurl/joinurl_test.go
+++ b/client/joinurl/joinurl_test.go
@@ -1,0 +1,99 @@
+package joinurl
+
+import (
+	"testing"
+)
+
+func TestBuildParseRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		join Join
+	}{
+		{"host only", Join{Host: "kb.example.com"}},
+		{"host with port", Join{Host: "kb.example.com:6310"}},
+		{"token", Join{Host: "kb.example.com", Token: "abc123"}},
+		{"token needing escaping", Join{Host: "kb.example.com:6309", Token: "tok+/=x"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := Build(tt.join)
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+			got, err := Parse(s)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", s, err)
+			}
+			if got != tt.join {
+				t.Errorf("round trip: got %+v, want %+v", got, tt.join)
+			}
+		})
+	}
+}
+
+func TestBuildRejects(t *testing.T) {
+	tests := []struct {
+		name string
+		join Join
+	}{
+		{"empty host", Join{}},
+		{"host with path", Join{Host: "h/x"}},
+		{"host with fragment", Join{Host: "h#f"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := Build(tt.join); err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestParseForms(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    Join
+		wantErr bool
+	}{
+		{"bare host", "kb.example.com", Join{Host: "kb.example.com"}, false},
+		{"mark scheme", "mark://kb.example.com", Join{Host: "kb.example.com"}, false},
+		{"trailing slash", "mark://kb.example.com/", Join{Host: "kb.example.com"}, false},
+		{"fragment", "kb.example.com#token=t", Join{Host: "kb.example.com", Token: "t"}, false},
+		{"whitespace", "  kb.example.com  ", Join{Host: "kb.example.com"}, false},
+		{"empty", "", Join{}, true},
+		{"https scheme", "https://kb.example.com", Join{}, true},
+		{"with path", "mark://h/docs/x.md", Join{}, true},
+		{"unknown fragment key", "h#token=t&extra=1", Join{}, true},
+		{"future fp key fails loudly", "h#token=t&fp=sha256:ab", Join{}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasCredentials(t *testing.T) {
+	if HasCredentials("kb.example.com") {
+		t.Error("bare host should not have credentials")
+	}
+	if !HasCredentials("kb.example.com#token=t") {
+		t.Error("token fragment should have credentials")
+	}
+	if HasCredentials("h#bogus=1") {
+		t.Error("invalid join URL should not report credentials")
+	}
+}

--- a/client/joinurl/joinurl_test.go
+++ b/client/joinurl/joinurl_test.go
@@ -42,6 +42,9 @@ func TestBuildRejects(t *testing.T) {
 		{"host with userinfo", Join{Host: "u@h"}},
 		{"ipv6 literal host", Join{Host: "[::1]:6309"}},
 		{"port-only host", Join{Host: ":6309"}},
+		{"non-numeric port", Join{Host: "h:bad"}},
+		{"out-of-range port", Join{Host: "h:65536"}},
+		{"zero port", Join{Host: "h:0"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -74,6 +77,8 @@ func TestParseForms(t *testing.T) {
 		{"duplicate token rejected", "h#token=a&token=b", Join{}, true},
 		{"ipv6 literal rejected", "mark://[2001:db8::1]:6309#token=t", Join{}, true},
 		{"port-only authority rejected", "mark://:6309#token=t", Join{}, true},
+		{"out-of-range port rejected", "mark://h:65536#token=t", Join{}, true},
+		{"zero port rejected", "mark://h:0#token=t", Join{}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/site/tools/index.md
+++ b/docs/site/tools/index.md
@@ -54,6 +54,26 @@ A descriptive label is how you'll know which entry to revoke when a device is lo
 ./server/bin/demarkus-token generate -label internal-reader -paths "/internal/**" -ops read -tokens tokens.toml
 ```
 
+### Join URLs (`demarkus-token join`)
+
+A join URL packs the host and token into one paste-able string, so onboarding a device or person is a single step instead of "here's a token, now assemble the flags":
+
+```bash
+# Compose with generate: mint a scoped token, wrap it in a join URL
+./server/bin/demarkus-token generate -label phone -paths "/*" -ops publish -tokens tokens.toml \
+  | ./server/bin/demarkus-token join -host kb.example.com
+# -> mark://kb.example.com#token=...
+```
+
+The recipient pastes it once:
+
+- Claude Code (demarkus-memory plugin): `/soul-join <join-url>` (add `--insecure` for a self-signed server)
+- CLI: `demarkus join '<join-url>'` (quote it; the shell would strip the `#fragment`)
+
+The credential rides in the URL fragment, which never appears in any request; still treat a join URL like the token it carries, and send it over a private channel.
+
+`install.sh` prints a ready-made join URL for the freshly installed server at the end of a server install.
+
 ### Read tokens (private paths)
 
 By default all paths are public. To protect paths, create a token with the `read` operation:

--- a/install.sh
+++ b/install.sh
@@ -1148,7 +1148,10 @@ do_install() {
     local join_host="$domain"
     [ -z "$join_host" ] && join_host=$(hostname 2>/dev/null || echo localhost)
     local join_url=""
-    join_url=$("${INSTALL_DIR}/demarkus-token" join -host "$join_host" -token "$raw_token" 2>/dev/null) || true
+    if ! join_url=$("${INSTALL_DIR}/demarkus-token" join -host "$join_host" -token "$raw_token"); then
+      log_warn "Could not generate a join URL; run: demarkus-token join -host <host> -token <TOKEN>"
+      join_url=""
+    fi
     if [ -n "$join_url" ]; then
       echo ""
       log_info "Join this server from another machine (paste one line):"

--- a/install.sh
+++ b/install.sh
@@ -1143,6 +1143,24 @@ do_install() {
     else
       echo "  demarkus --insecure -X PUBLISH -auth \$TOKEN -body \"# Hello World\" mark://localhost:6309/index.md"
     fi
+
+    # Ready-to-paste join line: one string carries host + token.
+    local join_host="$domain"
+    [ -z "$join_host" ] && join_host=$(hostname 2>/dev/null || echo localhost)
+    local join_url=""
+    join_url=$("${INSTALL_DIR}/demarkus-token" join -host "$join_host" -token "$raw_token" 2>/dev/null) || true
+    if [ -n "$join_url" ]; then
+      echo ""
+      log_info "Join this server from another machine (paste one line):"
+      echo "  Claude Code (demarkus-memory plugin):  /soul-join $join_url"
+      echo "  CLI:                                   demarkus join '$join_url'"
+      if [ -z "$domain" ]; then
+        log_warn "'$join_host' must resolve from the joining machine; if it doesn't, rebuild the line with the public address: demarkus-token join -host <public-host> -token <TOKEN>"
+      fi
+      if [ -z "$domain" ] || [ "$no_tls" = true ]; then
+        log_info "Self-signed cert: joining clients need --insecure alongside the join URL"
+      fi
+    fi
   fi
   echo ""
   log_info "Generate additional tokens:"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-memory",
-  "version": "0.12.16",
+  "version": "0.13.0",
   "description": "Local, versioned memory for Claude Code via demarkus. Zero-config install: spawns a local demarkus-server, auto-generates a token, wires MCP tools for fetch/publish/append/graph/lookup, injects standing guidance so sessions self-document to the soul, and enforces a publish tag-gate so documents stay findable via lookup.",
   "author": {
     "name": "latebit",

--- a/plugins/claude-code/commands/soul-join.md
+++ b/plugins/claude-code/commands/soul-join.md
@@ -15,18 +15,26 @@ launch via a wrapper, so it never sits in plaintext in `.mcp.json` or in
 ## Argument
 
 ```bash
+# Join URL (preferred): one string carries the host and token.
+# Emitted by install.sh and demarkus-token join.
+/soul-join mark://kb.example.com#token=<RAW> [--insecure]
+
+# Explicit form
 /soul-join mark://soul.demarkus.io --token <TOKEN> --insecure
 ```
 
-- The host may be a `mark://host[:port]` URL or a bare host (scheme inferred).
+- **Join URL**: the `#token=` fragment supplies the capability token; the
+  helper extracts and stores it.
+- Otherwise the host may be a `mark://host[:port]` URL or a bare host.
 - `--token <TOKEN>` is the capability token for the soul. Omit only for a
   read-only / public soul. The plugin cannot mint a token for a remote server
-  (its `tokens.toml` is not local) — the user supplies one.
-- `--insecure` skips TLS cert verification (needed for some self-hosted souls;
-  `soul.demarkus.io` uses it).
+  (its `tokens.toml` is not local) — the user supplies one. Do not combine
+  with a join URL that already carries a token.
+- `--insecure` skips TLS cert verification (needed for self-signed souls with
+  either form; `soul.demarkus.io` uses it).
 
 If invoked without a host, ask for it. Do NOT guess. If the user does not give a
-token, ask whether the soul needs one before proceeding.
+join URL or token, ask whether the soul needs one before proceeding.
 
 ## Steps
 
@@ -49,13 +57,15 @@ token, ask whether the soul needs one before proceeding.
    the soul is bound to the repo:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <host> [--token <TOKEN>] [--insecure] --bind "${CLAUDE_PROJECT_DIR}"
+   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join '<host-or-join-url>' [--token <TOKEN>] [--insecure] --bind "${CLAUDE_PROJECT_DIR}"
    ```
 
-   It normalizes the host, derives a slug from the first DNS label, writes the
-   token to `~/.demarkus/soul-<slug>.token` (mode 600), records the soul in the
-   catalog (`~/.demarkus/souls`), and binds the project. Output is line-oriented
-   `key=value`.
+   Quote the argument: a join URL's `#fragment` is shell-significant. The
+   helper normalizes the host (extracting the token from a join URL), derives
+   a slug from the first DNS label, writes the token to
+   `~/.demarkus/soul-<slug>.token` (mode 600), records the soul in the
+   catalog (`~/.demarkus/souls`), and binds the project. Output is
+   line-oriented `key=value`.
 
    - On `OK`, parse `slug=`, `host=`, `insecure=`, `token-file=`.
    - On `FAIL: <message>`, do NOT run `claude mcp add`. Show the message verbatim.
@@ -89,8 +99,9 @@ token, ask whether the soul needs one before proceeding.
 ## Don't
 
 - Don't run `claude mcp add` if step 2 emitted `FAIL`.
-- Don't read, echo, or store the token yourself — pass it to `soul-join.sh`,
-  which writes it to the 0600 file. It must never land in the transcript.
+- Don't read, echo, or store the token yourself — pass the join URL or token
+  through to the helper, which writes it to the 0600 file. A pasted join URL
+  is already in the transcript, but never repeat its fragment back in output.
 - Don't use this for an `https://` broker — that is `/knowledge-join`.
 - Don't conflate the three soul surfaces:
   - `/soul-init`: local, plugin-managed demarkus-server, plugin-minted token.

--- a/plugins/pi-memory/CHANGELOG.md
+++ b/plugins/pi-memory/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.13.0
+
+- `/soul-join` accepts a join URL (`mark://host#token=...`, as emitted by
+  install.sh and `demarkus-token join`): the fragment supplies the capability
+  token, so joining a remote soul is one paste-able string instead of
+  host + token assembly (shared binary; requires the tools release with
+  join-URL support).
+
 ## 0.12.10
 
 - Documentation style gate in the shared binary (tools release with the style

--- a/plugins/pi-memory/commands/soul-join.md
+++ b/plugins/pi-memory/commands/soul-join.md
@@ -14,16 +14,18 @@ launch by `demarkus-plugin mcp-serve`, so it never sits in plaintext in your MCP
 ## Argument
 
 ```bash
-# Join URL (preferred): one string carries the host and token.
-# Emitted by install.sh and demarkus-token join.
-/soul-join mark://kb.example.com#token=<RAW> [--insecure]
+# Public / read-only soul (no credential in the transcript)
+/soul-join mark://soul.demarkus.io --insecure
 
-# Explicit form
-/soul-join mark://soul.demarkus.io --token <TOKEN> --insecure
+# Tokened soul: the user runs the terminal command themselves (see below);
+# a join URL's #token= fragment or a --token value is a secret and must not
+# be pasted into chat.
 ```
 
-- **Join URL**: the `#token=` fragment supplies the capability token; the
-  helper extracts and stores it.
+- **Join URL** (`mark://host#token=...`, emitted by install.sh and
+  `demarkus-token join`): the `#token=` fragment supplies the capability
+  token; the helper extracts and stores it. Because the URL carries the
+  secret, it goes into the user-run terminal command, not the slash command.
 - Otherwise the host may be a `mark://host[:port]` URL or a bare host.
 - `--token <TOKEN>` is the capability token for the soul. Omit only for a
   read-only / public soul. The plugin cannot mint a token for a remote server

--- a/plugins/pi-memory/commands/soul-join.md
+++ b/plugins/pi-memory/commands/soul-join.md
@@ -14,23 +14,33 @@ launch by `demarkus-plugin mcp-serve`, so it never sits in plaintext in your MCP
 ## Argument
 
 ```bash
+# Join URL (preferred): one string carries the host and token.
+# Emitted by install.sh and demarkus-token join.
+/soul-join mark://kb.example.com#token=<RAW> [--insecure]
+
+# Explicit form
 /soul-join mark://soul.demarkus.io --token <TOKEN> --insecure
 ```
 
-- The host may be a `mark://host[:port]` URL or a bare host (scheme inferred).
+- **Join URL**: the `#token=` fragment supplies the capability token; the
+  helper extracts and stores it.
+- Otherwise the host may be a `mark://host[:port]` URL or a bare host.
 - `--token <TOKEN>` is the capability token for the soul. Omit only for a
   read-only / public soul. The plugin cannot mint a token for a remote server
-  (its `tokens.toml` is not local) — the user supplies one.
-- `--insecure` skips TLS cert verification (needed for some self-hosted souls;
-  `soul.demarkus.io` uses it).
+  (its `tokens.toml` is not local) — the user supplies one. Do not combine
+  with a join URL that already carries a token.
+- `--insecure` skips TLS cert verification (needed for self-signed souls with
+  either form; `soul.demarkus.io` uses it).
 
 **Token handling — do not put the token in the transcript.** A capability token
-is a secret; if it appears in a chat message or a tool-call command line it is
-captured in the session transcript. So for any soul that needs a token, you do
-NOT run the join yourself — instead give the user the exact command and have them
-run it in their own terminal (where the token never reaches you). Never ask the
-user to paste the token to you, and never echo it. (A read-only / public soul
-needs no token, so you may run that join directly.)
+is a secret, and a join URL with a `token=` fragment carries one; if either
+appears in a chat message or a tool-call command line it is captured in the
+session transcript. So for any soul that needs a token, you do NOT run the join
+yourself — instead give the user the exact command (join URL or `<TOKEN>` left
+as a placeholder) and have them run it in their own terminal (where the secret
+never reaches you). Never ask the user to paste the token or join URL to you,
+and never echo one back. (A read-only / public soul needs no token, so you may
+run that join directly.)
 
 If invoked without a host, ask for it. Do NOT guess. If the user does not say
 whether the soul needs a token, ask before proceeding.
@@ -41,18 +51,21 @@ whether the soul needs a token, ask before proceeding.
    the soul is bound to the repo:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <host> [--token <TOKEN>] [--insecure] --bind "${PWD}"
+   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join '<host-or-join-url>' [--token <TOKEN>] [--insecure] --bind "${PWD}"
    ```
 
-   **If the soul needs a token, do NOT run this yourself** — print the command
-   (with `<TOKEN>` left as a placeholder) and ask the user to run it in their own
-   terminal, then paste back only the non-secret `key=value` output lines (slug,
-   host, insecure, token-file). For a no-token (public/read-only) soul, you may
-   run it directly.
+   Quote the argument: a join URL's `#fragment` is shell-significant.
 
-   It normalizes the host, derives a slug from the first DNS label, writes the
-   token to `~/.demarkus/soul-<slug>.token` (mode 600), records the soul in the
-   catalog (`~/.demarkus/souls`), and binds the project. Output is line-oriented
+   **If the soul needs a token, do NOT run this yourself** — print the command
+   (join URL or `<TOKEN>` left as a placeholder) and ask the user to run it in
+   their own terminal, then paste back only the non-secret `key=value` output
+   lines (slug, host, insecure, token-file). For a no-token (public/read-only)
+   soul, you may run it directly.
+
+   It normalizes the host (extracting the token from a join URL), derives a
+   slug from the first DNS label, writes the token to
+   `~/.demarkus/soul-<slug>.token` (mode 600), records the soul in the catalog
+   (`~/.demarkus/souls`), and binds the project. Output is line-oriented
    `key=value`.
 
    - On `OK`, parse `slug=`, `host=`, `insecure=`, `token-file=`.

--- a/plugins/pi-memory/package.json
+++ b/plugins/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-pi-memory",
-  "version": "0.12.17",
+  "version": "0.13.0",
   "description": "Local, versioned memory for the pi coding agent via demarkus. Provisions a local demarkus-server, auto-generates a token, wires the demarkus-memory MCP server through pi-mcp-adapter, injects standing guidance so sessions self-document to the soul, and enforces a publish tag-gate plus a destination gate so documents stay findable and land on the right soul.",
   "author": "latebit",
   "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/pi-memory",

--- a/tools/demarkus-plugin/internal/registry/registry.go
+++ b/tools/demarkus-plugin/internal/registry/registry.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/latebit-io/demarkus/client/joinurl"
 	"github.com/latebit-io/demarkus/tools/demarkus-plugin/internal/config"
 )
 
@@ -73,29 +74,37 @@ func SoulRegister(slug, host string, insecure bool, tokenFile string) error {
 	})
 }
 
-// RemoteSoulRow returns the catalog row for SLUG (host, insecure, token file).
+// RemoteSoulRow returns the catalog row for SLUG.
 // ok is false when the slug isn't registered.
-func RemoteSoulRow(slug string) (host string, insecure bool, tokenFile string, ok bool, err error) {
+func RemoteSoulRow(slug string) (SoulRow, bool, error) {
 	rows, err := readRecords("souls")
 	if err != nil {
-		return "", false, "", false, err
+		return SoulRow{}, false, err
 	}
 	for _, r := range rows {
 		f := strings.Split(r, "\t")
 		if f[0] == slug {
+			var row SoulRow
 			if len(f) >= 2 {
-				host = f[1]
+				row.Host = f[1]
 			}
 			if len(f) >= 3 {
-				insecure = f[2] == "1"
+				row.Insecure = f[2] == "1"
 			}
 			if len(f) >= 4 {
-				tokenFile = f[3]
+				row.TokenFile = f[3]
 			}
-			return host, insecure, tokenFile, true, nil
+			return row, true, nil
 		}
 	}
-	return "", false, "", false, nil
+	return SoulRow{}, false, nil
+}
+
+// SoulRow is one souls-catalog record.
+type SoulRow struct {
+	Host      string
+	Insecure  bool
+	TokenFile string
 }
 
 // remoteSoulHost returns the host registered for slug, or "" when not registered.
@@ -510,11 +519,27 @@ type SoulJoinResult struct {
 // 0600 file, registers the catalog row (rejecting a slug collision to a different
 // host), and optionally binds the project. The token never transits any channel
 // but this call's argument + the 0600 file.
+//
+// rawHost may also be a join URL (mark://host#token=...) as emitted by
+// install.sh or demarkus-token join; its fragment supplies the token.
 func SoulJoin(rawHost, token string, insecure bool, bindDir string) (*SoulJoinResult, error) {
 	h := strings.TrimSpace(rawHost)
 	low := strings.ToLower(h)
 	if strings.HasPrefix(low, "https://") || strings.HasPrefix(low, "http://") {
 		return nil, fmt.Errorf("'%s' is an HTTPS URL; use /knowledge-join for broker-fronted knowledge systems", h)
+	}
+	if strings.Contains(h, "#") {
+		j, err := joinurl.Parse(h)
+		if err != nil {
+			return nil, err
+		}
+		if j.Token != "" {
+			if token != "" && token != j.Token {
+				return nil, fmt.Errorf("both --token and a join-URL token were given; pass one")
+			}
+			token = j.Token
+		}
+		h = j.Host
 	}
 	h = strings.TrimPrefix(h, "mark://")
 	h = strings.TrimRight(h, "/")

--- a/tools/demarkus-plugin/internal/registry/registry.go
+++ b/tools/demarkus-plugin/internal/registry/registry.go
@@ -84,6 +84,9 @@ func RemoteSoulRow(slug string) (SoulRow, bool, error) {
 	for _, r := range rows {
 		f := strings.Split(r, "\t")
 		if f[0] == slug {
+			if len(f) < 2 || f[1] == "" {
+				return SoulRow{}, false, fmt.Errorf("souls catalog row for %q has no host; re-run /soul-join", slug)
+			}
 			var row SoulRow
 			if len(f) >= 2 {
 				row.Host = f[1]

--- a/tools/demarkus-plugin/internal/registry/registry.go
+++ b/tools/demarkus-plugin/internal/registry/registry.go
@@ -531,22 +531,21 @@ func SoulJoin(rawHost, token string, insecure bool, bindDir string) (*SoulJoinRe
 	if strings.HasPrefix(low, "https://") || strings.HasPrefix(low, "http://") {
 		return nil, fmt.Errorf("'%s' is an HTTPS URL; use /knowledge-join for broker-fronted knowledge systems", h)
 	}
-	if strings.Contains(h, "#") {
-		j, err := joinurl.Parse(h)
-		if err != nil {
-			return nil, err
-		}
-		if j.Token != "" {
-			if token != "" && token != j.Token {
-				return nil, fmt.Errorf("both --token and a join-URL token were given; pass one")
-			}
-			token = j.Token
-		}
-		h = j.Host
+	// Every host form goes through joinurl.Parse so malformed input (paths,
+	// userinfo, query, IPv6 literals) is rejected instead of half-parsed
+	// into a broken catalog row.
+	j, err := joinurl.Parse(h)
+	if err != nil {
+		return nil, err
 	}
-	h = strings.TrimPrefix(h, "mark://")
-	h = strings.TrimRight(h, "/")
-	hostOnly := strings.SplitN(strings.SplitN(h, "/", 2)[0], ":", 2)[0]
+	if j.Token != "" {
+		if token != "" && token != j.Token {
+			return nil, fmt.Errorf("both --token and a join-URL token were given; pass one")
+		}
+		token = j.Token
+	}
+	h = j.Host
+	hostOnly := strings.SplitN(h, ":", 2)[0]
 	slug := deriveSlug(hostOnly)
 	if slug == "" {
 		return nil, fmt.Errorf("could not derive a slug from host '%s'", rawHost)

--- a/tools/demarkus-plugin/internal/registry/registry_test.go
+++ b/tools/demarkus-plugin/internal/registry/registry_test.go
@@ -231,4 +231,14 @@ func TestSoulJoinURLWithFragment(t *testing.T) {
 	if _, err := SoulJoin("mark://[2001:db8::1]:6309#token=a", "", false, ""); err == nil {
 		t.Error("expected error for bracketed IPv6 join URL")
 	}
+	// Malformed hosts on the legacy (no-fragment) path fail loudly too.
+	for _, bad := range []string{
+		"mark://kb.example.com?x=1",
+		"mark://user@kb.example.com",
+		"mark://kb.example.com/docs",
+	} {
+		if _, err := SoulJoin(bad, "t", false, ""); err == nil {
+			t.Errorf("expected error for malformed host %q", bad)
+		}
+	}
 }

--- a/tools/demarkus-plugin/internal/registry/registry_test.go
+++ b/tools/demarkus-plugin/internal/registry/registry_test.go
@@ -195,7 +195,9 @@ func TestPromoteTargetAdd(t *testing.T) {
 func TestSoulJoinURLWithFragment(t *testing.T) {
 	home := setupHome(t)
 	repo := filepath.Join(home, "repo")
-	_ = os.MkdirAll(repo, 0o755)
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	res, err := SoulJoin("mark://kb.example.com#token=fragtok", "", false, repo)
 	if err != nil {
@@ -224,5 +226,9 @@ func TestSoulJoinURLWithFragment(t *testing.T) {
 	// Bad fragment key fails loudly.
 	if _, err := SoulJoin("mark://kb3.example.com#tokn=a", "", false, ""); err == nil {
 		t.Error("expected error for unknown fragment key")
+	}
+	// Bracketed IPv6 would derive a garbage slug; the join-URL path rejects it.
+	if _, err := SoulJoin("mark://[2001:db8::1]:6309#token=a", "", false, ""); err == nil {
+		t.Error("expected error for bracketed IPv6 join URL")
 	}
 }

--- a/tools/demarkus-plugin/internal/registry/registry_test.go
+++ b/tools/demarkus-plugin/internal/registry/registry_test.go
@@ -191,3 +191,38 @@ func TestPromoteTargetAdd(t *testing.T) {
 		t.Fatalf("promote target row wrong: %v", rows)
 	}
 }
+
+func TestSoulJoinURLWithFragment(t *testing.T) {
+	home := setupHome(t)
+	repo := filepath.Join(home, "repo")
+	_ = os.MkdirAll(repo, 0o755)
+
+	res, err := SoulJoin("mark://kb.example.com#token=fragtok", "", false, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Slug != "kb" || res.Host != "mark://kb.example.com" {
+		t.Fatalf("slug/host: got %s %s", res.Slug, res.Host)
+	}
+	b, err := os.ReadFile(res.TokenFile)
+	if err != nil || string(b) != "fragtok" {
+		t.Fatalf("token file: %v %q", err, b)
+	}
+
+	row, ok, err := RemoteSoulRow("kb")
+	if err != nil || !ok {
+		t.Fatalf("RemoteSoulRow: %v ok=%v", err, ok)
+	}
+	if row.Host != "mark://kb.example.com" || row.Insecure {
+		t.Fatalf("row round trip: %+v", row)
+	}
+
+	// Conflicting explicit --token and fragment token is rejected.
+	if _, err := SoulJoin("mark://kb2.example.com#token=a", "b", false, ""); err == nil {
+		t.Error("expected conflict error for --token + fragment token")
+	}
+	// Bad fragment key fails loudly.
+	if _, err := SoulJoin("mark://kb3.example.com#tokn=a", "", false, ""); err == nil {
+		t.Error("expected error for unknown fragment key")
+	}
+}

--- a/tools/demarkus-plugin/registry_cmd.go
+++ b/tools/demarkus-plugin/registry_cmd.go
@@ -374,7 +374,11 @@ func cmdMcpServe(args []string) {
 		tokenFile = tf
 	} else {
 		row, ok, err := registry.RemoteSoulRow(*soul)
-		if err != nil || !ok {
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "[demarkus-plugin] mcp-serve: catalog lookup failed: "+err.Error())
+			os.Exit(1)
+		}
+		if !ok {
 			fmt.Fprintln(os.Stderr, "[demarkus-plugin] mcp-serve: soul '"+*soul+"' not in the catalog; re-run /soul-join")
 			os.Exit(1)
 		}

--- a/tools/demarkus-plugin/registry_cmd.go
+++ b/tools/demarkus-plugin/registry_cmd.go
@@ -373,12 +373,12 @@ func cmdMcpServe(args []string) {
 		tf, _ := config.StatePath("plugin-memory.token")
 		tokenFile = tf
 	} else {
-		h, ins, tf, ok, err := registry.RemoteSoulRow(*soul)
+		row, ok, err := registry.RemoteSoulRow(*soul)
 		if err != nil || !ok {
 			fmt.Fprintln(os.Stderr, "[demarkus-plugin] mcp-serve: soul '"+*soul+"' not in the catalog; re-run /soul-join")
 			os.Exit(1)
 		}
-		host, insecure, tokenFile = h, ins, tf
+		host, insecure, tokenFile = row.Host, row.Insecure, row.TokenFile
 	}
 
 	env := os.Environ()

--- a/tools/demarkus-token/main.go
+++ b/tools/demarkus-token/main.go
@@ -7,17 +7,20 @@
 //	demarkus-token generate -label fritz-laptop -paths "/docs/*" -ops "publish" -tokens tokens.toml
 //	demarkus-token list -tokens tokens.toml
 //	demarkus-token revoke -label fritz-laptop -tokens tokens.toml
+//	demarkus-token generate -label phone -tokens tokens.toml | demarkus-token join -host kb.example.com
 package main
 
 import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"sort"
 	"strings"
 
+	"github.com/latebit-io/demarkus/client/joinurl"
 	"github.com/latebit-io/demarkus/protocol/token"
 )
 
@@ -37,6 +40,8 @@ func main() {
 		cmdList(os.Args[2:])
 	case "revoke":
 		cmdRevoke(os.Args[2:])
+	case "join":
+		cmdJoin(os.Args[2:])
 	case "version", "-version", "--version":
 		fmt.Println(version)
 	default:
@@ -51,7 +56,47 @@ func printUsage() {
 	fmt.Fprintf(os.Stderr, "  generate  Generate a new auth token\n")
 	fmt.Fprintf(os.Stderr, "  list      List tokens in a tokens file\n")
 	fmt.Fprintf(os.Stderr, "  revoke    Revoke a token by label\n")
+	fmt.Fprintf(os.Stderr, "  join      Build a paste-ready join URL from a token and host\n")
 	fmt.Fprintf(os.Stderr, "  version   Print version and exit\n")
+}
+
+func cmdJoin(args []string) {
+	fs := flag.NewFlagSet("join", flag.ExitOnError)
+	host := fs.String("host", "", "server host[:port] the join URL targets (required)")
+	tok := fs.String("token", "", "raw token to embed; reads stdin when omitted (pipe from generate)")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: demarkus-token join -host HOST [-token RAW]\n\n")
+		fmt.Fprintf(os.Stderr, "Prints a single join URL carrying the token, for /soul-join or\n")
+		fmt.Fprintf(os.Stderr, "'demarkus join'. Compose with generate:\n")
+		fmt.Fprintf(os.Stderr, "  demarkus-token generate -label phone -tokens tokens.toml | demarkus-token join -host kb.example.com\n\n")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		log.Fatalf("parse flags: %v", err)
+	}
+	if *host == "" {
+		fmt.Fprintf(os.Stderr, "error: -host is required\n\n")
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	raw := strings.TrimSpace(*tok)
+	if raw == "" {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			log.Fatalf("read token from stdin: %v", err)
+		}
+		raw = strings.TrimSpace(string(data))
+	}
+	if raw == "" {
+		log.Fatal("nothing to embed: provide -token or pipe one in")
+	}
+
+	u, err := joinurl.Build(joinurl.Join{Host: *host, Token: raw})
+	if err != nil {
+		log.Fatalf("build join URL: %v", err)
+	}
+	fmt.Println(u)
 }
 
 func cmdGenerate(args []string) {

--- a/tools/demarkus-token/main.go
+++ b/tools/demarkus-token/main.go
@@ -82,9 +82,15 @@ func cmdJoin(args []string) {
 
 	raw := strings.TrimSpace(*tok)
 	if raw == "" {
-		data, err := io.ReadAll(os.Stdin)
+		// A raw token is 64 hex chars; cap the read so join never buffers a
+		// mistakenly piped file into a "token".
+		const maxTokenInput = 4096
+		data, err := io.ReadAll(io.LimitReader(os.Stdin, maxTokenInput+1))
 		if err != nil {
 			log.Fatalf("read token from stdin: %v", err)
+		}
+		if len(data) > maxTokenInput {
+			log.Fatalf("stdin exceeds %d bytes; that is not a token (pipe demarkus-token generate output)", maxTokenInput)
 		}
 		raw = strings.TrimSpace(string(data))
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added join URL support for remote soul connections using `mark://host#token=...`.
  * Introduced `demarkus join` and `demarkus-token join` commands to generate and consume join URLs (token can be embedded in `#token=`).
  * Installer now prints ready-to-paste cross-machine join instructions.
* **Bug Fixes**
  * Improved TLS certificate validation by using only the hostname for checks.
* **Documentation**
  * Updated join-flow guides and security guidance, including how to quote URL fragments.
* **Tests**
  * Added unit tests for join URL parsing/building and fragment token handling.
* **Chores**
  * Bumped relevant plugin versions/metadata to `0.13.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->