### PR TITLE
fix(install): make cert renewal setup reachable on re-run and timer-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       client: ${{ steps.filter.outputs.client }}
       broker: ${{ steps.filter.outputs.broker }}
       charts: ${{ steps.filter.outputs.charts }}
+      install: ${{ steps.filter.outputs.install }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -45,6 +46,9 @@ jobs:
               - 'protocol/**'
             charts:
               - 'deploy/helm/**'
+            install:
+              - 'install.sh'
+              - 'scripts/test-install-renewal.sh'
 
   test-protocol:
     needs: detect-changes
@@ -128,6 +132,18 @@ jobs:
         run: cd tools && go vet ./demarkus-broker/...
       - name: Build
         run: cd tools && go build -o /dev/null ./demarkus-broker
+
+  test-install:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.install == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Shellcheck install.sh
+        run: shellcheck -S error install.sh scripts/test-install-renewal.sh
+      - name: Test certbot renewal wiring
+        run: bash scripts/test-install-renewal.sh
 
   test-charts:
     needs: detect-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,10 +138,20 @@ jobs:
     if: needs.detect-changes.outputs.install == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Lints and runs a local script; no authenticated git operation, no API call.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      # install.sh carries a pre-existing warning/info backlog (SC2034, SC2206,
+      # SC2059, SC2024, SC2001) that is out of scope here, so it is gated at
+      # error only. The test script is new and held to warning.
       - name: Shellcheck install.sh
-        run: shellcheck -S error install.sh scripts/test-install-renewal.sh
+        run: shellcheck -S error install.sh
+      - name: Shellcheck the renewal test
+        run: shellcheck -S warning scripts/test-install-renewal.sh
       - name: Test certbot renewal wiring
         run: bash scripts/test-install-renewal.sh
 

--- a/install.sh
+++ b/install.sh
@@ -570,15 +570,32 @@ read_crontab() {
   esac
 }
 
+# strip_cron_entries prints TABLE without demarkus-owned entries. grep exits 1
+# when it filters every line out, which is the normal "our entry was the only
+# one" case, so only a status above 1 is a real failure. Under set -e an
+# unguarded assignment from that grep would abort the script outright.
+strip_cron_entries() {
+  local table="$1" out="" rc=0
+
+  if [ -n "$table" ]; then
+    out=$(printf '%s\n' "$table" | grep -Ev "$(cert_cron_pattern)") || rc=$?
+    if [ "$rc" -gt 1 ]; then
+      return "$rc"
+    fi
+  fi
+  if [ -n "$out" ]; then
+    printf '%s\n' "$out"
+  fi
+  return 0
+}
+
 # compose_cron_table prints TABLE with demarkus-owned entries dropped and ENTRY
 # appended. Filtering with grep -v '^$' instead would strip blank lines the user
 # put in their own crontab.
 compose_cron_table() {
-  local table="$1" entry="$2" kept=""
+  local table="$1" entry="$2" kept
 
-  if [ -n "$table" ]; then
-    kept=$(printf '%s\n' "$table" | grep -Ev "$(cert_cron_pattern)")
-  fi
+  kept=$(strip_cron_entries "$table") || return 1
   if [ -n "$kept" ]; then
     printf '%s\n%s\n' "$kept" "$entry"
   else
@@ -643,15 +660,16 @@ clear_cert_renewal() {
       failed=1
     fi
   fi
-  local table rc
-  table=$(read_crontab)
-  rc=$?
+  # Capture guarded with ||: set -e aborts on a bare assignment from a command
+  # substitution that exits nonzero, and rc 1 (no crontab) is a normal state.
+  local table rc=0
+  table=$(read_crontab) || rc=$?
   if [ "$rc" -eq 2 ]; then
     # Leaving a stale entry is recoverable; rewriting from an unread table is not.
     log_warn "Could not read the root crontab; leaving any stale renewal entry in place"
     failed=1
   elif [ "$rc" -eq 0 ] && printf '%s\n' "$table" | grep -Eq "$(cert_cron_pattern)"; then
-    if printf '%s\n' "$table" | grep -Ev "$(cert_cron_pattern)" | crontab -; then
+    if strip_cron_entries "$table" | crontab -; then
       cleared=true
     else
       log_warn "Could not drop the stale certbot renewal cron entry"
@@ -682,14 +700,15 @@ setup_cert_renewal() {
     write_cert_deploy_hook "$hook"
   fi
 
-  local table rc
-  table=$(read_crontab)
-  rc=$?
+  # Guarded with ||: set -e aborts a bare assignment whose command substitution
+  # exits nonzero, and rc 1 (no root crontab yet) is the normal fresh-host case.
+  local table rc=0
+  table=$(read_crontab) || rc=$?
   if [ "$rc" -eq 2 ]; then
     log_error "Could not read the root crontab; refusing to rewrite it. Renewal will not reload the services"
     exit 1
   fi
-  [ "$rc" -eq 1 ] && table=""
+  if [ "$rc" -eq 1 ]; then table=""; fi
 
   if printf '%s\n' "$table" | grep -q "$CERT_CRON_MARKER"; then
     log_info "Certbot renewal cron already configured"
@@ -721,14 +740,13 @@ setup_library_cert_renewal() {
   # server-only install may have written the server-only version of it.
   write_cert_deploy_hook "$hook"
 
-  local table rc
-  table=$(read_crontab)
-  rc=$?
+  local table rc=0
+  table=$(read_crontab) || rc=$?
   if [ "$rc" -eq 2 ]; then
     log_error "Could not read the root crontab; refusing to rewrite it. Renewal will not restart the library"
     exit 1
   fi
-  [ "$rc" -eq 1 ] && table=""
+  if [ "$rc" -eq 1 ]; then table=""; fi
 
   # Ours only: a user job mentioning the library must not suppress our entry.
   if printf '%s\n' "$table" | grep -F "$CERT_CRON_MARKER" | grep -q "try-restart demarkus-library"; then
@@ -2351,14 +2369,13 @@ do_uninstall() {
 
   # Remove certbot renewal cron and the deploy hook
   if [ "$PLATFORM" = "linux" ]; then
-    local cron_table cron_rc
-    cron_table=$(read_crontab)
-    cron_rc=$?
+    local cron_table cron_rc=0
+    cron_table=$(read_crontab) || cron_rc=$?
     if [ "$cron_rc" -eq 2 ]; then
       log_warn "Could not read the root crontab; the renewal entry may remain"
       uninstall_errors=$((uninstall_errors + 1))
     elif [ "$cron_rc" -eq 0 ] && printf '%s\n' "$cron_table" | grep -Eq "$(cert_cron_pattern)"; then
-      if ! printf '%s\n' "$cron_table" | grep -Ev "$(cert_cron_pattern)" | crontab -; then
+      if ! strip_cron_entries "$cron_table" | crontab -; then
         log_warn "Could not drop the certbot renewal entry from the root crontab"
         uninstall_errors=$((uninstall_errors + 1))
       fi

--- a/install.sh
+++ b/install.sh
@@ -543,23 +543,67 @@ fix_cert_permissions() {
 CERT_DEPLOY_HOOK="/etc/letsencrypt/renewal-hooks/deploy/demarkus-reload.sh"
 
 # write_cert_deploy_hook installs the reload command as a certbot deploy hook.
-# The packaged certbot.timer renews on its own schedule and runs only this
-# directory, ignoring our cron's --deploy-hook; without the file, a
-# timer-driven renewal leaves the services holding the previous certificate.
+# certbot.timer renews on its own schedule and runs only this directory, so
+# without the file a timer-driven renewal leaves stale certs loaded.
+# Staged through a temp file in the same directory: certbot executes whatever
+# is at this path, so it must never be observable half-written.
 write_cert_deploy_hook() {
   local hook="$1"
+  local dir tmp
+  dir=$(dirname "$CERT_DEPLOY_HOOK")
 
-  if ! mkdir -p "$(dirname "$CERT_DEPLOY_HOOK")"; then
-    log_error "Could not create $(dirname "$CERT_DEPLOY_HOOK"); renewals will not reload the services"
+  if ! mkdir -p "$dir"; then
+    log_error "Could not create ${dir}; renewals will not reload the services"
     exit 1
   fi
-  cat > "$CERT_DEPLOY_HOOK" << EOF
+  if ! tmp=$(mktemp "${CERT_DEPLOY_HOOK}.XXXXXX"); then
+    log_error "Could not stage the certbot deploy hook in ${dir}"
+    exit 1
+  fi
+
+  if ! cat > "$tmp" << EOF
 #!/bin/sh
 # Managed by demarkus install.sh. Reloads the certificate holders after a
 # successful renewal, whichever mechanism triggered it.
 ${hook}
 EOF
-  chmod 755 "$CERT_DEPLOY_HOOK"
+  then
+    rm -f "$tmp"
+    log_error "Could not write the certbot deploy hook"
+    exit 1
+  fi
+  if ! chmod 755 "$tmp" || ! mv -f "$tmp" "$CERT_DEPLOY_HOOK"; then
+    rm -f "$tmp"
+    log_error "Could not install the certbot deploy hook at ${CERT_DEPLOY_HOOK}"
+    exit 1
+  fi
+}
+
+# clear_cert_renewal drops demarkus-managed renewal wiring when this host is no
+# longer Let's Encrypt backed, so a switch to custom certs or --no-tls does not
+# leave a cron renewing and reloading against a cert nothing uses. Only our own
+# cron line and hook path are touched; user-managed certbot config is left.
+clear_cert_renewal() {
+  if [ "$PLATFORM" != "linux" ]; then return; fi
+
+  local cleared=false
+  if [ -f "$CERT_DEPLOY_HOOK" ]; then
+    if rm -f "$CERT_DEPLOY_HOOK"; then
+      cleared=true
+    else
+      log_warn "Could not remove the stale deploy hook ${CERT_DEPLOY_HOOK}"
+    fi
+  fi
+  if crontab -l 2>/dev/null | grep -q "certbot renew.*demarkus"; then
+    if (crontab -l 2>/dev/null | grep -v "certbot renew.*demarkus") | crontab -; then
+      cleared=true
+    else
+      log_warn "Could not drop the stale certbot renewal cron entry"
+    fi
+  fi
+  if [ "$cleared" = true ]; then
+    log_info "Removed demarkus certbot renewal wiring (no longer using Let's Encrypt)"
+  fi
 }
 
 setup_cert_renewal() {
@@ -1620,6 +1664,7 @@ do_install() {
   if [ -n "$tls_cert" ] && [ -n "$tls_key" ]; then
     # User-provided certificates
     setup_custom_tls "$tls_cert" "$tls_key"
+    clear_cert_renewal
     tls_cert_path="${CONFIG_DIR}/tls/cert.pem"
     tls_key_path="${CONFIG_DIR}/tls/key.pem"
   elif [ -n "$domain" ] && [ "$no_tls" = false ]; then
@@ -1637,8 +1682,12 @@ do_install() {
   elif [ -d "${CONFIG_DIR}/tls" ] && [ -f "${CONFIG_DIR}/tls/cert.pem" ]; then
     # Existing custom certs from a previous install
     log_info "Using existing custom certificates from ${CONFIG_DIR}/tls/"
+    clear_cert_renewal
     tls_cert_path="${CONFIG_DIR}/tls/cert.pem"
     tls_key_path="${CONFIG_DIR}/tls/key.pem"
+  else
+    # No TLS material: --no-tls, or a domainless install.
+    clear_cert_renewal
   fi
 
   # System tuning
@@ -2211,8 +2260,13 @@ do_uninstall() {
 
   # Remove certbot renewal cron and the deploy hook
   if [ "$PLATFORM" = "linux" ]; then
-    (crontab -l 2>/dev/null | grep -v "certbot renew.*demarkus" | crontab -) 2>/dev/null || true
-    rm -f "$CERT_DEPLOY_HOOK" 2>/dev/null || log_warn "Could not remove ${CERT_DEPLOY_HOOK}"
+    if crontab -l 2>/dev/null | grep -q "certbot renew.*demarkus"; then
+      if ! (crontab -l 2>/dev/null | grep -v "certbot renew.*demarkus") | crontab -; then
+        log_warn "Could not drop the certbot renewal entry from the root crontab"
+        uninstall_errors=$((uninstall_errors + 1))
+      fi
+    fi
+    remove_path "$CERT_DEPLOY_HOOK"
   fi
 
   if [ "$uninstall_errors" -ne 0 ]; then

--- a/install.sh
+++ b/install.sh
@@ -571,9 +571,8 @@ read_crontab() {
 }
 
 # strip_cron_entries prints TABLE without demarkus-owned entries. grep exits 1
-# when it filters every line out, which is the normal "our entry was the only
-# one" case, so only a status above 1 is a real failure. Under set -e an
-# unguarded assignment from that grep would abort the script outright.
+# when it filters everything out, which is success here, and would otherwise
+# trip set -e; only a status above 1 is a real failure.
 strip_cron_entries() {
   local table="$1" out="" rc=0
 
@@ -644,10 +643,9 @@ EOF
 # longer Let's Encrypt backed, so a switch to custom certs or --no-tls does not
 # leave a cron renewing and reloading against a cert nothing uses. Only our own
 # cron line and hook path are touched; user-managed certbot config is left.
-# Returns nonzero if any part of the teardown failed so the caller reports it.
-# Deliberately not fatal: this runs after cert material is already written, and
-# aborting here would leave the service unit unregenerated, which is worse than
-# a leftover entry that renews a certificate nothing reads.
+# Returns nonzero on a failed teardown but is deliberately not fatal: it runs
+# after cert material is written, so aborting would leave the unit
+# unregenerated — worse than a leftover entry renewing an unused cert.
 clear_cert_renewal() {
   if [ "$PLATFORM" != "linux" ]; then return 0; fi
 
@@ -1788,8 +1786,15 @@ do_install() {
     setup_cert_renewal "$domain"
     tls_cert_path="/etc/letsencrypt/live/${domain}/fullchain.pem"
     tls_key_path="/etc/letsencrypt/live/${domain}/privkey.pem"
-  elif [ -d "${CONFIG_DIR}/tls" ] && [ -f "${CONFIG_DIR}/tls/cert.pem" ]; then
-    # Existing custom certs from a previous install
+  elif [ -d "${CONFIG_DIR}/tls" ] \
+    && { [ -f "${CONFIG_DIR}/tls/cert.pem" ] || [ -f "${CONFIG_DIR}/tls/key.pem" ]; }; then
+    # Existing custom certs from a previous install. Half a pair would configure
+    # the unit against a missing file and crash-loop the service on start.
+    if [ ! -f "${CONFIG_DIR}/tls/cert.pem" ] || [ ! -f "${CONFIG_DIR}/tls/key.pem" ]; then
+      log_error "Incomplete custom TLS material in ${CONFIG_DIR}/tls/: need both cert.pem and key.pem"
+      log_error "Restore the missing file, or pass --tls-cert/--tls-key, or --no-tls"
+      exit 1
+    fi
     log_info "Using existing custom certificates from ${CONFIG_DIR}/tls/"
     clear_cert_renewal || report_stale_renewal
     tls_cert_path="${CONFIG_DIR}/tls/cert.pem"

--- a/install.sh
+++ b/install.sh
@@ -518,8 +518,8 @@ setup_tls() {
 
   fix_cert_permissions "$domain"
 
-  # Set up auto-renewal with SIGHUP reload
-  setup_cert_renewal "$domain"
+  # Renewal setup belongs to the caller: this function is skipped entirely when
+  # the cert already exists, so wiring it here left re-runs with no reload hook.
 
   log_info "TLS configured for ${domain}"
 }
@@ -540,6 +540,28 @@ fix_cert_permissions() {
   log_info "Certificate permissions updated for ${SERVICE_NAME} user"
 }
 
+CERT_DEPLOY_HOOK="/etc/letsencrypt/renewal-hooks/deploy/demarkus-reload.sh"
+
+# write_cert_deploy_hook installs the reload command as a certbot deploy hook.
+# The packaged certbot.timer renews on its own schedule and runs only this
+# directory, ignoring our cron's --deploy-hook; without the file, a
+# timer-driven renewal leaves the services holding the previous certificate.
+write_cert_deploy_hook() {
+  local hook="$1"
+
+  if ! mkdir -p "$(dirname "$CERT_DEPLOY_HOOK")"; then
+    log_error "Could not create $(dirname "$CERT_DEPLOY_HOOK"); renewals will not reload the services"
+    exit 1
+  fi
+  cat > "$CERT_DEPLOY_HOOK" << EOF
+#!/bin/sh
+# Managed by demarkus install.sh. Reloads the certificate holders after a
+# successful renewal, whichever mechanism triggered it.
+${hook}
+EOF
+  chmod 755 "$CERT_DEPLOY_HOOK"
+}
+
 setup_cert_renewal() {
   local domain="$1"
 
@@ -547,6 +569,11 @@ setup_cert_renewal() {
 
   local hook='pidof demarkus-server | xargs -r kill -HUP'
   local cron_line="0 */12 * * * certbot renew --quiet --deploy-hook \"${hook}\""
+
+  # Never downgrade the library-aware hook back to the server-only one.
+  if [ ! -f "$CERT_DEPLOY_HOOK" ] || ! grep -q "demarkus-library" "$CERT_DEPLOY_HOOK"; then
+    write_cert_deploy_hook "$hook"
+  fi
 
   # Add to root crontab if not already present
   if ! (crontab -l 2>/dev/null | grep -q "certbot renew.*demarkus"); then
@@ -563,12 +590,17 @@ setup_cert_renewal() {
 setup_library_cert_renewal() {
   if [ "$PLATFORM" != "linux" ]; then return; fi
 
+  local hook='pidof demarkus-server | xargs -r kill -HUP; systemctl try-restart demarkus-library'
+
+  # The deploy hook is rewritten even when the cron is already current: the
+  # server-only install may have written the server-only version of it.
+  write_cert_deploy_hook "$hook"
+
   if crontab -l 2>/dev/null | grep -q "try-restart demarkus-library"; then
     log_info "Certbot renewal cron already restarts the library"
     return
   fi
 
-  local hook='pidof demarkus-server | xargs -r kill -HUP; systemctl try-restart demarkus-library'
   local cron_line="0 */12 * * * certbot renew --quiet --deploy-hook \"${hook}\""
   if ! (crontab -l 2>/dev/null | grep -v "certbot renew.*demarkus"; echo "$cron_line") | crontab -; then
     log_error "Could not update the certbot renewal cron for the library"
@@ -1598,6 +1630,8 @@ do_install() {
       setup_tls "$domain"
     fi
     fix_cert_permissions "$domain"
+    # Unconditional: a re-run over an existing cert must still get a hook.
+    setup_cert_renewal "$domain"
     tls_cert_path="/etc/letsencrypt/live/${domain}/fullchain.pem"
     tls_key_path="/etc/letsencrypt/live/${domain}/privkey.pem"
   elif [ -d "${CONFIG_DIR}/tls" ] && [ -f "${CONFIG_DIR}/tls/cert.pem" ]; then
@@ -2175,9 +2209,10 @@ do_uninstall() {
     done
   fi
 
-  # Remove certbot renewal cron
+  # Remove certbot renewal cron and the deploy hook
   if [ "$PLATFORM" = "linux" ]; then
     (crontab -l 2>/dev/null | grep -v "certbot renew.*demarkus" | crontab -) 2>/dev/null || true
+    rm -f "$CERT_DEPLOY_HOOK" 2>/dev/null || log_warn "Could not remove ${CERT_DEPLOY_HOOK}"
   fi
 
   if [ "$uninstall_errors" -ne 0 ]; then

--- a/install.sh
+++ b/install.sh
@@ -544,10 +544,46 @@ CERT_DEPLOY_HOOK="/etc/letsencrypt/renewal-hooks/deploy/demarkus-reload.sh"
 CERT_CRON_MARKER="# demarkus-managed-renewal"
 
 # cert_cron_pattern matches only cron entries this installer wrote: the marker,
-# or the unmarked line older versions produced. A bare "certbot renew.*demarkus"
-# would also match a user's own job that reloads demarkus.
+# or the exact unmarked line older versions produced (setup_cert_renewal
+# migrates those to the marker). A bare "certbot renew.*demarkus" would also
+# match a user's own job that reloads demarkus.
 cert_cron_pattern() {
-  printf '%s|certbot renew .*pidof demarkus-server' "$CERT_CRON_MARKER"
+  printf '%s|certbot renew --quiet --deploy-hook "pidof demarkus-server' "$CERT_CRON_MARKER"
+}
+
+# read_crontab prints the root crontab. 0 = read it (may be empty), 1 = no
+# crontab installed, 2 = the read failed. crontab -l exits non-zero for both of
+# the latter, and treating a failed read as "empty" makes the usual
+# read-filter-write pipeline install an empty table, destroying the user's jobs.
+# Callers must never write back on 2.
+read_crontab() {
+  local out rc
+  out=$(crontab -l 2>&1)
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    printf '%s\n' "$out"
+    return 0
+  fi
+  case "$out" in
+    *"no crontab for"*) return 1 ;;
+    *) return 2 ;;
+  esac
+}
+
+# compose_cron_table prints TABLE with demarkus-owned entries dropped and ENTRY
+# appended. Filtering with grep -v '^$' instead would strip blank lines the user
+# put in their own crontab.
+compose_cron_table() {
+  local table="$1" entry="$2" kept=""
+
+  if [ -n "$table" ]; then
+    kept=$(printf '%s\n' "$table" | grep -Ev "$(cert_cron_pattern)")
+  fi
+  if [ -n "$kept" ]; then
+    printf '%s\n%s\n' "$kept" "$entry"
+  else
+    printf '%s\n' "$entry"
+  fi
 }
 
 # write_cert_deploy_hook installs the reload command as a certbot deploy hook.
@@ -602,8 +638,14 @@ clear_cert_renewal() {
       log_warn "Could not remove the stale deploy hook ${CERT_DEPLOY_HOOK}"
     fi
   fi
-  if crontab -l 2>/dev/null | grep -Eq "$(cert_cron_pattern)"; then
-    if (crontab -l 2>/dev/null | grep -Ev "$(cert_cron_pattern)") | crontab -; then
+  local table rc
+  table=$(read_crontab)
+  rc=$?
+  if [ "$rc" -eq 2 ]; then
+    # Leaving a stale entry is recoverable; rewriting from an unread table is not.
+    log_warn "Could not read the root crontab; leaving any stale renewal entry in place"
+  elif [ "$rc" -eq 0 ] && printf '%s\n' "$table" | grep -Eq "$(cert_cron_pattern)"; then
+    if printf '%s\n' "$table" | grep -Ev "$(cert_cron_pattern)" | crontab -; then
       cleared=true
     else
       log_warn "Could not drop the stale certbot renewal cron entry"
@@ -627,13 +669,31 @@ setup_cert_renewal() {
     write_cert_deploy_hook "$hook"
   fi
 
-  # Add to root crontab if not already present
-  if ! (crontab -l 2>/dev/null | grep -Eq "$(cert_cron_pattern)"); then
-    (crontab -l 2>/dev/null; echo "$cron_line") | crontab -
-    log_info "Added certbot renewal cron job (twice daily, zero-downtime reload)"
-  else
-    log_info "Certbot renewal cron already configured"
+  local table rc
+  table=$(read_crontab)
+  rc=$?
+  if [ "$rc" -eq 2 ]; then
+    log_error "Could not read the root crontab; refusing to rewrite it. Renewal will not reload the services"
+    exit 1
   fi
+  [ "$rc" -eq 1 ] && table=""
+
+  if printf '%s\n' "$table" | grep -q "$CERT_CRON_MARKER"; then
+    log_info "Certbot renewal cron already configured"
+    return
+  fi
+
+  # An unmarked entry from an older install is replaced, not duplicated, so
+  # hosts converge on the marker and stop relying on command matching.
+  local verb="Added"
+  if printf '%s\n' "$table" | grep -Eq "$(cert_cron_pattern)"; then
+    verb="Migrated"
+  fi
+  if ! compose_cron_table "$table" "$cron_line" | crontab -; then
+    log_error "Could not write the certbot renewal cron entry"
+    exit 1
+  fi
+  log_info "${verb} certbot renewal cron job (twice daily, zero-downtime reload)"
 }
 
 # setup_library_cert_renewal extends the renewal deploy-hook so certbot also
@@ -648,13 +708,23 @@ setup_library_cert_renewal() {
   # server-only install may have written the server-only version of it.
   write_cert_deploy_hook "$hook"
 
-  if crontab -l 2>/dev/null | grep -q "try-restart demarkus-library"; then
+  local table rc
+  table=$(read_crontab)
+  rc=$?
+  if [ "$rc" -eq 2 ]; then
+    log_error "Could not read the root crontab; refusing to rewrite it. Renewal will not restart the library"
+    exit 1
+  fi
+  [ "$rc" -eq 1 ] && table=""
+
+  # Ours only: a user job mentioning the library must not suppress our entry.
+  if printf '%s\n' "$table" | grep -F "$CERT_CRON_MARKER" | grep -q "try-restart demarkus-library"; then
     log_info "Certbot renewal cron already restarts the library"
     return
   fi
 
   local cron_line="0 */12 * * * certbot renew --quiet --deploy-hook \"${hook}\" ${CERT_CRON_MARKER}"
-  if ! (crontab -l 2>/dev/null | grep -Ev "$(cert_cron_pattern)"; echo "$cron_line") | crontab -; then
+  if ! compose_cron_table "$table" "$cron_line" | crontab -; then
     log_error "Could not update the certbot renewal cron for the library"
     exit 1
   fi
@@ -2268,8 +2338,14 @@ do_uninstall() {
 
   # Remove certbot renewal cron and the deploy hook
   if [ "$PLATFORM" = "linux" ]; then
-    if crontab -l 2>/dev/null | grep -Eq "$(cert_cron_pattern)"; then
-      if ! (crontab -l 2>/dev/null | grep -Ev "$(cert_cron_pattern)") | crontab -; then
+    local cron_table cron_rc
+    cron_table=$(read_crontab)
+    cron_rc=$?
+    if [ "$cron_rc" -eq 2 ]; then
+      log_warn "Could not read the root crontab; the renewal entry may remain"
+      uninstall_errors=$((uninstall_errors + 1))
+    elif [ "$cron_rc" -eq 0 ] && printf '%s\n' "$cron_table" | grep -Eq "$(cert_cron_pattern)"; then
+      if ! printf '%s\n' "$cron_table" | grep -Ev "$(cert_cron_pattern)" | crontab -; then
         log_warn "Could not drop the certbot renewal entry from the root crontab"
         uninstall_errors=$((uninstall_errors + 1))
       fi

--- a/install.sh
+++ b/install.sh
@@ -541,6 +541,14 @@ fix_cert_permissions() {
 }
 
 CERT_DEPLOY_HOOK="/etc/letsencrypt/renewal-hooks/deploy/demarkus-reload.sh"
+CERT_CRON_MARKER="# demarkus-managed-renewal"
+
+# cert_cron_pattern matches only cron entries this installer wrote: the marker,
+# or the unmarked line older versions produced. A bare "certbot renew.*demarkus"
+# would also match a user's own job that reloads demarkus.
+cert_cron_pattern() {
+  printf '%s|certbot renew .*pidof demarkus-server' "$CERT_CRON_MARKER"
+}
 
 # write_cert_deploy_hook installs the reload command as a certbot deploy hook.
 # certbot.timer renews on its own schedule and runs only this directory, so
@@ -594,8 +602,8 @@ clear_cert_renewal() {
       log_warn "Could not remove the stale deploy hook ${CERT_DEPLOY_HOOK}"
     fi
   fi
-  if crontab -l 2>/dev/null | grep -q "certbot renew.*demarkus"; then
-    if (crontab -l 2>/dev/null | grep -v "certbot renew.*demarkus") | crontab -; then
+  if crontab -l 2>/dev/null | grep -Eq "$(cert_cron_pattern)"; then
+    if (crontab -l 2>/dev/null | grep -Ev "$(cert_cron_pattern)") | crontab -; then
       cleared=true
     else
       log_warn "Could not drop the stale certbot renewal cron entry"
@@ -612,7 +620,7 @@ setup_cert_renewal() {
   if [ "$PLATFORM" != "linux" ]; then return; fi
 
   local hook='pidof demarkus-server | xargs -r kill -HUP'
-  local cron_line="0 */12 * * * certbot renew --quiet --deploy-hook \"${hook}\""
+  local cron_line="0 */12 * * * certbot renew --quiet --deploy-hook \"${hook}\" ${CERT_CRON_MARKER}"
 
   # Never downgrade the library-aware hook back to the server-only one.
   if [ ! -f "$CERT_DEPLOY_HOOK" ] || ! grep -q "demarkus-library" "$CERT_DEPLOY_HOOK"; then
@@ -620,7 +628,7 @@ setup_cert_renewal() {
   fi
 
   # Add to root crontab if not already present
-  if ! (crontab -l 2>/dev/null | grep -q "certbot renew.*demarkus"); then
+  if ! (crontab -l 2>/dev/null | grep -Eq "$(cert_cron_pattern)"); then
     (crontab -l 2>/dev/null; echo "$cron_line") | crontab -
     log_info "Added certbot renewal cron job (twice daily, zero-downtime reload)"
   else
@@ -645,8 +653,8 @@ setup_library_cert_renewal() {
     return
   fi
 
-  local cron_line="0 */12 * * * certbot renew --quiet --deploy-hook \"${hook}\""
-  if ! (crontab -l 2>/dev/null | grep -v "certbot renew.*demarkus"; echo "$cron_line") | crontab -; then
+  local cron_line="0 */12 * * * certbot renew --quiet --deploy-hook \"${hook}\" ${CERT_CRON_MARKER}"
+  if ! (crontab -l 2>/dev/null | grep -Ev "$(cert_cron_pattern)"; echo "$cron_line") | crontab -; then
     log_error "Could not update the certbot renewal cron for the library"
     exit 1
   fi
@@ -2260,8 +2268,8 @@ do_uninstall() {
 
   # Remove certbot renewal cron and the deploy hook
   if [ "$PLATFORM" = "linux" ]; then
-    if crontab -l 2>/dev/null | grep -q "certbot renew.*demarkus"; then
-      if ! (crontab -l 2>/dev/null | grep -v "certbot renew.*demarkus") | crontab -; then
+    if crontab -l 2>/dev/null | grep -Eq "$(cert_cron_pattern)"; then
+      if ! (crontab -l 2>/dev/null | grep -Ev "$(cert_cron_pattern)") | crontab -; then
         log_warn "Could not drop the certbot renewal entry from the root crontab"
         uninstall_errors=$((uninstall_errors + 1))
       fi

--- a/install.sh
+++ b/install.sh
@@ -627,15 +627,20 @@ EOF
 # longer Let's Encrypt backed, so a switch to custom certs or --no-tls does not
 # leave a cron renewing and reloading against a cert nothing uses. Only our own
 # cron line and hook path are touched; user-managed certbot config is left.
+# Returns nonzero if any part of the teardown failed so the caller reports it.
+# Deliberately not fatal: this runs after cert material is already written, and
+# aborting here would leave the service unit unregenerated, which is worse than
+# a leftover entry that renews a certificate nothing reads.
 clear_cert_renewal() {
-  if [ "$PLATFORM" != "linux" ]; then return; fi
+  if [ "$PLATFORM" != "linux" ]; then return 0; fi
 
-  local cleared=false
+  local cleared=false failed=0
   if [ -f "$CERT_DEPLOY_HOOK" ]; then
     if rm -f "$CERT_DEPLOY_HOOK"; then
       cleared=true
     else
       log_warn "Could not remove the stale deploy hook ${CERT_DEPLOY_HOOK}"
+      failed=1
     fi
   fi
   local table rc
@@ -644,16 +649,24 @@ clear_cert_renewal() {
   if [ "$rc" -eq 2 ]; then
     # Leaving a stale entry is recoverable; rewriting from an unread table is not.
     log_warn "Could not read the root crontab; leaving any stale renewal entry in place"
+    failed=1
   elif [ "$rc" -eq 0 ] && printf '%s\n' "$table" | grep -Eq "$(cert_cron_pattern)"; then
     if printf '%s\n' "$table" | grep -Ev "$(cert_cron_pattern)" | crontab -; then
       cleared=true
     else
       log_warn "Could not drop the stale certbot renewal cron entry"
+      failed=1
     fi
   fi
   if [ "$cleared" = true ]; then
     log_info "Removed demarkus certbot renewal wiring (no longer using Let's Encrypt)"
   fi
+  return "$failed"
+}
+
+# report_stale_renewal names what to clean by hand after a failed teardown.
+report_stale_renewal() {
+  log_warn "Stale demarkus renewal wiring may remain; check the root crontab for '${CERT_CRON_MARKER}' and remove ${CERT_DEPLOY_HOOK}"
 }
 
 setup_cert_renewal() {
@@ -1742,7 +1755,7 @@ do_install() {
   if [ -n "$tls_cert" ] && [ -n "$tls_key" ]; then
     # User-provided certificates
     setup_custom_tls "$tls_cert" "$tls_key"
-    clear_cert_renewal
+    clear_cert_renewal || report_stale_renewal
     tls_cert_path="${CONFIG_DIR}/tls/cert.pem"
     tls_key_path="${CONFIG_DIR}/tls/key.pem"
   elif [ -n "$domain" ] && [ "$no_tls" = false ]; then
@@ -1760,12 +1773,12 @@ do_install() {
   elif [ -d "${CONFIG_DIR}/tls" ] && [ -f "${CONFIG_DIR}/tls/cert.pem" ]; then
     # Existing custom certs from a previous install
     log_info "Using existing custom certificates from ${CONFIG_DIR}/tls/"
-    clear_cert_renewal
+    clear_cert_renewal || report_stale_renewal
     tls_cert_path="${CONFIG_DIR}/tls/cert.pem"
     tls_key_path="${CONFIG_DIR}/tls/key.pem"
   else
     # No TLS material: --no-tls, or a domainless install.
-    clear_cert_renewal
+    clear_cert_renewal || report_stale_renewal
   fi
 
   # System tuning

--- a/scripts/test-install-renewal.sh
+++ b/scripts/test-install-renewal.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Test: certbot renewal wiring in install.sh — the deploy hook, the root cron
+# entry, and the teardown that runs when a host stops using Let's Encrypt.
+#
+# The renewal functions are sourced out of install.sh and run against a fake
+# root: crontab is stubbed over a file, the hook path is redirected into a
+# tempdir. Nothing here touches the real system, so it runs anywhere.
+#
+# Usage: bash scripts/test-install-renewal.sh [path/to/install.sh]
+#
+# Runs with the same `set -euo pipefail` install.sh uses. That matters: without
+# -e, an assignment from a command substitution that exits nonzero looks
+# harmless here while aborting the real installer.
+set -euo pipefail
+
+SRC="${1:-$(cd "$(dirname "$0")/.." && pwd)/install.sh}"
+[ -f "$SRC" ] || { echo "not found: $SRC" >&2; exit 1; }
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+CRON="$TMP/crontab.txt"; : > "$CRON"
+
+# Stubs: crontab reads/writes a file, log_* are silent, chmod/mkdir are real.
+# Real `crontab -` reads stdin to EOF before installing the new table, so a
+# `crontab -l | ... | crontab -` pipeline does not truncate its own input.
+# A stub that redirects straight to the file would fake a race that cannot
+# happen in production.
+# CRON_MODE models the three real outcomes of `crontab -l`:
+#   ok   - table read
+#   none - "no crontab for root" on stderr, exit 1 (normal on a fresh host)
+#   fail - some other failure, exit 1 (must never be read as "empty")
+CRON_MODE="ok"
+crontab() {
+  case "${1:-}" in
+    -l)
+      case "$CRON_MODE" in
+        none) echo "no crontab for root" >&2; return 1 ;;
+        fail) echo "crontab: cannot open spool" >&2; return 1 ;;
+        *)    cat "$CRON" ;;
+      esac
+      ;;
+    -)
+      if [ "$CRON_MODE" = "fail" ]; then echo "crontab: install failed" >&2; return 1; fi
+      local buf; buf=$(cat)
+      if [ -n "$buf" ]; then printf '%s\n' "$buf" > "$CRON"; else : > "$CRON"; fi
+      ;;
+  esac
+}
+log_info() { :; }; log_warn() { :; }; log_error() { echo "ERROR: $*"; }
+# Read by the functions eval'd below, which all return early off Linux.
+# shellcheck disable=SC2034
+PLATFORM="linux"
+
+# Pull in only the renewal functions, redirected at the fake root.
+eval "$(awk '/^CERT_DEPLOY_HOOK=/{on=1} /^setup_custom_tls\(\)/{on=0} on' "$SRC" \
+  | sed "s|^CERT_DEPLOY_HOOK=.*|CERT_DEPLOY_HOOK=\"$TMP/hooks/deploy/demarkus-reload.sh\"|")"
+HOOK="$TMP/hooks/deploy/demarkus-reload.sh"
+
+pass=0; fail=0
+check() { # check <desc> <condition-cmd...>
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then echo "  ok   $desc"; pass=$((pass+1))
+  else echo "  FAIL $desc"; fail=$((fail+1)); fi
+}
+
+echo "== fresh install (server only)"
+setup_cert_renewal example.com
+check "deploy hook written"            test -f "$HOOK"
+check "hook is executable"             test -x "$HOOK"
+check "hook HUPs the server"           grep -q "kill -HUP" "$HOOK"
+check "cron line added"                grep -q "certbot renew" "$CRON"
+
+echo "== re-run over an existing cert (the original bug)"
+: > "$CRON"; rm -f "$HOOK"
+setup_cert_renewal example.com
+check "hook re-created on re-run"      test -f "$HOOK"
+check "cron re-added on re-run"        grep -q "certbot renew" "$CRON"
+
+echo "== library install extends the hook"
+setup_library_cert_renewal
+check "hook restarts the library"      grep -q "try-restart demarkus-library" "$HOOK"
+check "hook still HUPs the server"     grep -q "kill -HUP" "$HOOK"
+check "cron covers the library"        grep -q "try-restart demarkus-library" "$CRON"
+check "exactly one cron line"          test "$(grep -c 'certbot renew' "$CRON")" -eq 1
+
+echo "== later server re-run must not downgrade the library hook"
+setup_cert_renewal example.com
+check "library restart survives"       grep -q "try-restart demarkus-library" "$HOOK"
+
+echo "== hook install leaves no staging files behind"
+check "no temp files in hook dir"      test "$(find "$(dirname "$HOOK")" -name 'demarkus-reload.sh.*' | wc -l)" -eq 0
+
+echo "== our cron entry carries an ownership marker"
+check "marker on the cron line"        grep -q "demarkus-managed-renewal" "$CRON"
+
+echo "== switching away from Let's Encrypt clears our wiring"
+printf '0 3 * * * /usr/local/bin/backup.sh\n' >> "$CRON"   # unrelated user entry
+# A user's own certbot job that reloads demarkus must survive: it is theirs.
+printf '30 4 * * * certbot renew --deploy-hook "systemctl reload demarkus-extra"\n' >> "$CRON"
+clear_cert_renewal
+check "hook removed"                   test ! -f "$HOOK"
+check "our cron entry removed"         bash -c "! grep -q 'demarkus-managed-renewal' '$CRON'"
+check "unrelated cron entry kept"      grep -q "backup.sh" "$CRON"
+check "user certbot job kept"          grep -q "demarkus-extra" "$CRON"
+
+echo "== a legacy unmarked entry is still recognised as ours"
+: > "$CRON"
+printf '%s\n' '0 */12 * * * certbot renew --quiet --deploy-hook "pidof demarkus-server | xargs -r kill -HUP"' >> "$CRON"
+printf '30 4 * * * certbot renew --deploy-hook "systemctl reload demarkus-extra"\n' >> "$CRON"
+clear_cert_renewal
+check "legacy entry removed"           bash -c "! grep -q 'pidof demarkus-server' '$CRON'"
+check "user certbot job still kept"    grep -q "demarkus-extra" "$CRON"
+
+echo "== clear is safe when nothing is installed"
+clear_rc=0; clear_cert_renewal || clear_rc=$?
+check "second clear reports success"   test "$clear_rc" -eq 0
+check "user certbot job untouched"     grep -q "demarkus-extra" "$CRON"
+
+echo "== our entry being the only line is not a failure"
+# grep -Ev exits 1 when it filters everything out; treating that as an error
+# would report a false failure, and under set -e abort the installer.
+: > "$CRON"; rm -f "$HOOK"
+setup_cert_renewal example.com >/dev/null
+clear_rc=0; clear_cert_renewal >/dev/null || clear_rc=$?
+check "clear reports success"          test "$clear_rc" -eq 0
+check "table is now empty"             test ! -s "$CRON"
+setup_cert_renewal example.com >/dev/null
+check "re-add onto empty table works"  grep -q "demarkus-managed-renewal" "$CRON"
+
+echo "== a failed crontab read must never cause a write"
+: > "$CRON"
+printf '0 3 * * * /usr/local/bin/backup.sh\n' >> "$CRON"
+before=$(cat "$CRON")
+CRON_MODE="fail"
+clear_rc=0; clear_cert_renewal >/dev/null 2>&1 || clear_rc=$?
+check "clear reports the failure"      test "$clear_rc" -ne 0
+check "clear leaves the table alone"   test "$(cat "$CRON")" = "$before"
+rc=0; ( setup_cert_renewal example.com >/dev/null 2>&1 ) || rc=$?
+check "setup fails closed on read err" test "$rc" -ne 0
+check "table survived setup failure"   test "$(cat "$CRON")" = "$before"
+CRON_MODE="ok"
+
+echo "== a host with no crontab at all still gets the entry"
+: > "$CRON"; rm -f "$HOOK"
+CRON_MODE="none"
+# Called bare, NOT wrapped in `|| true`: a wrapper would suppress set -e inside
+# the function and hide the very abort this checks for. If the installer takes
+# rc=1 as fatal, this script dies here and the run reports no total at all.
+setup_cert_renewal example.com >/dev/null
+check "entry added on bare host"       grep -q "demarkus-managed-renewal" "$CRON"
+check "no blank first line"            bash -c "! head -1 '$CRON' | grep -q '^$'"
+CRON_MODE="ok"
+
+echo "== legacy entry is migrated to the marker, not duplicated"
+: > "$CRON"; rm -f "$HOOK"
+printf '%s\n' '0 */12 * * * certbot renew --quiet --deploy-hook "pidof demarkus-server | xargs -r kill -HUP"' >> "$CRON"
+setup_cert_renewal example.com >/dev/null
+check "marker now present"             grep -q "demarkus-managed-renewal" "$CRON"
+check "exactly one renewal entry"      test "$(grep -c 'certbot renew' "$CRON")" -eq 1
+
+echo "== the user's own crontab formatting survives"
+: > "$CRON"; rm -f "$HOOK"
+printf '# my jobs\n\n0 3 * * * /usr/local/bin/backup.sh\n' > "$CRON"
+setup_cert_renewal example.com >/dev/null
+check "user comment kept"              grep -q "^# my jobs" "$CRON"
+check "user blank line kept"           bash -c "sed -n '2p' '$CRON' | grep -q '^$'"
+check "our entry appended"             grep -q "demarkus-managed-renewal" "$CRON"
+
+echo "== a user job naming the library must not suppress ours"
+: > "$CRON"; rm -f "$HOOK"
+printf '15 2 * * * systemctl try-restart demarkus-library\n' >> "$CRON"
+setup_library_cert_renewal >/dev/null
+check "our library entry installed"    bash -c "grep 'demarkus-managed-renewal' '$CRON' | grep -q 'try-restart demarkus-library'"
+check "user job preserved"             grep -q "^15 2 " "$CRON"
+
+echo "== static: renewal is wired from the main flow, not from setup_tls"
+# The bug was a call-graph one: setup_cert_renewal lived inside setup_tls,
+# which the main flow skips whenever the certificate already exists.
+in_setup_tls=$(awk '/^setup_tls\(\)/{on=1} on && /^}/{print; on=0} on' "$SRC" | grep -c "setup_cert_renewal" || true)
+in_main=$(awk '/# Let.s Encrypt/{on=1} on && /^  elif/{on=0} on' "$SRC" | grep -c "setup_cert_renewal")
+check "setup_tls no longer owns renewal"  test "$in_setup_tls" -eq 0
+check "main LE branch calls renewal"      test "$in_main" -ge 1
+
+# Every non-Let's-Encrypt path through the TLS block must tear our wiring down.
+non_le=$(awk '/^  # TLS setup/{on=1} on && /^  # System tuning/{on=0} on' "$SRC" | grep -c "clear_cert_renewal")
+check "non-LE branches clear wiring"      test "$non_le" -eq 3
+# A bare call would discard the teardown result the function now returns.
+guarded=$(grep -c "clear_cert_renewal || report_stale_renewal" "$SRC")
+check "every call site checks result"     test "$guarded" -eq 3
+check "uninstall uses remove_path"        grep -q 'remove_path "$CERT_DEPLOY_HOOK"' "$SRC"
+# Pipelines must be wrapped: `check ... cmd | grep` would pipe check's own
+# output into grep and lose the result.
+check "uninstall cron failure tracked"    bash -c "awk '/# Remove certbot renewal cron/,/^  fi/' '$SRC' | grep -q uninstall_errors"
+
+echo
+echo "passed=$pass failed=$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/test-install-renewal.sh
+++ b/scripts/test-install-renewal.sh
@@ -62,10 +62,21 @@ check() { # check <desc> <condition-cmd...>
   else echo "  FAIL $desc"; fail=$((fail+1)); fi
 }
 
-# count_matches reads stdin and prints the match count. grep -c exits 1 on zero
-# matches, which inside a bare assignment aborts under set -e — turning the
-# regression these checks exist to catch into a crash with no diagnostic.
-count_matches() { grep -c "$1" || true; }
+# count_matches reads stdin and prints the match count. Status 1 is "no
+# matches" and must not abort under set -e; anything above it is a real grep
+# failure and is propagated rather than passed off as a count of zero.
+count_matches() {
+  local out rc=0
+  out=$(grep -c -- "$1") || rc=$?
+  if [ "$rc" -gt 1 ]; then return "$rc"; fi
+  printf '%s\n' "$out"
+}
+
+echo "== the harness's own count helper"
+zero_count=$(printf 'x\n' | count_matches nomatch)
+check "zero matches counts as 0"       test "$zero_count" = "0"
+hard_rc=0; printf 'x\n' | count_matches '[' >/dev/null 2>&1 || hard_rc=$?
+check "real grep errors propagate"     test "$hard_rc" -gt 1
 
 echo "== fresh install (server only)"
 setup_cert_renewal example.com

--- a/scripts/test-install-renewal.sh
+++ b/scripts/test-install-renewal.sh
@@ -62,6 +62,11 @@ check() { # check <desc> <condition-cmd...>
   else echo "  FAIL $desc"; fail=$((fail+1)); fi
 }
 
+# count_matches reads stdin and prints the match count. grep -c exits 1 on zero
+# matches, which inside a bare assignment aborts under set -e — turning the
+# regression these checks exist to catch into a crash with no diagnostic.
+count_matches() { grep -c "$1" || true; }
+
 echo "== fresh install (server only)"
 setup_cert_renewal example.com
 check "deploy hook written"            test -f "$HOOK"
@@ -175,18 +180,20 @@ check "user job preserved"             grep -q "^15 2 " "$CRON"
 echo "== static: renewal is wired from the main flow, not from setup_tls"
 # The bug was a call-graph one: setup_cert_renewal lived inside setup_tls,
 # which the main flow skips whenever the certificate already exists.
-in_setup_tls=$(awk '/^setup_tls\(\)/{on=1} on && /^}/{print; on=0} on' "$SRC" | grep -c "setup_cert_renewal" || true)
-in_main=$(awk '/# Let.s Encrypt/{on=1} on && /^  elif/{on=0} on' "$SRC" | grep -c "setup_cert_renewal")
+in_setup_tls=$(awk '/^setup_tls\(\)/{on=1} on && /^}/{print; on=0} on' "$SRC" | count_matches "setup_cert_renewal")
+in_main=$(awk '/# Let.s Encrypt/{on=1} on && /^  elif/{on=0} on' "$SRC" | count_matches "setup_cert_renewal")
 check "setup_tls no longer owns renewal"  test "$in_setup_tls" -eq 0
 check "main LE branch calls renewal"      test "$in_main" -ge 1
 
 # Every non-Let's-Encrypt path through the TLS block must tear our wiring down.
-non_le=$(awk '/^  # TLS setup/{on=1} on && /^  # System tuning/{on=0} on' "$SRC" | grep -c "clear_cert_renewal")
+non_le=$(awk '/^  # TLS setup/{on=1} on && /^  # System tuning/{on=0} on' "$SRC" | count_matches "clear_cert_renewal")
 check "non-LE branches clear wiring"      test "$non_le" -eq 3
 # A bare call would discard the teardown result the function now returns.
-guarded=$(grep -c "clear_cert_renewal || report_stale_renewal" "$SRC")
+guarded=$(count_matches "clear_cert_renewal || report_stale_renewal" < "$SRC")
 check "every call site checks result"     test "$guarded" -eq 3
 check "uninstall uses remove_path"        grep -q 'remove_path "$CERT_DEPLOY_HOOK"' "$SRC"
+# Configuring the unit from half a custom-TLS pair crash-loops the service.
+check "custom TLS needs cert and key"     bash -c "awk '/Existing custom certs from a previous install/,/tls_key_path=/' '$SRC' | grep -q 'need both cert.pem and key.pem'"
 # Pipelines must be wrapped: `check ... cmd | grep` would pipe check's own
 # output into grep and lose the result.
 check "uninstall cron failure tracked"    bash -c "awk '/# Remove certbot renewal cron/,/^  fi/' '$SRC' | grep -q uninstall_errors"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Let’s Encrypt renewal wiring for reinstalls and TLS mode changes, ensuring the intended service reload/restart occurs reliably after `certbot renew`.
  * Made renewal scheduling marker-based and idempotent to prevent duplicate or conflicting cron entries.
  * Updated uninstall/teardown to remove only managed renewal entries and the deploy hook, with safer handling when cron cannot be read.

* **Tests / CI**
  * Added an install renewal-wiring test harness validating setup, idempotency, migration from legacy entries, correct cleanup, and “fail closed” behavior.
  * Extended CI to detect install-script changes and run shellcheck plus the renewal wiring tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->