### PR TITLE
feat(client): SecretStore interface with file backend for single-host

### DIFF
--- a/tools/demarkus-broker/internal/broker/authz.go
+++ b/tools/demarkus-broker/internal/broker/authz.go
@@ -1,17 +1,9 @@
 package broker
 
 import (
-	"bytes"
-	"context"
 	"errors"
-	"fmt"
 	"slices"
 	"strings"
-
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -175,82 +167,4 @@ func groupsMatch(have, allowed []string) bool {
 		}
 	}
 	return false
-}
-
-// mutateSecret performs an optimistic-concurrency read-modify-write on
-// the Secret data[key]. If the Secret does not exist, it is created with
-// the named key set to the mutate-result on empty input. Retries
-// resourceVersion conflicts up to maxConflictRetries; surfaces all other
-// errors immediately.
-//
-// Free function rather than a method on any one type so the broker's
-// refreshStore and worldWriteTokenStore can share the same
-// Secret-mutation contract without duplicating the conflict-retry loop.
-// See /guidelines.md "Don't Duplicate Logic".
-func mutateSecret(ctx context.Context, k8s kubernetes.Interface, namespace, name, key string, mutate func([]byte) ([]byte, error)) error {
-	for range maxConflictRetries {
-		secret, getErr := k8s.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
-		if getErr != nil && !apierrors.IsNotFound(getErr) {
-			return fmt.Errorf("get secret %s/%s: %w", namespace, name, getErr)
-		}
-		var existing []byte
-		if getErr == nil {
-			existing = secret.Data[key]
-		}
-		next, err := mutate(existing)
-		if err != nil {
-			return err
-		}
-		if apierrors.IsNotFound(getErr) {
-			// No-op closure on an absent Secret: don't materialize an
-			// empty Secret as a side effect. Refresh-store Revoke and
-			// Sweep both return existing-unchanged when there's
-			// nothing to do; without this guard the first such call
-			// would create a `{key: nil}` Secret that the next call
-			// then has to read back. The no-write contract is
-			// observable (helm-rendered Secrets, audit logs), so
-			// preserving "absent stays absent" is part of the
-			// store's behavior, not an internal detail.
-			if len(next) == 0 {
-				return nil
-			}
-			fresh := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: namespace,
-				},
-				Type: corev1.SecretTypeOpaque,
-				Data: map[string][]byte{key: next},
-			}
-			_, createErr := k8s.CoreV1().Secrets(namespace).Create(ctx, fresh, metav1.CreateOptions{})
-			if createErr == nil {
-				return nil
-			}
-			if apierrors.IsAlreadyExists(createErr) {
-				continue
-			}
-			return fmt.Errorf("create secret %s/%s: %w", namespace, name, createErr)
-		}
-		// No-op mutation: the value is unchanged, so skip the Update.
-		// Writing it anyway bumps the Secret's resourceVersion, which
-		// triggers a kubelet re-projection on every world tokens.toml
-		// mount and amplifies conflict retries across replicas — the
-		// exact propagation churn the broker works to avoid.
-		if bytes.Equal(existing, next) {
-			return nil
-		}
-		if secret.Data == nil {
-			secret.Data = make(map[string][]byte, 1)
-		}
-		secret.Data[key] = next
-		_, updateErr := k8s.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{})
-		if updateErr == nil {
-			return nil
-		}
-		if apierrors.IsConflict(updateErr) {
-			continue
-		}
-		return fmt.Errorf("update secret %s/%s: %w", namespace, name, updateErr)
-	}
-	return fmt.Errorf("conflict on secret %s/%s after %d retries", namespace, name, maxConflictRetries)
 }

--- a/tools/demarkus-broker/internal/broker/authz_test.go
+++ b/tools/demarkus-broker/internal/broker/authz_test.go
@@ -345,7 +345,7 @@ func TestMutateSecretConflictRetries(t *testing.T) {
 		return false, nil, nil
 	})
 
-	err := mutateSecret(context.Background(), k8s, "team-a", "team-a-tokens", TokensSecretKey,
+	err := NewK8sSecretStore(k8s).Mutate(context.Background(), SecretRef{Namespace: "team-a", Name: "team-a-tokens", Key: TokensSecretKey},
 		func(existing []byte) ([]byte, error) {
 			return append(append([]byte{}, existing...), []byte("-mutated")...), nil
 		})
@@ -381,7 +381,7 @@ func TestMutateSecretConflictExhaustsRetries(t *testing.T) {
 		return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "secrets"}, "team-a-tokens", errors.New("simulated"))
 	})
 
