### PR TITLE
fix(tools): mint plugin token with recursive /** scope

### DIFF
--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -80,6 +80,14 @@ const (
 
 const tokenLabel = "claude-code-plugin"
 
+// tokenPaths is the scope minted for the plugin token. legacyTokenPaths is the
+// pre-fix scope: path.Match's "*" does not cross "/", so it blocked writes to
+// nested docs; entries still carrying it are revoked and reminted.
+const (
+	tokenPaths       = "/**"
+	legacyTokenPaths = "/*"
+)
+
 //go:embed seed/index.md seed/project-template.md
 var seedFS embed.FS
 
@@ -529,9 +537,9 @@ func installFile(src, dst string) error {
 // ensureTokenEntry generates a plugin-scoped token, writes the raw token to
 // ~/.demarkus/plugin-memory.token (mode 0600), and appends an entry for
 // tokenLabel to tokensTOML. Idempotent: a no-op when the token file and a
-// matching tokens.toml entry already exist. Stale state (token file gone but the
-// label still present, or an entry with the old single-segment "/*" scope) is
-// revoked before regenerating.
+// current tokens.toml entry already exist. Stale state (token file gone but the
+// label still present, or an entry with the legacy scope) is revoked before
+// regenerating.
 func ensureTokenEntry(tokensTOML string) error {
 	tokenFile, err := pluginToken()
 	if err != nil {
@@ -542,8 +550,11 @@ func ensureTokenEntry(tokensTOML string) error {
 		return err
 	}
 
-	labelPresent := tokensHasLabel(tokensTOML)
-	if fileExists(tokenFile) && fileExists(tokensTOML) && labelPresent && !tokenScopeStale(tokensTOML) {
+	entry, present, err := pluginEntry(tokensTOML)
+	if err != nil {
+		return err
+	}
+	if fileExists(tokenFile) && present && !scopeStale(&entry) {
 		// Reassert 0600 on the idempotent path: an existing token left
 		// world/group-readable (e.g. from an older install) would otherwise stay
 		// exposed forever since we return without regenerating.
@@ -552,11 +563,15 @@ func ensureTokenEntry(tokensTOML string) error {
 	}
 
 	// Stale state — revoke any prior entry with our label before regenerating.
-	if labelPresent {
+	// A failed revoke would make the generate below fail on a label collision,
+	// so surface it here where the cause is clear.
+	if present {
 		revoke := exec.Command(tokenBin, "revoke", "-label", tokenLabel, "-tokens", tokensTOML)
 		revoke.Stdout = io.Discard
 		revoke.Stderr = io.Discard
-		_ = revoke.Run() // best-effort
+		if err := revoke.Run(); err != nil {
+			return fmt.Errorf("revoke stale plugin token (label=%s, tokens.toml: %s): %w", tokenLabel, tokensTOML, err)
+		}
 	}
 
 	if err := os.MkdirAll(filepath.Dir(tokensTOML), 0o755); err != nil {
@@ -578,9 +593,7 @@ func ensureTokenEntry(tokensTOML string) error {
 		defer func() { _ = tf.Close() }()
 		gen := exec.Command(tokenBin, "generate",
 			"-label", tokenLabel,
-			// "/**" is recursive; "/*" only matches single-segment paths and
-			// forced agents to widen the scope by hand after install.
-			"-paths", "/**",
+			"-paths", tokenPaths,
 			"-ops", "publish,archive",
 			"-tokens", tokensTOML,
 		)
@@ -604,40 +617,47 @@ func ensureTokenEntry(tokensTOML string) error {
 	// A server already running against this root loaded the pre-remint token
 	// table; without a reload the fresh raw token fails auth until restart.
 	if pid := pidOfServerAtRoot(filepath.Dir(tokensTOML)); pid > 0 {
-		if err := signalPID(pid, syscall.SIGHUP); err == nil {
-			logf("sent SIGHUP to server (pid=%d) to reload reminted token", pid)
-		} else {
-			warnf("SIGHUP to pid %d failed; reminted token inactive until the server restarts", pid)
+		if err := signalReload(pid); err != nil {
+			return fmt.Errorf("reload reminted token: %w", err)
 		}
 	}
 	return nil
 }
 
-// tokensHasLabel reports whether tokensTOML contains a "[tokens.<label>]"
-// section (bash grep "tokens\.LABEL\]").
-func tokensHasLabel(tokensTOML string) bool {
-	b, err := os.ReadFile(tokensTOML)
-	if err != nil {
-		return false
+// signalReload SIGHUPs a server so it reloads tokens.toml. A vanished process
+// is fine: the respawn path loads the fresh table.
+func signalReload(pid int) error {
+	err := signalPID(pid, syscall.SIGHUP)
+	switch {
+	case err == nil:
+		logf("sent SIGHUP to server (pid=%d) to reload tokens", pid)
+		return nil
+	case errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH):
+		return nil
+	default:
+		return fmt.Errorf("SIGHUP to server pid %d: %w", pid, err)
 	}
-	return strings.Contains(string(b), "tokens."+tokenLabel+"]")
 }
 
-// tokenScopeStale reports whether the plugin's entry still carries the old
-// "/*" scope, which only matches single-segment paths and blocked writes to
-// nested docs until an agent widened it by hand. Stale entries are revoked and
-// reminted with "/**". Unreadable files are not stale: regenerating on a parse
-// error would clobber a tokens.toml we can't safely interpret.
-func tokenScopeStale(tokensTOML string) bool {
+// pluginEntry parses tokensTOML and returns the plugin's entry and whether it
+// exists. A missing file is absence, not an error. Parse errors surface: an
+// uninterpretable tokens.toml must not pass as current (or be clobbered).
+func pluginEntry(tokensTOML string) (token.Entry, bool, error) {
 	f, err := token.ReadFile(tokensTOML)
+	if errors.Is(err, os.ErrNotExist) {
+		return token.Entry{}, false, nil
+	}
 	if err != nil {
-		return false
+		return token.Entry{}, false, fmt.Errorf("inspect plugin token entry: %w", err)
 	}
 	entry, ok := f.Tokens[tokenLabel]
-	if !ok {
-		return false
-	}
-	return slices.Contains(entry.Paths, "/*") && !slices.Contains(entry.Paths, "/**")
+	return entry, ok, nil
+}
+
+// scopeStale reports whether an entry still carries the legacy scope without
+// the current one. A manually widened entry listing both is left alone.
+func scopeStale(entry *token.Entry) bool {
+	return slices.Contains(entry.Paths, legacyTokenPaths) && !slices.Contains(entry.Paths, tokenPaths)
 }
 
 // withUmask runs fn with the process umask set to mask, restoring it after.
@@ -1199,10 +1219,10 @@ func doReuse(port int, root string) error {
 		if actualPort != "" && actualPort != strconv.Itoa(port) {
 			return fmt.Errorf("the demarkus-server at root %s (pid %d) is listening on port %s, not %d; re-run with --port %s", root, targetPID, actualPort, port, actualPort)
 		}
-		if err := signalPID(targetPID, syscall.SIGHUP); err == nil {
-			logf("sent SIGHUP to adopted server (pid=%d) to reload tokens", targetPID)
-		} else {
-			warnf("SIGHUP to pid %d failed; tokens may not be active until the server restarts", targetPID)
+		// Warn-only here: the adopted server may not be ours, and with no remint
+		// implied the loaded token table is usually already current.
+		if err := signalReload(targetPID); err != nil {
+			warnf("%v; tokens may not be active until the server restarts", err)
 		}
 	} else {
 		warnf("no running server found with -root %s; proceeding with config, but /soul-init may need a rerun once it's up", root)

--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -567,10 +567,11 @@ func ensureTokenEntry(tokensTOML string) error {
 	// so surface it here where the cause is clear.
 	if present {
 		revoke := exec.Command(tokenBin, "revoke", "-label", tokenLabel, "-tokens", tokensTOML)
+		var stderr bytes.Buffer
 		revoke.Stdout = io.Discard
-		revoke.Stderr = io.Discard
+		revoke.Stderr = &stderr
 		if err := revoke.Run(); err != nil {
-			return fmt.Errorf("revoke stale plugin token (label=%s, tokens.toml: %s): %w", tokenLabel, tokensTOML, err)
+			return fmt.Errorf("revoke stale plugin token (label=%s, tokens.toml: %s): %w: %s", tokenLabel, tokensTOML, err, strings.TrimSpace(stderr.String()))
 		}
 	}
 
@@ -616,8 +617,12 @@ func ensureTokenEntry(tokensTOML string) error {
 
 	// A server already running against this root loaded the pre-remint token
 	// table; without a reload the fresh raw token fails auth until restart.
+	// On failure, drop the token file so the next run re-enters the mint path
+	// (and re-signals) instead of passing the idempotent gate with a token the
+	// server never loaded.
 	if pid := pidOfServerAtRoot(filepath.Dir(tokensTOML)); pid > 0 {
 		if err := signalReload(pid); err != nil {
+			_ = os.Remove(tokenFile)
 			return fmt.Errorf("reload reminted token: %w", err)
 		}
 	}

--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -36,6 +36,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/latebit-io/demarkus/protocol"
 	"github.com/latebit-io/demarkus/protocol/token"
 	"github.com/latebit-io/demarkus/tools/demarkus-plugin/internal/config"
 )
@@ -551,7 +552,7 @@ func ensureTokenEntry(tokensTOML string) error {
 	if err != nil {
 		return err
 	}
-	if fileExists(tokenFile) && present && !scopeStale(&entry) {
+	if present && !scopeStale(&entry) && rawMatchesEntry(tokenFile, &entry) {
 		// Reassert 0600 on the idempotent path: an existing token left
 		// world/group-readable (e.g. from an older install) would otherwise stay
 		// exposed forever since we return without regenerating.
@@ -604,6 +605,17 @@ func ensureTokenEntry(tokensTOML string) error {
 		return fmt.Errorf("demarkus-token generate failed (tokens.toml: %s): %w", tokensTOML, genErr)
 	}
 
+	// Reload BEFORE committing the raw token: a running server holds the
+	// pre-remint table, and committing only after a successful reload keeps the
+	// gate's invariant — a matching token file implies the server loaded it, so
+	// any failure here self-heals via a remint on the next run.
+	if pid := findServerAtRoot(filepath.Dir(tokensTOML)); pid > 0 {
+		if err := reloadServer(pid); err != nil {
+			_ = os.Remove(tmpTok) // best-effort; a leftover .tmp never satisfies the gate
+			return fmt.Errorf("reload reminted token: %w", err)
+		}
+	}
+
 	if err := os.Rename(tmpTok, tokenFile); err != nil {
 		return err
 	}
@@ -611,19 +623,24 @@ func ensureTokenEntry(tokensTOML string) error {
 		return err
 	}
 	logf("generated plugin token (label=%s)", tokenLabel)
-
-	// A running server still holds the pre-remint token table; reload or the
-	// fresh raw token fails auth. On failure, drop the token file so the next
-	// run re-enters the mint path and re-signals.
-	if pid := pidOfServerAtRoot(filepath.Dir(tokensTOML)); pid > 0 {
-		if err := signalReload(pid); err != nil {
-			if removeErr := os.Remove(tokenFile); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-				return fmt.Errorf("reload reminted token: %w; remove token file for retry: %v", err, removeErr)
-			}
-			return fmt.Errorf("reload reminted token: %w", err)
-		}
-	}
 	return nil
+}
+
+// Test seams: reload-path coverage stubs these without a live server.
+var (
+	findServerAtRoot = pidOfServerAtRoot
+	reloadServer     = signalReload
+)
+
+// rawMatchesEntry reports whether the raw token on disk hashes to the entry's
+// hash. False on a missing or unreadable file: an inconsistent pair (e.g.
+// leftovers of a failed run) must fall through to a remint.
+func rawMatchesEntry(tokenFile string, entry *token.Entry) bool {
+	raw, err := os.ReadFile(tokenFile)
+	if err != nil {
+		return false
+	}
+	return protocol.HashToken(strings.TrimSpace(string(raw))) == entry.Hash
 }
 
 // signalReload SIGHUPs a server so it reloads tokens.toml. A vanished process

--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -29,12 +29,14 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
+	"github.com/latebit-io/demarkus/protocol/token"
 	"github.com/latebit-io/demarkus/tools/demarkus-plugin/internal/config"
 )
 
@@ -528,7 +530,8 @@ func installFile(src, dst string) error {
 // ~/.demarkus/plugin-memory.token (mode 0600), and appends an entry for
 // tokenLabel to tokensTOML. Idempotent: a no-op when the token file and a
 // matching tokens.toml entry already exist. Stale state (token file gone but the
-// label still present) is revoked before regenerating.
+// label still present, or an entry with the old single-segment "/*" scope) is
+// revoked before regenerating.
 func ensureTokenEntry(tokensTOML string) error {
 	tokenFile, err := pluginToken()
 	if err != nil {
@@ -540,7 +543,7 @@ func ensureTokenEntry(tokensTOML string) error {
 	}
 
 	labelPresent := tokensHasLabel(tokensTOML)
-	if fileExists(tokenFile) && fileExists(tokensTOML) && labelPresent {
+	if fileExists(tokenFile) && fileExists(tokensTOML) && labelPresent && !tokenScopeStale(tokensTOML) {
 		// Reassert 0600 on the idempotent path: an existing token left
 		// world/group-readable (e.g. from an older install) would otherwise stay
 		// exposed forever since we return without regenerating.
@@ -575,7 +578,9 @@ func ensureTokenEntry(tokensTOML string) error {
 		defer func() { _ = tf.Close() }()
 		gen := exec.Command(tokenBin, "generate",
 			"-label", tokenLabel,
-			"-paths", "/*",
+			// "/**" is recursive; "/*" only matches single-segment paths and
+			// forced agents to widen the scope by hand after install.
+			"-paths", "/**",
 			"-ops", "publish,archive",
 			"-tokens", tokensTOML,
 		)
@@ -595,6 +600,16 @@ func ensureTokenEntry(tokensTOML string) error {
 		return err
 	}
 	logf("generated plugin token (label=%s)", tokenLabel)
+
+	// A server already running against this root loaded the pre-remint token
+	// table; without a reload the fresh raw token fails auth until restart.
+	if pid := pidOfServerAtRoot(filepath.Dir(tokensTOML)); pid > 0 {
+		if err := signalPID(pid, syscall.SIGHUP); err == nil {
+			logf("sent SIGHUP to server (pid=%d) to reload reminted token", pid)
+		} else {
+			warnf("SIGHUP to pid %d failed; reminted token inactive until the server restarts", pid)
+		}
+	}
 	return nil
 }
 
@@ -606,6 +621,23 @@ func tokensHasLabel(tokensTOML string) bool {
 		return false
 	}
 	return strings.Contains(string(b), "tokens."+tokenLabel+"]")
+}
+
+// tokenScopeStale reports whether the plugin's entry still carries the old
+// "/*" scope, which only matches single-segment paths and blocked writes to
+// nested docs until an agent widened it by hand. Stale entries are revoked and
+// reminted with "/**". Unreadable files are not stale: regenerating on a parse
+// error would clobber a tokens.toml we can't safely interpret.
+func tokenScopeStale(tokensTOML string) bool {
+	f, err := token.ReadFile(tokensTOML)
+	if err != nil {
+		return false
+	}
+	entry, ok := f.Tokens[tokenLabel]
+	if !ok {
+		return false
+	}
+	return slices.Contains(entry.Paths, "/*") && !slices.Contains(entry.Paths, "/**")
 }
 
 // withUmask runs fn with the process umask set to mask, restoring it after.

--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -534,12 +534,9 @@ func installFile(src, dst string) error {
 
 // --- token (lib.sh ensure_token_entry) ---------------------------------------
 
-// ensureTokenEntry generates a plugin-scoped token, writes the raw token to
-// ~/.demarkus/plugin-memory.token (mode 0600), and appends an entry for
-// tokenLabel to tokensTOML. Idempotent: a no-op when the token file and a
-// current tokens.toml entry already exist. Stale state (token file gone but the
-// label still present, or an entry with the legacy scope) is revoked before
-// regenerating.
+// ensureTokenEntry mints the plugin token (raw to plugin-memory.token, entry to
+// tokensTOML). Idempotent when both exist with a current scope; stale state
+// (missing token file, or a legacy-scope entry) is revoked and reminted.
 func ensureTokenEntry(tokensTOML string) error {
 	tokenFile, err := pluginToken()
 	if err != nil {
@@ -615,14 +612,14 @@ func ensureTokenEntry(tokensTOML string) error {
 	}
 	logf("generated plugin token (label=%s)", tokenLabel)
 
-	// A server already running against this root loaded the pre-remint token
-	// table; without a reload the fresh raw token fails auth until restart.
-	// On failure, drop the token file so the next run re-enters the mint path
-	// (and re-signals) instead of passing the idempotent gate with a token the
-	// server never loaded.
+	// A running server still holds the pre-remint token table; reload or the
+	// fresh raw token fails auth. On failure, drop the token file so the next
+	// run re-enters the mint path and re-signals.
 	if pid := pidOfServerAtRoot(filepath.Dir(tokensTOML)); pid > 0 {
 		if err := signalReload(pid); err != nil {
-			_ = os.Remove(tokenFile)
+			if removeErr := os.Remove(tokenFile); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+				return fmt.Errorf("reload reminted token: %w; remove token file for retry: %v", err, removeErr)
+			}
 			return fmt.Errorf("reload reminted token: %w", err)
 		}
 	}

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -363,8 +363,10 @@ if [[ "$cmd" == "revoke" ]]; then
   : > "$tokens"
 fi
 if [[ "$cmd" == "generate" ]]; then
-  printf '\n[tokens.%s]\nhash = "fake"\npaths = ["%s"]\noperations = ["publish", "archive"]\n' "$label" "$paths" >> "$tokens"
-  echo "raw-token-value"
+  raw="raw-token-value"
+  sum=$(printf %s "$raw" | shasum -a 256 | cut -d' ' -f1)
+  printf '\n[tokens.%s]\nhash = "sha256-%s"\npaths = ["%s"]\noperations = ["publish", "archive"]\n' "$label" "$sum" "$paths" >> "$tokens"
+  echo "$raw"
 fi
 `
 	if err := os.WriteFile(filepath.Join(binDir, "demarkus-token"), []byte(fake), 0o755); err != nil {
@@ -462,6 +464,102 @@ fi
 	if err := ensureTokenEntry(tokensTOML); err == nil {
 		t.Error("malformed tokens.toml did not surface an error")
 	}
+
+	// A raw token that no longer matches the entry's hash (leftovers of a
+	// failed run) fails the gate and is reminted.
+	if err := os.Remove(tokensTOML); err != nil { // clear the malformed file
+		t.Fatal(err)
+	}
+	if err := ensureTokenEntry(tokensTOML); err != nil {
+		t.Fatalf("re-mint after malformed: %v", err)
+	}
+	tokenFile, err := pluginToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tokenFile, []byte("not-the-minted-raw"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	log = phaseLog(func() {
+		if err := ensureTokenEntry(tokensTOML); err != nil {
+			t.Fatalf("mismatched-raw remint: %v", err)
+		}
+	})
+	if !strings.Contains(log, "-paths /**") {
+		t.Errorf("mismatched raw token did not trigger a remint; argv:\n%s", log)
+	}
+}
+
+// TestEnsureTokenEntryReload covers the reload branch via the test seams: a
+// failed reload aborts before the token file is committed, and the next run
+// re-enters the mint path and re-signals.
+func TestEnsureTokenEntryReload(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	binDir := filepath.Join(home, ".demarkus", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fake := `#!/bin/bash
+cmd="$1"; shift
+label=""; paths=""; tokens=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -label) label="$2"; shift 2 ;;
+    -paths) paths="$2"; shift 2 ;;
+    -tokens) tokens="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[[ "$cmd" == "revoke" ]] && : > "$tokens"
+if [[ "$cmd" == "generate" ]]; then
+  raw="raw-token-value"
+  sum=$(printf %s "$raw" | shasum -a 256 | cut -d' ' -f1)
+  printf '\n[tokens.%s]\nhash = "sha256-%s"\npaths = ["%s"]\noperations = ["publish", "archive"]\n' "$label" "$sum" "$paths" >> "$tokens"
+  echo "$raw"
+fi
+`
+	if err := os.WriteFile(filepath.Join(binDir, "demarkus-token"), []byte(fake), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	soul := filepath.Join(home, "root")
+	if err := os.MkdirAll(soul, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tokensTOML := filepath.Join(soul, "tokens.toml")
+	tokenFile, err := pluginToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	origFind, origReload := findServerAtRoot, reloadServer
+	t.Cleanup(func() { findServerAtRoot, reloadServer = origFind, origReload })
+	findServerAtRoot = func(string) int { return 4242 }
+	reloads := 0
+	reloadServer = func(int) error { reloads++; return errors.New("injected reload failure") }
+
+	if err := ensureTokenEntry(tokensTOML); err == nil {
+		t.Fatal("failed reload did not surface an error")
+	}
+	if reloads != 1 {
+		t.Fatalf("reloads = %d, want 1", reloads)
+	}
+	if fileExists(tokenFile) {
+		t.Error("token file committed despite failed reload; gate would skip the retry")
+	}
+
+	// The next run retries: mint again, reload succeeds, token file commits.
+	reloadServer = func(int) error { reloads++; return nil }
+	if err := ensureTokenEntry(tokensTOML); err != nil {
+		t.Fatalf("retry after failed reload: %v", err)
+	}
+	if reloads != 2 {
+		t.Fatalf("reloads = %d, want 2", reloads)
+	}
+	if !fileExists(tokenFile) {
+		t.Error("token file missing after successful retry")
+	}
 }
 
 // TestSignalReload covers the nil paths: live owned child, then vanished pid.
@@ -490,5 +588,13 @@ func TestSignalReload(t *testing.T) {
 
 	if err := signalReload(pid); err != nil {
 		t.Errorf("signalReload(dead pid) = %v, want nil", err)
+	}
+
+	// Non-positive pids are rejected before any signal: kill(0)/kill(-1)
+	// broadcast to the process group / all reachable processes.
+	for _, bad := range []int{0, -1} {
+		if err := signalReload(bad); err == nil {
+			t.Errorf("signalReload(%d) = nil, want error", bad)
+		}
 	}
 }

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -333,20 +333,22 @@ func TestPluginEntry(t *testing.T) {
 	}
 }
 
-// TestEnsureTokenEntryScope pins the minted scope to the recursive "/**" and
-// the remint-on-stale-scope behavior, via a fake demarkus-token binary that
-// logs its argv and mirrors generate's tokens.toml append.
-func TestEnsureTokenEntryScope(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
+// writeFakeTokenBin installs a fake demarkus-token under $HOME/.demarkus/bin
+// that mirrors revoke (truncate; fixtures hold only the plugin's stanza, and
+// FAKE_REVOKE_FAIL=1 forces failure) and generate (real sha256- hash so the
+// gate's verification runs). A non-empty argsLog gets each invocation's argv.
+func writeFakeTokenBin(t *testing.T, home, argsLog string) {
+	t.Helper()
 	binDir := filepath.Join(home, ".demarkus", "bin")
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	argsLog := filepath.Join(home, "args.log")
+	logLine := ""
+	if argsLog != "" {
+		logLine = `echo "$@" >> "` + argsLog + `"`
+	}
 	fake := `#!/bin/bash
-echo "$@" >> "` + argsLog + `"
+` + logLine + `
 cmd="$1"; shift
 label=""; paths=""; tokens=""
 while [[ $# -gt 0 ]]; do
@@ -359,12 +361,16 @@ while [[ $# -gt 0 ]]; do
 done
 if [[ "$cmd" == "revoke" ]]; then
   [[ -n "$FAKE_REVOKE_FAIL" ]] && exit 1
-  # Fixtures hold only the plugin's stanza, so revoke == truncate.
   : > "$tokens"
 fi
 if [[ "$cmd" == "generate" ]]; then
   raw="raw-token-value"
-  sum=$(printf %s "$raw" | shasum -a 256 | cut -d' ' -f1)
+  # sha256sum on minimal Linux images, shasum on macOS; neither alone is portable.
+  if command -v sha256sum >/dev/null 2>&1; then
+    sum=$(printf %s "$raw" | sha256sum | cut -d' ' -f1)
+  else
+    sum=$(printf %s "$raw" | shasum -a 256 | cut -d' ' -f1)
+  fi
   printf '\n[tokens.%s]\nhash = "sha256-%s"\npaths = ["%s"]\noperations = ["publish", "archive"]\n' "$label" "$sum" "$paths" >> "$tokens"
   echo "$raw"
 fi
@@ -372,6 +378,16 @@ fi
 	if err := os.WriteFile(filepath.Join(binDir, "demarkus-token"), []byte(fake), 0o755); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// TestEnsureTokenEntryScope pins the minted scope to the recursive "/**" and
+// the remint-on-stale-scope behavior, via a fake demarkus-token binary that
+// logs its argv and mirrors generate's tokens.toml append.
+func TestEnsureTokenEntryScope(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	argsLog := filepath.Join(home, "args.log")
+	writeFakeTokenBin(t, home, argsLog)
 
 	soul := filepath.Join(home, "root")
 	if err := os.MkdirAll(soul, 0o755); err != nil {
@@ -496,33 +512,8 @@ fi
 func TestEnsureTokenEntryReload(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	writeFakeTokenBin(t, home, "")
 
-	binDir := filepath.Join(home, ".demarkus", "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	fake := `#!/bin/bash
-cmd="$1"; shift
-label=""; paths=""; tokens=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -label) label="$2"; shift 2 ;;
-    -paths) paths="$2"; shift 2 ;;
-    -tokens) tokens="$2"; shift 2 ;;
-    *) shift ;;
-  esac
-done
-[[ "$cmd" == "revoke" ]] && : > "$tokens"
-if [[ "$cmd" == "generate" ]]; then
-  raw="raw-token-value"
-  sum=$(printf %s "$raw" | shasum -a 256 | cut -d' ' -f1)
-  printf '\n[tokens.%s]\nhash = "sha256-%s"\npaths = ["%s"]\noperations = ["publish", "archive"]\n' "$label" "$sum" "$paths" >> "$tokens"
-  echo "$raw"
-fi
-`
-	if err := os.WriteFile(filepath.Join(binDir, "demarkus-token"), []byte(fake), 0o755); err != nil {
-		t.Fatal(err)
-	}
 	soul := filepath.Join(home, "root")
 	if err := os.MkdirAll(soul, 0o755); err != nil {
 		t.Fatal(err)

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/latebit-io/demarkus/protocol/token"
@@ -463,20 +464,29 @@ fi
 	}
 }
 
-// TestSignalReload covers the nil paths directly: a live process we own is
-// signalled, and a vanished pid is tolerated (the respawn path takes over).
-// The hard-error branch (e.g. EPERM) needs a process under another uid and is
-// not reachable from a unit test.
+// TestSignalReload covers the nil paths: live owned child, then vanished pid.
+// The hard-error branch (EPERM) needs a foreign-uid process; not unit-reachable.
 func TestSignalReload(t *testing.T) {
 	cmd := exec.Command("sleep", "30")
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
+	// Kill on an already-reaped child returns ErrProcessDone; safe to ignore.
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
 	pid := cmd.Process.Pid
+
 	if err := signalReload(pid); err != nil {
-		t.Errorf("signalReload(live child) = %v", err)
+		t.Fatalf("signalReload(live child) = %v", err)
 	}
-	_ = cmd.Wait() // reaps the HUP-terminated child
+	// The child must die to our SIGHUP, not run out its sleep.
+	err := cmd.Wait()
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("child exit was not an ExitError: %v", err)
+	}
+	if sig := ee.ProcessState.Sys().(syscall.WaitStatus).Signal(); sig != syscall.SIGHUP {
+		t.Fatalf("child terminated by %v, want SIGHUP", sig)
+	}
 
 	if err := signalReload(pid); err != nil {
 		t.Errorf("signalReload(dead pid) = %v, want nil", err)

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/latebit-io/demarkus/protocol/token"
 )
 
 // TestDetectPlatform checks the OS_arch mapping produces a sane release suffix on
@@ -270,41 +273,61 @@ func TestSeedDocNeverClobbers(t *testing.T) {
 	}
 }
 
-func TestTokenScopeStale(t *testing.T) {
-	dir := t.TempDir()
-	write := func(name, body string) string {
-		p := filepath.Join(dir, name)
-		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		return p
-	}
-	entry := func(paths string) string {
-		return "[tokens." + tokenLabel + "]\nhash = \"abc\"\npaths = [" + paths + "]\noperations = [\"publish\"]\n"
-	}
-
+func TestScopeStale(t *testing.T) {
 	tests := []struct {
 		name  string
-		body  string
+		paths []string
 		stale bool
 	}{
-		{"old single-segment scope", entry(`"/*"`), true},
-		{"recursive scope", entry(`"/**"`), false},
-		{"both patterns present", entry(`"/*", "/**"`), false},
-		{"other label only", "[tokens.other]\nhash = \"x\"\npaths = [\"/*\"]\noperations = [\"publish\"]\n", false},
-		{"unparseable file", "not toml [[[", false},
+		{"legacy single-segment scope", []string{"/*"}, true},
+		{"recursive scope", []string{"/**"}, false},
+		{"both patterns present", []string{"/*", "/**"}, false},
+		{"unrelated scope", []string{"/docs/*"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := write(strings.ReplaceAll(tt.name, " ", "-")+".toml", tt.body)
-			if got := tokenScopeStale(p); got != tt.stale {
-				t.Errorf("tokenScopeStale = %v, want %v", got, tt.stale)
+			if got := scopeStale(&token.Entry{Paths: tt.paths}); got != tt.stale {
+				t.Errorf("scopeStale(%v) = %v, want %v", tt.paths, got, tt.stale)
 			}
 		})
 	}
+}
 
-	if tokenScopeStale(filepath.Join(dir, "missing.toml")) {
-		t.Error("missing file reported stale")
+func TestPluginEntry(t *testing.T) {
+	dir := t.TempDir()
+	pluginStanza := token.FormatEntry(tokenLabel, &token.Entry{Hash: "abc", Paths: []string{"/*"}, Operations: []string{"publish"}})
+	otherStanza := token.FormatEntry("other", &token.Entry{Hash: "x", Paths: []string{"/*"}, Operations: []string{"publish"}})
+
+	tests := []struct {
+		name    string
+		body    string // empty means don't write the file
+		present bool
+		wantErr bool
+	}{
+		{"plugin entry present", pluginStanza, true, false},
+		{"other label only", otherStanza, false, false},
+		{"unparseable file", "not toml [[[", false, true},
+		{"missing file", "", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := filepath.Join(dir, strings.ReplaceAll(tt.name, " ", "-")+".toml")
+			if tt.body != "" {
+				if err := os.WriteFile(p, []byte(tt.body), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			entry, present, err := pluginEntry(p)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("pluginEntry err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if present != tt.present {
+				t.Errorf("present = %v, want %v", present, tt.present)
+			}
+			if present && len(entry.Paths) == 0 {
+				t.Error("present entry has no paths")
+			}
+		})
 	}
 }
 
@@ -332,6 +355,11 @@ while [[ $# -gt 0 ]]; do
     *) shift ;;
   esac
 done
+if [[ "$cmd" == "revoke" ]]; then
+  [[ -n "$FAKE_REVOKE_FAIL" ]] && exit 1
+  # Fixtures hold only the plugin's stanza, so revoke == truncate.
+  : > "$tokens"
+fi
 if [[ "$cmd" == "generate" ]]; then
   printf '\n[tokens.%s]\nhash = "fake"\npaths = ["%s"]\noperations = ["publish", "archive"]\n' "$label" "$paths" >> "$tokens"
   echo "raw-token-value"
@@ -347,47 +375,89 @@ fi
 	}
 	tokensTOML := filepath.Join(soul, "tokens.toml")
 	readLog := func() string {
-		b, _ := os.ReadFile(argsLog)
+		t.Helper()
+		b, err := os.ReadFile(argsLog)
+		if errors.Is(err, os.ErrNotExist) {
+			return ""
+		}
+		if err != nil {
+			t.Fatalf("read args log: %v", err)
+		}
 		return string(b)
 	}
+	// phaseLog scopes assertions to the invocations one phase made.
+	phaseLog := func(fn func()) string {
+		t.Helper()
+		before := len(readLog())
+		fn()
+		return readLog()[before:]
+	}
+	staleStanza := token.FormatEntry(tokenLabel, &token.Entry{Hash: "old", Paths: []string{"/*"}, Operations: []string{"publish"}})
 
 	// Fresh install mints with the recursive scope.
-	if err := ensureTokenEntry(tokensTOML); err != nil {
-		t.Fatalf("fresh mint: %v", err)
-	}
-	if !strings.Contains(readLog(), "-paths /**") {
-		t.Fatalf("fresh mint did not use /**; argv log:\n%s", readLog())
-	}
-	toml, err := os.ReadFile(tokensTOML)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(toml), `"/**"`) {
-		t.Fatalf("tokens.toml entry not recursive:\n%s", toml)
+	log := phaseLog(func() {
+		if err := ensureTokenEntry(tokensTOML); err != nil {
+			t.Fatalf("fresh mint: %v", err)
+		}
+	})
+	if !strings.Contains(log, "-paths /**") {
+		t.Fatalf("fresh mint did not use /**; argv:\n%s", log)
 	}
 
 	// Provisioned-and-current is a no-op: no further binary invocations.
-	before := readLog()
-	if err := ensureTokenEntry(tokensTOML); err != nil {
-		t.Fatalf("idempotent rerun: %v", err)
-	}
-	if readLog() != before {
-		t.Fatalf("idempotent rerun invoked demarkus-token; argv log:\n%s", readLog())
+	log = phaseLog(func() {
+		if err := ensureTokenEntry(tokensTOML); err != nil {
+			t.Fatalf("idempotent rerun: %v", err)
+		}
+	})
+	if log != "" {
+		t.Fatalf("idempotent rerun invoked demarkus-token; argv:\n%s", log)
 	}
 
 	// An old install with the single-segment "/*" scope is revoked and reminted.
-	stale := "[tokens." + tokenLabel + "]\nhash = \"old\"\npaths = [\"/*\"]\noperations = [\"publish\"]\n"
-	if err := os.WriteFile(tokensTOML, []byte(stale), 0o600); err != nil {
+	if err := os.WriteFile(tokensTOML, []byte(staleStanza), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := ensureTokenEntry(tokensTOML); err != nil {
-		t.Fatalf("stale-scope remint: %v", err)
-	}
-	log := readLog()
+	log = phaseLog(func() {
+		if err := ensureTokenEntry(tokensTOML); err != nil {
+			t.Fatalf("stale-scope remint: %v", err)
+		}
+	})
 	if !strings.Contains(log, "revoke -label "+tokenLabel) {
-		t.Errorf("stale scope did not revoke; argv log:\n%s", log)
+		t.Errorf("stale scope did not revoke; argv:\n%s", log)
 	}
-	if strings.Count(log, "-paths /**") != 2 {
-		t.Errorf("stale scope did not remint with /**; argv log:\n%s", log)
+	if !strings.Contains(log, "-paths /**") {
+		t.Errorf("stale scope did not remint with /**; argv:\n%s", log)
+	}
+	f, err := token.ReadFile(tokensTOML)
+	if err != nil {
+		t.Fatalf("reminted tokens.toml unparseable: %v", err)
+	}
+	got, ok := f.Tokens[tokenLabel]
+	if !ok {
+		t.Fatalf("reminted tokens.toml lacks %s entry", tokenLabel)
+	}
+	if len(got.Paths) != 1 || got.Paths[0] != "/**" {
+		t.Errorf("reminted entry paths = %v, want [/**]", got.Paths)
+	}
+
+	// A revoke failure surfaces instead of proceeding to a colliding generate.
+	if err := os.WriteFile(tokensTOML, []byte(staleStanza), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FAKE_REVOKE_FAIL", "1")
+	if err := ensureTokenEntry(tokensTOML); err == nil {
+		t.Error("revoke failure did not surface an error")
+	}
+	t.Setenv("FAKE_REVOKE_FAIL", "")
+
+	// A tokens.toml we cannot parse fails provisioning rather than being
+	// silently treated as current (or clobbered).
+	malformed := "[tokens." + tokenLabel + "]\nnot toml [[["
+	if err := os.WriteFile(tokensTOML, []byte(malformed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureTokenEntry(tokensTOML); err == nil {
+		t.Error("malformed tokens.toml did not surface an error")
 	}
 }

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -269,3 +269,125 @@ func TestSeedDocNeverClobbers(t *testing.T) {
 		t.Errorf("seeded content does not look like index.md: %q", b[:min(40, len(b))])
 	}
 }
+
+func TestTokenScopeStale(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	entry := func(paths string) string {
+		return "[tokens." + tokenLabel + "]\nhash = \"abc\"\npaths = [" + paths + "]\noperations = [\"publish\"]\n"
+	}
+
+	tests := []struct {
+		name  string
+		body  string
+		stale bool
+	}{
+		{"old single-segment scope", entry(`"/*"`), true},
+		{"recursive scope", entry(`"/**"`), false},
+		{"both patterns present", entry(`"/*", "/**"`), false},
+		{"other label only", "[tokens.other]\nhash = \"x\"\npaths = [\"/*\"]\noperations = [\"publish\"]\n", false},
+		{"unparseable file", "not toml [[[", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := write(strings.ReplaceAll(tt.name, " ", "-")+".toml", tt.body)
+			if got := tokenScopeStale(p); got != tt.stale {
+				t.Errorf("tokenScopeStale = %v, want %v", got, tt.stale)
+			}
+		})
+	}
+
+	if tokenScopeStale(filepath.Join(dir, "missing.toml")) {
+		t.Error("missing file reported stale")
+	}
+}
+
+// TestEnsureTokenEntryScope pins the minted scope to the recursive "/**" and
+// the remint-on-stale-scope behavior, via a fake demarkus-token binary that
+// logs its argv and mirrors generate's tokens.toml append.
+func TestEnsureTokenEntryScope(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	binDir := filepath.Join(home, ".demarkus", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	argsLog := filepath.Join(home, "args.log")
+	fake := `#!/bin/bash
+echo "$@" >> "` + argsLog + `"
+cmd="$1"; shift
+label=""; paths=""; tokens=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -label) label="$2"; shift 2 ;;
+    -paths) paths="$2"; shift 2 ;;
+    -tokens) tokens="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [[ "$cmd" == "generate" ]]; then
+  printf '\n[tokens.%s]\nhash = "fake"\npaths = ["%s"]\noperations = ["publish", "archive"]\n' "$label" "$paths" >> "$tokens"
+  echo "raw-token-value"
+fi
+`
+	if err := os.WriteFile(filepath.Join(binDir, "demarkus-token"), []byte(fake), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	soul := filepath.Join(home, "root")
+	if err := os.MkdirAll(soul, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tokensTOML := filepath.Join(soul, "tokens.toml")
+	readLog := func() string {
+		b, _ := os.ReadFile(argsLog)
+		return string(b)
+	}
+
+	// Fresh install mints with the recursive scope.
+	if err := ensureTokenEntry(tokensTOML); err != nil {
+		t.Fatalf("fresh mint: %v", err)
+	}
+	if !strings.Contains(readLog(), "-paths /**") {
+		t.Fatalf("fresh mint did not use /**; argv log:\n%s", readLog())
+	}
+	toml, err := os.ReadFile(tokensTOML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(toml), `"/**"`) {
+		t.Fatalf("tokens.toml entry not recursive:\n%s", toml)
+	}
+
+	// Provisioned-and-current is a no-op: no further binary invocations.
+	before := readLog()
+	if err := ensureTokenEntry(tokensTOML); err != nil {
+		t.Fatalf("idempotent rerun: %v", err)
+	}
+	if readLog() != before {
+		t.Fatalf("idempotent rerun invoked demarkus-token; argv log:\n%s", readLog())
+	}
+
+	// An old install with the single-segment "/*" scope is revoked and reminted.
+	stale := "[tokens." + tokenLabel + "]\nhash = \"old\"\npaths = [\"/*\"]\noperations = [\"publish\"]\n"
+	if err := os.WriteFile(tokensTOML, []byte(stale), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureTokenEntry(tokensTOML); err != nil {
+		t.Fatalf("stale-scope remint: %v", err)
+	}
+	log := readLog()
+	if !strings.Contains(log, "revoke -label "+tokenLabel) {
+		t.Errorf("stale scope did not revoke; argv log:\n%s", log)
+	}
+	if strings.Count(log, "-paths /**") != 2 {
+		t.Errorf("stale scope did not remint with /**; argv log:\n%s", log)
+	}
+}

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -459,5 +460,25 @@ fi
 	}
 	if err := ensureTokenEntry(tokensTOML); err == nil {
 		t.Error("malformed tokens.toml did not surface an error")
+	}
+}
+
+// TestSignalReload covers the nil paths directly: a live process we own is
+// signalled, and a vanished pid is tolerated (the respawn path takes over).
+// The hard-error branch (e.g. EPERM) needs a process under another uid and is
+// not reachable from a unit test.
+func TestSignalReload(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pid := cmd.Process.Pid
+	if err := signalReload(pid); err != nil {
+		t.Errorf("signalReload(live child) = %v", err)
+	}
+	_ = cmd.Wait() // reaps the HUP-terminated child
+
+	if err := signalReload(pid); err != nil {
+		t.Errorf("signalReload(dead pid) = %v, want nil", err)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated token provisioning to use recursive access scopes.
  * Automatically replaces tokens with outdated scopes or mismatched credentials.
  * Validates plugin configuration before provisioning credentials.
  * Running servers now reload refreshed credentials automatically when possible.
  * Added warnings when credential reloads cannot be completed.
  * Provisioning now reports errors when outdated credentials cannot be revoked or configuration is invalid.

* **Tests**
  * Added coverage for scope validation, idempotent updates, stale-token replacement, configuration errors, and credential reload scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->