### PR TITLE
fix(mcp): guard MCP gateway render paths against non-UTF-8 bodies

### DIFF
--- a/client/cmd/demarkus-mcp/explore.go
+++ b/client/cmd/demarkus-mcp/explore.go
@@ -58,8 +58,8 @@ func (h *handler) markExplore(_ context.Context, req mcp.CallToolRequest) (*mcp.
 	body := result.Response.Body
 
 	// Binary/non-UTF-8 body: an outline over it is garbage; return a notice.
-	if binaryBody(body) {
-		return mcp.NewToolResultText(formatResultWith(result, nonMarkdownNotice(len(body)),
+	if mdoutline.BinaryBody(body) {
+		return mcp.NewToolResultText(formatResultWith(result, mdoutline.NonMarkdownNotice(len(body)),
 			map[string]string{"mode": "binary"}, "version", "modified", "etag")), nil
 	}
 

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode/utf8"
 
 	"github.com/latebit-io/demarkus/client/fetch"
 	"github.com/latebit-io/demarkus/client/fetchdedup"
@@ -264,16 +263,6 @@ func markFetchTool(host string) mcp.Tool {
 // an outline instead of the full body, unless force=true or a #section is
 // requested.
 const outlineThreshold = 8 * 1024
-
-// nonMarkdownNotice replaces a non-UTF-8 body in the agent-facing render paths;
-// rendering the raw bytes as text would inject mojibake into the model's context.
-func nonMarkdownNotice(nBytes int) string {
-	return fmt.Sprintf("non-markdown or binary document (%d bytes); not rendered as text. Retrieve the raw bytes with a non-MCP client, e.g. the demarkus CLI.", nBytes)
-}
-
-// binaryBody flags a body that must not be rendered as text. Separate from the
-// store's ValidateBody: client render-time check, no dependency on storage.
-func binaryBody(body string) bool { return !utf8.ValidString(body) }
 
 func markListTool(host string) mcp.Tool {
 	return mcp.NewTool("mark_list",
@@ -624,8 +613,8 @@ func (h *handler) markFetch(_ context.Context, req mcp.CallToolRequest) (*mcp.Ca
 
 	// Binary/non-UTF-8 body: always a notice, never bytes. MCP text can't carry
 	// binary faithfully (JSON mangles it); byte-exact retrieval is the CLI's job.
-	if binaryBody(body) {
-		return mcp.NewToolResultText(formatResultWith(result, nonMarkdownNotice(len(body)),
+	if mdoutline.BinaryBody(body) {
+		return mcp.NewToolResultText(formatResultWith(result, mdoutline.NonMarkdownNotice(len(body)),
 			map[string]string{"mode": "binary"}, "version", "modified", "etag")), nil
 	}
 

--- a/client/cmd/demarkus-mcp/resources.go
+++ b/client/cmd/demarkus-mcp/resources.go
@@ -128,11 +128,11 @@ func (h *handler) readResource(_ context.Context, req mcp.ReadResourceRequest) (
 
 	body := result.Response.Body
 	// Binary/non-UTF-8 body: return a plain-text notice, not mojibake.
-	if binaryBody(body) {
+	if mdoutline.BinaryBody(body) {
 		return []mcp.ResourceContents{mcp.TextResourceContents{
 			URI:      raw,
 			MIMEType: "text/plain",
-			Text:     nonMarkdownNotice(len(body)),
+			Text:     mdoutline.NonMarkdownNotice(len(body)),
 		}}, nil
 	}
 	if anchor != "" {

--- a/client/mdoutline/render.go
+++ b/client/mdoutline/render.go
@@ -3,6 +3,7 @@ package mdoutline
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/latebit-io/demarkus/client/links"
 )
@@ -65,4 +66,15 @@ func CappedList(b *strings.Builder, lines []string, limit int, noun string) {
 	if n := len(lines) - limit; n > 0 {
 		fmt.Fprintf(b, "+%d more %s\n", n, noun)
 	}
+}
+
+// BinaryBody flags a body that must not be rendered as text. Separate from
+// the store's ValidateBody: render-time check, no dependency on storage.
+func BinaryBody(body string) bool { return !utf8.ValidString(body) }
+
+// NonMarkdownNotice replaces a non-UTF-8 body in the agent-facing render
+// paths; rendering the raw bytes as text would inject mojibake into the
+// model's context.
+func NonMarkdownNotice(nBytes int) string {
+	return fmt.Sprintf("non-markdown or binary document (%d bytes); not rendered as text. Retrieve the raw bytes with a non-MCP client, e.g. the demarkus CLI.", nBytes)
 }

--- a/client/mdoutline/render_test.go
+++ b/client/mdoutline/render_test.go
@@ -1,0 +1,37 @@
+package mdoutline
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBinaryBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"markdown", "# Doc\n\nText.\n", false},
+		{"empty", "", false},
+		{"multibyte utf8", "héllo — ✓\n", false},
+		{"png magic", "\x89PNG\r\n\x1a\n\xff\xfe\x00", true},
+		{"lone continuation byte", "ok\xb1", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BinaryBody(tt.body); got != tt.want {
+				t.Errorf("BinaryBody(%q) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNonMarkdownNotice(t *testing.T) {
+	notice := NonMarkdownNotice(42)
+	if !strings.Contains(notice, "42 bytes") {
+		t.Errorf("notice should carry the byte count, got: %s", notice)
+	}
+	if !strings.Contains(notice, "non-markdown or binary document") {
+		t.Errorf("notice missing the identifying phrase, got: %s", notice)
+	}
+}

--- a/tools/demarkus-broker/internal/broker/mcp_resources.go
+++ b/tools/demarkus-broker/internal/broker/mcp_resources.go
@@ -70,6 +70,14 @@ func (g *mcpGateway) readResource(_ context.Context, req mcp.ReadResourceRequest
 	}
 
 	body := result.Response.Body
+	// Binary/non-UTF-8 body: return a plain-text notice, not mojibake.
+	if mdoutline.BinaryBody(body) {
+		return []mcp.ResourceContents{mcp.TextResourceContents{
+			URI:      raw,
+			MIMEType: "text/plain",
+			Text:     mdoutline.NonMarkdownNotice(len(body)),
+		}}, nil
+	}
 	if anchor != "" {
 		section, ok := mdoutline.Section(body, anchor)
 		if !ok {

--- a/tools/demarkus-broker/internal/broker/mcp_resources_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_resources_test.go
@@ -161,3 +161,29 @@ func TestGatewayReadResource_Errors(t *testing.T) {
 		})
 	}
 }
+
+func TestGatewayReadResource_BinaryNotice(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), fetchModeDispatcher(binaryFetchModeDoc, "1", "abc"))
+	contents, err := g.readResource(context.Background(), mcp.ReadResourceRequest{
+		Params: mcp.ReadResourceParams{URI: "mark://team-a/img.png"},
+	})
+	if err != nil {
+		t.Fatalf("readResource: %v", err)
+	}
+	if len(contents) != 1 {
+		t.Fatalf("got %d contents, want 1", len(contents))
+	}
+	text, ok := contents[0].(mcp.TextResourceContents)
+	if !ok {
+		t.Fatalf("contents[0] is %T, want TextResourceContents", contents[0])
+	}
+	if text.MIMEType != "text/plain" {
+		t.Errorf("MIMEType = %q, want text/plain", text.MIMEType)
+	}
+	if !strings.Contains(text.Text, "non-markdown or binary document") {
+		t.Errorf("binary body should return the notice, got:\n%s", text.Text)
+	}
+	if strings.Contains(text.Text, "\x89PNG") {
+		t.Error("binary bytes must not be rendered into the resource")
+	}
+}

--- a/tools/demarkus-broker/internal/broker/mcp_tools_explore.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_explore.go
@@ -44,6 +44,12 @@ func (g *mcpGateway) handleMarkExplore(ctx context.Context, req mcp.CallToolRequ
 	}
 	body := result.Response.Body
 
+	// Binary/non-UTF-8 body: an outline over it is garbage; return a notice.
+	if mdoutline.BinaryBody(body) {
+		return mcp.NewToolResultText(formatToolResultWith(result, mdoutline.NonMarkdownNotice(len(body)),
+			map[string]string{"mode": "binary"}, "version", "modified", "etag")), nil
+	}
+
 	var b strings.Builder
 
 	b.WriteString("## Outline\n")

--- a/tools/demarkus-broker/internal/broker/mcp_tools_explore_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_explore_test.go
@@ -168,3 +168,14 @@ func TestHandleMarkExploreInvalidURL(t *testing.T) {
 		t.Fatal("expected tool error for missing world name")
 	}
 }
+
+func TestHandleMarkExploreBinaryNotice(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), fetchModeDispatcher(binaryFetchModeDoc, "1", "abc"))
+	text := exploreResultText(t, g, "mark://team-a/img.png")
+	if !strings.Contains(text, "non-markdown or binary document") {
+		t.Errorf("binary body should return the notice, got:\n%s", text)
+	}
+	if strings.Contains(text, "## Outline") {
+		t.Error("binary body must not be run through the outline builder")
+	}
+}

--- a/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode.go
@@ -176,6 +176,13 @@ func (g *mcpGateway) handleMarkFetch(ctx context.Context, req mcp.CallToolReques
 	etag := result.Response.Metadata["etag"]
 	key := worldName + path
 
+	// Binary/non-UTF-8 body: always a notice, never bytes. MCP text can't
+	// carry binary faithfully (JSON mangles it). Matches the local client.
+	if mdoutline.BinaryBody(body) {
+		return mcp.NewToolResultText(formatToolResultWith(result, mdoutline.NonMarkdownNotice(len(body)),
+			map[string]string{"mode": "binary"}, "version", "modified", "etag")), nil
+	}
+
 	// #section slice: works at any size and bypasses dedup — the agent
 	// is asking for content it has not necessarily seen.
 	if anchor != "" {

--- a/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_fetchmode_test.go
@@ -352,3 +352,34 @@ func TestHandleMarkFetchNoIdentityNoDedup(t *testing.T) {
 		}
 	}
 }
+
+// binaryFetchModeDoc is a non-UTF-8 body (PNG magic), standing in for legacy
+// or out-of-band binary a brokered fetch might still encounter.
+const binaryFetchModeDoc = "\x89PNG\r\n\x1a\n\xff\xfe\x00\xb1\xa5"
+
+func TestHandleMarkFetchBinaryNotice(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), fetchModeDispatcher(binaryFetchModeDoc, "1", "abc"))
+	text := fetchModeText(withAliceClaims(context.Background()), t, g, map[string]any{"url": "mark://team-a/img.png"})
+	if !strings.Contains(text, "mode: binary") {
+		t.Errorf("binary body should be flagged mode: binary, got:\n%s", text)
+	}
+	if !strings.Contains(text, "non-markdown or binary document") {
+		t.Errorf("binary body should return the notice, got:\n%s", text)
+	}
+	if strings.Contains(text, "\x89PNG") {
+		t.Error("binary bytes must not be rendered into the response")
+	}
+}
+
+func TestHandleMarkFetchBinaryForceStillNotice(t *testing.T) {
+	// force bypasses the size gate, never the binary gate: MCP text cannot
+	// carry binary faithfully, so force=true must still return the notice.
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), fetchModeDispatcher(binaryFetchModeDoc, "1", "abc"))
+	text := fetchModeText(withAliceClaims(context.Background()), t, g, map[string]any{"url": "mark://team-a/img.png", "force": true})
+	if !strings.Contains(text, "non-markdown or binary document") {
+		t.Errorf("force=true must still return the binary notice, got:\n%s", text)
+	}
+	if strings.Contains(text, "\x89PNG") {
+		t.Error("force=true must not leak raw binary bytes")
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Binary and non-markdown documents are now detected consistently across exploration, fetching, and resource views.
  - These documents return a clear text notice with their size instead of attempting to render unreadable content.
  - Binary responses include explicit binary-mode metadata where applicable.
  - Raw binary data is no longer exposed in rendered results, while normal Markdown behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->