### PR TITLE
feat(client): ship demarkus-agent as a release tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,7 +410,7 @@ jobs:
           GORELEASER_CURRENT_TAG: "client/v${{ needs.semver-client.outputs.new_version }}"
 
       # Stage pre-built agent binaries (built by client/.goreleaser.yml's
-      # demarkus-agent build entry, image-only — no archive) into
+      # demarkus-agent build entry, which also ships a linux tarball) into
       # dist/docker/<arch>/ so the Dockerfile is COPY-only and buildx
       # skips QEMU compilation.
       - name: Stage binaries for Docker build

--- a/client/.goreleaser.yml
+++ b/client/.goreleaser.yml
@@ -58,10 +58,9 @@ builds:
     ldflags:
       - -s -w -X main.version={{ .Version }}
 
-  # demarkus-agent ships only as a container image (release-client job
-  # bundles it into ghcr.io/.../demarkus-agent). Listed under builds:
-  # so goreleaser cross-compiles per-arch binaries that the Dockerfile
-  # then COPYs in — no archive entry, no end-user binary tarball.
+  # demarkus-agent ships as a container image (release-client bundles it
+  # into ghcr.io/.../demarkus-agent) AND as a linux tarball for native
+  # single-host installs (install.sh --with-agent).
   - id: demarkus-agent
     main: ./cmd/demarkus-agent
     binary: demarkus-agent
@@ -76,7 +75,7 @@ builds:
     goarm:
       - "7"
     ldflags:
-      - -s -w
+      - -s -w -X main.version={{ .Version }}
 
 archives:
   - id: demarkus
@@ -93,6 +92,11 @@ archives:
     builds:
       - demarkus-mcp
     name_template: "demarkus-mcp_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+  - id: demarkus-agent
+    builds:
+      - demarkus-agent
+    name_template: "demarkus-agent_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
   name_template: "demarkus-client_checksums.txt"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linux tarball releases for the agent, enabling single-host installations alongside container images.
  * Tarballs now include versioned filenames and embedded version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->