-	err := mutateSecret(context.Background(), k8s, "team-a", "team-a-tokens", TokensSecretKey,
+	err := NewK8sSecretStore(k8s).Mutate(context.Background(), SecretRef{Namespace: "team-a", Name: "team-a-tokens", Key: TokensSecretKey},
 		func(existing []byte) ([]byte, error) { return append(existing, 'x'), nil })
 	if err == nil {
 		t.Fatal("mutateSecret returned nil, want conflict error after retry budget")
@@ -396,7 +396,7 @@ func TestMutateSecretConflictExhaustsRetries(t *testing.T) {
 // mutateSecret materializes a fresh Secret with the key set.
 func TestMutateSecretCreatesWhenAbsent(t *testing.T) {
 	k8s := fake.NewSimpleClientset()
-	err := mutateSecret(context.Background(), k8s, "team-a", "team-a-tokens", TokensSecretKey,
+	err := NewK8sSecretStore(k8s).Mutate(context.Background(), SecretRef{Namespace: "team-a", Name: "team-a-tokens", Key: TokensSecretKey},
 		func(existing []byte) ([]byte, error) {
 			if len(existing) != 0 {
 				t.Errorf("existing = %q, want empty on absent Secret", existing)
@@ -421,7 +421,7 @@ func TestMutateSecretCreatesWhenAbsent(t *testing.T) {
 // depend on this so "absent stays absent" is observable.
 func TestMutateSecretAbsentStaysAbsentOnEmptyResult(t *testing.T) {
 	k8s := fake.NewSimpleClientset()
-	err := mutateSecret(context.Background(), k8s, "team-a", "team-a-tokens", TokensSecretKey,
+	err := NewK8sSecretStore(k8s).Mutate(context.Background(), SecretRef{Namespace: "team-a", Name: "team-a-tokens", Key: TokensSecretKey},
 		func([]byte) ([]byte, error) { return nil, nil })
 	if err != nil {
 		t.Fatalf("mutateSecret: %v", err)

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -68,10 +68,8 @@ func (c *Config) validateStorage() error {
 	return nil
 }
 
-// validateFilePaths rejects world tokensFile values that alias each other
-// or a broker-state file under storage.dir: two stores mutating the same
-// document would corrupt it at runtime, and the collision is only ever a
-// config mistake.
+// validateFilePaths rejects tokensFile values aliasing each other or a
+// broker-state file: two stores mutating one document corrupts it.
 func (c *Config) validateFilePaths() error {
 	seen := map[string]string{
 		filepath.Clean(c.refreshTokensRef().Path): "storage.dir refresh-tokens state",

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -59,10 +60,36 @@ func (c *Config) validateStorage() error {
 		if c.Storage.Dir == "" {
 			return fmt.Errorf("storage.dir is required when storage.backend is %q", storageBackendFile)
 		}
-		return nil
+		return c.validateFilePaths()
 	}
 	if c.Server.BrokerNamespace == "" {
 		return fmt.Errorf("server.brokerNamespace is required")
+	}
+	return nil
+}
+
+// validateFilePaths rejects world tokensFile values that alias each other
+// or a broker-state file under storage.dir: two stores mutating the same
+// document would corrupt it at runtime, and the collision is only ever a
+// config mistake.
+func (c *Config) validateFilePaths() error {
+	seen := map[string]string{
+		filepath.Clean(c.refreshTokensRef().Path): "storage.dir refresh-tokens state",
+	}
+	for i := range c.Worlds {
+		w := &c.Worlds[i]
+		seen[filepath.Clean(c.worldWriteTokenRef(w.Name).Path)] = fmt.Sprintf("storage.dir write-token state for world %q", w.Name)
+	}
+	for i := range c.Worlds {
+		w := &c.Worlds[i]
+		if w.TokensFile == "" {
+			continue
+		}
+		p := filepath.Clean(w.TokensFile)
+		if other, ok := seen[p]; ok {
+			return fmt.Errorf("worlds[%d] (%s): tokensFile %q collides with %s", i, w.Name, w.TokensFile, other)
+		}
+		seen[p] = fmt.Sprintf("tokensFile of world %q", w.Name)
 	}
 	return nil
 }

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -20,12 +20,61 @@ import (
 type Config struct {
 	Server      ServerConfig      `yaml:"server"`
 	OIDC        OIDCConfig        `yaml:"oidc"`
+	Storage     StorageConfig     `yaml:"storage"`
 	Worlds      []WorldConfig     `yaml:"worlds"`
 	WebClients  []WebClientConfig `yaml:"webClients"`
 	Sweeper     SweeperConfig     `yaml:"sweeper"`
 	RateLimit   RateLimitConfig   `yaml:"rateLimit"`
 	WorldDialer WorldDialerConfig `yaml:"worldDialer"`
 }
+
+// StorageConfig selects the credential-persistence backend. "kubernetes"
+// (the default) stores everything in Secrets; "file" is single-host mode:
+// broker state lives under Dir and each world's token hashes go straight
+// into that world's tokensFile, which the co-located demarkus-server
+// already watches and hot-reloads.
+type StorageConfig struct {
+	Backend string `yaml:"backend"`
+	// Dir is the broker's state directory in file mode (refresh tokens,
+	// per-world write-token records). Required when backend is "file".
+	Dir string `yaml:"dir"`
+}
+
+func (c *Config) fileBackend() bool {
+	return c.Storage.Backend == storageBackendFile
+}
+
+// validateStorage normalizes the backend selection and enforces the
+// per-backend requirements (file: a state dir; kubernetes: the broker
+// namespace). Split from validate() for the gocyclo budget.
+func (c *Config) validateStorage() error {
+	switch c.Storage.Backend {
+	case "":
+		c.Storage.Backend = storageBackendKubernetes
+	case storageBackendKubernetes, storageBackendFile:
+	default:
+		return fmt.Errorf("storage.backend must be %q or %q (got %q)", storageBackendKubernetes, storageBackendFile, c.Storage.Backend)
+	}
+	if c.fileBackend() {
+		if c.Storage.Dir == "" {
+			return fmt.Errorf("storage.dir is required when storage.backend is %q", storageBackendFile)
+		}
+		return nil
+	}
+	if c.Server.BrokerNamespace == "" {
+		return fmt.Errorf("server.brokerNamespace is required")
+	}
+	return nil
+}
+
+// FileBackend reports whether the broker runs in single-host file mode.
+// Exported for main.go wiring (backend selection, sweeper mode).
+func (c *Config) FileBackend() bool { return c.fileBackend() }
+
+const (
+	storageBackendKubernetes = "kubernetes"
+	storageBackendFile       = "file"
+)
 
 // WebClientConfig registers one confidential web client (RFC 6749 §2.1)
 // at the broker — a server-side app that can keep a secret and receives
@@ -321,6 +370,11 @@ type WorldConfig struct {
 	// The Mark Protocol scheme is always `mark://`; the value here is
 	// host:port only (e.g. `team-a-mark.team-a:6309`).
 	InternalAddress string `yaml:"internalAddress"`
+	// TokensFile is the world server's tokens.toml path on local disk.
+	// Required (and only meaningful) in file-backend mode, where the
+	// broker writes token hashes directly to the file the world server
+	// watches; ignored in kubernetes mode.
+	TokensFile string `yaml:"tokensFile"`
 	// Allow is the per-world authorization predicate. See AllowConfig for
 	// the rules. When every list is empty the world accepts any verified
 	// identity (back-compat with pre-Slice-C configs that had only
@@ -520,8 +574,8 @@ func (c *Config) validate() error {
 	if c.Server.CookieKey == "" {
 		return fmt.Errorf("server.cookieKey is required")
 	}
-	if c.Server.BrokerNamespace == "" {
-		return fmt.Errorf("server.brokerNamespace is required")
+	if err := c.validateStorage(); err != nil {
+		return err
 	}
 	// Normalize before the empty-check so values like "   " or "/" are
 	// caught here instead of silently producing a broken issuer URL
@@ -570,7 +624,7 @@ func (c *Config) validate() error {
 	seen := make(map[string]bool, len(c.Worlds))
 	for i := range c.Worlds {
 		w := &c.Worlds[i]
-		if err := validateWorld(i, w); err != nil {
+		if err := validateWorld(i, w, c.fileBackend()); err != nil {
 			return err
 		}
 		if seen[w.Name] {
@@ -798,16 +852,31 @@ const maxSweeperInterval = 24 * time.Hour
 // gocyclo budget on each function stays inside the linter threshold;
 // the outer loop owns cross-world checks (duplicates), the helper owns
 // single-world checks.
-func validateWorld(i int, w *WorldConfig) error {
+func validateWorld(i int, w *WorldConfig, fileMode bool) error {
 	switch {
 	case w.Name == "":
 		return fmt.Errorf("worlds[%d]: name is required", i)
-	case w.Namespace == "":
-		return fmt.Errorf("worlds[%d] (%s): namespace is required", i, w.Name)
-	case w.TokensSecret == "":
-		return fmt.Errorf("worlds[%d] (%s): tokensSecret is required", i, w.Name)
 	case len(w.DefaultToken.Paths) == 0:
 		return fmt.Errorf("worlds[%d] (%s): defaultToken.paths is required", i, w.Name)
+	}
+	// The location invariants differ per backend: kubernetes worlds live in
+	// a namespace with a tokens Secret; file-mode worlds need a local
+	// tokens.toml path and an explicit dial address (the cluster-DNS
+	// default is meaningless off-cluster).
+	if fileMode {
+		switch {
+		case w.TokensFile == "":
+			return fmt.Errorf("worlds[%d] (%s): tokensFile is required in file-backend mode", i, w.Name)
+		case w.InternalAddress == "":
+			return fmt.Errorf("worlds[%d] (%s): internalAddress is required in file-backend mode", i, w.Name)
+		}
+	} else {
+		switch {
+		case w.Namespace == "":
+			return fmt.Errorf("worlds[%d] (%s): namespace is required", i, w.Name)
+		case w.TokensSecret == "":
+			return fmt.Errorf("worlds[%d] (%s): tokensSecret is required", i, w.Name)
+		}
 	}
 	// All three lists are lowercased+trimmed at load so authorizedWorlds
 	// can do plain string compares on every login. Group-name match is

--- a/tools/demarkus-broker/internal/broker/mcp_auth_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_auth_test.go
@@ -162,7 +162,7 @@ func TestGatewayAuthValidBearerStashesClaimsOnContext(t *testing.T) {
 
 	signer := newTestSigner(t)
 	k8s := fake.NewSimpleClientset()
-	brokerSrv := NewServer(cfg, signer, v, k8s, nil, nil, nil)
+	brokerSrv := NewServer(cfg, signer, v, NewK8sSecretStore(k8s), nil, nil, nil)
 
 	var seen *Claims
 	var sawClaims bool

--- a/tools/demarkus-broker/internal/broker/mcp_gateway_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_gateway_test.go
@@ -33,7 +33,7 @@ func newTestMCPGateway(t *testing.T, cfg *Config, verifier Verifier) *httptest.S
 	t.Helper()
 	signer := newTestSigner(t)
 	k8s := fake.NewSimpleClientset()
-	brokerSrv := NewServer(cfg, signer, verifier, k8s, nil, nil, nil)
+	brokerSrv := NewServer(cfg, signer, verifier, NewK8sSecretStore(k8s), nil, nil, nil)
 	ts := httptest.NewServer(brokerSrv.MCPGateway("test"))
 	t.Cleanup(ts.Close)
 	return ts
@@ -239,7 +239,7 @@ func TestMCPGatewayEveryAdvertisedToolHasAHandler(t *testing.T) {
 	signer := newTestSigner(t)
 	verifier := &fakeVerifier{claims: Claims{Subject: "google|alice", Email: "alice@example.com", EmailVerified: true}}
 	k8s := fake.NewSimpleClientset()
-	srv := NewServer(mcpTestConfig(), signer, verifier, k8s, nil, nil, nil)
+	srv := NewServer(mcpTestConfig(), signer, verifier, NewK8sSecretStore(k8s), nil, nil, nil)
 	gw := newMCPGateway(srv, "test", &fakeDispatcher{})
 
 	handlers := gw.toolHandlers()

--- a/tools/demarkus-broker/internal/broker/mcp_oauth_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_oauth_test.go
@@ -82,7 +82,7 @@ func TestOAuthAuthorizationServerMetadataReusesDiscoveryWhenWired(t *testing.T) 
 	signer := newTestSigner(t)
 	k8s := fake.NewSimpleClientset()
 	// Discovery requires IDTokenSigner (NewServer enforces this).
-	brokerSrv := NewServer(cfg, signer, &fakeVerifier{}, k8s, d, newTestIDTokenSigner(t), nil)
+	brokerSrv := NewServer(cfg, signer, &fakeVerifier{}, NewK8sSecretStore(k8s), d, newTestIDTokenSigner(t), nil)
 	handler := brokerSrv.MCPGateway("test")
 	if handler == nil {
 		t.Fatal("MCPGateway returned nil despite cfg.Server.MCP.Enabled=true")

--- a/tools/demarkus-broker/internal/broker/mcp_tools_federation_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_federation_test.go
@@ -501,7 +501,7 @@ func TestMCPGatewayMarkDiscoverEndToEnd(t *testing.T) {
 	}}
 	signer := newTestSigner(t)
 	k8s := fake.NewSimpleClientset()
-	brokerSrv := NewServer(cfg, signer, verifier, k8s, nil, nil, nil)
+	brokerSrv := NewServer(cfg, signer, verifier, NewK8sSecretStore(k8s), nil, nil, nil)
 	ts := httptest.NewServer(brokerSrv.MCPGatewayWith("test", d))
 	t.Cleanup(ts.Close)
 

--- a/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode_test.go
@@ -267,7 +267,7 @@ func newTestMCPGatewayWith(t *testing.T, cfg *Config, verifier Verifier, d world
 	t.Helper()
 	signer := newTestSigner(t)
 	k8s := fake.NewSimpleClientset()
-	brokerSrv := NewServer(cfg, signer, verifier, k8s, nil, nil, nil)
+	brokerSrv := NewServer(cfg, signer, verifier, NewK8sSecretStore(k8s), nil, nil, nil)
 	ts := httptest.NewServer(brokerSrv.MCPGatewayWith("test", d))
 	t.Cleanup(ts.Close)
 	return ts

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph_test.go
@@ -698,7 +698,7 @@ func TestMCPGatewayMarkGraphEndToEnd(t *testing.T) {
 	}}
 	signer := newTestSigner(t)
 	k8s := fake.NewSimpleClientset()
-	brokerSrv := NewServer(cfg, signer, verifier, k8s, nil, nil, nil)
+	brokerSrv := NewServer(cfg, signer, verifier, NewK8sSecretStore(k8s), nil, nil, nil)
 	brokerSrv.clock = func() time.Time { return time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC) }
 	ts := httptest.NewServer(brokerSrv.MCPGatewayWith("test", d))
 	t.Cleanup(ts.Close)

--- a/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
@@ -346,7 +346,7 @@ func newGatewayWithDispatcher(t *testing.T, cfg *Config, d worldDispatcher) *mcp
 	signer := newTestSigner(t)
 	verifier := &fakeVerifier{claims: Claims{Subject: "google|alice", Email: "alice@example.com", EmailVerified: true}}
 	k8s := fake.NewSimpleClientset()
-	srv := NewServer(cfg, signer, verifier, k8s, nil, nil, nil)
+	srv := NewServer(cfg, signer, verifier, NewK8sSecretStore(k8s), nil, nil, nil)
 	srv.clock = func() time.Time { return time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC) }
 	return newMCPGateway(srv, "test", d)
 }
@@ -787,7 +787,7 @@ func TestMCPGatewayMarkFetchEndToEnd(t *testing.T) {
 	}}
 	signer := newTestSigner(t)
 	k8s := fake.NewSimpleClientset()
-	brokerSrv := NewServer(cfg, signer, verifier, k8s, nil, nil, nil)
+	brokerSrv := NewServer(cfg, signer, verifier, NewK8sSecretStore(k8s), nil, nil, nil)
 	ts := httptest.NewServer(brokerSrv.MCPGatewayWith("test", d))
 	t.Cleanup(ts.Close)
 

--- a/tools/demarkus-broker/internal/broker/mcp_tools_write_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_write_test.go
@@ -942,7 +942,7 @@ func TestMCPGatewayMarkPublishEndToEnd(t *testing.T) {
 	}}
 	signer := newTestSigner(t)
 	k8s := fake.NewSimpleClientset()
-	brokerSrv := NewServer(cfg, signer, verifier, k8s, nil, nil, nil)
+	brokerSrv := NewServer(cfg, signer, verifier, NewK8sSecretStore(k8s), nil, nil, nil)
 	ts := httptest.NewServer(brokerSrv.MCPGatewayWith("test", d))
 	t.Cleanup(ts.Close)
 

--- a/tools/demarkus-broker/internal/broker/ratelimit_test.go
+++ b/tools/demarkus-broker/internal/broker/ratelimit_test.go
@@ -185,7 +185,7 @@ func TestSubjectRateLimitMissingClaimsIs500(t *testing.T) {
 	// as 500 + an error log rather than silently disabling the limit
 	// (which would be the worst-of-both: production looks fine, but
 	// a misbehaving caller gets unbounded throughput).
-	srv := NewServer(testConfigWithRateLimit(), newTestSigner(t), &fakeVerifier{}, fake.NewSimpleClientset(), nil, nil, nil)
+	srv := NewServer(testConfigWithRateLimit(), newTestSigner(t), &fakeVerifier{}, NewK8sSecretStore(fake.NewSimpleClientset()), nil, nil, nil)
 	h := srv.subjectRateLimit(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Error("handler reached despite missing claims")
 		w.WriteHeader(http.StatusOK)

--- a/tools/demarkus-broker/internal/broker/refresh.go
+++ b/tools/demarkus-broker/internal/broker/refresh.go
@@ -9,8 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"time"
-
-	"k8s.io/client-go/kubernetes"
 )
 
 // RefreshTokensSecretKey is the key inside the broker-namespace
@@ -104,7 +102,7 @@ type refreshTokens struct {
 // migration.
 type RefreshStore struct {
 	cfg    *Config
-	k8s    kubernetes.Interface
+	store  SecretStore
 	clock  func() time.Time
 	randFn func([]byte) (int, error)
 }
@@ -113,10 +111,10 @@ type RefreshStore struct {
 // crypto/rand. Tests override clock and randFn on the returned
 // struct for deterministic behavior. Exported because main.go and
 // the Sweeper share a single instance with the Server (PR4 Step 5).
-func NewRefreshStore(cfg *Config, k8s kubernetes.Interface) *RefreshStore {
+func NewRefreshStore(cfg *Config, store SecretStore) *RefreshStore {
 	return &RefreshStore{
 		cfg:    cfg,
-		k8s:    k8s,
+		store:  store,
 		clock:  time.Now,
 		randFn: rand.Read,
 	}
@@ -151,7 +149,7 @@ func (s *RefreshStore) Issue(ctx context.Context, claims *Claims, clientID strin
 		ExpiresAt: now.Add(ttl),
 		ClientID:  clientID,
 	}
-	err := mutateSecret(ctx, s.k8s, s.cfg.Server.BrokerNamespace, s.cfg.Server.RefreshTokensSecret, RefreshTokensSecretKey, func(existing []byte) ([]byte, error) {
+	err := s.store.Mutate(ctx, s.cfg.refreshTokensRef(), func(existing []byte) ([]byte, error) {
 		store, err := decodeRefreshTokens(existing)
 		if err != nil {
 			return nil, err
@@ -184,7 +182,7 @@ func (s *RefreshStore) Refresh(ctx context.Context, rawToken string) (refreshTok
 	}
 	keyHash := hashRefreshToken(rawToken)
 	var out refreshTokenRecord
-	err := mutateSecret(ctx, s.k8s, s.cfg.Server.BrokerNamespace, s.cfg.Server.RefreshTokensSecret, RefreshTokensSecretKey, func(existing []byte) ([]byte, error) {
+	err := s.store.Mutate(ctx, s.cfg.refreshTokensRef(), func(existing []byte) ([]byte, error) {
 		// Reset on each retry — a conflict-driven re-run must not
 		// leak state from the prior closure invocation.
 		out = refreshTokenRecord{}
@@ -219,7 +217,7 @@ func (s *RefreshStore) Revoke(ctx context.Context, rawToken string) error {
 		return nil
 	}
 	keyHash := hashRefreshToken(rawToken)
-	return mutateSecret(ctx, s.k8s, s.cfg.Server.BrokerNamespace, s.cfg.Server.RefreshTokensSecret, RefreshTokensSecretKey, func(existing []byte) ([]byte, error) {
+	return s.store.Mutate(ctx, s.cfg.refreshTokensRef(), func(existing []byte) ([]byte, error) {
 		if len(existing) == 0 {
 			return existing, nil
 		}
@@ -241,7 +239,7 @@ func (s *RefreshStore) Revoke(ctx context.Context, rawToken string) error {
 // per-tick loop, which is refresh-token-only — Step 5 wires it.
 func (s *RefreshStore) Sweep(ctx context.Context) (int, error) {
 	var swept int
-	err := mutateSecret(ctx, s.k8s, s.cfg.Server.BrokerNamespace, s.cfg.Server.RefreshTokensSecret, RefreshTokensSecretKey, func(existing []byte) ([]byte, error) {
+	err := s.store.Mutate(ctx, s.cfg.refreshTokensRef(), func(existing []byte) ([]byte, error) {
 		// Reset on each retry — same rationale as Refresh.
 		swept = 0
 		if len(existing) == 0 {

--- a/tools/demarkus-broker/internal/broker/refresh_test.go
+++ b/tools/demarkus-broker/internal/broker/refresh_test.go
@@ -426,10 +426,8 @@ func TestRefreshStoreCollisionRetry(t *testing.T) {
 	}
 }
 
-// Invariant: the refresh lifecycle is backend-neutral. One
-// issue/refresh/revoke round trip against the file store, persisted to
-// storage.dir, pins the single-host path end to end (including surviving a
-// broker restart via a fresh store over the same directory).
+// Invariant: the refresh lifecycle is backend-neutral and file-backed
+// grants survive a broker restart (fresh store over the same directory).
 func TestRefreshStoreFileBackend(t *testing.T) {
 	cfg := testRefreshConfig()
 	cfg.Storage = StorageConfig{Backend: storageBackendFile, Dir: t.TempDir()}

--- a/tools/demarkus-broker/internal/broker/refresh_test.go
+++ b/tools/demarkus-broker/internal/broker/refresh_test.go
@@ -39,7 +39,7 @@ func testRefreshConfig() *Config {
 
 func newRefreshStoreForTest(t *testing.T, k8s *fake.Clientset) *RefreshStore {
 	t.Helper()
-	s := NewRefreshStore(testRefreshConfig(), k8s)
+	s := NewRefreshStore(testRefreshConfig(), NewK8sSecretStore(k8s))
 	s.clock = func() time.Time { return time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC) }
 	return s
 }

--- a/tools/demarkus-broker/internal/broker/refresh_test.go
+++ b/tools/demarkus-broker/internal/broker/refresh_test.go
@@ -425,3 +425,39 @@ func TestRefreshStoreCollisionRetry(t *testing.T) {
 		t.Errorf("randFn calls = %d, want 2", calls)
 	}
 }
+
+// Invariant: the refresh lifecycle is backend-neutral. One
+// issue/refresh/revoke round trip against the file store, persisted to
+// storage.dir, pins the single-host path end to end (including surviving a
+// broker restart via a fresh store over the same directory).
+func TestRefreshStoreFileBackend(t *testing.T) {
+	cfg := testRefreshConfig()
+	cfg.Storage = StorageConfig{Backend: storageBackendFile, Dir: t.TempDir()}
+	s := NewRefreshStore(cfg, NewFileSecretStore())
+	s.clock = func() time.Time { return time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC) }
+	ctx := context.Background()
+
+	claims := Claims{Subject: "user-1", Email: "alice@example.com", EmailVerified: true}
+	raw, err := s.Issue(ctx, &claims, "", cfg.Server.RefreshTokenTTL)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	// Restart: a fresh store over the same dir must honor the grant.
+	s2 := NewRefreshStore(cfg, NewFileSecretStore())
+	s2.clock = s.clock
+	rec, err := s2.Refresh(ctx, raw)
+	if err != nil {
+		t.Fatalf("Refresh after restart: %v", err)
+	}
+	if rec.Claims.Subject != "user-1" {
+		t.Errorf("Subject = %q", rec.Claims.Subject)
+	}
+
+	if err := s2.Revoke(ctx, raw); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if _, err := s2.Refresh(ctx, raw); err == nil {
+		t.Error("Refresh after Revoke succeeded")
+	}
+}

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -9,8 +9,6 @@ import (
 	"net/http"
 	"strings"
 	"time"
-
-	"k8s.io/client-go/kubernetes"
 )
 
 // stateCookieName is the name of the signed cookie holding the OIDC state
@@ -107,7 +105,7 @@ type Server struct {
 // compositeVerifier in oidc.go) — callers don't have to wrap
 // manually, and tests that pass &fakeVerifier{} get broker-signed
 // verification "for free" against the supplied signer.
-func NewServer(cfg *Config, signer *Signer, verifier Verifier, k8s kubernetes.Interface, discovery *Discovery, idTokenSigner *IDTokenSigner, log *slog.Logger) *Server {
+func NewServer(cfg *Config, signer *Signer, verifier Verifier, store SecretStore, discovery *Discovery, idTokenSigner *IDTokenSigner, log *slog.Logger) *Server {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -162,8 +160,8 @@ func NewServer(cfg *Config, signer *Signer, verifier Verifier, k8s kubernetes.In
 		clock:             clock,
 		deviceStore:       newDeviceStore(clock, deviceTTL, pollInterval),
 		authCodeStore:     newAuthCodeStore(clock, defaultPendingAuthCodeTTL, defaultAuthCodeTTL),
-		refreshStore:      NewRefreshStore(cfg, k8s),
-		worldWriteTokens:  newWorldWriteTokenStore(cfg, k8s),
+		refreshStore:      NewRefreshStore(cfg, store),
+		worldWriteTokens:  newWorldWriteTokenStore(cfg, store),
 		trustForwardedFor: cfg.RateLimit.TrustForwardedFor,
 	}
 	if idTokenSigner != nil {

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -44,12 +44,9 @@ type Server struct {
 	// owns the pending → code → exchange state machine.
 	authCodeStore *authCodeStore
 
-	// RefreshStore owns the Secret-backed map of sha256(refresh_token)
-	// → record. Wired by NewServer with the configured (or defaulted)
-	// broker-namespace Secret. Survives broker restarts unlike
-	// deviceStore. Universe-onboarding PR4. NewServer passes the
-	// kubernetes client straight through so the refresh and
-	// write-token stores share one client.
+	// refreshStore owns the persisted map of sha256(refresh_token) →
+	// record; survives broker restarts unlike deviceStore. NewServer
+	// injects one SecretStore shared with the write-token store.
 	refreshStore *RefreshStore
 
 	// idTokenSigner mints broker-signed id_tokens on the

--- a/tools/demarkus-broker/internal/broker/server_test.go
+++ b/tools/demarkus-broker/internal/broker/server_test.go
@@ -45,7 +45,7 @@ func newTestServer(t *testing.T, cfg *Config, verifier Verifier, k8s *fake.Clien
 	// a fixed date would expire the OIDC state cookie under any real
 	// wall-clock that is later than that date, breaking the callback
 	// tests.
-	brokerSrv = NewServer(cfg, signer, verifier, k8s, nil, nil, nil)
+	brokerSrv = NewServer(cfg, signer, verifier, NewK8sSecretStore(k8s), nil, nil, nil)
 	// NewTLSServer (not NewServer): the state cookie is set with
 	// Secure=true and Path=/auth/callback, attributes only enforceable
 	// over HTTPS. Without TLS we'd be relying on manual AddCookie calls
@@ -64,7 +64,7 @@ func newTestServer(t *testing.T, cfg *Config, verifier Verifier, k8s *fake.Clien
 func newTestServerWithSigner(t *testing.T, cfg *Config, verifier Verifier, k8s *fake.Clientset, signer *IDTokenSigner) (testSrv *httptest.Server, brokerSrv *Server) {
 	t.Helper()
 	cookieSigner := newTestSigner(t)
-	brokerSrv = NewServer(cfg, cookieSigner, verifier, k8s, nil, signer, nil)
+	brokerSrv = NewServer(cfg, cookieSigner, verifier, NewK8sSecretStore(k8s), nil, signer, nil)
 	testSrv = httptest.NewTLSServer(brokerSrv.Routes())
 	t.Cleanup(testSrv.Close)
 	return testSrv, brokerSrv
@@ -111,7 +111,7 @@ func TestNewServerPanicsOnDiscoveryWithoutSigner(t *testing.T) {
 			t.Fatal("expected panic for discovery != nil + idTokenSigner == nil")
 		}
 	}()
-	NewServer(cfg, newTestSigner(t), &fakeVerifier{}, fake.NewSimpleClientset(), d, nil, nil)
+	NewServer(cfg, newTestSigner(t), &fakeVerifier{}, NewK8sSecretStore(fake.NewSimpleClientset()), d, nil, nil)
 }
 
 // TestWellKnownDiscoveryRouteRegistered guards the Routes() composition:
@@ -140,7 +140,7 @@ func TestWellKnownDiscoveryRouteRegistered(t *testing.T) {
 	// IDTokenSigner so the jwks_uri override the discovery doc
 	// advertises actually has a handler mounted. NewServer panics
 	// otherwise.
-	srv := NewServer(cfg, newTestSigner(t), &fakeVerifier{}, fake.NewSimpleClientset(), d, newTestIDTokenSigner(t), nil)
+	srv := NewServer(cfg, newTestSigner(t), &fakeVerifier{}, NewK8sSecretStore(fake.NewSimpleClientset()), d, newTestIDTokenSigner(t), nil)
 	tsrv := httptest.NewServer(srv.Routes())
 	t.Cleanup(tsrv.Close)
 
@@ -476,7 +476,7 @@ func TestAuthCallbackUnauthorizedDomain(t *testing.T) {
 // Sanity guard so the clock override on Server is exercised at least once.
 func TestServerClockExposed(t *testing.T) {
 	cfg := testConfig()
-	s := NewServer(cfg, newTestSigner(t), &fakeVerifier{}, fake.NewSimpleClientset(), nil, nil, nil)
+	s := NewServer(cfg, newTestSigner(t), &fakeVerifier{}, NewK8sSecretStore(fake.NewSimpleClientset()), nil, nil, nil)
 	fixed := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	s.clock = func() time.Time { return fixed }
 	if !s.clock().Equal(fixed) {

--- a/tools/demarkus-broker/internal/broker/storage.go
+++ b/tools/demarkus-broker/internal/broker/storage.go
@@ -167,16 +167,18 @@ func (s *fileSecretStore) Mutate(_ context.Context, ref SecretRef, mutate func([
 		return nil
 	}
 
-	// Preserve the mode and ownership of a pre-existing file (install.sh
-	// sets group-read so the world server user can read tokens.toml; a
-	// rename would otherwise re-own the file to the broker user and its
-	// primary group, silently revoking the server's read). New files are
-	// owner-only.
+	// Preserve a pre-existing file's mode and ownership: rename would
+	// otherwise re-own it to the broker user, revoking the world server's
+	// group-read on tokens.toml. New files are owner-only.
 	mode := os.FileMode(0o600)
 	var owner *fileOwner
 	if info, statErr := os.Stat(ref.Path); statErr == nil {
 		mode = info.Mode().Perm()
 		owner = ownerOf(info)
+	} else if !os.IsNotExist(statErr) {
+		// A file that exists but cannot be statted must not be replaced
+		// with downgraded metadata.
+		return fmt.Errorf("stat %s: %w", ref.Path, statErr)
 	}
 	dir := filepath.Dir(ref.Path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -229,13 +231,9 @@ func removeIfPresent(path string) error {
 	return nil
 }
 
-// chownPreserving restores the original owner on the replacement file.
-// An unprivileged broker can always keep a group it belongs to; when it
-// cannot restore the uid (EPERM), the gid alone preserves the shared-group
-// read policy, so that degradation is accepted. Anything else errors: a
-// deployment where the broker can neither own nor re-group the tokens file
-// is misconfigured, and silently re-owning it would revoke the world
-// server's read on the next mutation.
+// chownPreserving restores the original owner; when uid restoration needs
+// privilege the gid alone keeps the shared-group read policy, so that
+// degradation is accepted. Any other failure errors rather than re-owning.
 func chownPreserving(path string, owner *fileOwner) error {
 	if err := os.Chown(path, owner.uid, owner.gid); err == nil {
 		return nil

--- a/tools/demarkus-broker/internal/broker/storage.go
+++ b/tools/demarkus-broker/internal/broker/storage.go
@@ -3,6 +3,7 @@ package broker
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -166,12 +167,16 @@ func (s *fileSecretStore) Mutate(_ context.Context, ref SecretRef, mutate func([
 		return nil
 	}
 
-	// Preserve the mode of a pre-existing file (install.sh sets group-read
-	// perms so the world server user can read tokens.toml); new files are
+	// Preserve the mode and ownership of a pre-existing file (install.sh
+	// sets group-read so the world server user can read tokens.toml; a
+	// rename would otherwise re-own the file to the broker user and its
+	// primary group, silently revoking the server's read). New files are
 	// owner-only.
 	mode := os.FileMode(0o600)
+	var owner *fileOwner
 	if info, statErr := os.Stat(ref.Path); statErr == nil {
 		mode = info.Mode().Perm()
+		owner = ownerOf(info)
 	}
 	dir := filepath.Dir(ref.Path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -182,29 +187,77 @@ func (s *fileSecretStore) Mutate(_ context.Context, ref SecretRef, mutate func([
 		return fmt.Errorf("create temp for %s: %w", ref.Path, err)
 	}
 	tmpName := tmp.Name()
-	cleanup := func() {
-		_ = tmp.Close()
-		_ = os.Remove(tmpName)
+	fail := func(step string, cause error) error {
+		return errors.Join(
+			fmt.Errorf("%s for %s: %w", step, ref.Path, cause),
+			removeIfPresent(tmpName),
+		)
 	}
 	if err := tmp.Chmod(mode); err != nil {
-		cleanup()
-		return fmt.Errorf("chmod temp for %s: %w", ref.Path, err)
+		_ = tmp.Close()
+		return fail("chmod temp", err)
+	}
+	if owner != nil {
+		if err := chownPreserving(tmpName, owner); err != nil {
+			_ = tmp.Close()
+			return fail("preserve ownership", err)
+		}
 	}
 	if _, err := tmp.Write(next); err != nil {
-		cleanup()
-		return fmt.Errorf("write temp for %s: %w", ref.Path, err)
+		_ = tmp.Close()
+		return fail("write temp", err)
 	}
 	if err := tmp.Sync(); err != nil {
-		cleanup()
-		return fmt.Errorf("sync temp for %s: %w", ref.Path, err)
+		_ = tmp.Close()
+		return fail("sync temp", err)
 	}
 	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpName)
-		return fmt.Errorf("close temp for %s: %w", ref.Path, err)
+		return fail("close temp", err)
 	}
 	if err := os.Rename(tmpName, ref.Path); err != nil {
-		_ = os.Remove(tmpName)
-		return fmt.Errorf("replace %s: %w", ref.Path, err)
+		return fail("replace", err)
+	}
+	// Sync the directory so the rename itself survives a crash: file
+	// contents were fsynced above, but the new directory entry was not.
+	return syncDir(dir)
+}
+
+func removeIfPresent(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("cleanup temp %s: %w", path, err)
+	}
+	return nil
+}
+
+// chownPreserving restores the original owner on the replacement file.
+// An unprivileged broker can always keep a group it belongs to; when it
+// cannot restore the uid (EPERM), the gid alone preserves the shared-group
+// read policy, so that degradation is accepted. Anything else errors: a
+// deployment where the broker can neither own nor re-group the tokens file
+// is misconfigured, and silently re-owning it would revoke the world
+// server's read on the next mutation.
+func chownPreserving(path string, owner *fileOwner) error {
+	if err := os.Chown(path, owner.uid, owner.gid); err == nil {
+		return nil
+	}
+	if err := os.Chown(path, -1, owner.gid); err != nil {
+		return fmt.Errorf("cannot preserve owner uid=%d gid=%d (run the broker as the file's owner or a member of its group): %w", owner.uid, owner.gid, err)
+	}
+	return nil
+}
+
+func syncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("open dir %s for sync: %w", dir, err)
+	}
+	syncErr := d.Sync()
+	closeErr := d.Close()
+	if syncErr != nil {
+		return fmt.Errorf("sync dir %s: %w", dir, syncErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close dir %s: %w", dir, closeErr)
 	}
 	return nil
 }

--- a/tools/demarkus-broker/internal/broker/storage.go
+++ b/tools/demarkus-broker/internal/broker/storage.go
@@ -1,0 +1,246 @@
+package broker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// SecretRef names one credential document in both backends: the k8s
+// (Namespace, Name, Key) Secret tuple and the file backend's Path. Refs are
+// built by the Config helpers so every call site resolves locations one way.
+type SecretRef struct {
+	Namespace string
+	Name      string
+	Key       string
+	Path      string
+}
+
+func (r SecretRef) String() string {
+	if r.Path != "" {
+		return r.Path
+	}
+	return r.Namespace + "/" + r.Name + "[" + r.Key + "]"
+}
+
+// SecretStore is the broker's credential-persistence backend: an atomic
+// read-modify-write on one credential document. Contract shared by both
+// implementations: a mutation that leaves an absent document empty writes
+// nothing (absent stays absent), and an unchanged value is not rewritten
+// (no spurious version/mtime churn for watchers).
+type SecretStore interface {
+	Mutate(ctx context.Context, ref SecretRef, mutate func(current []byte) ([]byte, error)) error
+}
+
+// NewK8sSecretStore returns the Kubernetes-backed SecretStore.
+func NewK8sSecretStore(client kubernetes.Interface) SecretStore {
+	return &k8sSecretStore{client: client}
+}
+
+type k8sSecretStore struct {
+	client kubernetes.Interface
+}
+
+// Mutate performs an optimistic-concurrency read-modify-write on the Secret
+// data[ref.Key], retrying resourceVersion conflicts up to maxConflictRetries.
+func (s *k8sSecretStore) Mutate(ctx context.Context, ref SecretRef, mutate func([]byte) ([]byte, error)) error {
+	for range maxConflictRetries {
+		secret, getErr := s.client.CoreV1().Secrets(ref.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
+		if getErr != nil && !apierrors.IsNotFound(getErr) {
+			return fmt.Errorf("get secret %s/%s: %w", ref.Namespace, ref.Name, getErr)
+		}
+		var existing []byte
+		if getErr == nil {
+			existing = secret.Data[ref.Key]
+		}
+		next, err := mutate(existing)
+		if err != nil {
+			return err
+		}
+		if apierrors.IsNotFound(getErr) {
+			// Absent stays absent: don't materialize an empty Secret as a
+			// side effect of a no-op mutation (observable in helm-rendered
+			// Secrets and audit logs).
+			if len(next) == 0 {
+				return nil
+			}
+			fresh := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ref.Name,
+					Namespace: ref.Namespace,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{ref.Key: next},
+			}
+			_, createErr := s.client.CoreV1().Secrets(ref.Namespace).Create(ctx, fresh, metav1.CreateOptions{})
+			if createErr == nil {
+				return nil
+			}
+			if apierrors.IsAlreadyExists(createErr) {
+				continue
+			}
+			return fmt.Errorf("create secret %s/%s: %w", ref.Namespace, ref.Name, createErr)
+		}
+		// No-op mutation: skip the Update. Writing anyway bumps the
+		// resourceVersion, triggering kubelet re-projection on every world
+		// tokens.toml mount — the exact churn the broker works to avoid.
+		if bytes.Equal(existing, next) {
+			return nil
+		}
+		if secret.Data == nil {
+			secret.Data = make(map[string][]byte, 1)
+		}
+		secret.Data[ref.Key] = next
+		_, updateErr := s.client.CoreV1().Secrets(ref.Namespace).Update(ctx, secret, metav1.UpdateOptions{})
+		if updateErr == nil {
+			return nil
+		}
+		if apierrors.IsConflict(updateErr) {
+			continue
+		}
+		return fmt.Errorf("update secret %s/%s: %w", ref.Namespace, ref.Name, updateErr)
+	}
+	return fmt.Errorf("conflict on secret %s/%s after %d retries", ref.Namespace, ref.Name, maxConflictRetries)
+}
+
+// NewFileSecretStore returns the file-backed SecretStore for single-host
+// mode. Writes are atomic (temp file + rename, preserving an existing file's
+// mode) so the world server's tokens-file watcher, which watches the parent
+// directory, sees exactly one complete replacement per mutation. Concurrency
+// is guarded per path within this process; a concurrent out-of-process
+// writer (an operator running demarkus-token by hand) has the same
+// last-write-wins exposure as hand-editing tokens.toml today.
+func NewFileSecretStore() SecretStore {
+	return &fileSecretStore{locks: make(map[string]*sync.Mutex)}
+}
+
+type fileSecretStore struct {
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func (s *fileSecretStore) lockFor(path string) *sync.Mutex {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	l, ok := s.locks[path]
+	if !ok {
+		l = &sync.Mutex{}
+		s.locks[path] = l
+	}
+	return l
+}
+
+func (s *fileSecretStore) Mutate(_ context.Context, ref SecretRef, mutate func([]byte) ([]byte, error)) error {
+	if ref.Path == "" {
+		return fmt.Errorf("file secret store: ref %s has no path (storage.dir or world tokensFile missing)", ref)
+	}
+	l := s.lockFor(ref.Path)
+	l.Lock()
+	defer l.Unlock()
+
+	existing, readErr := os.ReadFile(ref.Path)
+	absent := false
+	if readErr != nil {
+		if !os.IsNotExist(readErr) {
+			return fmt.Errorf("read %s: %w", ref.Path, readErr)
+		}
+		absent = true
+		existing = nil
+	}
+	next, err := mutate(existing)
+	if err != nil {
+		return err
+	}
+	if absent && len(next) == 0 {
+		return nil
+	}
+	if !absent && bytes.Equal(existing, next) {
+		return nil
+	}
+
+	// Preserve the mode of a pre-existing file (install.sh sets group-read
+	// perms so the world server user can read tokens.toml); new files are
+	// owner-only.
+	mode := os.FileMode(0o600)
+	if info, statErr := os.Stat(ref.Path); statErr == nil {
+		mode = info.Mode().Perm()
+	}
+	dir := filepath.Dir(ref.Path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(ref.Path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp for %s: %w", ref.Path, err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		cleanup()
+		return fmt.Errorf("chmod temp for %s: %w", ref.Path, err)
+	}
+	if _, err := tmp.Write(next); err != nil {
+		cleanup()
+		return fmt.Errorf("write temp for %s: %w", ref.Path, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return fmt.Errorf("sync temp for %s: %w", ref.Path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("close temp for %s: %w", ref.Path, err)
+	}
+	if err := os.Rename(tmpName, ref.Path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("replace %s: %w", ref.Path, err)
+	}
+	return nil
+}
+
+// Ref builders: one place resolves every credential document's location for
+// both backends. Path fields are populated only in file-backend mode.
+
+func (c *Config) refreshTokensRef() SecretRef {
+	ref := SecretRef{
+		Namespace: c.Server.BrokerNamespace,
+		Name:      c.Server.RefreshTokensSecret,
+		Key:       RefreshTokensSecretKey,
+	}
+	if c.fileBackend() {
+		ref.Path = filepath.Join(c.Storage.Dir, RefreshTokensSecretKey)
+	}
+	return ref
+}
+
+func (c *Config) worldWriteTokenRef(worldName string) SecretRef {
+	ref := SecretRef{
+		Namespace: c.Server.BrokerNamespace,
+		Name:      worldWriteTokenSecretName(worldName),
+		Key:       worldWriteTokenSecretKey,
+	}
+	if c.fileBackend() {
+		ref.Path = filepath.Join(c.Storage.Dir, worldWriteTokenSecretName(worldName)+".json")
+	}
+	return ref
+}
+
+func (c *Config) worldTokensRef(world *WorldConfig) SecretRef {
+	return SecretRef{
+		Namespace: world.Namespace,
+		Name:      world.TokensSecret,
+		Key:       TokensSecretKey,
+		Path:      world.TokensFile,
+	}
+}

--- a/tools/demarkus-broker/internal/broker/storage_other.go
+++ b/tools/demarkus-broker/internal/broker/storage_other.go
@@ -1,0 +1,12 @@
+//go:build !unix
+
+package broker
+
+import "os"
+
+type fileOwner struct {
+	uid, gid int
+}
+
+// ownerOf is a no-op on platforms without unix ownership semantics.
+func ownerOf(_ os.FileInfo) *fileOwner { return nil }

--- a/tools/demarkus-broker/internal/broker/storage_test.go
+++ b/tools/demarkus-broker/internal/broker/storage_test.go
@@ -23,7 +23,7 @@ func TestFileStoreCreateAndUpdate(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("create: %v", err)
 	}
-	if got, _ := os.ReadFile(ref.Path); string(got) != "v1" {
+	if got := mustRead(t, ref.Path); string(got) != "v1" {
 		t.Fatalf("file = %q, want v1", got)
 	}
 
@@ -32,7 +32,7 @@ func TestFileStoreCreateAndUpdate(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("update: %v", err)
 	}
-	if got, _ := os.ReadFile(ref.Path); string(got) != "v1-v2" {
+	if got := mustRead(t, ref.Path); string(got) != "v1-v2" {
 		t.Errorf("file = %q, want v1-v2", got)
 	}
 }
@@ -71,9 +71,13 @@ func TestFileStoreNoRewriteOnEqual(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Unchanged value must not be rewritten: the world server's tokens-file
-	// watcher would reload on every no-op otherwise.
+	// watcher would reload on every no-op otherwise. SameFile catches a
+	// rewrite that lands within the filesystem's mtime resolution.
 	if !after.ModTime().Equal(before.ModTime()) {
 		t.Error("file rewritten on unchanged value")
+	}
+	if !os.SameFile(before, after) {
+		t.Error("file replaced (new inode) on unchanged value")
 	}
 }
 
@@ -127,15 +131,22 @@ func TestFileStoreConcurrentMutations(t *testing.T) {
 	s := NewFileSecretStore()
 
 	const n = 20
+	errs := make(chan error, n)
 	var wg sync.WaitGroup
 	for range n {
 		wg.Go(func() {
-			_ = s.Mutate(context.Background(), ref, func(existing []byte) ([]byte, error) {
+			errs <- s.Mutate(context.Background(), ref, func(existing []byte) ([]byte, error) {
 				return append(existing, 'x'), nil
 			})
 		})
 	}
 	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent Mutate: %v", err)
+		}
+	}
 	got, err := os.ReadFile(ref.Path)
 	if err != nil {
 		t.Fatal(err)
@@ -229,5 +240,27 @@ func TestValidateKubernetesBackendDefaults(t *testing.T) {
 	broken := strings.Replace(validConfig, "  brokerNamespace: demarkus-broker\n", "", 1)
 	if _, err := LoadConfig(writeConfig(t, broken)); err == nil {
 		t.Error("k8s mode without brokerNamespace should fail")
+	}
+}
+
+func TestValidateFileBackendPathCollisions(t *testing.T) {
+	tests := []struct {
+		name       string
+		tokensFile string
+	}{
+		{"aliases refresh state", "/var/lib/demarkus-broker/refresh_tokens.json"},
+		{"aliases write-token state", "/var/lib/demarkus-broker/demarkus-broker-write-token-team-a.json"},
+		{"aliases via non-clean path", "/var/lib/demarkus-broker/../demarkus-broker/refresh_tokens.json"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := fileBackendConfig(func(s string) string {
+				return strings.Replace(s, "    tokensFile: /etc/demarkus/tokens.toml\n",
+					"    tokensFile: "+tt.tokensFile+"\n", 1)
+			})
+			if _, err := LoadConfig(writeConfig(t, body)); err == nil {
+				t.Error("expected collision error")
+			}
+		})
 	}
 }

--- a/tools/demarkus-broker/internal/broker/storage_test.go
+++ b/tools/demarkus-broker/internal/broker/storage_test.go
@@ -1,0 +1,233 @@
+package broker
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestFileStoreCreateAndUpdate(t *testing.T) {
+	dir := t.TempDir()
+	ref := SecretRef{Path: filepath.Join(dir, "tokens.toml")}
+	s := NewFileSecretStore()
+
+	if err := s.Mutate(context.Background(), ref, func(existing []byte) ([]byte, error) {
+		if len(existing) != 0 {
+			t.Errorf("existing = %q, want empty on absent file", existing)
+		}
+		return []byte("v1"), nil
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if got, _ := os.ReadFile(ref.Path); string(got) != "v1" {
+		t.Fatalf("file = %q, want v1", got)
+	}
+
+	if err := s.Mutate(context.Background(), ref, func(existing []byte) ([]byte, error) {
+		return append(existing, []byte("-v2")...), nil
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if got, _ := os.ReadFile(ref.Path); string(got) != "v1-v2" {
+		t.Errorf("file = %q, want v1-v2", got)
+	}
+}
+
+func TestFileStoreAbsentStaysAbsent(t *testing.T) {
+	dir := t.TempDir()
+	ref := SecretRef{Path: filepath.Join(dir, "refresh_tokens.json")}
+	s := NewFileSecretStore()
+
+	if err := s.Mutate(context.Background(), ref, func([]byte) ([]byte, error) { return nil, nil }); err != nil {
+		t.Fatalf("no-op mutate: %v", err)
+	}
+	if _, err := os.Stat(ref.Path); !os.IsNotExist(err) {
+		t.Errorf("file materialized on empty-result no-op: %v", err)
+	}
+}
+
+func TestFileStoreNoRewriteOnEqual(t *testing.T) {
+	dir := t.TempDir()
+	ref := SecretRef{Path: filepath.Join(dir, "tokens.toml")}
+	if err := os.WriteFile(ref.Path, []byte("same"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(ref.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewFileSecretStore()
+	if err := s.Mutate(context.Background(), ref, func(existing []byte) ([]byte, error) {
+		return existing, nil
+	}); err != nil {
+		t.Fatalf("equal mutate: %v", err)
+	}
+	after, err := os.Stat(ref.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Unchanged value must not be rewritten: the world server's tokens-file
+	// watcher would reload on every no-op otherwise.
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Error("file rewritten on unchanged value")
+	}
+}
+
+func TestFileStorePreservesMode(t *testing.T) {
+	dir := t.TempDir()
+	ref := SecretRef{Path: filepath.Join(dir, "tokens.toml")}
+	if err := os.WriteFile(ref.Path, []byte("v0"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	s := NewFileSecretStore()
+	if err := s.Mutate(context.Background(), ref, func([]byte) ([]byte, error) {
+		return []byte("v1"), nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(ref.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o640 {
+		t.Errorf("mode = %o, want 640 (install.sh group-read preserved)", info.Mode().Perm())
+	}
+}
+
+func TestFileStoreMutateErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	ref := SecretRef{Path: filepath.Join(dir, "f")}
+	s := NewFileSecretStore()
+	boom := errors.New("boom")
+	if err := s.Mutate(context.Background(), ref, func([]byte) ([]byte, error) { return nil, boom }); !errors.Is(err, boom) {
+		t.Errorf("err = %v, want boom", err)
+	}
+	if _, statErr := os.Stat(ref.Path); !os.IsNotExist(statErr) {
+		t.Error("file written despite mutate error")
+	}
+}
+
+func TestFileStoreMissingPath(t *testing.T) {
+	s := NewFileSecretStore()
+	err := s.Mutate(context.Background(), SecretRef{Namespace: "ns", Name: "n", Key: "k"}, func([]byte) ([]byte, error) {
+		return []byte("x"), nil
+	})
+	if err == nil {
+		t.Fatal("expected error for ref without path")
+	}
+}
+
+func TestFileStoreConcurrentMutations(t *testing.T) {
+	dir := t.TempDir()
+	ref := SecretRef{Path: filepath.Join(dir, "counter")}
+	s := NewFileSecretStore()
+
+	const n = 20
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() {
+			_ = s.Mutate(context.Background(), ref, func(existing []byte) ([]byte, error) {
+				return append(existing, 'x'), nil
+			})
+		})
+	}
+	wg.Wait()
+	got, err := os.ReadFile(ref.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Per-path locking makes read-modify-write atomic: no lost updates.
+	if len(got) != n {
+		t.Errorf("len = %d, want %d (lost updates under concurrency)", len(got), n)
+	}
+}
+
+func TestConfigRefsFileMode(t *testing.T) {
+	cfg := &Config{
+		Storage: StorageConfig{Backend: storageBackendFile, Dir: "/var/lib/demarkus-broker"},
+		Server:  ServerConfig{RefreshTokensSecret: "rt"},
+	}
+	world := &WorldConfig{Name: "soul", TokensFile: "/etc/demarkus/tokens.toml"}
+
+	if got := cfg.refreshTokensRef().Path; got != "/var/lib/demarkus-broker/"+RefreshTokensSecretKey {
+		t.Errorf("refresh ref path = %q", got)
+	}
+	if got := cfg.worldWriteTokenRef("soul").Path; got != "/var/lib/demarkus-broker/demarkus-broker-write-token-soul.json" {
+		t.Errorf("write-token ref path = %q", got)
+	}
+	if got := cfg.worldTokensRef(world).Path; got != "/etc/demarkus/tokens.toml" {
+		t.Errorf("world tokens ref path = %q", got)
+	}
+
+	// kubernetes mode: no file paths on broker-state refs.
+	cfg.Storage = StorageConfig{}
+	if got := cfg.refreshTokensRef().Path; got != "" {
+		t.Errorf("k8s-mode refresh ref path = %q, want empty", got)
+	}
+}
+
+// fileBackendConfig renders validConfig re-shaped for single-host mode:
+// storage block added, brokerNamespace dropped, the world addressed by
+// file + dial address instead of namespace + Secret.
+func fileBackendConfig(mutate func(string) string) string {
+	body := strings.Replace(validConfig, "  brokerNamespace: demarkus-broker\n", "", 1)
+	body = strings.Replace(body, "server:\n", "storage:\n  backend: file\n  dir: /var/lib/demarkus-broker\nserver:\n", 1)
+	body = strings.Replace(body,
+		"  - name: team-a\n    namespace: team-a\n    tokensSecret: team-a-tokens\n",
+		"  - name: team-a\n    tokensFile: /etc/demarkus/tokens.toml\n    internalAddress: localhost:6309\n", 1)
+	if mutate != nil {
+		body = mutate(body)
+	}
+	return body
+}
+
+func TestValidateFileBackend(t *testing.T) {
+	if _, err := LoadConfig(writeConfig(t, fileBackendConfig(nil))); err != nil {
+		t.Fatalf("valid file-backend config rejected: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(string) string
+	}{
+		{"missing storage dir", func(s string) string {
+			return strings.Replace(s, "  dir: /var/lib/demarkus-broker\n", "", 1)
+		}},
+		{"missing world tokensFile", func(s string) string {
+			return strings.Replace(s, "    tokensFile: /etc/demarkus/tokens.toml\n", "", 1)
+		}},
+		{"missing world internalAddress", func(s string) string {
+			return strings.Replace(s, "    internalAddress: localhost:6309\n", "", 1)
+		}},
+		{"unknown backend", func(s string) string {
+			return strings.Replace(s, "  backend: file\n", "  backend: etcd\n", 1)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := LoadConfig(writeConfig(t, fileBackendConfig(tt.mutate))); err == nil {
+				t.Error("expected validation error")
+			}
+		})
+	}
+}
+
+func TestValidateKubernetesBackendDefaults(t *testing.T) {
+	// The unmodified valid config carries no storage block: backend must
+	// default to kubernetes and keep requiring the namespace fields.
+	cfg, err := LoadConfig(writeConfig(t, validConfig))
+	if err != nil {
+		t.Fatalf("valid k8s config rejected: %v", err)
+	}
+	if cfg.Storage.Backend != storageBackendKubernetes {
+		t.Errorf("backend not defaulted, got %q", cfg.Storage.Backend)
+	}
+	broken := strings.Replace(validConfig, "  brokerNamespace: demarkus-broker\n", "", 1)
+	if _, err := LoadConfig(writeConfig(t, broken)); err == nil {
+		t.Error("k8s mode without brokerNamespace should fail")
+	}
+}

--- a/tools/demarkus-broker/internal/broker/storage_unix.go
+++ b/tools/demarkus-broker/internal/broker/storage_unix.go
@@ -1,0 +1,22 @@
+//go:build unix
+
+package broker
+
+import (
+	"os"
+	"syscall"
+)
+
+type fileOwner struct {
+	uid, gid int
+}
+
+// ownerOf extracts uid/gid from a stat result; nil when the platform
+// stat shape is unavailable (callers then skip ownership preservation).
+func ownerOf(info os.FileInfo) *fileOwner {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil
+	}
+	return &fileOwner{uid: int(st.Uid), gid: int(st.Gid)}
+}

--- a/tools/demarkus-broker/internal/broker/sweeper.go
+++ b/tools/demarkus-broker/internal/broker/sweeper.go
@@ -88,6 +88,13 @@ func (s *Sweeper) RunLeaderElected(ctx context.Context, leaseName, namespace, id
 	})
 }
 
+// Run starts the sweep loop directly, with no leader election: for
+// single-host (file-backend) deployments, which are single-instance by
+// construction. Multi-replica k8s deployments use RunLeaderElected.
+func (s *Sweeper) Run(ctx context.Context) {
+	s.runLoop(ctx)
+}
+
 // runLoop runs an initial sweep then ticks every Sweeper.interval until
 // ctx is canceled. The eager first pass means a freshly-elected leader
 // doesn't have to wait a full interval before pruning expired grants

--- a/tools/demarkus-broker/internal/broker/sweeper_test.go
+++ b/tools/demarkus-broker/internal/broker/sweeper_test.go
@@ -16,7 +16,7 @@ func TestSweepRemovesExpiredRefreshTokens(t *testing.T) {
 	// refresh tokens are the only thing the sweeper retires.
 	k8s := fake.NewSimpleClientset()
 	cfg := testRefreshConfig()
-	rs := NewRefreshStore(cfg, k8s)
+	rs := NewRefreshStore(cfg, NewK8sSecretStore(k8s))
 	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
 	rs.clock = func() time.Time { return base }
 

--- a/tools/demarkus-broker/internal/broker/world_write_tokens.go
+++ b/tools/demarkus-broker/internal/broker/world_write_tokens.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/latebit-io/demarkus/protocol/token"
-	"k8s.io/client-go/kubernetes"
 )
 
 // worldWriteTokenSecretKey is the data key in the broker's
@@ -55,17 +54,17 @@ type writeTokenRecord struct {
 // only party that ever holds the raw token.
 type worldWriteTokenStore struct {
 	cfg   *Config
-	k8s   kubernetes.Interface
+	store SecretStore
 	clock func() time.Time
 
 	mu    sync.Mutex
 	cache map[string]string // worldName → raw token
 }
 
-func newWorldWriteTokenStore(cfg *Config, k8s kubernetes.Interface) *worldWriteTokenStore {
+func newWorldWriteTokenStore(cfg *Config, store SecretStore) *worldWriteTokenStore {
 	return &worldWriteTokenStore{
 		cfg:   cfg,
-		k8s:   k8s,
+		store: store,
 		clock: time.Now,
 		cache: make(map[string]string),
 	}
@@ -109,15 +108,14 @@ func (s *worldWriteTokenStore) Provision(ctx context.Context, worldName string) 
 	}
 
 	label := worldWriteTokenLabel(worldName)
-	secretName := worldWriteTokenSecretName(worldName)
 
-	// mutateSecret races concurrent broker pods on the broker Secret.
+	// The store mutation races concurrent broker pods on the broker record.
 	// On a fresh world: the closure mints once and the encoded
 	// record lands. On a re-provision (or a loser of the race): the
 	// closure sees existing data and returns it unchanged so the
 	// already-committed token wins.
 	var finalRecord writeTokenRecord
-	err := mutateSecret(ctx, s.k8s, s.cfg.Server.BrokerNamespace, secretName, worldWriteTokenSecretKey, func(existing []byte) ([]byte, error) {
+	err := s.store.Mutate(ctx, s.cfg.worldWriteTokenRef(worldName), func(existing []byte) ([]byte, error) {
 		if len(existing) > 0 {
 			if err := json.Unmarshal(existing, &finalRecord); err != nil {
 				return nil, fmt.Errorf("decode write token record: %w", err)
@@ -180,7 +178,7 @@ func (s *worldWriteTokenStore) Provision(ctx context.Context, worldName string) 
 // never authorize and every write would burn the propagation-race
 // budget pretending kubelet was lagging.
 func (s *worldWriteTokenStore) syncWorldHash(ctx context.Context, world *WorldConfig, label string, entry *token.Entry) error {
-	return mutateSecret(ctx, s.k8s, world.Namespace, world.TokensSecret, TokensSecretKey, func(existing []byte) ([]byte, error) {
+	return s.store.Mutate(ctx, s.cfg.worldTokensRef(world), func(existing []byte) ([]byte, error) {
 		next, err := token.AppendBytes(existing, label, entry)
 		if err == nil {
 			return next, nil

--- a/tools/demarkus-broker/internal/broker/world_write_tokens.go
+++ b/tools/demarkus-broker/internal/broker/world_write_tokens.go
@@ -109,11 +109,8 @@ func (s *worldWriteTokenStore) Provision(ctx context.Context, worldName string) 
 
 	label := worldWriteTokenLabel(worldName)
 
-	// The store mutation races concurrent broker pods on the broker record.
-	// On a fresh world: the closure mints once and the encoded
-	// record lands. On a re-provision (or a loser of the race): the
-	// closure sees existing data and returns it unchanged so the
-	// already-committed token wins.
+	// Invariant: concurrent provisioners converge on the first committed
+	// token; the closure returns existing data unchanged when present.
 	var finalRecord writeTokenRecord
 	err := s.store.Mutate(ctx, s.cfg.worldWriteTokenRef(worldName), func(existing []byte) ([]byte, error) {
 		if len(existing) > 0 {

--- a/tools/demarkus-broker/internal/broker/world_write_tokens_test.go
+++ b/tools/demarkus-broker/internal/broker/world_write_tokens_test.go
@@ -234,10 +234,8 @@ func contains(haystack, needle string) bool {
 	return false
 }
 
-// TestProvisionFileBackend pins the single-host seam: Provision against the
-// file store mints once, lands the hash in the world's local tokens.toml
-// (the file the co-located demarkus-server watches), and re-provision is a
-// no-op that does not rewrite the file.
+// Invariant: file-backend Provision lands the hash in the world's local
+// tokens.toml, and a broker-restart re-provision converges without a rewrite.
 func TestProvisionFileBackend(t *testing.T) {
 	dir := t.TempDir()
 	tokensFile := filepath.Join(dir, "tokens.toml")

--- a/tools/demarkus-broker/internal/broker/world_write_tokens_test.go
+++ b/tools/demarkus-broker/internal/broker/world_write_tokens_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -18,7 +20,7 @@ import (
 func TestWorldWriteTokenStoreProvisionIsIdempotent(t *testing.T) {
 	cfg := testConfig()
 	k8s := fake.NewSimpleClientset()
-	store := newWorldWriteTokenStore(cfg, k8s)
+	store := newWorldWriteTokenStore(cfg, NewK8sSecretStore(k8s))
 
 	first, err := store.Provision(context.Background(), "team-a")
 	if err != nil {
@@ -76,13 +78,13 @@ func TestWorldWriteTokenStoreProvisionRecoversAcrossStores(t *testing.T) {
 	cfg := testConfig()
 	k8s := fake.NewSimpleClientset()
 
-	podA := newWorldWriteTokenStore(cfg, k8s)
+	podA := newWorldWriteTokenStore(cfg, NewK8sSecretStore(k8s))
 	first, err := podA.Provision(context.Background(), "team-a")
 	if err != nil {
 		t.Fatalf("podA.Provision: %v", err)
 	}
 
-	podB := newWorldWriteTokenStore(cfg, k8s)
+	podB := newWorldWriteTokenStore(cfg, NewK8sSecretStore(k8s))
 	second, err := podB.Provision(context.Background(), "team-a")
 	if err != nil {
 		t.Fatalf("podB.Provision: %v", err)
@@ -136,7 +138,7 @@ func TestWorldWriteTokenStoreRewritesStaleWorldEntry(t *testing.T) {
 		Data:       map[string][]byte{TokensSecretKey: staleBytes},
 	})
 
-	store := newWorldWriteTokenStore(cfg, k8s)
+	store := newWorldWriteTokenStore(cfg, NewK8sSecretStore(k8s))
 	raw, err := store.Provision(context.Background(), "team-a")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
@@ -181,7 +183,7 @@ func TestWorldWriteTokenStoreProvisionIgnoresConfiguredOperations(t *testing.T) 
 	cfg := testConfig()
 
 	k8s := fake.NewSimpleClientset()
-	store := newWorldWriteTokenStore(cfg, k8s)
+	store := newWorldWriteTokenStore(cfg, NewK8sSecretStore(k8s))
 	if _, err := store.Provision(context.Background(), "team-a"); err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -202,7 +204,7 @@ func TestWorldWriteTokenStoreProvisionIgnoresConfiguredOperations(t *testing.T) 
 func TestWorldWriteTokenStoreProvisionUnknownWorld(t *testing.T) {
 	cfg := testConfig()
 	k8s := fake.NewSimpleClientset()
-	store := newWorldWriteTokenStore(cfg, k8s)
+	store := newWorldWriteTokenStore(cfg, NewK8sSecretStore(k8s))
 
 	_, err := store.Provision(context.Background(), "no-such-world")
 	if err == nil {
@@ -230,4 +232,74 @@ func contains(haystack, needle string) bool {
 		}
 	}
 	return false
+}
+
+// TestProvisionFileBackend pins the single-host seam: Provision against the
+// file store mints once, lands the hash in the world's local tokens.toml
+// (the file the co-located demarkus-server watches), and re-provision is a
+// no-op that does not rewrite the file.
+func TestProvisionFileBackend(t *testing.T) {
+	dir := t.TempDir()
+	tokensFile := filepath.Join(dir, "tokens.toml")
+	cfg := &Config{
+		Storage: StorageConfig{Backend: storageBackendFile, Dir: filepath.Join(dir, "state")},
+		Worlds: []WorldConfig{{
+			Name:            "soul",
+			TokensFile:      tokensFile,
+			InternalAddress: "localhost:6309",
+			DefaultToken:    TokenScope{Paths: []string{"/*"}},
+		}},
+	}
+	store := newWorldWriteTokenStore(cfg, NewFileSecretStore())
+
+	raw, err := store.Provision(context.Background(), "soul")
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if raw == "" {
+		t.Fatal("Provision returned empty token")
+	}
+
+	parsed, err := token.ParseBytes(mustRead(t, tokensFile))
+	if err != nil {
+		t.Fatalf("parse tokens.toml: %v", err)
+	}
+	entry, ok := parsed.Tokens[worldWriteTokenLabel("soul")]
+	if !ok {
+		t.Fatalf("tokens.toml missing label %q", worldWriteTokenLabel("soul"))
+	}
+	if entry.Hash != protocol.HashToken(raw) {
+		t.Error("tokens.toml hash does not match minted token")
+	}
+
+	// Fresh store (broker restart): converges on the same token, no rewrite.
+	before := mustStat(t, tokensFile)
+	raw2, err := newWorldWriteTokenStore(cfg, NewFileSecretStore()).Provision(context.Background(), "soul")
+	if err != nil {
+		t.Fatalf("re-Provision: %v", err)
+	}
+	if raw2 != raw {
+		t.Error("re-provision minted a different token instead of converging")
+	}
+	if after := mustStat(t, tokensFile); !after.ModTime().Equal(before.ModTime()) {
+		t.Error("tokens.toml rewritten on steady-state re-provision")
+	}
+}
+
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func mustStat(t *testing.T, path string) os.FileInfo {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return info
 }

--- a/tools/demarkus-broker/main.go
+++ b/tools/demarkus-broker/main.go
@@ -84,9 +84,19 @@ func run(configPath, kubeconfigPath string, log *slog.Logger) error {
 		return err
 	}
 
-	k8s, err := newKubeClient(kubeconfigPath)
-	if err != nil {
-		return err
+	// Storage backend: kubernetes needs a client; file mode (single-host)
+	// runs with no cluster at all.
+	var store broker.SecretStore
+	var k8s kubernetes.Interface
+	if cfg.FileBackend() {
+		store = broker.NewFileSecretStore()
+		log.Info("broker: file storage backend", "dir", cfg.Storage.Dir)
+	} else {
+		k8s, err = newKubeClient(kubeconfigPath)
+		if err != nil {
+			return err
+		}
+		store = broker.NewK8sSecretStore(k8s)
 	}
 
 	// Discovery does an eager IdP fetch at startup — same failure mode
@@ -114,7 +124,7 @@ func run(configPath, kubeconfigPath string, log *slog.Logger) error {
 	}
 	log.Info("broker: id_token signer ready", "kid", idTokenSigner.KeyID())
 
-	srv := broker.NewServer(cfg, signer, verifier, k8s, discovery, idTokenSigner, log)
+	srv := broker.NewServer(cfg, signer, verifier, store, discovery, idTokenSigner, log)
 	if cfg.RateLimit.Disabled {
 		log.Info("broker: rate limit disabled (rateLimit.disabled=true)")
 	} else {
@@ -184,16 +194,24 @@ func run(configPath, kubeconfigPath string, log *slog.Logger) error {
 	if !cfg.Sweeper.Disabled {
 		// Share the Server's refresh-token store so the sweeper
 		// retires expired grants from the same in-memory cache +
-		// Secret view the /device/token refresh-grant handler uses.
+		// store view the /device/token refresh-grant handler uses.
 		// Server owns the lifecycle; Sweeper just borrows.
 		sweeper := broker.NewSweeper(k8s, srv.RefreshStore(), cfg.Sweeper.Interval, log)
-		identity := brokerIdentity()
-		log.Info("broker: starting sweeper",
-			"interval", cfg.Sweeper.Interval, "leaseName", cfg.Sweeper.LeaseName,
-			"namespace", cfg.Server.BrokerNamespace, "identity", identity)
-		sweepWG.Go(func() {
-			sweeper.RunLeaderElected(sweepCtx, cfg.Sweeper.LeaseName, cfg.Server.BrokerNamespace, identity)
-		})
+		if cfg.FileBackend() {
+			// Single-instance by construction: no Lease, no election.
+			log.Info("broker: starting sweeper (single-host)", "interval", cfg.Sweeper.Interval)
+			sweepWG.Go(func() {
+				sweeper.Run(sweepCtx)
+			})
+		} else {
+			identity := brokerIdentity()
+			log.Info("broker: starting sweeper",
+				"interval", cfg.Sweeper.Interval, "leaseName", cfg.Sweeper.LeaseName,
+				"namespace", cfg.Server.BrokerNamespace, "identity", identity)
+			sweepWG.Go(func() {
+				sweeper.RunLeaderElected(sweepCtx, cfg.Sweeper.LeaseName, cfg.Server.BrokerNamespace, identity)
+			})
+		}
 	} else {
 		log.Info("broker: sweeper disabled (sweeper.disabled=true)")
 	}

--- a/tools/demarkus-broker/main.go
+++ b/tools/demarkus-broker/main.go
@@ -192,10 +192,8 @@ func run(configPath, kubeconfigPath string, log *slog.Logger) error {
 	defer cancelSweep()
 	var sweepWG sync.WaitGroup
 	if !cfg.Sweeper.Disabled {
-		// Share the Server's refresh-token store so the sweeper
-		// retires expired grants from the same in-memory cache +
-		// store view the /device/token refresh-grant handler uses.
-		// Server owns the lifecycle; Sweeper just borrows.
+		// Server owns the refresh store's lifecycle; the sweeper borrows
+		// the same instance so both share one view of the grants.
 		sweeper := broker.NewSweeper(k8s, srv.RefreshStore(), cfg.Sweeper.Interval, log)
 		if cfg.FileBackend() {
 			// Single-instance by construction: no Lease, no election.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional single-host file storage backend for broker credentials (file mode); Kubernetes remains the default.
  * Introduced storage-backend configuration with mode-specific validation and support for per-world `tokensFile`.
  * Updated sweeper startup for single-instance deployments to run immediately (no leader election).
* **Bug Fixes**
  * Improved credential persistence with atomic read-modify-write behavior, concurrency safety, permission preservation, and no-op writes when values are unchanged.
* **Tests**
  * Added/updated coverage for file-backend mutation, refresh lifecycle across restarts, revocation, provisioning, and backend validation (including path-collision checks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->