### PR TITLE
feat(protocol): enforce markdown-only document contract

### DIFF
--- a/client/cmd/demarkus-mcp/explore.go
+++ b/client/cmd/demarkus-mcp/explore.go
@@ -57,6 +57,12 @@ func (h *handler) markExplore(_ context.Context, req mcp.CallToolRequest) (*mcp.
 	}
 	body := result.Response.Body
 
+	// Binary/non-UTF-8 body: an outline over it is garbage; return a notice.
+	if binaryBody(body) {
+		return mcp.NewToolResultText(formatResultWith(result, nonMarkdownNotice(len(body)),
+			map[string]string{"mode": "binary"}, "version", "modified", "etag")), nil
+	}
+
 	var b strings.Builder
 
 	b.WriteString("## Outline\n")

--- a/client/cmd/demarkus-mcp/explore_test.go
+++ b/client/cmd/demarkus-mcp/explore_test.go
@@ -186,6 +186,26 @@ func TestHandlerMarkExplore_NonOKPassthrough(t *testing.T) {
 	}
 }
 
+func TestHandlerMarkExplore_BinaryNotice(t *testing.T) {
+	sc := &stubClient{
+		fetchFn: func(_, _, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: protocol.Response{
+				Status:   protocol.StatusOK,
+				Metadata: map[string]string{"version": "1", "modified": "2026-07-04T00:00:00Z", "etag": "abc"},
+				Body:     "\x89PNG\r\n\x1a\n\xff\xfe\x00",
+			}}, nil
+		},
+	}
+	h := &handler{client: sc}
+	text := exploreText(t, h, "mark://host:6309/img.png")
+	if !strings.Contains(text, "non-markdown or binary document") {
+		t.Errorf("binary body should return the notice, got:\n%s", text)
+	}
+	if strings.Contains(text, "## Outline") {
+		t.Error("binary body must not be run through the outline builder")
+	}
+}
+
 func TestHandlerMarkExplore_InvalidURL(t *testing.T) {
 	h := &handler{client: &stubClient{}}
 	result, err := h.markExplore(context.Background(), newCallToolRequest(map[string]any{"url": "/bare"}))

--- a/client/cmd/demarkus-mcp/fetchmode_test.go
+++ b/client/cmd/demarkus-mcp/fetchmode_test.go
@@ -86,9 +86,8 @@ func TestHandlerMarkFetch_LargeDocForceFullBody(t *testing.T) {
 	}
 }
 
-// binaryDoc is a body that is not valid UTF-8 (PNG magic plus stray bytes),
-// standing in for legacy or out-of-band binary the publish gate can no longer
-// admit but which a fetch might still encounter.
+// binaryDoc is a non-UTF-8 body (PNG magic), standing in for legacy or
+// out-of-band binary a fetch might still encounter.
 const binaryDoc = "\x89PNG\r\n\x1a\n\xff\xfe\x00\xb1\xa5"
 
 func TestHandlerMarkFetch_BinaryNotice(t *testing.T) {
@@ -105,14 +104,16 @@ func TestHandlerMarkFetch_BinaryNotice(t *testing.T) {
 	}
 }
 
