### PR TITLE
feat(install): probe self-dial and pin the domain to loopback on hair…

### DIFF
--- a/docs/site/deployment/single-host.md
+++ b/docs/site/deployment/single-host.md
@@ -113,6 +113,7 @@ To put the library behind broker SSO (org login, per-reader identity):
 
   Route the MCP gateway (`127.0.0.1:8081`) from the same or a second hostname as you prefer; `/knowledge-join` and the library talk to whatever `publicURL` resolves to.
 - With a Let's Encrypt domain the generated config dials the world at `<domain>:6309` with verification on (the certificate can never match `localhost`); with a self-signed cert it dials `localhost:6309` with `worldDialer.insecureSkipVerify: true`.
+- Dialing the public domain from the host itself requires hairpin NAT, which home routers often lack (external clients work, same-host components see the world as unreadable). The installer probes this after the world starts and, when the dial fails, pins the domain to loopback in `/etc/hosts` — the dial then bypasses NAT while the certificate name still matches. A failed probe with the pin already in place aborts the install with diagnostics instead.
 
 ## Verify the stack
 

--- a/install.sh
+++ b/install.sh
@@ -654,13 +654,11 @@ verify_service_running() {
 self_dial_probe() {
   local cli="$1"
   local domain="$2"
-  local timeout_cmd=""
-  if command -v timeout >/dev/null 2>&1; then timeout_cmd="timeout 15"; fi
-  if $timeout_cmd "$cli" "mark://${domain}/health" >/dev/null 2>&1; then
+  if timeout 15 "$cli" "mark://${domain}/health" >/dev/null 2>&1; then
     return 0
   fi
   sleep 2
-  $timeout_cmd "$cli" "mark://${domain}/health" >/dev/null 2>&1
+  timeout 15 "$cli" "mark://${domain}/health" >/dev/null 2>&1
 }
 
 # hosts_maps_domain reports whether a non-comment HOSTS_FILE line already
@@ -670,12 +668,9 @@ hosts_maps_domain() {
   awk -v d="$domain" '$1 !~ /^#/ { for (i = 2; i <= NF; i++) if ($i == d) found = 1 } END { exit found ? 0 : 1 }' "$HOSTS_FILE"
 }
 
-# ensure_self_dial verifies this host can read its own world at the public
-# domain. Home-NAT networks often cannot hairpin UDP back to their own
-# public IP, which strands same-host dialers (broker, library): the install
-# looks healthy while the world is unreadable. On failure, pin the domain
-# to loopback in HOSTS_FILE so the dial bypasses NAT while the certificate
-# name keeps matching, then re-probe.
+# ensure_self_dial proves this host can read its own world at the public
+# domain; home NAT often cannot loop back, stranding same-host dialers.
+# On failure, pin the domain to loopback in HOSTS_FILE and re-probe.
 ensure_self_dial() {
   local domain="$1"
   if [ "$PLATFORM" != "linux" ]; then return; fi
@@ -684,6 +679,12 @@ ensure_self_dial() {
   if [ ! -x "$cli" ]; then
     log_warn "Client binary not found at ${cli}; skipping the self-dial check for ${domain}"
     return
+  fi
+  # Fail closed: an unbounded probe could hang on the very black-holed
+  # dial this check exists to detect.
+  if ! command -v timeout >/dev/null 2>&1; then
+    log_error "timeout (coreutils) is required for the self-dial check; install it and re-run"
+    exit 1
   fi
 
   log_step "Checking this host can read its own world (mark://${domain})"
@@ -700,6 +701,14 @@ ensure_self_dial() {
 
   log_warn "This host cannot reach its own world at mark://${domain} (likely hairpin NAT)"
   log_info "Pinning ${domain} to loopback in ${HOSTS_FILE} so same-host components dial locally"
+  # A hosts file without a trailing newline would merge the new entry into
+  # its last line; normalize first.
+  if [ -s "$HOSTS_FILE" ] && [ -n "$(tail -c 1 "$HOSTS_FILE")" ]; then
+    if ! printf '\n' >> "$HOSTS_FILE"; then
+      log_error "Could not update ${HOSTS_FILE}"
+      exit 1
+    fi
+  fi
   if ! printf '127.0.0.1 %s # demarkus: self-dial (hairpin NAT workaround)\n' "$domain" >> "$HOSTS_FILE"; then
     log_error "Could not update ${HOSTS_FILE}"
     exit 1

--- a/install.sh
+++ b/install.sh
@@ -67,6 +67,8 @@ SYSTEMD_DIR="/etc/systemd/system"
 if [ "${DEMARKUS_INSTALL_TESTMODE:-}" = "1" ] && [ -n "${DEMARKUS_TEST_SYSTEMD_DIR:-}" ]; then
   SYSTEMD_DIR="$DEMARKUS_TEST_SYSTEMD_DIR"
 fi
+# Touched only by the hairpin self-dial fallback (ensure_self_dial).
+HOSTS_FILE="/etc/hosts"
 
 # Global state
 SUDO=""       # set to "sudo" if needed for INSTALL_DIR writes
@@ -644,6 +646,70 @@ verify_service_running() {
     log_info "Check service status with: systemctl status demarkus"
     exit 1
   fi
+}
+
+# self_dial_probe reads the world's health doc at the public domain with
+# certificate verification on; one retry covers a world still settling
+# after a restart.
+self_dial_probe() {
+  local cli="$1"
+  local domain="$2"
+  local timeout_cmd=""
+  if command -v timeout >/dev/null 2>&1; then timeout_cmd="timeout 15"; fi
+  if $timeout_cmd "$cli" "mark://${domain}/health" >/dev/null 2>&1; then
+    return 0
+  fi
+  sleep 2
+  $timeout_cmd "$cli" "mark://${domain}/health" >/dev/null 2>&1
+}
+
+# hosts_maps_domain reports whether a non-comment HOSTS_FILE line already
+# maps the domain (exact token match, not substring).
+hosts_maps_domain() {
+  local domain="$1"
+  awk -v d="$domain" '$1 !~ /^#/ { for (i = 2; i <= NF; i++) if ($i == d) found = 1 } END { exit found ? 0 : 1 }' "$HOSTS_FILE"
+}
+
+# ensure_self_dial verifies this host can read its own world at the public
+# domain. Home-NAT networks often cannot hairpin UDP back to their own
+# public IP, which strands same-host dialers (broker, library): the install
+# looks healthy while the world is unreadable. On failure, pin the domain
+# to loopback in HOSTS_FILE so the dial bypasses NAT while the certificate
+# name keeps matching, then re-probe.
+ensure_self_dial() {
+  local domain="$1"
+  if [ "$PLATFORM" != "linux" ]; then return; fi
+
+  local cli="${INSTALL_DIR}/demarkus"
+  if [ ! -x "$cli" ]; then
+    log_warn "Client binary not found at ${cli}; skipping the self-dial check for ${domain}"
+    return
+  fi
+
+  log_step "Checking this host can read its own world (mark://${domain})"
+  if self_dial_probe "$cli" "$domain"; then
+    log_info "Self-dial OK"
+    return
+  fi
+
+  if hosts_maps_domain "$domain"; then
+    log_error "mark://${domain} is unreadable from this host even though ${HOSTS_FILE} already maps ${domain}."
+    log_error "Check the world service (journalctl -u demarkus --no-pager), UDP 6309, and that the TLS certificate matches ${domain}"
+    exit 1
+  fi
+
+  log_warn "This host cannot reach its own world at mark://${domain} (likely hairpin NAT)"
+  log_info "Pinning ${domain} to loopback in ${HOSTS_FILE} so same-host components dial locally"
+  if ! printf '127.0.0.1 %s # demarkus: self-dial (hairpin NAT workaround)\n' "$domain" >> "$HOSTS_FILE"; then
+    log_error "Could not update ${HOSTS_FILE}"
+    exit 1
+  fi
+  if ! self_dial_probe "$cli" "$domain"; then
+    log_error "mark://${domain} is still unreadable after pinning it to loopback."
+    log_error "Check the world service (journalctl -u demarkus --no-pager), UDP 6309, and that the TLS certificate matches ${domain}"
+    exit 1
+  fi
+  log_info "Self-dial OK via loopback; certificate verification stays on"
 }
 
 # --- Service management ---
@@ -1550,6 +1616,14 @@ do_install() {
 
   # Verify the service actually started
   verify_service_running
+
+  # Same-host dialers (broker, library) reach the world by its public name
+  # with verification on; prove that works from this host before installing
+  # them, and pin the name to loopback when hairpin NAT breaks it.
+  if [ "$PLATFORM" = "linux" ] && [ -n "$domain" ] && [ "$no_tls" = false ] \
+    && { [ "$with_broker" = true ] || [ "$with_library" = true ]; }; then
+    ensure_self_dial "$domain"
+  fi
 
   # Optional single-host stack components (after the world server is up:
   # the broker writes its tokens file, the library reads its documents).


### PR DESCRIPTION
…pin NAT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced installer behavior for same-host broker and library setup when TLS is enabled with a public domain.
  * Added connectivity verification that retries after startup and, when needed, pins the domain to loopback in `/etc/hosts` as a hairpin NAT workaround.
  * If verification still fails (or if a mapping already exists), the installer aborts with clearer diagnostics.

* **Documentation**
  * Updated the “TLS and the reverse proxy” deployment guide with details about the self-connectivity checks and loopback mapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->