### PR TITLE
fix(mcp): serve RFC 8414 metadata on issuer host only

### DIFF
--- a/deploy/helm/demarkus-broker/README.md
+++ b/deploy/helm/demarkus-broker/README.md
@@ -145,12 +145,17 @@ ingress:
 ```
 
 Splitting the hosts avoids `.well-known/*` path collisions: the
-management API serves `/.well-known/openid-configuration` and
-`/.well-known/jwks.json` for OIDC discovery, while the MCP gateway
-serves `/.well-known/oauth-protected-resource` (RFC 9728) and
-`/.well-known/oauth-authorization-server` (RFC 8414) for OAuth
-metadata. Two hostnames, two TLS contexts, no path-routing
-fragility, and operators rotate certs on either side independently.
+management API (the issuer origin) serves
+`/.well-known/openid-configuration`,
+`/.well-known/oauth-authorization-server` (RFC 8414 — must live on
+the issuer's origin per §3.3, strict clients validate issuer ==
+fetch origin) and `/.well-known/jwks.json`, while the MCP gateway
+serves only `/.well-known/oauth-protected-resource` (RFC 9728,
+bare and path-inserted `/mcp` forms). Set `server.mcp.publicURL`
+to the gateway host so the `resource` field and the 401
+`resource_metadata` link name the gateway, not the issuer. Two
+hostnames, two TLS contexts, no path-routing fragility, and
+operators rotate certs on either side independently.
 
 ### TLS termination
 
@@ -190,16 +195,18 @@ The gateway implements MCP's [authorization
 spec](https://modelcontextprotocol.io/specification/2024-11-05/basic/authorization)
 using the broker's existing OIDC machinery:
 
-- `GET /.well-known/oauth-protected-resource` (RFC 9728) — declares
-  the resource server and points clients at the authorization-server
-  metadata.
-- `GET /.well-known/oauth-authorization-server` (RFC 8414) —
-  authorization-server metadata. Aliases the broker's existing OIDC
-  Discovery handler (`/.well-known/openid-configuration` on the
-  management API) so the broker advertises itself as both the MCP
-  resource server AND the authorization server. The actual IdP
-  (Google, Okta, Entra) is one hop deeper, handled by the broker's
-  existing PR3 device-flow + PR4 refresh-grant code.
+- `GET /.well-known/oauth-protected-resource` (RFC 9728, also the
+  path-inserted `/mcp` form) — declares the resource server
+  (`resource` = gateway host `/mcp`) and points clients at the
+  authorization server (`authorization_servers` = the management
+  host, i.e. `server.publicURL`).
+- `GET /.well-known/oauth-authorization-server` (RFC 8414) — served
+  on the **management host**, aliasing the OIDC Discovery handler
+  (`/.well-known/openid-configuration`): §3.3 requires the metadata
+  on the issuer's own origin, so the gateway deliberately does not
+  serve it. The actual IdP (Google, Okta, Entra) is one hop deeper,
+  handled by the broker's existing PR3 device-flow + PR4
+  refresh-grant code.
 - `POST /mcp` — single JSON-RPC endpoint. Unauthenticated requests
   receive `401 + WWW-Authenticate: Bearer
   resource_metadata="...oauth-protected-resource"` per RFC 6750 +

--- a/deploy/helm/demarkus-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-broker/templates/secret-config.yaml
@@ -90,6 +90,9 @@ stringData:
              listens plain HTTP and the Ingress terminates TLS. */}}
       mcp:
         addr: {{ .Values.server.mcp.addr | quote }}
+        {{- with .Values.server.mcp.publicURL }}
+        publicURL: {{ . | quote }}
+        {{- end }}
         {{- with .Values.server.mcp.tls.existingSecretRef.name }}
         tls:
           certFile: {{ printf "%s/tls.crt" (include "demarkus-broker.mcpTLSMountPath" $) | quote }}

--- a/deploy/helm/demarkus-broker/tests/mcp_test.yaml
+++ b/deploy/helm/demarkus-broker/tests/mcp_test.yaml
@@ -137,6 +137,22 @@ tests:
           path: stringData["config.yaml"]
           pattern: 'mcp:\s*\n\s*addr: ":8081"\s*\n\s*firstMintMaxAttempts: 6\s*\n\s*firstMintInitialBackoff: "250ms"\s*\n\s*firstMintMaxBackoff: "8s"'
 
+  - it: config.yaml omits mcp.publicURL when unset (falls back to server.publicURL in the broker)
+    template: secret-config.yaml
+    asserts:
+      - notMatchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'mcp:\s*\n\s*addr: ":8081"\s*\n\s*publicURL:'
+
+  - it: server.mcp.publicURL renders into the mcp block (split-host ingress)
+    template: secret-config.yaml
+    set:
+      server.mcp.publicURL: https://knowledge.example.com
+    asserts:
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'mcp:\s*\n\s*addr: ":8081"\s*\n\s*publicURL: "https://knowledge.example.com"'
+
   - it: config.yaml omits mcp.tls block when no existingSecretRef set
     template: secret-config.yaml
     asserts:

--- a/deploy/helm/demarkus-broker/values.yaml
+++ b/deploy/helm/demarkus-broker/values.yaml
@@ -99,12 +99,9 @@ server:
     # the management API and the MCP surface bind distinct listeners.
     # The Service exposes both ports; the Ingress routes by hostname.
     addr: ":8081"
-    # Externally-reachable base URL of the MCP gateway, no trailing
-    # slash (e.g. https://knowledge.acmecorp.com). Set it whenever
-    # ingress.mcp.host differs from ingress.host: it feeds the
-    # RFC 9728 `resource` field and the 401 resource_metadata link,
-    # which must name the gateway host, not the issuer. Empty falls
-    # back to server.publicURL (single-host deployments).
+    # Externally-reachable base URL of the MCP gateway, no trailing slash.
+    # Set when ingress.mcp.host differs from ingress.host (feeds RFC 9728
+    # `resource` + the 401 resource_metadata link). Empty = server.publicURL.
     publicURL: ""
     # TLS termination at the broker for the MCP listener. Two modes:
     #

