### PR TITLE
fix(release): dispatch pin-bump from release.yml (release trigger was dead)

### DIFF
--- a/.github/workflows/plugin-pin-bump.yml
+++ b/.github/workflows/plugin-pin-bump.yml
@@ -2,14 +2,14 @@ name: Bump plugin binary pins
 
 # Keeps the demarkus-memory plugin's pinned managed-binary versions current
 # without manual churn: resolves the latest server/client/tools releases and, if
-# they differ from the pins, opens (or updates) a single PR. Runs daily, on every
-# release, and on demand. The bump is idempotent, so the overlapping triggers
-# converge on one PR.
+# they differ from the pins, opens (or updates) a single PR. Dispatched by
+# release.yml right after any binary release (a release trigger here would be
+# dead: GoReleaser publishes with the default GITHUB_TOKEN, whose events do not
+# trigger workflows). The daily cron is the safety-net backstop. The bump is
+# idempotent, so overlapping triggers converge on one PR.
 on:
   schedule:
     - cron: "23 7 * * *"
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,6 @@ on:
 permissions:
   contents: write
   packages: write
-  # actions: write lets the final job dispatch the pin-bump workflow.
-  actions: write
 
 jobs:
   detect-changes:
@@ -548,6 +546,10 @@ jobs:
     needs: [release-server, release-client, release-tools]
     if: ${{ !cancelled() && (needs.release-server.result == 'success' || needs.release-client.result == 'success' || needs.release-tools.result == 'success') }}
     runs-on: ubuntu-latest
+    # Job-level permissions replace the workflow block: this job only
+    # dispatches, so it gets exactly actions: write and nothing else.
+    permissions:
+      actions: write
     steps:
       - name: Trigger plugin pin bump
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   contents: write
   packages: write
+  # actions: write lets the final job dispatch the pin-bump workflow.
+  actions: write
 
 jobs:
   detect-changes:
@@ -535,3 +537,19 @@ jobs:
           VER="${{ needs.semver-tools.outputs.new_version }}"
           helm package deploy/helm/demarkus-broker --version "$VER" --app-version "$VER" --destination /tmp/charts
           helm push "/tmp/charts/demarkus-broker-${VER}.tgz" oci://ghcr.io/latebit-io/charts
+
+  # Dispatch the pin-bump workflow after any binary release. The bump
+  # workflow's own release trigger never fires: GoReleaser publishes with
+  # the default GITHUB_TOKEN, and GitHub suppresses workflow triggering
+  # from events that token creates. workflow_dispatch is the documented
+  # exception to that suppression, so an explicit dispatch here is what
+  # makes the pin chain release-driven instead of daily-cron-driven.
+  dispatch-pin-bump:
+    needs: [release-server, release-client, release-tools]
+    if: ${{ !cancelled() && (needs.release-server.result == 'success' || needs.release-client.result == 'success' || needs.release-tools.result == 'success') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger plugin pin bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run plugin-pin-bump.yml --repo "${{ github.repository }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the plugin pin bump workflow to stop triggering on release publish events.
  * Added an automated dispatch step to run the plugin pin bump workflow after the relevant binary release jobs complete successfully.
  * Kept the daily scheduled run as a safety net to prevent missed updates.
  * Adjusted workflow permissions to allow the automated workflow dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->