-func TestHandlerMarkFetch_BinaryForceBypasses(t *testing.T) {
+func TestHandlerMarkFetch_BinaryForceStillNotice(t *testing.T) {
+	// force bypasses the size gate, never the binary gate: MCP text cannot carry
+	// binary faithfully, so force=true must still return the notice, not bytes.
 	h := &handler{client: fetchStub(binaryDoc, "1", "abc", nil)}
 	text := fetchText(t, h, map[string]any{"url": "mark://example.com/img.png", "force": true})
-	if strings.Contains(text, "non-markdown or binary document") {
-		t.Error("force=true should bypass the binary notice and return raw bytes")
+	if !strings.Contains(text, "non-markdown or binary document") {
+		t.Errorf("force=true must still return the binary notice, got:\n%s", text)
 	}
-	if !strings.Contains(text, "\x89PNG") {
-		t.Error("force=true should return the raw body")
+	if strings.Contains(text, "\x89PNG") {
+		t.Error("force=true must not leak raw binary bytes")
 	}
 }
 

--- a/client/cmd/demarkus-mcp/fetchmode_test.go
+++ b/client/cmd/demarkus-mcp/fetchmode_test.go
@@ -86,6 +86,36 @@ func TestHandlerMarkFetch_LargeDocForceFullBody(t *testing.T) {
 	}
 }
 
+// binaryDoc is a body that is not valid UTF-8 (PNG magic plus stray bytes),
+// standing in for legacy or out-of-band binary the publish gate can no longer
+// admit but which a fetch might still encounter.
+const binaryDoc = "\x89PNG\r\n\x1a\n\xff\xfe\x00\xb1\xa5"
+
+func TestHandlerMarkFetch_BinaryNotice(t *testing.T) {
+	h := &handler{client: fetchStub(binaryDoc, "1", "abc", nil)}
+	text := fetchText(t, h, map[string]any{"url": "mark://example.com/img.png"})
+	if !strings.Contains(text, "mode: binary") {
+		t.Errorf("binary body should be flagged mode: binary, got:\n%s", text)
+	}
+	if !strings.Contains(text, "non-markdown or binary document") {
+		t.Errorf("binary body should return the notice, got:\n%s", text)
+	}
+	if strings.Contains(text, "\x89PNG") {
+		t.Error("binary bytes must not be rendered into the response")
+	}
+}
+
+func TestHandlerMarkFetch_BinaryForceBypasses(t *testing.T) {
+	h := &handler{client: fetchStub(binaryDoc, "1", "abc", nil)}
+	text := fetchText(t, h, map[string]any{"url": "mark://example.com/img.png", "force": true})
+	if strings.Contains(text, "non-markdown or binary document") {
+		t.Error("force=true should bypass the binary notice and return raw bytes")
+	}
+	if !strings.Contains(text, "\x89PNG") {
+		t.Error("force=true should return the raw body")
+	}
+}
+
 func TestHandlerMarkFetch_SectionSlice(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/latebit-io/demarkus/client/fetch"
 	"github.com/latebit-io/demarkus/client/fetchdedup"
@@ -263,6 +264,22 @@ func markFetchTool(host string) mcp.Tool {
 // an outline instead of the full body, unless force=true or a #section is
 // requested.
 const outlineThreshold = 8 * 1024
+
+// nonMarkdownNotice is what the agent-facing render paths (mark_fetch,
+// mark_explore, resource read) return when a body is not valid UTF-8. The
+// publish gate rejects such content, but data predating the gate or loaded
+// into the store out-of-band can still exist; rendering it as text would inject
+// mojibake and control bytes straight into the model's context.
+func nonMarkdownNotice(nBytes int) string {
+	return fmt.Sprintf("non-markdown or binary document (%d bytes); not rendered as text. Retrieve the raw bytes with a non-MCP client, e.g. the demarkus CLI.", nBytes)
+}
+
+// binaryBody reports whether a fetched body is not markdown text and so must
+// not be rendered into the model's context. Every render path shares this one
+// decision. It is intentionally separate from the store's ValidateBody: this is
+// render-time detection on the client, not the persist-time contract, so the
+// client does not depend on server storage internals.
+func binaryBody(body string) bool { return !utf8.ValidString(body) }
 
 func markListTool(host string) mcp.Tool {
 	return mcp.NewTool("mark_list",
@@ -610,6 +627,13 @@ func (h *handler) markFetch(_ context.Context, req mcp.CallToolRequest) (*mcp.Ca
 	version := result.Response.Metadata["version"]
 	etag := result.Response.Metadata["etag"]
 	key := host + path
+
+	// Binary/non-UTF-8 body: render a notice, not mojibake. force lets an
+	// operator pull the raw bytes through MCP anyway.
+	if !force && binaryBody(body) {
+		return mcp.NewToolResultText(formatResultWith(result, nonMarkdownNotice(len(body)),
+			map[string]string{"mode": "binary"}, "version", "modified", "etag")), nil
+	}
 
 	// #section slice: works at any size and bypasses dedup — the agent is
 	// asking for content it has not necessarily seen.

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -265,20 +265,14 @@ func markFetchTool(host string) mcp.Tool {
 // requested.
 const outlineThreshold = 8 * 1024
 
-// nonMarkdownNotice is what the agent-facing render paths (mark_fetch,
-// mark_explore, resource read) return when a body is not valid UTF-8. The
-// publish gate rejects such content, but data predating the gate or loaded
-// into the store out-of-band can still exist; rendering it as text would inject
-// mojibake and control bytes straight into the model's context.
+// nonMarkdownNotice replaces a non-UTF-8 body in the agent-facing render paths;
+// rendering the raw bytes as text would inject mojibake into the model's context.
 func nonMarkdownNotice(nBytes int) string {
 	return fmt.Sprintf("non-markdown or binary document (%d bytes); not rendered as text. Retrieve the raw bytes with a non-MCP client, e.g. the demarkus CLI.", nBytes)
 }
 
-// binaryBody reports whether a fetched body is not markdown text and so must
-// not be rendered into the model's context. Every render path shares this one
-// decision. It is intentionally separate from the store's ValidateBody: this is
-// render-time detection on the client, not the persist-time contract, so the
-// client does not depend on server storage internals.
+// binaryBody flags a body that must not be rendered as text. Separate from the
+// store's ValidateBody: client render-time check, no dependency on storage.
 func binaryBody(body string) bool { return !utf8.ValidString(body) }
 
 func markListTool(host string) mcp.Tool {
@@ -628,9 +622,9 @@ func (h *handler) markFetch(_ context.Context, req mcp.CallToolRequest) (*mcp.Ca
 	etag := result.Response.Metadata["etag"]
 	key := host + path
 
-	// Binary/non-UTF-8 body: render a notice, not mojibake. force lets an
-	// operator pull the raw bytes through MCP anyway.
-	if !force && binaryBody(body) {
+	// Binary/non-UTF-8 body: always a notice, never bytes. MCP text can't carry
+	// binary faithfully (JSON mangles it); byte-exact retrieval is the CLI's job.
+	if binaryBody(body) {
 		return mcp.NewToolResultText(formatResultWith(result, nonMarkdownNotice(len(body)),
 			map[string]string{"mode": "binary"}, "version", "modified", "etag")), nil
 	}

--- a/client/cmd/demarkus-mcp/resources.go
+++ b/client/cmd/demarkus-mcp/resources.go
@@ -127,6 +127,14 @@ func (h *handler) readResource(_ context.Context, req mcp.ReadResourceRequest) (
 	}
 
 	body := result.Response.Body
+	// Binary/non-UTF-8 body: return a plain-text notice, not mojibake.
+	if binaryBody(body) {
+		return []mcp.ResourceContents{mcp.TextResourceContents{
+			URI:      raw,
+			MIMEType: "text/plain",
+			Text:     nonMarkdownNotice(len(body)),
+		}}, nil
+	}
 	if anchor != "" {
 		section, ok := mdoutline.Section(body, anchor)
 		if !ok {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -124,6 +124,7 @@ Everything after the metadata closing delimiter (or after the request line if no
 
 - The body is OPTIONAL for all verbs.
 - For PUBLISH requests, the body contains the document content.
+- For PUBLISH and APPEND, the body MUST be valid UTF-8. A document is markdown text (§2.3); the server MUST reject a non-UTF-8 body with `bad-request` and MUST NOT store it.
 - There is no protocol-level size limit on the body; servers SHOULD enforce a maximum document size (see Section 12.3).
 
 ## 5. Response Format
@@ -329,6 +330,8 @@ The `auth` metadata field is REQUIRED. The server hashes the raw token with SHA-
 
 The request body is the document content. It is stored as-is (the server prepends its own store frontmatter; the original content is preserved verbatim).
 
+**Document contract**: a published document is markdown text. The request path MUST end in `.md` and the body MUST be valid UTF-8 (§2.3, §4.4). The server MUST reject a path that does not end in `.md`, or a body that is not valid UTF-8, with `bad-request` and MUST NOT create a version. This gate also applies to APPEND (§6.6).
+
 **Success response** (`created`):
 
 ```text
@@ -378,6 +381,7 @@ The request MAY include an `expected-version` metadata field containing a decima
 **Other errors**:
 
 - `not-found`: Path validation failed (e.g., path traversal attempt).
+- `bad-request`: Path does not end in `.md`, or the body is not valid UTF-8 (see Document contract above).
 - `conflict`: `expected-version` does not match the current version (see optimistic concurrency above).
 - `server-error`: Internal error, content exceeds size limit, or publishing not configured.
 
@@ -464,7 +468,7 @@ modified: <RFC 3339 timestamp>
 
 **Other errors**:
 
-- `bad-request`: Missing or invalid `expected-version` (must be >= 1).
+- `bad-request`: Missing or invalid `expected-version` (must be >= 1), a non-`.md` path, or a body that is not valid UTF-8 (see §6.4 Document contract).
 - `not-found`: Document does not exist or path validation failed.
 - `archived`: Document is archived. Unarchive first via PUBLISH with empty body.
 - `conflict`: `expected-version` does not match the current version. Response includes `your-version` and `server-version` metadata.
@@ -543,6 +547,8 @@ Status values are text strings. There are no numeric status codes.
 | `archived` | The document has been archived. Version-pinned fetches still succeed. |
 | `unauthorized` | Missing or invalid authentication token. |
 | `not-permitted` | Valid authentication but insufficient capability for the requested operation or path. |
+| `conflict` | Version conflict; `expected-version` did not match the current version. |
+| `bad-request` | Malformed request, or a document that violates the content contract (non-`.md` path, non-UTF-8 body). |
 | `server-error` | The server encountered an error processing the request. |
 
 ### 7.1. Future Status Values
@@ -551,8 +557,6 @@ The following status values are reserved for future use:
 
 | Value | Intended meaning |
 |---|---|
-| `conflict` | Version conflict (e.g., simultaneous publishes). |
-| `bad-request` | Malformed request. |
 | `too-large` | Document exceeds the size limit. |
 | `unavailable` | Server temporarily cannot fulfil the request. |
 

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -35,6 +35,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/latebit-io/demarkus/protocol"
 )
@@ -87,6 +88,14 @@ var ErrVersionExists = fmt.Errorf("version already exists")
 
 // ErrSizeLimit is returned when combined content exceeds protocol.MaxBodyLength.
 var ErrSizeLimit = fmt.Errorf("combined content exceeds size limit")
+
+// ErrInvalidPath is returned when a publish path does not end in .md. The
+// protocol serves markdown documents; a non-.md path is not a document (SPEC 2.3).
+var ErrInvalidPath = fmt.Errorf("publish path must end in .md")
+
+// ErrInvalidContent is returned when a document body is not valid UTF-8.
+// Markdown is UTF-8 text; binary content is not a markdown document (SPEC 2.3, 4.4).
+var ErrInvalidContent = fmt.Errorf("document body must be valid UTF-8 text")
 
 // maxStoreFrontmatter is the maximum overhead the store-managed frontmatter
 // adds to a version file (version, archived, previous-hash, publisher
@@ -949,6 +958,9 @@ func (s *Store) Write(reqPath string, content []byte, meta map[string]string) (*
 	if err := validateMeta(meta); err != nil {
 		return nil, err
 	}
+	if err := ValidateBody(content); err != nil {
+		return nil, err
+	}
 
 	// Validate path stays within the store root (resolve handles traversal + symlinks).
 	if _, err := s.resolve(reqPath); err != nil {
@@ -1474,6 +1486,32 @@ func buildVersionFile(versionsDir, base string, version int, content []byte, met
 // handler's initial validation (e.g. injecting a default OKF type) can re-check
 // before the write and surface a precise error rather than a generic failure.
 func ValidateMeta(meta map[string]string) error { return validateMeta(meta) }
+
+// ValidateDocumentContent enforces the Mark Protocol document contract for
+// PUBLISH and APPEND: a document lives at a .md path and its body is UTF-8
+// text (markdown). Binary or non-.md content is not a markdown document and is
+// rejected before it reaches the store, where the markdown-derived features
+// (outline, title extraction, link graph) would otherwise produce garbage.
+// Callers map ErrInvalidPath / ErrInvalidContent to a bad-request response.
+func ValidateDocumentContent(reqPath string, content []byte) error {
+	if !strings.HasSuffix(reqPath, ".md") {
+		return ErrInvalidPath
+	}
+	return ValidateBody(content)
+}
+
+// ValidateBody is the content half of the document contract: a document body is
+// UTF-8 text (markdown). Each store backend's Write calls it as defense in depth
+// (the handler validates the full path+body via ValidateDocumentContent first),
+// so binary never persists even through a caller outside the network path. The
+// path (.md) rule is intentionally not enforced here: the store is path-agnostic
+// (versioning, hash chain, and traversal safety operate on arbitrary paths).
+func ValidateBody(content []byte) error {
+	if !utf8.Valid(content) {
+		return ErrInvalidContent
+	}
+	return nil
+}
 
 // validateMeta checks that metadata keys and values are safe for frontmatter
 // serialization. This is defense in depth — the handler also validates, but

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -1487,12 +1487,8 @@ func buildVersionFile(versionsDir, base string, version int, content []byte, met
 // before the write and surface a precise error rather than a generic failure.
 func ValidateMeta(meta map[string]string) error { return validateMeta(meta) }
 
-// ValidateDocumentContent enforces the Mark Protocol document contract for
-// PUBLISH and APPEND: a document lives at a .md path and its body is UTF-8
-// text (markdown). Binary or non-.md content is not a markdown document and is
-// rejected before it reaches the store, where the markdown-derived features
-// (outline, title extraction, link graph) would otherwise produce garbage.
-// Callers map ErrInvalidPath / ErrInvalidContent to a bad-request response.
+// ValidateDocumentContent enforces the document contract for PUBLISH/APPEND: a
+// .md path with a UTF-8 body. Callers map the errors to bad-request.
 func ValidateDocumentContent(reqPath string, content []byte) error {
 	if !strings.HasSuffix(reqPath, ".md") {
 		return ErrInvalidPath
@@ -1500,12 +1496,8 @@ func ValidateDocumentContent(reqPath string, content []byte) error {
 	return ValidateBody(content)
 }
 
-// ValidateBody is the content half of the document contract: a document body is
-// UTF-8 text (markdown). Each store backend's Write calls it as defense in depth
-// (the handler validates the full path+body via ValidateDocumentContent first),
-// so binary never persists even through a caller outside the network path. The
-// path (.md) rule is intentionally not enforced here: the store is path-agnostic
-// (versioning, hash chain, and traversal safety operate on arbitrary paths).
+// ValidateBody checks a body is UTF-8 text. Each backend's Write calls it as
+// defense in depth. No .md check here: the store is deliberately path-agnostic.
 func ValidateBody(content []byte) error {
 	if !utf8.Valid(content) {
 		return ErrInvalidContent

--- a/protocol/store/store_test.go
+++ b/protocol/store/store_test.go
@@ -2109,3 +2109,33 @@ func TestPruneVersions_DocDirOutsideRootRejected(t *testing.T) {
 		t.Errorf("file outside the store root was deleted: %v", err)
 	}
 }
+
+func TestValidateDocumentContent(t *testing.T) {
+	png := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 0xb1, 0xa5}
+	tests := []struct {
+		name    string
+		path    string
+		content []byte
+		want    error
+	}{
+		{"markdown at .md", "/doc.md", []byte("# Hello\n"), nil},
+		{"empty body at .md", "/doc.md", []byte(""), nil},
+		{"utf8 multibyte at .md", "/doc.md", []byte("# café ☕\n"), nil},
+		{"nested .md path", "/a/b/c.md", []byte("x"), nil},
+		{"png bytes at .png", "/img.png", png, ErrInvalidPath},
+		{"text at .txt", "/notes.txt", []byte("plain"), ErrInvalidPath},
+		{"no extension", "/README", []byte("x"), ErrInvalidPath},
+		{"uppercase .MD rejected", "/doc.MD", []byte("x"), ErrInvalidPath},
+		{"png bytes smuggled into .md", "/sneaky.md", png, ErrInvalidContent},
+		{"invalid utf8 in .md", "/doc.md", []byte{0xff, 0xfe}, ErrInvalidContent},
+		{"path checked before content", "/img.png", png, ErrInvalidPath},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateDocumentContent(tt.path, tt.content)
+			if !errors.Is(err, tt.want) {
+				t.Errorf("ValidateDocumentContent(%q, %d bytes) = %v, want %v", tt.path, len(tt.content), err, tt.want)
+			}
+		})
+	}
+}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -828,6 +828,11 @@ func (h *Handler) handlePublish(w io.Writer, req protocol.Request) {
 		h.writeError(w, protocol.StatusBadRequest, err.Error())
 		return
 	}
+	if err := store.ValidateDocumentContent(req.Path, []byte(req.Body)); err != nil {
+		h.logger().Info("publish rejected", "audit", true, "operation", "PUBLISH", "path", sanitize(req.Path), "token_label", sanitize(tokenLabel), "success", false, "reason", "invalid document")
+		h.writeError(w, protocol.StatusBadRequest, err.Error())
+		return
+	}
 
 	expectedVersion := -1 // default: no check when expected-version is absent
 	if ev := req.Metadata["expected-version"]; ev != "" {
@@ -951,6 +956,11 @@ func (h *Handler) handleAppend(w io.Writer, req protocol.Request) {
 	}
 	pubMeta = applyOKFTypeDefault(req.Path, pubMeta)
 	if err := store.ValidateMeta(pubMeta); err != nil {
+		h.writeError(w, protocol.StatusBadRequest, err.Error())
+		return
+	}
+	if err := store.ValidateDocumentContent(req.Path, []byte(req.Body)); err != nil {
+		h.logger().Info("append rejected", "audit", true, "operation", "APPEND", "path", sanitize(req.Path), "token_label", sanitize(tokenLabel), "success", false, "reason", "invalid document")
 		h.writeError(w, protocol.StatusBadRequest, err.Error())
 		return
 	}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -777,6 +777,14 @@ func (h *Handler) handlePublish(w io.Writer, req protocol.Request) {
 		return
 	}
 
+	// Contract before the empty-body shortcut: a non-.md path is rejected
+	// even with an empty body.
+	if err := store.ValidateDocumentContent(req.Path, []byte(req.Body)); err != nil {
+		h.logger().Info("publish rejected", "audit", true, "operation", "PUBLISH", "path", sanitize(req.Path), "token_label", sanitize(tokenLabel), "success", false, "reason", "invalid document")
+		h.writeError(w, protocol.StatusBadRequest, err.Error())
+		return
+	}
+
 	// Handle empty body case: unarchive if archived, no-op if active
 	if req.Body == "" {
 		doc, err := h.Store.Get(req.Path, 0)
@@ -825,11 +833,6 @@ func (h *Handler) handlePublish(w io.Writer, req protocol.Request) {
 	}
 	pubMeta = applyOKFTypeDefault(req.Path, pubMeta)
 	if err := store.ValidateMeta(pubMeta); err != nil {
-		h.writeError(w, protocol.StatusBadRequest, err.Error())
-		return
-	}
-	if err := store.ValidateDocumentContent(req.Path, []byte(req.Body)); err != nil {
-		h.logger().Info("publish rejected", "audit", true, "operation", "PUBLISH", "path", sanitize(req.Path), "token_label", sanitize(tokenLabel), "success", false, "reason", "invalid document")
 		h.writeError(w, protocol.StatusBadRequest, err.Error())
 		return
 	}
@@ -921,10 +924,6 @@ func (h *Handler) handleAppend(w io.Writer, req protocol.Request) {
 		h.writeError(w, protocol.StatusServerError, "content exceeds size limit")
 		return
 	}
-	if req.Body == "" {
-		h.writeError(w, protocol.StatusServerError, "append requires a body")
-		return
-	}
 
 	var ts *auth.TokenStore
 	if h.GetTokenStore != nil {
@@ -949,6 +948,18 @@ func (h *Handler) handleAppend(w io.Writer, req protocol.Request) {
 		return
 	}
 
+	// Contract before the empty-body check: a non-.md path is rejected as
+	// bad-request rather than reported as a missing body.
+	if err := store.ValidateDocumentContent(req.Path, []byte(req.Body)); err != nil {
+		h.logger().Info("append rejected", "audit", true, "operation", "APPEND", "path", sanitize(req.Path), "token_label", sanitize(tokenLabel), "success", false, "reason", "invalid document")
+		h.writeError(w, protocol.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Body == "" {
+		h.writeError(w, protocol.StatusServerError, "append requires a body")
+		return
+	}
+
 	pubMeta, err := extractPublisherMeta(req.Metadata)
 	if err != nil {
 		h.writeError(w, protocol.StatusBadRequest, err.Error())
@@ -956,11 +967,6 @@ func (h *Handler) handleAppend(w io.Writer, req protocol.Request) {
 	}
 	pubMeta = applyOKFTypeDefault(req.Path, pubMeta)
 	if err := store.ValidateMeta(pubMeta); err != nil {
-		h.writeError(w, protocol.StatusBadRequest, err.Error())
-		return
-	}
-	if err := store.ValidateDocumentContent(req.Path, []byte(req.Body)); err != nil {
-		h.logger().Info("append rejected", "audit", true, "operation", "APPEND", "path", sanitize(req.Path), "token_label", sanitize(tokenLabel), "success", false, "reason", "invalid document")
 		h.writeError(w, protocol.StatusBadRequest, err.Error())
 		return
 	}

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -1286,6 +1286,58 @@ func TestHandlePublish(t *testing.T) {
 	})
 }
 
+func TestHandleWrite_RejectsNonMarkdown(t *testing.T) {
+	const secret = "reject-secret"
+	ts := auth.NewTokenStore(map[string]auth.Token{
+		protocol.HashToken(secret): {Paths: []string{"/*"}, Operations: []string{"publish"}},
+	})
+	authMeta := "---\nauth: " + secret + "\n---\n"
+	// PNG magic: invalid UTF-8, so it fails the content check even at a .md path.
+	png := "\x89PNG\r\n\x1a\n\xb1\xa5"
+
+	tests := []struct {
+		name string
+		req  string
+	}{
+		{"publish png to .png path", "PUBLISH /img.png\n" + authMeta + png},
+		{"publish png bytes to .md path", "PUBLISH /sneaky.md\n" + authMeta + png},
+		{"publish text to .txt path", "PUBLISH /notes.txt\n" + authMeta + "plain text\n"},
+		{"append needs expected-version too, but path is gated first",
+			"APPEND /img.png\n---\nauth: " + secret + "\nexpected-version: 1\n---\nmore\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			h := &Handler{ContentDir: dir, Store: store.New(dir), Logger: discardLogger, GetTokenStore: func() *auth.TokenStore { return ts }}
+
+			stream := newMockStream(tt.req)
+			h.HandleStream(stream)
+
+			resp, err := protocol.ParseResponse(&stream.output)
+			if err != nil {
+				t.Fatalf("parse response: %v", err)
+			}
+			if resp.Status != protocol.StatusBadRequest {
+				t.Errorf("status: got %q, want %q (body: %q)", resp.Status, protocol.StatusBadRequest, resp.Body)
+			}
+		})
+	}
+
+	t.Run("valid markdown still publishes", func(t *testing.T) {
+		dir := t.TempDir()
+		h := &Handler{ContentDir: dir, Store: store.New(dir), Logger: discardLogger, GetTokenStore: func() *auth.TokenStore { return ts }}
+		stream := newMockStream("PUBLISH /ok.md\n" + authMeta + "# Good\n")
+		h.HandleStream(stream)
+		resp, err := protocol.ParseResponse(&stream.output)
+		if err != nil {
+			t.Fatalf("parse response: %v", err)
+		}
+		if resp.Status != protocol.StatusCreated {
+			t.Errorf("status: got %q, want %q", resp.Status, protocol.StatusCreated)
+		}
+	})
+}
+
 func TestHandlePublishAuth(t *testing.T) {
 	// Raw secrets used in requests. Store keys are their hashes.
 	const (

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -1302,8 +1302,12 @@ func TestHandleWrite_RejectsNonMarkdown(t *testing.T) {
 		{"publish png to .png path", "PUBLISH /img.png\n" + authMeta + png},
 		{"publish png bytes to .md path", "PUBLISH /sneaky.md\n" + authMeta + png},
 		{"publish text to .txt path", "PUBLISH /notes.txt\n" + authMeta + "plain text\n"},
+		// Empty body must not slip past the .md contract via the no-op shortcut.
+		{"publish empty body to .txt path", "PUBLISH /notes.txt\n" + authMeta},
 		{"append needs expected-version too, but path is gated first",
 			"APPEND /img.png\n---\nauth: " + secret + "\nexpected-version: 1\n---\nmore\n"},
+		{"append empty body to .txt path",
+			"APPEND /notes.txt\n---\nauth: " + secret + "\nexpected-version: 1\n---\n"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/server/internal/pgstore/pgstore.go
+++ b/server/internal/pgstore/pgstore.go
@@ -463,6 +463,9 @@ func (s *Store) write(reqPath string, expectedVersion int, content []byte, meta 
 	if err := store.ValidateMeta(meta); err != nil {
 		return nil, err
 	}
+	if err := store.ValidateBody(content); err != nil {
+		return nil, err
+	}
 	p := canonical(reqPath)
 	if p == "" {
 		return nil, os.ErrNotExist

--- a/server/internal/storetest/conformance.go
+++ b/server/internal/storetest/conformance.go
@@ -36,6 +36,7 @@ func RunConformance(t *testing.T, factory Factory) {
 		{"RetentionPrune", testRetentionPrune},
 		{"MissingDocument", testMissingDocument},
 		{"PathCollisions", testPathCollisions},
+		{"RejectsBinaryBody", testRejectsBinaryBody},
 	}
 	for _, st := range subtests {
 		t.Run(st.name, func(t *testing.T) {
@@ -339,6 +340,33 @@ func testPathCollisions(t *testing.T, s handler.DocumentStore) {
 	}
 	if cur := s.CurrentVersion("/col/doc.md/child.md"); cur != 0 {
 		t.Errorf("collision write left version state under /col/doc.md (version %d)", cur)
+	}
+}
+
+func testRejectsBinaryBody(t *testing.T, s handler.DocumentStore) {
+	// Not valid UTF-8: a document body is markdown text. Every backend must
+	// refuse to persist it, so binary never reaches the store even through a
+	// caller outside the network path (the handler validates too).
+	binary := []byte{0x89, 'P', 'N', 'G', 0xff, 0xfe, 0x00}
+
+	if _, err := s.WriteVersion("/bin.md", 0, binary, nil); !errors.Is(err, store.ErrInvalidContent) {
+		t.Errorf("WriteVersion binary body: err = %v, want ErrInvalidContent", err)
+	}
+	if _, err := s.Get("/bin.md", 0); err == nil {
+		t.Error("rejected binary write left a fetchable document at /bin.md")
+	}
+	if cur := s.CurrentVersion("/bin.md"); cur != 0 {
+		t.Errorf("rejected binary write left version state at /bin.md (version %d)", cur)
+	}
+
+	// An append that would introduce binary must be rejected too, leaving the
+	// existing text version untouched.
+	mustWrite(t, s, "/doc.md", 0, "# Text\n")
+	if _, err := s.Append("/doc.md", 1, binary, nil); !errors.Is(err, store.ErrInvalidContent) {
+		t.Errorf("Append binary body: err = %v, want ErrInvalidContent", err)
+	}
+	if cur := s.CurrentVersion("/doc.md"); cur != 1 {
+		t.Errorf("rejected binary append advanced /doc.md to version %d, want 1", cur)
 	}
 }
 

--- a/server/internal/storetest/conformance.go
+++ b/server/internal/storetest/conformance.go
@@ -344,9 +344,8 @@ func testPathCollisions(t *testing.T, s handler.DocumentStore) {
 }
 
 func testRejectsBinaryBody(t *testing.T, s handler.DocumentStore) {
-	// Not valid UTF-8: a document body is markdown text. Every backend must
-	// refuse to persist it, so binary never reaches the store even through a
-	// caller outside the network path (the handler validates too).
+	// A document body is markdown text; every backend must refuse to persist
+	// non-UTF-8, even when called outside the network path.
 	binary := []byte{0x89, 'P', 'N', 'G', 0xff, 0xfe, 0x00}
 
 	if _, err := s.WriteVersion("/bin.md", 0, binary, nil); !errors.Is(err, store.ErrInvalidContent) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Binary/non-UTF-8 document fetches and resource views now show a clear non-Markdown notice (with existing identity metadata preserved) instead of attempting Markdown rendering or slicing.
* **Bug Fixes**
  * Publish and append now validate request bodies as UTF-8 and require valid `.md` paths, rejecting invalid inputs with `bad-request`.
  * Binary content is blocked from being persisted or advanced; conformance and handler tests cover these cases.
* **Documentation**
  * Updated the protocol specification to tighten UTF-8 and `.md` requirements for write operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->