--- a/deploy/helm/demarkus-broker/values.yaml
+++ b/deploy/helm/demarkus-broker/values.yaml
@@ -99,6 +99,13 @@ server:
     # the management API and the MCP surface bind distinct listeners.
     # The Service exposes both ports; the Ingress routes by hostname.
     addr: ":8081"
+    # Externally-reachable base URL of the MCP gateway, no trailing
+    # slash (e.g. https://knowledge.acmecorp.com). Set it whenever
+    # ingress.mcp.host differs from ingress.host: it feeds the
+    # RFC 9728 `resource` field and the 401 resource_metadata link,
+    # which must name the gateway host, not the issuer. Empty falls
+    # back to server.publicURL (single-host deployments).
+    publicURL: ""
     # TLS termination at the broker for the MCP listener. Two modes:
     #
     #   1. existingSecretRef.name unset (default) — broker speaks

--- a/deploy/kind/up.sh
+++ b/deploy/kind/up.sh
@@ -511,10 +511,12 @@ if [[ "$WITH_BROKER" == "true" ]]; then
     # below (broker-auth-code-grant plan, PR3).
     echo "--- driving MCP gateway smoke checks from an ephemeral curl pod"
     BROKER_MCP_URL="http://$BROKER_RELEASE-demarkus-broker.$NAMESPACE.svc.cluster.local:8081"
+    BROKER_MGMT_URL="http://$BROKER_RELEASE-demarkus-broker.$NAMESPACE.svc.cluster.local:8080"
     kubectl run -n "$NAMESPACE" mcp-smoke --rm -i --restart=Never \
       --image="$MINT_CURL_IMAGE" --command -- sh -c '
 set -eu
 BROKER_MCP='"$BROKER_MCP_URL"'
+BROKER_MGMT='"$BROKER_MGMT_URL"'
 CURL="curl -sS --connect-timeout 5 --max-time 15"
 
 # Wait for the MCP Service endpoint to be reachable. Service object
@@ -532,11 +534,20 @@ META=$($CURL "$BROKER_MCP/.well-known/oauth-protected-resource")
 echo "$META" | grep -q "resource" || { echo "FAIL: oauth-protected-resource missing resource field"; echo "$META"; exit 1; }
 echo "OK: /.well-known/oauth-protected-resource"
 
-# 2. RFC 8414 metadata endpoint. Auth-server metadata — aliases
-#    the broker OIDC Discovery handler. Plain GET, no auth.
-META=$($CURL "$BROKER_MCP/.well-known/oauth-authorization-server")
-echo "$META" | grep -q "issuer" || { echo "FAIL: oauth-authorization-server missing issuer field"; echo "$META"; exit 1; }
-echo "OK: /.well-known/oauth-authorization-server"
+# 2. RFC 8414 metadata lives on the ISSUER host (management listener)
+#    only — RFC 8414 s3.3 requires issuer == fetch origin, so the
+#    gateway must NOT serve it (strict clients hard-fail on the copy).
+META=$($CURL "$BROKER_MGMT/.well-known/oauth-authorization-server")
+echo "$META" | grep -q "issuer" || { echo "FAIL: oauth-authorization-server missing issuer field on management host"; echo "$META"; exit 1; }
+echo "OK: management /.well-known/oauth-authorization-server"
+HTTP=$($CURL -o /dev/null -w "%{http_code}" "$BROKER_MCP/.well-known/oauth-authorization-server")
+[ "$HTTP" = "404" ] || { echo "FAIL: gateway serves oauth-authorization-server (got $HTTP, want 404)"; exit 1; }
+echo "OK: gateway oauth-authorization-server 404"
+
+# 2b. RFC 9728 s3.1 path-inserted form for resource <host>/mcp.
+META=$($CURL "$BROKER_MCP/.well-known/oauth-protected-resource/mcp")
+echo "$META" | grep -q "resource" || { echo "FAIL: path-inserted oauth-protected-resource/mcp missing resource field"; echo "$META"; exit 1; }
+echo "OK: /.well-known/oauth-protected-resource/mcp"
 
 # 3. /mcp without auth must 401 with a WWW-Authenticate challenge
 #    per RFC 6750 + RFC 9728 — point fresh clients at the metadata
@@ -825,6 +836,7 @@ probe the broker (from another shell):
 probe the MCP gateway:
   kubectl -n $NAMESPACE port-forward svc/$BROKER_RELEASE-demarkus-broker 8081:8081
   curl http://localhost:8081/.well-known/oauth-protected-resource
+  # RFC 8414 auth-server metadata is on the management listener (:8080), not here
 
 server fetch from inside the cluster:
   kubectl -n $NAMESPACE exec -it $POD -- \\

--- a/tools/demarkus-broker/MCP-API.md
+++ b/tools/demarkus-broker/MCP-API.md
@@ -25,9 +25,12 @@ For deployment instructions, TLS, and Ingress topology, see
   the device-flow completion, PR3). Unverified-email tokens are
   rejected at the gateway boundary.
 - **OAuth metadata**: standard discovery via RFC 9728
-  (`/.well-known/oauth-protected-resource`) and RFC 8414
-  (`/.well-known/oauth-authorization-server`). An unauthenticated
-  request to `/mcp` receives `401 + WWW-Authenticate: Bearer
+  (`/.well-known/oauth-protected-resource`, bare and path-inserted
+  `/mcp` forms, on the gateway listener) and RFC 8414
+  (`/.well-known/oauth-authorization-server`, on the management
+  listener — §3.3 requires the issuer's own origin). An
+  unauthenticated request to `/mcp` receives `401 +
+  WWW-Authenticate: Bearer
   resource_metadata="…oauth-protected-resource"` per RFC 6750 + RFC
   9728, so a fresh client knows where to bootstrap.
 

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -280,6 +280,13 @@ type MCPConfig struct {
 	// MCP surface bind their own listeners — the chart routes the
 	// two through distinct Ingress hosts or paths.
 	Addr string `yaml:"addr"`
+	// PublicURL is the gateway's externally-reachable base URL (e.g.
+	// https://knowledge.acmecorp.com) under split-host ingress, where
+	// it differs from Server.PublicURL (the issuer host). Feeds the
+	// RFC 9728 `resource` field and the 401 resource_metadata link.
+	// Defaults to Server.PublicURL so single-host deployments need no
+	// new config.
+	PublicURL string `yaml:"publicURL"`
 	// TLS terminates HTTPS at the broker when CertFile and KeyFile
 	// are set. Leave blank to run plain HTTP inside the cluster (the
 	// Ingress terminates HTTPS at the edge), matching the existing
@@ -602,19 +609,8 @@ func (c *Config) validate() error {
 	if err := c.validateStorage(); err != nil {
 		return err
 	}
-	// Normalize before the empty-check so values like "   " or "/" are
-	// caught here instead of silently producing a broken issuer URL
-	// downstream (e.g. "/device/authorize" with no scheme/host).
-	c.Server.PublicURL = strings.TrimRight(strings.TrimSpace(c.Server.PublicURL), "/")
-	if c.Server.PublicURL == "" {
-		return fmt.Errorf("server.publicURL is required")
-	}
-	// Enforce absolute-URL shape. Without scheme+host the override would
-	// emit values like "/device/authorize" into the discovery doc, which
-	// every OIDC client would reject — fail fast at config load instead
-	// of producing a broker that boots but serves a useless well-known.
-	if u, err := url.Parse(c.Server.PublicURL); err != nil || u.Scheme == "" || u.Host == "" {
-		return fmt.Errorf("server.publicURL must be an absolute URL (got %q)", c.Server.PublicURL)
+	if err := c.Server.normalizePublicURLs(); err != nil {
+		return err
 	}
 	if c.Server.StateTTL == 0 {
 		c.Server.StateTTL = 5 * time.Minute
@@ -757,6 +753,43 @@ func (s *ServerConfig) applyRefreshDefaults() error {
 // outer function inside the gocyclo budget. PollInterval must be
 // strictly less than the TTL — a configuration where every legitimate
 // poll trips slow_down would deadlock a real client.
+// normalizePublicURL trims whitespace and a trailing slash and enforces
+// absolute-URL shape — without scheme+host the value would render nonsense
+// like "/device/authorize" into the discovery doc, which every OIDC client
+// rejects. Empty after trim is returned as-is; required-ness is the caller's
+// rule.
+func normalizePublicURL(field, raw string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(raw), "/")
+	if trimmed == "" {
+		return "", nil
+	}
+	if u, err := url.Parse(trimmed); err != nil || u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("%s must be an absolute URL (got %q)", field, trimmed)
+	}
+	return trimmed, nil
+}
+
+// normalizePublicURLs canonicalizes the two externally-advertised base URLs
+// at load so every downstream consumer sees a canonical form. publicURL is
+// required (it is the issuer); mcp.publicURL falls back to it so single-host
+// deployments need no extra config.
+func (s *ServerConfig) normalizePublicURLs() error {
+	var err error
+	if s.PublicURL, err = normalizePublicURL("server.publicURL", s.PublicURL); err != nil {
+		return err
+	}
+	if s.PublicURL == "" {
+		return fmt.Errorf("server.publicURL is required")
+	}
+	if s.MCP.PublicURL, err = normalizePublicURL("server.mcp.publicURL", s.MCP.PublicURL); err != nil {
+		return err
+	}
+	if s.MCP.PublicURL == "" {
+		s.MCP.PublicURL = s.PublicURL
+	}
+	return nil
+}
+
 func (s *ServerConfig) applyDeviceFlowDefaults() error {
 	if s.DeviceCodeTTL == 0 {
 		s.DeviceCodeTTL = 10 * time.Minute

--- a/tools/demarkus-broker/internal/broker/config.go
+++ b/tools/demarkus-broker/internal/broker/config.go
@@ -280,12 +280,10 @@ type MCPConfig struct {
 	// MCP surface bind their own listeners — the chart routes the
 	// two through distinct Ingress hosts or paths.
 	Addr string `yaml:"addr"`
-	// PublicURL is the gateway's externally-reachable base URL (e.g.
-	// https://knowledge.acmecorp.com) under split-host ingress, where
-	// it differs from Server.PublicURL (the issuer host). Feeds the
-	// RFC 9728 `resource` field and the 401 resource_metadata link.
-	// Defaults to Server.PublicURL so single-host deployments need no
-	// new config.
+	// PublicURL is the gateway's externally-reachable base URL when
+	// split-host ingress gives it a different hostname than the issuer
+	// (Server.PublicURL, the default). Feeds RFC 9728 `resource` + the
+	// 401 resource_metadata link.
 	PublicURL string `yaml:"publicURL"`
 	// TLS terminates HTTPS at the broker when CertFile and KeyFile
 	// are set. Leave blank to run plain HTTP inside the cluster (the
@@ -753,26 +751,26 @@ func (s *ServerConfig) applyRefreshDefaults() error {
 // outer function inside the gocyclo budget. PollInterval must be
 // strictly less than the TTL — a configuration where every legitimate
 // poll trips slow_down would deadlock a real client.
-// normalizePublicURL trims whitespace and a trailing slash and enforces
-// absolute-URL shape — without scheme+host the value would render nonsense
-// like "/device/authorize" into the discovery doc, which every OIDC client
-// rejects. Empty after trim is returned as-is; required-ness is the caller's
-// rule.
+// normalizePublicURL trims whitespace + trailing slash and enforces
+// absolute-URL shape with no query/fragment — a bad value renders broken
+// URLs into discovery metadata. Empty passes through; required is the caller's rule.
 func normalizePublicURL(field, raw string) (string, error) {
 	trimmed := strings.TrimRight(strings.TrimSpace(raw), "/")
 	if trimmed == "" {
 		return "", nil
 	}
-	if u, err := url.Parse(trimmed); err != nil || u.Scheme == "" || u.Host == "" {
+	u, err := url.Parse(trimmed)
+	if err != nil || u.Scheme == "" || u.Host == "" {
 		return "", fmt.Errorf("%s must be an absolute URL (got %q)", field, trimmed)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("%s must not carry a query or fragment (got %q)", field, trimmed)
 	}
 	return trimmed, nil
 }
 
-// normalizePublicURLs canonicalizes the two externally-advertised base URLs
-// at load so every downstream consumer sees a canonical form. publicURL is
-// required (it is the issuer); mcp.publicURL falls back to it so single-host
-// deployments need no extra config.
+// normalizePublicURLs canonicalizes the advertised base URLs at load.
+// publicURL is required (the issuer); mcp.publicURL falls back to it.
 func (s *ServerConfig) normalizePublicURLs() error {
 	var err error
 	if s.PublicURL, err = normalizePublicURL("server.publicURL", s.PublicURL); err != nil {

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -519,6 +519,29 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: "server.mcp.publicURL must be an absolute URL",
 		},
 		{
+			// A query or fragment would corrupt the string-appended
+			// metadata URLs (resource, resource_metadata).
+			name: "server.mcp.publicURL with query rejected",
+			body: strings.Replace(validConfig,
+				`publicURL: "https://broker.example.com"`,
+				"publicURL: \"https://broker.example.com\"\n  mcp:\n    publicURL: \"https://gateway.example.com?x=1\"", 1),
+			wantErr: "server.mcp.publicURL must not carry a query or fragment",
+		},
+		{
+			name: "server.mcp.publicURL with fragment rejected",
+			body: strings.Replace(validConfig,
+				`publicURL: "https://broker.example.com"`,
+				"publicURL: \"https://broker.example.com\"\n  mcp:\n    publicURL: \"https://gateway.example.com#frag\"", 1),
+			wantErr: "server.mcp.publicURL must not carry a query or fragment",
+		},
+		{
+			name: "server.publicURL with query rejected",
+			body: strings.Replace(validConfig,
+				`publicURL: "https://broker.example.com"`,
+				`publicURL: "https://broker.example.com?x=1"`, 1),
+			wantErr: "server.publicURL must not carry a query or fragment",
+		},
+		{
 			// publicURL is optional — when omitted (validConfig), it
 			// must round-trip to the zero value. /me/install will
 			// skip worlds whose PublicURL is blank.

--- a/tools/demarkus-broker/internal/broker/config_test.go
+++ b/tools/demarkus-broker/internal/broker/config_test.go
@@ -488,6 +488,37 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
+			// mcp.publicURL empty falls back to the issuer host so
+			// single-host deployments need no new config.
+			name: "server.mcp.publicURL defaults to server.publicURL",
+			body: validConfig,
+			validate: func(t *testing.T, c *Config) {
+				if c.Server.MCP.PublicURL != c.Server.PublicURL {
+					t.Errorf("MCP.PublicURL = %q, want fallback to %q", c.Server.MCP.PublicURL, c.Server.PublicURL)
+				}
+			},
+		},
+		{
+			// Split-host: gateway host set explicitly, trailing slash
+			// stripped like server.publicURL.
+			name: "server.mcp.publicURL honored and normalized",
+			body: strings.Replace(validConfig,
+				`publicURL: "https://broker.example.com"`,
+				"publicURL: \"https://broker.example.com\"\n  mcp:\n    publicURL: \"https://gateway.example.com/\"", 1),
+			validate: func(t *testing.T, c *Config) {
+				if c.Server.MCP.PublicURL != "https://gateway.example.com" {
+					t.Errorf("MCP.PublicURL = %q, want https://gateway.example.com", c.Server.MCP.PublicURL)
+				}
+			},
+		},
+		{
+			name: "server.mcp.publicURL without scheme rejected",
+			body: strings.Replace(validConfig,
+				`publicURL: "https://broker.example.com"`,
+				"publicURL: \"https://broker.example.com\"\n  mcp:\n    publicURL: \"gateway.example.com\"", 1),
+			wantErr: "server.mcp.publicURL must be an absolute URL",
+		},
+		{
 			// publicURL is optional — when omitted (validConfig), it
 			// must round-trip to the zero value. /me/install will
 			// skip worlds whose PublicURL is blank.

--- a/tools/demarkus-broker/internal/broker/mcp_auth.go
+++ b/tools/demarkus-broker/internal/broker/mcp_auth.go
@@ -82,7 +82,9 @@ func canonicalEmail(email string) string {
 // authorization-server metadata, and initiates the OAuth dance — no
 // hard-coded broker URL required on the client side.
 func (s *Server) writeMCPAuthChallenge(w http.ResponseWriter, errCode, body string) {
-	metadataURL := s.cfg.Server.PublicURL + "/.well-known/oauth-protected-resource"
+	// Built from the gateway's own host — the metadata path only
+	// exists on the MCP listener, not the issuer host.
+	metadataURL := s.cfg.Server.MCP.PublicURL + prmPath
 	challenge := fmt.Sprintf(`Bearer realm="demarkus-broker", error=%q, resource_metadata=%q`, errCode, metadataURL)
 	w.Header().Set("WWW-Authenticate", challenge)
 	http.Error(w, body, http.StatusUnauthorized)

--- a/tools/demarkus-broker/internal/broker/mcp_auth_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_auth_test.go
@@ -56,7 +56,7 @@ func TestGatewayAuthMissingBearerReturns401WithChallenge(t *testing.T) {
 	if m == nil {
 		t.Fatalf("WWW-Authenticate missing resource_metadata param: %q", challenge)
 	}
-	wantMetadata := cfg.Server.PublicURL + "/.well-known/oauth-protected-resource"
+	wantMetadata := cfg.Server.MCP.PublicURL + "/.well-known/oauth-protected-resource"
 	if m[1] != wantMetadata {
 		t.Errorf("resource_metadata = %q, want %q", m[1], wantMetadata)
 	}

--- a/tools/demarkus-broker/internal/broker/mcp_gateway.go
+++ b/tools/demarkus-broker/internal/broker/mcp_gateway.go
@@ -160,6 +160,14 @@ func (g *mcpGateway) notImplementedHandler(_ context.Context, req mcp.CallToolRe
 	return mcp.NewToolResultError(fmt.Sprintf("tool %q not yet implemented (Slice 1 gateway foundation)", req.Params.Name)), nil
 }
 
+// mcpPath is the gateway's JSON-RPC endpoint path. The RFC 9728
+// `resource` field and the path-inserted metadata route derive from
+// it so the three can never drift apart.
+const (
+	mcpPath = "/mcp"
+	prmPath = "/.well-known/oauth-protected-resource"
+)
+
 // Routes returns the http.Handler for the MCP listener. /mcp is the
 // JSON-RPC + SSE endpoint behind the gateway auth chain; the OAuth
 // metadata endpoints are unauthenticated by design (RFC 9728 + 8414
@@ -167,21 +175,19 @@ func (g *mcpGateway) notImplementedHandler(_ context.Context, req mcp.CallToolRe
 // surface is that an unauthenticated client can read it to learn how
 // to authenticate).
 //
-// /.well-known/oauth-authorization-server is registered only when
-// Discovery is wired. The handler reuses the existing OIDC discovery
-// body — RFC 8414 §3 tolerates extra fields, and the broker is its
-// own authorization server so the two metadata documents describe
-// the same surface.
+// Authorization-server metadata is deliberately NOT served here: RFC
+// 8414 §3.3 requires it at the issuer's own origin (the management
+// listener); a copy here breaks strict clients.
 func (g *mcpGateway) Routes() http.Handler {
 	mux := http.NewServeMux()
 	// /mcp accepts both POST (request/notification) and GET (SSE
 	// listen channel) per the Streamable HTTP spec. No method filter
 	// on the route so mcp-go's transport sees every request type.
-	mux.Handle("/mcp", g.srv.gatewayAuth(g.srv.subjectRateLimit(g.transport)))
-	mux.HandleFunc("GET /.well-known/oauth-protected-resource", g.oauthProtectedResource)
-	if g.srv.discovery != nil {
-		mux.Handle("GET /.well-known/oauth-authorization-server", g.srv.discovery.Handler())
-	}
+	mux.Handle(mcpPath, g.srv.gatewayAuth(g.srv.subjectRateLimit(g.transport)))
+	mux.HandleFunc("GET "+prmPath, g.oauthProtectedResource)
+	// prmPath+mcpPath is RFC 9728 §3.1's path-inserted form for a
+	// resource URL that carries a path. Same document.
+	mux.HandleFunc("GET "+prmPath+mcpPath, g.oauthProtectedResource)
 	return mux
 }
 

--- a/tools/demarkus-broker/internal/broker/mcp_gateway.go
+++ b/tools/demarkus-broker/internal/broker/mcp_gateway.go
@@ -168,16 +168,9 @@ const (
 	prmPath = "/.well-known/oauth-protected-resource"
 )
 
-// Routes returns the http.Handler for the MCP listener. /mcp is the
-// JSON-RPC + SSE endpoint behind the gateway auth chain; the OAuth
-// metadata endpoints are unauthenticated by design (RFC 9728 + 8414
-// require public discoverability — the whole point of the metadata
-// surface is that an unauthenticated client can read it to learn how
-// to authenticate).
-//
-// Authorization-server metadata is deliberately NOT served here: RFC
-// 8414 §3.3 requires it at the issuer's own origin (the management
-// listener); a copy here breaks strict clients.
+// Routes returns the http.Handler for the MCP listener. Metadata routes
+// are unauthenticated by design (RFC 9728/8414 discovery). AS metadata is
+// NOT served here: RFC 8414 §3.3 wants the issuer's origin, not the gateway's.
 func (g *mcpGateway) Routes() http.Handler {
 	mux := http.NewServeMux()
 	// /mcp accepts both POST (request/notification) and GET (SSE

--- a/tools/demarkus-broker/internal/broker/mcp_gateway_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_gateway_test.go
@@ -14,13 +14,13 @@ import (
 )
 
 // mcpTestConfig returns a Config like testConfig() but with the MCP
-// gateway configured. Setting MCP.Addr is the on-switch; PublicURL is
-// set so the gateway's auth challenge and OAuth metadata documents
-// include the broker's external URL.
+// gateway configured. Setting MCP.Addr is the on-switch. The two
+// PublicURLs are deliberately distinct (split-host topology) so tests
+// catch any handler building a URL from the wrong one.
 func mcpTestConfig() *Config {
 	cfg := testConfig()
 	cfg.Server.PublicURL = "https://broker.example.com"
-	cfg.Server.MCP = MCPConfig{Addr: ":0"}
+	cfg.Server.MCP = MCPConfig{Addr: ":0", PublicURL: "https://gateway.example.com"}
 	return cfg
 }
 

--- a/tools/demarkus-broker/internal/broker/mcp_oauth.go
+++ b/tools/demarkus-broker/internal/broker/mcp_oauth.go
@@ -9,9 +9,10 @@ import (
 // Metadata. MCP clients (and any OAuth-aware caller) read this
 // document to discover which authorization server issues tokens
 // accepted by /mcp. The broker is its own authorization server, so
-// `authorization_servers` is single-element and points at the broker's
-// own PublicURL — the authorization-server metadata lives at
-// /.well-known/oauth-authorization-server on the same origin.
+// `authorization_servers` is single-element and points at
+// Server.PublicURL (the issuer origin, i.e. the management listener).
+// Under the chart's split-host topology that differs from the gateway
+// host serving /mcp, so `resource` is built from MCP.PublicURL.
 //
 // RFC 9728 §2 fields exposed:
 //
@@ -33,10 +34,11 @@ import (
 // the well-known surface uses so an intermediary CDN treats them
 // uniformly.
 func (g *mcpGateway) oauthProtectedResource(w http.ResponseWriter, _ *http.Request) {
-	base := g.srv.cfg.Server.PublicURL
+	// resource = the gateway's own host; authorization_servers = the
+	// issuer. Distinct knobs under split-host ingress.
 	body := map[string]any{
-		"resource":                 base + "/mcp",
-		"authorization_servers":    []string{base},
+		"resource":                 g.srv.cfg.Server.MCP.PublicURL + mcpPath,
+		"authorization_servers":    []string{g.srv.cfg.Server.PublicURL},
 		"bearer_methods_supported": []string{"header"},
 		"scopes_supported":         []string{"mark.read", "mark.write"},
 	}

--- a/tools/demarkus-broker/internal/broker/mcp_oauth.go
+++ b/tools/demarkus-broker/internal/broker/mcp_oauth.go
@@ -8,11 +8,9 @@ import (
 // oauthProtectedResource implements RFC 9728 — Protected Resource
 // Metadata. MCP clients (and any OAuth-aware caller) read this
 // document to discover which authorization server issues tokens
-// accepted by /mcp. The broker is its own authorization server, so
-// `authorization_servers` is single-element and points at
-// Server.PublicURL (the issuer origin, i.e. the management listener).
-// Under the chart's split-host topology that differs from the gateway
-// host serving /mcp, so `resource` is built from MCP.PublicURL.
+// accepted by /mcp. The broker is its own authorization server:
+// `authorization_servers` = Server.PublicURL (the issuer); `resource` =
+// MCP.PublicURL (the gateway host, distinct under split-host ingress).
 //
 // RFC 9728 §2 fields exposed:
 //
@@ -34,8 +32,6 @@ import (
 // the well-known surface uses so an intermediary CDN treats them
 // uniformly.
 func (g *mcpGateway) oauthProtectedResource(w http.ResponseWriter, _ *http.Request) {
-	// resource = the gateway's own host; authorization_servers = the
-	// issuer. Distinct knobs under split-host ingress.
 	body := map[string]any{
 		"resource":                 g.srv.cfg.Server.MCP.PublicURL + mcpPath,
 		"authorization_servers":    []string{g.srv.cfg.Server.PublicURL},

--- a/tools/demarkus-broker/internal/broker/mcp_oauth_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_oauth_test.go
@@ -4,7 +4,11 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
+
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestOAuthProtectedResourceMetadata(t *testing.T) {
@@ -30,7 +34,10 @@ func TestOAuthProtectedResourceMetadata(t *testing.T) {
 				t.Error("Cache-Control header missing — intermediaries lose the caching hint that mirrors the OIDC well-known")
 			}
 
-			body, _ := io.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
 			var doc map[string]any
 			if err := json.Unmarshal(body, &doc); err != nil {
 				t.Fatalf("decode metadata: %v\nbody: %s", err, body)
@@ -59,9 +66,14 @@ func TestOAuthProtectedResourceMetadata(t *testing.T) {
 }
 
 func TestOAuthAuthorizationServerNeverOnGateway(t *testing.T) {
-	// RFC 8414 §3.3: AS metadata lives on the issuer's origin (the
-	// management listener) only; the gateway must 404 unconditionally.
-	ts := newTestMCPGateway(t, mcpTestConfig(), &fakeVerifier{})
+	// RFC 8414 §3.3: AS metadata lives on the issuer's origin only; the
+	// gateway must 404 even with Discovery wired (the state that used to
+	// mount the alias).
+	d, _ := newTestDiscovery(t, newFakeDiscoveryIdP(t), time.Minute)
+	brokerSrv := NewServer(mcpTestConfig(), newTestSigner(t), &fakeVerifier{},
+		NewK8sSecretStore(fake.NewSimpleClientset()), d, newTestIDTokenSigner(t), nil)
+	ts := httptest.NewServer(brokerSrv.MCPGateway("test"))
+	t.Cleanup(ts.Close)
 
 	resp, err := http.Get(ts.URL + "/.well-known/oauth-authorization-server")
 	if err != nil {

--- a/tools/demarkus-broker/internal/broker/mcp_oauth_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_oauth_test.go
@@ -1,129 +1,74 @@
 package broker
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"testing"
-
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestOAuthProtectedResourceMetadata(t *testing.T) {
 	cfg := mcpTestConfig()
 	ts := newTestMCPGateway(t, cfg, &fakeVerifier{})
 
-	resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource")
-	if err != nil {
-		t.Fatalf("GET /.well-known/oauth-protected-resource: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
+	// Bare and RFC 9728 §3.1 path-inserted forms serve the same doc.
+	for _, path := range []string{prmPath, prmPath + mcpPath} {
+		t.Run(path, func(t *testing.T) {
+			resp, err := http.Get(ts.URL + path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", path, err)
+			}
+			defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d", resp.StatusCode)
-	}
-	if got := resp.Header.Get("Content-Type"); got != "application/json" {
-		t.Errorf("Content-Type = %q, want application/json", got)
-	}
-	if got := resp.Header.Get("Cache-Control"); got == "" {
-		t.Error("Cache-Control header missing — intermediaries lose the caching hint that mirrors the OIDC well-known")
-	}
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d", resp.StatusCode)
+			}
+			if got := resp.Header.Get("Content-Type"); got != "application/json" {
+				t.Errorf("Content-Type = %q, want application/json", got)
+			}
+			if got := resp.Header.Get("Cache-Control"); got == "" {
+				t.Error("Cache-Control header missing — intermediaries lose the caching hint that mirrors the OIDC well-known")
+			}
 
-	body, _ := io.ReadAll(resp.Body)
-	var doc map[string]any
-	if err := json.Unmarshal(body, &doc); err != nil {
-		t.Fatalf("decode metadata: %v\nbody: %s", err, body)
-	}
-	wantResource := cfg.Server.PublicURL + "/mcp"
-	if got, _ := doc["resource"].(string); got != wantResource {
-		t.Errorf("resource = %q, want %q", got, wantResource)
-	}
-	servers, _ := doc["authorization_servers"].([]any)
-	if len(servers) != 1 {
-		t.Fatalf("authorization_servers len = %d, want 1: %+v", len(servers), servers)
-	}
-	if got, _ := servers[0].(string); got != cfg.Server.PublicURL {
-		t.Errorf("authorization_servers[0] = %q, want %q", got, cfg.Server.PublicURL)
-	}
-	methods, _ := doc["bearer_methods_supported"].([]any)
-	if len(methods) != 1 || methods[0] != "header" {
-		t.Errorf("bearer_methods_supported = %+v, want [\"header\"]", methods)
-	}
-	scopes, _ := doc["scopes_supported"].([]any)
-	if len(scopes) == 0 {
-		t.Error("scopes_supported empty — clients need a vocabulary hint")
+			body, _ := io.ReadAll(resp.Body)
+			var doc map[string]any
+			if err := json.Unmarshal(body, &doc); err != nil {
+				t.Fatalf("decode metadata: %v\nbody: %s", err, body)
+			}
+			wantResource := cfg.Server.MCP.PublicURL + mcpPath
+			if got, _ := doc["resource"].(string); got != wantResource {
+				t.Errorf("resource = %q, want %q (gateway host, not issuer host)", got, wantResource)
+			}
+			servers, _ := doc["authorization_servers"].([]any)
+			if len(servers) != 1 {
+				t.Fatalf("authorization_servers len = %d, want 1: %+v", len(servers), servers)
+			}
+			if got, _ := servers[0].(string); got != cfg.Server.PublicURL {
+				t.Errorf("authorization_servers[0] = %q, want %q", got, cfg.Server.PublicURL)
+			}
+			methods, _ := doc["bearer_methods_supported"].([]any)
+			if len(methods) != 1 || methods[0] != "header" {
+				t.Errorf("bearer_methods_supported = %+v, want [\"header\"]", methods)
+			}
+			scopes, _ := doc["scopes_supported"].([]any)
+			if len(scopes) == 0 {
+				t.Error("scopes_supported empty — clients need a vocabulary hint")
+			}
+		})
 	}
 }
 
-func TestOAuthAuthorizationServerMetadataReusesDiscoveryWhenWired(t *testing.T) {
-	// The plan calls for /.well-known/oauth-authorization-server to
-	// share the OIDC discovery body (broker is its own auth server,
-	// RFC 8414 tolerates extras). This test pins the alias is mounted
-	// when Discovery is wired into the Server.
-	idpMux := http.NewServeMux()
-	idpMux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"issuer":"https://idp.example.com","jwks_uri":"https://idp.example.com/jwks","authorization_endpoint":"https://idp.example.com/authz","token_endpoint":"https://idp.example.com/token"}`)
-	})
-	idp := httptest.NewServer(idpMux)
-	t.Cleanup(idp.Close)
-
-	d, err := NewDiscovery(context.Background(), DiscoveryConfig{
-		BrokerURL: "https://broker.example.com",
-		IdPIssuer: idp.URL,
-	})
-	if err != nil {
-		t.Fatalf("NewDiscovery: %v", err)
-	}
-
-	cfg := mcpTestConfig()
-	signer := newTestSigner(t)
-	k8s := fake.NewSimpleClientset()
-	// Discovery requires IDTokenSigner (NewServer enforces this).
-	brokerSrv := NewServer(cfg, signer, &fakeVerifier{}, NewK8sSecretStore(k8s), d, newTestIDTokenSigner(t), nil)
-	handler := brokerSrv.MCPGateway("test")
-	if handler == nil {
-		t.Fatal("MCPGateway returned nil despite cfg.Server.MCP.Enabled=true")
-	}
-	ts := httptest.NewServer(handler)
-	t.Cleanup(ts.Close)
+func TestOAuthAuthorizationServerNeverOnGateway(t *testing.T) {
+	// RFC 8414 §3.3: AS metadata lives on the issuer's origin (the
+	// management listener) only; the gateway must 404 unconditionally.
+	ts := newTestMCPGateway(t, mcpTestConfig(), &fakeVerifier{})
 
 	resp, err := http.Get(ts.URL + "/.well-known/oauth-authorization-server")
 	if err != nil {
 		t.Fatalf("GET /.well-known/oauth-authorization-server: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d", resp.StatusCode)
-	}
-	body, _ := io.ReadAll(resp.Body)
-	var doc map[string]any
-	if err := json.Unmarshal(body, &doc); err != nil {
-		t.Fatalf("decode auth-server metadata: %v\nbody: %s", err, body)
-	}
-	// The Discovery handler rewrites issuer to the broker URL — that
-	// rewrite is what makes the OIDC doc usable as RFC 8414 metadata
-	// for a broker-as-auth-server deployment.
-	if got, _ := doc["issuer"].(string); got != "https://broker.example.com" {
-		t.Errorf("issuer = %q, want broker URL (Discovery override applied via shared body)", got)
-	}
-}
-
-func TestOAuthAuthorizationServerAbsentWhenDiscoveryNotWired(t *testing.T) {
-	// Discovery is optional in tests / dev wiring. When it's nil the
-	// gateway must skip the auth-server metadata route — registering
-	// a 404-or-empty handler would mislead RFC 8414 clients that
-	// follow the resource_metadata → authorization_servers chain.
-	ts := newTestMCPGateway(t, mcpTestConfig(), &fakeVerifier{})
-
-	resp, err := http.Get(ts.URL + "/.well-known/oauth-authorization-server")
-	if err != nil {
-		t.Fatalf("GET: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusNotFound {
-		t.Errorf("status = %d, want 404 (route should be absent when Discovery is nil)", resp.StatusCode)
+		t.Errorf("status = %d, want 404 (AS metadata belongs on the issuer host only)", resp.StatusCode)
 	}
 }

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -207,8 +207,13 @@ func (s *Server) Routes() http.Handler {
 	// rate limit. Polling-friendly: device-flow clients fetch it once
 	// per /soul-join and never again; intermediaries cache via the
 	// Cache-Control header the Discovery handler emits.
+	// oauth-authorization-server is the same document at the RFC 8414
+	// path: §3.3 requires it on the issuer's origin, which is this
+	// listener (issuer = server.publicURL). RFC 8414 §3 tolerates the
+	// extra OIDC fields.
 	if s.discovery != nil {
 		mux.Handle("GET /.well-known/openid-configuration", s.discovery.Handler())
+		mux.Handle("GET /.well-known/oauth-authorization-server", s.discovery.Handler())
 	}
 	// JWKS: served only when the broker has a signing key. Public,
 	// unauthenticated, no rate limit — same posture as the OIDC

--- a/tools/demarkus-broker/internal/broker/server.go
+++ b/tools/demarkus-broker/internal/broker/server.go
@@ -207,10 +207,8 @@ func (s *Server) Routes() http.Handler {
 	// rate limit. Polling-friendly: device-flow clients fetch it once
 	// per /soul-join and never again; intermediaries cache via the
 	// Cache-Control header the Discovery handler emits.
-	// oauth-authorization-server is the same document at the RFC 8414
-	// path: §3.3 requires it on the issuer's origin, which is this
-	// listener (issuer = server.publicURL). RFC 8414 §3 tolerates the
-	// extra OIDC fields.
+	// oauth-authorization-server aliases the same doc at the RFC 8414
+	// path; §3.3 requires it on the issuer's origin, which is this listener.
 	if s.discovery != nil {
 		mux.Handle("GET /.well-known/openid-configuration", s.discovery.Handler())
 		mux.Handle("GET /.well-known/oauth-authorization-server", s.discovery.Handler())

--- a/tools/demarkus-broker/internal/broker/server_test.go
+++ b/tools/demarkus-broker/internal/broker/server_test.go
@@ -116,9 +116,11 @@ func TestNewServerPanicsOnDiscoveryWithoutSigner(t *testing.T) {
 
 // TestWellKnownDiscoveryRouteRegistered guards the Routes() composition:
 // when a Discovery is wired into NewServer, the broker mux exposes it at
-// /.well-known/openid-configuration. The discovery_test.go suite covers
-// the proxy + cache mechanics; this test just confirms the mount point so
-// a future refactor can't quietly drop the route registration.
+// /.well-known/openid-configuration AND the RFC 8414 alias
+// /.well-known/oauth-authorization-server (strict clients require the
+// latter on the issuer's origin — this listener). The discovery_test.go
+// suite covers the proxy + cache mechanics; this test just confirms the
+// mount points so a future refactor can't quietly drop a registration.
 func TestWellKnownDiscoveryRouteRegistered(t *testing.T) {
 	idpMux := http.NewServeMux()
 	idpMux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
@@ -144,21 +146,23 @@ func TestWellKnownDiscoveryRouteRegistered(t *testing.T) {
 	tsrv := httptest.NewServer(srv.Routes())
 	t.Cleanup(tsrv.Close)
 
-	resp, err := testClient(tsrv).Get(tsrv.URL + "/.well-known/openid-configuration")
-	if err != nil {
-		t.Fatalf("GET well-known: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d", resp.StatusCode)
-	}
-	body, _ := io.ReadAll(resp.Body)
-	var doc map[string]any
-	if err := json.Unmarshal(body, &doc); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if got, _ := doc["issuer"].(string); got != "https://broker.example.com" {
-		t.Errorf("issuer = %q, want broker URL (override applied via mounted route)", got)
+	for _, path := range []string{"/.well-known/openid-configuration", "/.well-known/oauth-authorization-server"} {
+		resp, err := testClient(tsrv).Get(tsrv.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("%s status = %d", path, resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		var doc map[string]any
+		if err := json.Unmarshal(body, &doc); err != nil {
+			t.Fatalf("decode %s: %v", path, err)
+		}
+		if got, _ := doc["issuer"].(string); got != "https://broker.example.com" {
+			t.Errorf("%s issuer = %q, want broker URL (override applied via mounted route)", path, got)
+		}
 	}
 }
 

--- a/tools/demarkus-broker/internal/broker/server_test.go
+++ b/tools/demarkus-broker/internal/broker/server_test.go
@@ -114,13 +114,9 @@ func TestNewServerPanicsOnDiscoveryWithoutSigner(t *testing.T) {
 	NewServer(cfg, newTestSigner(t), &fakeVerifier{}, NewK8sSecretStore(fake.NewSimpleClientset()), d, nil, nil)
 }
 
-// TestWellKnownDiscoveryRouteRegistered guards the Routes() composition:
-// when a Discovery is wired into NewServer, the broker mux exposes it at
-// /.well-known/openid-configuration AND the RFC 8414 alias
-// /.well-known/oauth-authorization-server (strict clients require the
-// latter on the issuer's origin — this listener). The discovery_test.go
-// suite covers the proxy + cache mechanics; this test just confirms the
-// mount points so a future refactor can't quietly drop a registration.
+// TestWellKnownDiscoveryRouteRegistered guards Routes() composition: with
+// Discovery wired, the mux serves openid-configuration AND the RFC 8414
+// alias (strict clients need the latter on the issuer origin — this listener).
 func TestWellKnownDiscoveryRouteRegistered(t *testing.T) {
 	idpMux := http.NewServeMux()
 	idpMux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
@@ -154,8 +150,11 @@ func TestWellKnownDiscoveryRouteRegistered(t *testing.T) {
 		if resp.StatusCode != http.StatusOK {
 			t.Fatalf("%s status = %d", path, resp.StatusCode)
 		}
-		body, _ := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
+		if err != nil {
+			t.Fatalf("read %s body: %v", path, err)
+		}
 		var doc map[string]any
 		if err := json.Unmarshal(body, &doc); err != nil {
 			t.Fatalf("decode %s: %v", path, err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a separate public URL for the MCP gateway, with automatic fallback to the broker URL.
  * Added protected-resource metadata discovery at standard and `/mcp` path variants.
  * Added OAuth authorization-server metadata discovery on the management endpoint.

* **Bug Fixes**
  * Corrected metadata and authentication challenge links for deployments using separate MCP and management hosts.
  * Added validation for absolute public URLs and normalized trailing slashes.

* **Documentation**
  * Updated deployment and OAuth discovery guidance for split-host configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->