### PR TITLE
fix(server): flat files are not documents; migrate legacy layout

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -482,12 +482,13 @@ Or via directory-level `.mark-acl` files:
 
 ```
 content-root/
-  doc.md -> versions/doc.md.v42  # symlink to current
+  doc.md -> versions/doc.md/v42  # symlink to current
   versions/
-    doc.md.v1
-    doc.md.v2
-    ...
-    doc.md.v42
+    doc.md/
+      v1
+      v2
+      ...
+      v42
 ```
 
 **Security Audit Log** (server-side only, not public):

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -478,7 +478,7 @@ Or via directory-level `.mark-acl` files:
 
 ### Versioning & Audit Trail
 
-**Every write creates a new version** (immutable history). Only documents written through the protocol are served — flat files without version history are treated as non-existent.
+**Every write creates a new version** (immutable history). Only documents written through the protocol are served — flat files without version history are not documents: FETCH treats them as non-existent, LIST omits them, and a PUBLISH to their path replaces them.
 
 ```
 content-root/

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -256,7 +256,7 @@ The body MUST be a markdown document containing a list of entries:
 - Directories are listed as `- [name/](url-encoded-name/)`
 - Files are listed as `- [name](url-encoded-name)`
 
-Servers MUST exclude hidden files (names beginning with `.`) from directory listings.
+Servers MUST exclude hidden files (names beginning with `.`) from directory listings. Servers MUST also exclude non-document files — content with no version history, which FETCH would refuse (§11.9) — so a listing never names an entry that cannot be fetched.
 
 Servers MUST impose a maximum entry count. The RECOMMENDED limit is **1000** entries. If the listing is truncated, the body SHOULD end with a note indicating truncation.
 
@@ -350,7 +350,7 @@ The `created` response MUST NOT include a body.
 - If the body is byte-for-byte identical to the current version's content, the server MUST NOT create a new version. It MUST respond with `ok` and the current version's `version` and `modified` metadata.
 - If the document does not exist, version 1 is created.
 - If the document exists, the version number is incremented from the current highest version.
-- If the document exists as a flat file (no version history), the server MUST migrate the flat file to version 1 before creating version 2.
+- A flat file (no version history) at the path is not a document (§11.9). PUBLISH treats the path as non-existent: version 1 is created and the file is replaced by the current-version pointer. Servers MUST NOT incorporate the flat file's content into version history.
 
 **OKF type default**: when a written document declares no `type` metadata, the server assigns the default `type` (`Document`; see §14), so every stored concept document is a typed Open Knowledge Format concept by construction. This applies to both PUBLISH and APPEND (§6.6). Reserved OKF files (`index.md`, `log.md`) are exempt, as OKF defines them as navigation and history rather than concepts. A document that already declares a `type` is stored unchanged. Because the default is part of the document's metadata, it participates in duplicate detection: republishing a previously untyped document acquires the default type once, creating a single new version.
 
@@ -625,20 +625,21 @@ The version segment MUST match the pattern `v` followed by a positive integer (n
 
 This section describes the reference layout for filesystem-backed stores. A store backed by another medium (for example a relational database) is exempt from this layout but MUST persist the same stored version bytes (§9.4) and preserve the observable version model (§9.1) under its own representation.
 
-Filesystem-backed servers SHOULD store versioned documents using the following layout:
+Filesystem-backed servers SHOULD store versioned documents using the per-document subdirectory layout:
 
 ```text
 root/
-  doc.md              ← symlink to versions/doc.md.v<current>
+  doc.md              ← symlink to versions/doc.md/v<current>
   versions/
-    doc.md.v1
-    doc.md.v2
-    doc.md.v<N>
+    doc.md/
+      v1
+      v2
+      v<N>
 ```
 
-The current file (`doc.md`) SHOULD be a symbolic link to the latest version file. Version files reside in a `versions/` subdirectory at the same level as the document.
+The current file (`doc.md`) SHOULD be a symbolic link to the latest version file. Each document's version files reside in their own subdirectory of `versions/`, at the same level as the document, named `v<N>` where N is the version number.
 
-Version files are named `<filename>.v<N>` where N is the version number.
+An older layout named version files `versions/<filename>.v<N>` directly in the `versions/` directory. Servers encountering it MUST migrate those files into the per-document layout before serving the store (§9.8).
 
 ### 9.4. Version File Format
 
@@ -723,14 +724,11 @@ When retention pruning (§9.9) has removed the oldest versions, verification app
 
 Servers MUST NOT overwrite existing version files. Before writing a new version file, the server MUST verify that no file exists at the target path. If the target file already exists, the write MUST fail.
 
-### 9.8. Flat File Migration
+### 9.8. Non-Document Files
 
-When a PUBLISH is performed on a document that exists as a flat file (no version history), the server MUST:
+A flat file present in the storage medium without version history never passed the protocol's write path: no token authorized it, no content contract validated it, and no hash chain anchors it. It is not a document (§11.9). Servers MUST NOT migrate such a file's content into version history; a PUBLISH to its path creates version 1 from the request body and replaces the file with the current-version pointer.
 
-1. Create the versions directory if it does not exist.
-2. Migrate the flat file content to `versions/<filename>.v1` with store frontmatter (`version: 1`, no `previous-hash`).
-3. Create the new version as `versions/<filename>.v2` with a `previous-hash` referencing the hash of the migrated v1 file.
-4. Update the current file to a symlink pointing to the new version.
+This is distinct from the legacy flat *layout* (`versions/<filename>.v<N>`), whose versions were written through the protocol and MUST be preserved by layout migration to the on-disk layout of §9.3.
 
 ### 9.9. Version Retention
 
@@ -851,7 +849,7 @@ Servers MUST enforce read auth on FETCH, LIST, and VERSIONS operations. Content-
 
 ### 11.9. Versioned-Only Serving
 
-Servers MUST only serve documents that have been written through the protocol, i.e., documents with at least one stored version (in the filesystem layout, a `versions/` directory containing at least one version file). Content present in the storage medium without version history — such as flat files placed directly on the filesystem — MUST be treated as `not-found`.
+Servers MUST only serve documents that have been written through the protocol, i.e., documents with at least one stored version (in the filesystem layout, a `versions/` directory containing at least one version file). Content present in the storage medium without version history — such as flat files placed directly on the filesystem — MUST be treated as `not-found` and MUST be excluded from LIST responses (§6.2). A directory whose subtree contains no documents MUST likewise be excluded.
 
 This ensures every served document has:
 

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -16,4 +16,7 @@ for mod in protocol server client tools; do
   (cd "$mod" && golangci-lint run ./...)
 done
 
+echo "Checking comment length on changed code..."
+bash scripts/check-comment-length.sh
+
 echo "✓ All checks passed"

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -452,6 +452,7 @@ func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, er
 	if !includeArchived {
 		live = s.liveChildren(reqPath)
 	}
+	dc := s.docCandidates(dirPath)
 	filtered := entries[:0]
 	for _, e := range entries {
 		name := e.Name()
@@ -486,7 +487,7 @@ func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, er
 			filtered = append(filtered, e)
 			continue
 		}
-		if !s.isDocumentEntry(dirPath, e) {
+		if !dc.isDocument(name) {
 			continue
 		}
 		if !includeArchived && entryArchived(filepath.Join(dirPath, name), absRoot) {
@@ -497,14 +498,42 @@ func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, er
 	return filtered, nil
 }
 
-// isDocumentEntry reports whether a file entry in dirAbs is a document a
-// listing may show: it has per-doc version history, so Get would serve it
-// (SPEC 9.8) — the single definition ListDir and the directory walks share.
-// A symlink is not trusted on its own: a hand-placed or orphaned current
-// pointer without versions must not be listed (a listing never names an
-// entry FETCH refuses, SPEC 6.2).
-func (s *Store) isDocumentEntry(dirAbs string, e os.DirEntry) bool {
-	return highestPerDocVersion(filepath.Join(dirAbs, "versions"), e.Name()) > 0
+// docCandidates answers "is this file entry a served document?" for one
+// directory (SPEC 9.8): its per-doc directory holds at least one version, so
+// Get would serve it. A symlink is not trusted on its own — a hand-placed or
+// orphaned current pointer without versions must not be listed (a listing
+// never names an entry FETCH refuses, SPEC 6.2). The candidate set (one
+// ReadDir of versions/) is memoized on first use, so a directory of N
+// non-documents costs one syscall instead of N probes and a fully indexed
+// listing never loads it; the per-candidate confirm keeps an empty
+// crash-artifact directory unlisted. The set is built from Lstat-level entry
+// types, a strict subset of what the confirm would accept: a symlinked
+// per-doc directory is deliberately not a candidate.
+type docCandidates struct {
+	dirAbs string
+	bases  map[string]bool
+	loaded bool
+}
+
+func (s *Store) docCandidates(dirAbs string) *docCandidates {
+	return &docCandidates{dirAbs: dirAbs}
+}
+
+func (dc *docCandidates) isDocument(name string) bool {
+	if !dc.loaded {
+		dc.loaded = true
+		entries, err := os.ReadDir(filepath.Join(dc.dirAbs, "versions"))
+		if err != nil {
+			return false
+		}
+		dc.bases = make(map[string]bool, len(entries))
+		for _, e := range entries {
+			if e.IsDir() {
+				dc.bases[e.Name()] = true
+			}
+		}
+	}
+	return dc.bases[name] && highestPerDocVersion(filepath.Join(dc.dirAbs, "versions"), name) > 0
 }
 
 // isHiddenEntry reports whether a directory entry name is always excluded from
@@ -582,21 +611,28 @@ func (s *Store) dirHasDocument(dirAbs, absRoot string, includeArchived bool) boo
 	if err != nil {
 		return false
 	}
+	// Files first: a qualifying file at this level answers with at most one
+	// candidate load, before any subtree recursion is paid.
+	dc := s.docCandidates(dirAbs)
+	var dirs []string
 	for _, e := range entries {
 		name := e.Name()
 		if isHiddenEntry(name) {
 			continue
 		}
 		if e.IsDir() {
-			if s.dirHasDocument(filepath.Join(dirAbs, name), absRoot, includeArchived) {
-				return true
-			}
+			dirs = append(dirs, name)
 			continue
 		}
-		if !s.isDocumentEntry(dirAbs, e) {
+		if !dc.isDocument(name) {
 			continue
 		}
 		if includeArchived || !entryArchived(filepath.Join(dirAbs, name), absRoot) {
+			return true
+		}
+	}
+	for _, name := range dirs {
+		if s.dirHasDocument(filepath.Join(dirAbs, name), absRoot, includeArchived) {
 			return true
 		}
 	}
@@ -774,9 +810,12 @@ func highestPerDocVersion(versionsDir, base string) int {
 }
 
 // perDocVersionNumber parses a per-doc version filename ("v{N}", N >= 1),
-// returning 0 for directories and any other name.
+// returning 0 for any other name. Regular files only: version files are
+// store-written and immutable, so a symlink (or anything else) planted in a
+// per-doc directory is never counted as a version, anywhere the store
+// answers version questions.
 func perDocVersionNumber(e os.DirEntry) int {
-	if e.IsDir() {
+	if !e.Type().IsRegular() {
 		return 0
 	}
 	name := e.Name()
@@ -1700,16 +1739,34 @@ func (s *Store) migrateLegacyVersionsDir(versionsDir string) error {
 	if err != nil {
 		return fmt.Errorf("read %s: %w", versionsDir, err)
 	}
-	docs := make(map[string][]legacyFile)
+	// byVersion picks one filename per (base, n). Names can collide on the
+	// normalized version ("doc.md.v01" vs "doc.md.v1"); the canonical
+	// (unpadded) name wins deliberately and the loser is left on disk as an
+	// unserved stray, so a collision never deletes content or blocks Open.
+	byVersion := make(map[string]map[int]string)
 	for _, e := range entries {
-		if e.IsDir() {
+		// Regular files only: a symlink named like a version would otherwise
+		// be moved into the per-doc dir (redundant defense; version reads
+		// reject non-regular entries too, see perDocVersionNumber).
+		if !e.Type().IsRegular() {
 			continue
 		}
-		if base, n, ok := legacyVersion(e.Name()); ok {
-			docs[base] = append(docs[base], legacyFile{e.Name(), n})
+		base, n, ok := legacyVersion(e.Name())
+		if !ok {
+			continue
+		}
+		if byVersion[base] == nil {
+			byVersion[base] = make(map[int]string)
+		}
+		if _, exists := byVersion[base][n]; !exists || e.Name() == fmt.Sprintf("%s.v%d", base, n) {
+			byVersion[base][n] = e.Name()
 		}
 	}
-	for base, files := range docs {
+	for base, versions := range byVersion {
+		files := make([]legacyFile, 0, len(versions))
+		for n, name := range versions {
+			files = append(files, legacyFile{name, n})
+		}
 		currentFile := filepath.Join(filepath.Dir(versionsDir), base)
 		if err := s.migrateToPerDocDir(versionsDir, base, currentFile, files); err != nil {
 			return fmt.Errorf("migrate %s: %w", currentFile, err)
@@ -1756,10 +1813,9 @@ func (s *Store) migrateToPerDocDir(versionsDir, base, currentFile string, files 
 		oldPath := filepath.Join(versionsDir, f.name)
 		newPath := newVersionFilePath(versionsDir, base, f.n)
 
-		// Skip if already migrated (e.g. by a concurrent opener). Best-effort
-		// removal: a leftover duplicate is re-skipped on the next open.
+		// Destination already exists: a concurrent opener moved this version
+		// first (collisions were resolved at grouping time, one name per n).
 		if _, err := os.Stat(newPath); err == nil {
-			_ = os.Remove(oldPath)
 			continue
 		}
 

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -2,7 +2,9 @@
 //
 // The store manages documents in a content directory. Only documents written
 // through the protocol (with a versions directory) are served. Flat files
-// without version history are treated as non-existent.
+// without version history are not documents (SPEC 9.8, 11.9): FETCH treats
+// them as non-existent, LIST omits them, and a publish to their path replaces
+// them without incorporating their content.
 //
 // Layout (per-document subdirectory):
 //
@@ -14,10 +16,11 @@
 //	      v2
 //	      v3
 //
-// The store also supports a legacy flat layout (versions/doc.md.v{N}) for
-// backward compatibility. Old-layout documents are migrated to the per-document
-// subdirectory layout on the next write.
-// TODO(v1): remove flat layout support and migration code.
+// A legacy flat layout (versions/doc.md.v{N}) predates the per-document
+// subdirectory layout. The read and write paths assume per-doc layout only;
+// callers opening a store over a pre-existing root run MigrateLegacyLayout
+// once at startup to convert any remaining legacy files.
+// TODO(v1): remove MigrateLegacyLayout once no pre-per-doc stores remain.
 package store
 
 import (
@@ -150,31 +153,6 @@ func IsReservedMetaKey(key string) bool {
 	return reservedMetaKeys[key]
 }
 
-// isPerDocLayout reports whether a document uses the per-document subdirectory
-// layout (versions/{base}/v{N}) rather than the flat layout (versions/{base}.v{N}).
-// TODO(v1): remove once all stores have been migrated; assume per-doc layout.
-func isPerDocLayout(versionsDir, base string) bool {
-	info, err := os.Stat(filepath.Join(versionsDir, base))
-	return err == nil && info.IsDir()
-}
-
-// resolveVersionFile returns the absolute path to an existing version file,
-// checking per-doc layout first then falling back to flat layout. This handles
-// partially-migrated stores where some versions may still be in the old layout.
-// TODO(v1): remove flat layout fallback; always use per-doc path directly.
-func resolveVersionFile(versionsDir, base string, version int) string {
-	perDoc := filepath.Join(versionsDir, base, fmt.Sprintf("v%d", version))
-	if _, err := os.Stat(perDoc); err == nil {
-		return perDoc
-	}
-	flat := filepath.Join(versionsDir, fmt.Sprintf("%s.v%d", base, version))
-	if _, err := os.Stat(flat); err == nil {
-		return flat
-	}
-	// Neither exists; return per-doc path so callers get a meaningful error.
-	return perDoc
-}
-
 // newVersionFilePath returns the absolute path for a new version file,
 // always using the per-document subdirectory layout.
 func newVersionFilePath(versionsDir, base string, version int) string {
@@ -200,13 +178,27 @@ type Store struct {
 	pathIdx map[string]string
 }
 
-// New creates a store rooted at the given directory.
+// New creates a store rooted at the given directory. For a pre-existing root
+// use Open, which migrates any legacy-layout version files first.
 func New(root string) *Store {
 	return &Store{
 		root:    root,
 		hashIdx: make(map[string]string),
 		pathIdx: make(map[string]string),
 	}
+}
+
+// Open returns a store for an existing content root, migrating legacy
+// flat-layout version files to the per-document layout first. The read and
+// write paths assume per-doc layout, so serving or writing an unmigrated
+// root would hide every legacy document and restart its version numbering.
+// TODO(v1): fold back into New when migrateLegacyLayout is removed.
+func Open(root string) (*Store, error) {
+	s := New(root)
+	if err := s.migrateLegacyLayout(); err != nil {
+		return nil, fmt.Errorf("migrate legacy layout: %w", err)
+	}
+	return s, nil
 }
 
 // contentHash computes the sha256 content hash for a document body.
@@ -421,12 +413,14 @@ func (s *Store) ListEntries(reqPath string, includeArchived bool) ([]DirEntry, e
 	return out, nil
 }
 
-// ListDir returns directory entries at the given path, excluding dot-files
-// and the versions/ directory. When includeArchived is false, archived
-// documents are omitted, as are subdirectories whose entire subtree contains
-// only archived documents (an all-archived directory would otherwise linger as
-// an empty shell). When true, every current entry is returned regardless of
-// archival — the recovery/audit view.
+// ListDir returns directory entries at the given path, excluding dot-files,
+// the versions/ directory, and non-document files (no version history — FETCH
+// would refuse them, SPEC 9.8/11.9). When includeArchived is false, archived
+// documents are omitted, as are subdirectories with no live document in their
+// subtree (an all-archived or document-free directory would otherwise linger
+// as an empty shell). When true, archived documents and the directories
+// holding them return — the recovery/audit view — but non-documents stay
+// excluded.
 func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, error) {
 	dirPath, err := s.resolve(reqPath)
 	if err != nil {
@@ -450,13 +444,13 @@ func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, er
 	// unless the caller asked to see them. liveChildren is computed once (a
 	// single pathIdx pass) so classification is an O(1) lookup per entry —
 	// files and directories the index names as live never touch disk.
+	absRoot, err := s.resolvedRoot()
+	if err != nil {
+		return nil, err
+	}
 	var live liveChildren
-	var absRoot string
 	if !includeArchived {
 		live = s.liveChildren(reqPath)
-		if absRoot, err = s.resolvedRoot(); err != nil {
-			return nil, err
-		}
 	}
 	filtered := entries[:0]
 	for _, e := range entries {
@@ -464,23 +458,49 @@ func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, er
 		if isHiddenEntry(name) {
 			continue
 		}
-		if !includeArchived {
-			if e.IsDir() {
-				// Fast path: the index names this child as holding a live
-				// versioned doc. Fallback: the index only tracks versioned
-				// documents, so a child it misses may still hold visible
-				// entries (regular/legacy flat files) — scan disk before
-				// pruning rather than hide content the listing would show.
-				if _, ok := live.dirs[name]; !ok && !dirHasVisibleEntry(filepath.Join(dirPath, name), absRoot) {
-					continue // subtree holds only archived documents
+		if e.IsDir() {
+			if includeArchived {
+				// Recovery/audit view: any document in the subtree, archived
+				// included, keeps the directory visible.
+				if !s.dirHasDocument(filepath.Join(dirPath, name), absRoot, true) {
+					continue
 				}
-			} else if _, ok := live.files[name]; !ok && entryArchived(filepath.Join(dirPath, name), absRoot) {
+			} else {
+				// Fast path: the index names this child as holding a live
+				// versioned doc. Fallback: the index only tracks per-doc
+				// versioned documents, so a child it misses may still hold
+				// visible docs — scan disk before pruning rather than hide
+				// content the listing would show.
+				if _, ok := live.dirs[name]; !ok && !s.dirHasDocument(filepath.Join(dirPath, name), absRoot, false) {
+					continue // subtree holds no listable documents
+				}
+			}
+			filtered = append(filtered, e)
+			continue
+		}
+		if !s.isDocumentEntry(dirPath, e) {
+			continue
+		}
+		if !includeArchived {
+			if _, ok := live.files[name]; !ok && entryArchived(filepath.Join(dirPath, name), absRoot) {
 				continue
 			}
 		}
 		filtered = append(filtered, e)
 	}
 	return filtered, nil
+}
+
+// isDocumentEntry reports whether a file entry in dirAbs is a document a
+// listing may show: a current-version symlink, or a regular file (legacy
+// current pointer) with per-doc version history. Anything else never passed
+// PUBLISH and is not a document (SPEC 9.8) — the single definition ListDir
+// and the directory walks share.
+func (s *Store) isDocumentEntry(dirAbs string, e os.DirEntry) bool {
+	if e.Type()&os.ModeSymlink != 0 {
+		return true
+	}
+	return highestPerDocVersion(filepath.Join(dirAbs, "versions"), e.Name()) > 0
 }
 
 // isHiddenEntry reports whether a directory entry name is always excluded from
@@ -544,16 +564,16 @@ func hasHiddenSegment(rel string) bool {
 	return false
 }
 
-// dirHasVisibleEntry reports whether the directory subtree rooted at dirAbs
-// holds at least one entry a filtered listing would show — any non-archived
-// file, including regular/legacy flat files that pathIdx does not track
-// (entryArchived errs toward visibility for those). It is the slow-path
-// complement to liveChildren: only consulted for child directories the index
-// does not already name, so an indexed (common-case) directory never pays for
-// a disk walk, and an all-archived directory is scanned rather than a live
-// flat file being wrongly hidden. Returns false on an unreadable directory so
-// an inaccessible subtree is pruned rather than shown empty.
-func dirHasVisibleEntry(dirAbs, absRoot string) bool {
+// dirHasDocument reports whether the directory subtree rooted at dirAbs
+// holds at least one document the listing view would show: any document when
+// includeArchived (the recovery/audit view), else a non-archived one. A
+// directory of only non-document files is excluded in both views (SPEC 11.9).
+// It is the slow-path complement to liveChildren: only consulted for child
+// directories the index does not already name, so an indexed (common-case)
+// live-view directory never pays for a disk walk. Returns false on an
+// unreadable directory so an inaccessible subtree is pruned rather than
+// shown empty.
+func (s *Store) dirHasDocument(dirAbs, absRoot string, includeArchived bool) bool {
 	entries, err := os.ReadDir(dirAbs)
 	if err != nil {
 		return false
@@ -563,14 +583,16 @@ func dirHasVisibleEntry(dirAbs, absRoot string) bool {
 		if isHiddenEntry(name) {
 			continue
 		}
-		child := filepath.Join(dirAbs, name)
 		if e.IsDir() {
-			if dirHasVisibleEntry(child, absRoot) {
+			if s.dirHasDocument(filepath.Join(dirAbs, name), absRoot, includeArchived) {
 				return true
 			}
 			continue
 		}
-		if !entryArchived(child, absRoot) {
+		if !s.isDocumentEntry(dirAbs, e) {
+			continue
+		}
+		if includeArchived || !entryArchived(filepath.Join(dirAbs, name), absRoot) {
 			return true
 		}
 	}
@@ -722,22 +744,47 @@ func (s *Store) resolve(reqPath string) (string, error) {
 // CurrentVersion returns the latest version number for a document.
 // Returns 0 if no version history exists.
 func (s *Store) CurrentVersion(reqPath string) int {
-	versions := s.findVersions(reqPath)
-	if len(versions) == 0 {
-		return 0
-	}
-	latest := 0
-	for _, v := range versions {
-		if v.Version > latest {
-			latest = v.Version
-		}
-	}
-	return latest
+	cleaned := filepath.Clean(reqPath)
+	cleaned = strings.TrimLeft(cleaned, "/")
+	versionsDir := filepath.Join(s.root, filepath.Dir(cleaned), "versions")
+	return highestPerDocVersion(versionsDir, filepath.Base(cleaned))
 }
 
-// findVersions looks for versioned files in the versions directory.
-// Supports both per-document subdirectory layout (versions/{base}/v{N})
-// and flat layout (versions/{base}.v{N}).
+// highestPerDocVersion returns the highest version number in base's per-doc
+// directory, or 0 when it has none. Names-only: no per-file stats.
+func highestPerDocVersion(versionsDir, base string) int {
+	entries, err := os.ReadDir(filepath.Join(versionsDir, base))
+	if err != nil {
+		return 0
+	}
+	highest := 0
+	for _, e := range entries {
+		if n := perDocVersionNumber(e); n > highest {
+			highest = n
+		}
+	}
+	return highest
+}
+
+// perDocVersionNumber parses a per-doc version filename ("v{N}", N >= 1),
+// returning 0 for directories and any other name.
+func perDocVersionNumber(e os.DirEntry) int {
+	if e.IsDir() {
+		return 0
+	}
+	name := e.Name()
+	if !strings.HasPrefix(name, "v") {
+		return 0
+	}
+	n, err := strconv.Atoi(name[1:])
+	if err != nil || n < 1 {
+		return 0
+	}
+	return n
+}
+
+// findVersions looks for versioned files in the versions directory
+// (per-document subdirectory layout, versions/{base}/v{N}).
 // Returns nil if no versions directory or no matching files exist.
 func (s *Store) findVersions(reqPath string) []VersionInfo {
 	cleaned := filepath.Clean(reqPath)
@@ -745,11 +792,7 @@ func (s *Store) findVersions(reqPath string) []VersionInfo {
 	base := filepath.Base(cleaned)
 
 	versionsDir := filepath.Join(s.root, filepath.Dir(cleaned), "versions")
-
-	if isPerDocLayout(versionsDir, base) {
-		return s.findVersionsPerDoc(versionsDir, base)
-	}
-	return s.findVersionsFlat(versionsDir, base)
+	return s.findVersionsPerDoc(versionsDir, base)
 }
 
 // findVersionsPerDoc reads versions from the per-document subdirectory layout.
@@ -762,43 +805,8 @@ func (s *Store) findVersionsPerDoc(versionsDir, base string) []VersionInfo {
 
 	var versions []VersionInfo
 	for _, e := range entries {
-		if e.IsDir() || !strings.HasPrefix(e.Name(), "v") {
-			continue
-		}
-		numStr := e.Name()[1:] // strip "v" prefix
-		num, err := strconv.Atoi(numStr)
-		if err != nil || num < 1 {
-			continue
-		}
-		info, err := e.Info()
-		if err != nil {
-			continue
-		}
-		versions = append(versions, VersionInfo{
-			Version:  num,
-			Modified: info.ModTime().UTC().Truncate(time.Second),
-		})
-	}
-	return versions
-}
-
-// findVersionsFlat reads versions from the flat layout.
-// TODO(v1): remove this function; all stores will use per-doc layout.
-func (s *Store) findVersionsFlat(versionsDir, base string) []VersionInfo {
-	entries, err := os.ReadDir(versionsDir)
-	if err != nil {
-		return nil
-	}
-
-	prefix := base + ".v"
-	var versions []VersionInfo
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasPrefix(e.Name(), prefix) {
-			continue
-		}
-		numStr := strings.TrimPrefix(e.Name(), prefix)
-		num, err := strconv.Atoi(numStr)
-		if err != nil || num < 1 {
+		num := perDocVersionNumber(e)
+		if num == 0 {
 			continue
 		}
 		info, err := e.Info()
@@ -820,22 +828,11 @@ func (s *Store) getVersion(reqPath string, version int) (*Document, error) {
 	cleaned = strings.TrimLeft(cleaned, "/")
 	base := filepath.Base(cleaned)
 
-	// Try per-doc layout first, fall back to flat layout for backward compatibility.
-	// TODO(v1): remove flat layout fallback.
 	dir := filepath.Dir(cleaned)
 	perDocPath := "/" + filepath.Join(dir, "versions", base, fmt.Sprintf("v%d", version))
 	filePath, err := s.resolve(perDocPath)
-	if err == nil {
-		if _, statErr := os.Stat(filePath); statErr != nil {
-			filePath = "" // per-doc path resolved but file doesn't exist; try flat
-		}
-	}
-	if filePath == "" {
-		flatPath := "/" + filepath.Join(dir, "versions", fmt.Sprintf("%s.v%d", base, version))
-		filePath, err = s.resolve(flatPath)
-		if err != nil {
-			return nil, err
-		}
+	if err != nil {
+		return nil, err
 	}
 
 	info, err := os.Stat(filePath)
@@ -887,10 +884,8 @@ func (s *Store) Archive(reqPath string, archived bool) error {
 		return os.ErrNotExist
 	}
 
-	// Resolve the version file path, trying per-doc layout first.
-	// TODO(v1): remove flat layout fallback.
 	versionsDir := filepath.Join(s.root, dir, "versions")
-	resolvedFile := resolveVersionFile(versionsDir, base, currentVersion)
+	resolvedFile := newVersionFilePath(versionsDir, base, currentVersion)
 	rel, _ := filepath.Rel(s.root, resolvedFile)
 	versionRelPath := "/" + rel
 	versionFile, err := s.resolve(versionRelPath)
@@ -1000,9 +995,9 @@ func (s *Store) Write(reqPath string, content []byte, meta map[string]string) (*
 	}
 
 	// For existing documents: reject writes to archived documents (closes
-	// TOCTOU gap with handler), run migrations, and check for duplicate content.
+	// TOCTOU gap with handler) and check for duplicate content.
 	if next > 1 {
-		doc, err := s.prepareExistingDoc(versionsDir, base, currentFile, next, content, meta)
+		doc, err := s.prepareExistingDoc(versionsDir, base, next, content, meta)
 		if doc != nil || err != nil {
 			return doc, err
 		}
@@ -1171,10 +1166,10 @@ func (s *Store) pruneVersions(versionsDir, base string, current, keep int) *Prun
 }
 
 // prepareExistingDoc handles pre-write checks for existing documents:
-// rejects archived documents, migrates flat files and old layout to per-doc
-// subdirectories, and returns ErrNotModified if content is unchanged.
+// rejects archived documents and returns ErrNotModified if content is
+// unchanged.
 // Returns (nil, nil) when the caller should proceed with writing a new version.
-func (s *Store) prepareExistingDoc(versionsDir, base, currentFile string, next int, content []byte, meta map[string]string) (*Document, error) {
+func (s *Store) prepareExistingDoc(versionsDir, base string, next int, content []byte, meta map[string]string) (*Document, error) {
 	archived, err := s.isCurrentArchived(versionsDir, base, next-1)
 	if err != nil {
 		return nil, err
@@ -1182,17 +1177,8 @@ func (s *Store) prepareExistingDoc(versionsDir, base, currentFile string, next i
 	if archived {
 		return nil, ErrArchived
 	}
-	if err := s.migrateFlatFile(versionsDir, base, currentFile); err != nil {
-		return nil, err
-	}
-	if !isPerDocLayout(versionsDir, base) {
-		if err := s.migrateToPerDocDir(versionsDir, base, currentFile); err != nil {
-			return nil, err
-		}
-	}
 
 	// Skip creating a new version if content and metadata are identical.
-	// After migration, always use per-doc layout for reads.
 	prevFile := newVersionFilePath(versionsDir, base, next-1)
 	prevData, err := os.ReadFile(prevFile)
 	if err != nil {
@@ -1337,8 +1323,8 @@ func (s *Store) VerifyChain(reqPath string) error {
 	for i, curr := range versions[1:] {
 		prev := versions[i]
 
-		prevFile := resolveVersionFile(versionsDir, base, prev.Version)
-		currFile := resolveVersionFile(versionsDir, base, curr.Version)
+		prevFile := newVersionFilePath(versionsDir, base, prev.Version)
+		currFile := newVersionFilePath(versionsDir, base, curr.Version)
 
 		prevData, err := os.ReadFile(prevFile)
 		if err != nil {
@@ -1471,7 +1457,7 @@ func joinContent(existing, content []byte) ([]byte, error) {
 func buildVersionFile(versionsDir, base string, version int, content []byte, meta map[string]string) ([]byte, error) {
 	var prevData []byte
 	if version > 1 {
-		prevFile := resolveVersionFile(versionsDir, base, version-1)
+		prevFile := newVersionFilePath(versionsDir, base, version-1)
 		var err error
 		prevData, err = os.ReadFile(prevFile)
 		if err != nil {
@@ -1662,110 +1648,113 @@ func extractBody(data []byte) []byte {
 	return data[4+end+5:]
 }
 
-// migrateFlatFile promotes a flat file (no version history) to v1 in the
-// versions directory using the per-document subdirectory layout.
-// If v1 already exists (concurrent write), it is a no-op.
-// TODO(v1): remove this function; flat files without version history won't exist.
-func (s *Store) migrateFlatFile(versionsDir, base, currentFile string) error {
-	// A document with any per-doc version history is not a flat file. This
-	// must not check for v1 specifically: retention pruning deletes the
-	// oldest versions, and misclassifying a pruned document here would
-	// resurrect a bogus v1 from the current symlink's raw bytes (store
-	// frontmatter included) and break the hash chain.
-	if len(s.findVersionsPerDoc(versionsDir, base)) > 0 {
-		return nil
-	}
-	flatV1 := filepath.Join(versionsDir, fmt.Sprintf("%s.v1", base))
-	if _, err := os.Stat(flatV1); !errors.Is(err, os.ErrNotExist) {
-		return nil // v1 already exists (old layout, will be migrated by migrateToPerDocDir)
-	}
-	flatData, err := os.ReadFile(currentFile)
-	if err != nil {
-		return fmt.Errorf("read flat file for migration: %w", err)
-	}
-
-	// Create per-document subdirectory.
-	docDir := filepath.Join(versionsDir, base)
-	if err := os.MkdirAll(docDir, 0o755); err != nil {
-		return fmt.Errorf("create per-doc dir for migration: %w", err)
-	}
-
-	v1File := newVersionFilePath(versionsDir, base, 1)
-	v1Data := []byte("---\nversion: 1\n---\n")
-	v1Data = append(v1Data, flatData...)
-	// Use exclusive create to prevent overwriting a v1 that appeared
-	// between the Stat check and now (TOCTOU race).
-	f, err := os.OpenFile(v1File, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
-	if err != nil {
-		if os.IsExist(err) {
-			return nil // v1 was created concurrently
+// migrateLegacyLayout migrates every legacy flat-layout document
+// (versions/{base}.v{N}) under the content root to the per-document
+// subdirectory layout (versions/{base}/v{N}) and repairs current pointers.
+// Runs once from Open, before the store serves or writes anything.
+// Idempotent; a store with no legacy version files performs no writes.
+// TODO(v1): remove once no pre-per-doc stores remain.
+func (s *Store) migrateLegacyLayout() error {
+	return filepath.WalkDir(s.root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
-		return fmt.Errorf("migrate flat file to v1: %w", err)
+		if !d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if path != s.root && strings.HasPrefix(name, ".") {
+			return filepath.SkipDir
+		}
+		if name != "versions" {
+			return nil
+		}
+		if merr := s.migrateLegacyVersionsDir(path); merr != nil {
+			return merr
+		}
+		return filepath.SkipDir // per-doc subdirs hold only version files
+	})
+}
+
+// migrateLegacyVersionsDir migrates every legacy-layout document in one
+// versions directory. A single ReadDir groups version numbers by document;
+// the per-base worker gets the list so nothing rescans the directory.
+func (s *Store) migrateLegacyVersionsDir(versionsDir string) error {
+	entries, err := os.ReadDir(versionsDir)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", versionsDir, err)
 	}
-	if _, err := f.Write(v1Data); err != nil {
-		_ = f.Close()
-		_ = os.Remove(v1File)
-		return fmt.Errorf("migrate flat file to v1: %w", err)
+	docs := make(map[string][]int)
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if base, n, ok := legacyVersion(e.Name()); ok {
+			docs[base] = append(docs[base], n)
+		}
 	}
-	if err := f.Close(); err != nil {
-		_ = os.Remove(v1File)
-		return fmt.Errorf("migrate flat file to v1: %w", err)
+	for base, versions := range docs {
+		currentFile := filepath.Join(filepath.Dir(versionsDir), base)
+		if err := s.migrateToPerDocDir(versionsDir, base, currentFile, versions); err != nil {
+			return fmt.Errorf("migrate %s: %w", currentFile, err)
+		}
 	}
 	return nil
 }
 
-// migrateToPerDocDir moves version files from the flat layout (versions/{base}.v{N})
-// to the per-document subdirectory layout (versions/{base}/v{N}).
-// Updates the current symlink to point at the new location.
-// No-op if already using per-document layout or no flat files exist.
-// TODO(v1): remove this function; all stores will use per-doc layout.
-func (s *Store) migrateToPerDocDir(versionsDir, base, currentFile string) error {
+// legacyVersion parses a legacy flat-layout version filename ({base}.v{N})
+// into its document basename and version, or ok=false for any other name.
+// Only visible markdown basenames qualify: the protocol never publishes
+// anything else (ErrInvalidPath), and a stray name like "..v1" (base ".")
+// would otherwise aim the migration's current-pointer at the directory
+// itself.
+func legacyVersion(name string) (base string, n int, ok bool) {
+	i := strings.LastIndex(name, ".v")
+	if i <= 0 {
+		return "", 0, false
+	}
+	n, err := strconv.Atoi(name[i+2:])
+	if err != nil || n < 1 {
+		return "", 0, false
+	}
+	base = name[:i]
+	if !strings.HasSuffix(base, ".md") || isHiddenEntry(base) {
+		return "", 0, false
+	}
+	return base, n, true
+}
+
+// migrateToPerDocDir moves the given legacy flat-layout versions of base
+// (versions/{base}.v{N}) into the per-document subdirectory and points the
+// current symlink at the highest version present after the move (a crashed
+// earlier migration may have left versions split across both layouts).
+// TODO(v1): remove with migrateLegacyLayout.
+func (s *Store) migrateToPerDocDir(versionsDir, base, currentFile string, versions []int) error {
 	// Create per-document subdirectory.
 	docDir := filepath.Join(versionsDir, base)
 	if err := os.MkdirAll(docDir, 0o755); err != nil {
 		return fmt.Errorf("create per-doc dir for migration: %w", err)
 	}
 
-	// Find all flat-layout version files for this document.
-	entries, err := os.ReadDir(versionsDir)
-	if err != nil {
-		return fmt.Errorf("read versions dir for migration: %w", err)
-	}
-
-	prefix := base + ".v"
-	var highestVersion int
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasPrefix(e.Name(), prefix) {
-			continue
-		}
-		numStr := strings.TrimPrefix(e.Name(), prefix)
-		num, err := strconv.Atoi(numStr)
-		if err != nil || num < 1 {
-			continue
-		}
-
-		oldPath := filepath.Join(versionsDir, e.Name())
+	for _, num := range versions {
+		oldPath := filepath.Join(versionsDir, fmt.Sprintf("%s.v%d", base, num))
 		newPath := newVersionFilePath(versionsDir, base, num)
 
 		// Skip if already migrated (e.g. concurrent migration).
 		if _, err := os.Stat(newPath); err == nil {
 			_ = os.Remove(oldPath)
-			if num > highestVersion {
-				highestVersion = num
-			}
 			continue
 		}
 
 		if err := os.Rename(oldPath, newPath); err != nil {
 			return fmt.Errorf("migrate version %d: %w", num, err)
 		}
-		if num > highestVersion {
-			highestVersion = num
-		}
 	}
 
-	// Update symlink to point at the new location.
-	if highestVersion > 0 {
+	// Point the current symlink at the highest per-doc version now present —
+	// scanned after the moves, so versions a crashed migration already moved
+	// are counted and the pointer never regresses.
+	if highestVersion := highestPerDocVersion(versionsDir, base); highestVersion > 0 {
 		relTarget := newVersionSymlinkTarget(base, highestVersion)
 		tmpLink := currentFile + ".tmp"
 		_ = os.Remove(tmpLink)
@@ -1785,7 +1774,7 @@ func (s *Store) migrateToPerDocDir(versionsDir, base, currentFile string) error 
 // Returns (false, nil) if the file doesn't exist (new document).
 // Returns an error for non-ErrNotExist read failures.
 func (s *Store) isCurrentArchived(versionsDir, base string, version int) (bool, error) {
-	path := resolveVersionFile(versionsDir, base, version)
+	path := newVersionFilePath(versionsDir, base, version)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -522,6 +522,10 @@ func (s *Store) docCandidates(dirAbs string) *docCandidates {
 func (dc *docCandidates) isDocument(name string) bool {
 	if !dc.loaded {
 		dc.loaded = true
+		// A failed ReadDir leaves an empty set for the whole listing —
+		// deliberately, matching dirHasDocument and highestPerDocVersion:
+		// an inaccessible versions/ hides its documents rather than serving
+		// them broken, and heals when the permission problem does.
 		entries, err := os.ReadDir(filepath.Join(dc.dirAbs, "versions"))
 		if err != nil {
 			return false

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -188,11 +188,9 @@ func New(root string) *Store {
 	}
 }
 
-// Open returns a store for an existing content root, migrating legacy
-// flat-layout version files to the per-document layout first. The read and
-// write paths assume per-doc layout, so serving or writing an unmigrated
-// root would hide every legacy document and restart its version numbering.
-// TODO(v1): fold back into New when migrateLegacyLayout is removed.
+// Open returns a store for an existing root, migrating legacy flat-layout
+// versions first: an unmigrated root would hide every legacy document and
+// restart its numbering. TODO(v1): fold into New with migrateLegacyLayout.
 func Open(root string) (*Store, error) {
 	s := New(root)
 	if err := s.migrateLegacyLayout(); err != nil {
@@ -413,14 +411,9 @@ func (s *Store) ListEntries(reqPath string, includeArchived bool) ([]DirEntry, e
 	return out, nil
 }
 
-// ListDir returns directory entries at the given path, excluding dot-files,
-// the versions/ directory, and non-document files (no version history — FETCH
-// would refuse them, SPEC 9.8/11.9). When includeArchived is false, archived
-// documents are omitted, as are subdirectories with no live document in their
-// subtree (an all-archived or document-free directory would otherwise linger
-// as an empty shell). When true, archived documents and the directories
-// holding them return — the recovery/audit view — but non-documents stay
-// excluded.
+// ListDir returns entries at reqPath, excluding dot-files, versions/, and
+// non-documents (SPEC 9.8/11.9). includeArchived=false also omits archived
+// docs and document-free subtrees; true is the recovery/audit view.
 func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, error) {
 	dirPath, err := s.resolve(reqPath)
 	if err != nil {
@@ -467,11 +460,8 @@ func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, er
 					continue
 				}
 			} else {
-				// Fast path: the index names this child as holding a live
-				// versioned doc. Fallback: the index only tracks per-doc
-				// versioned documents, so a child it misses may still hold
-				// visible docs — scan disk before pruning rather than hide
-				// content the listing would show.
+				// Index fast path; on a miss, scan disk before pruning
+				// rather than hide content the listing would show.
 				if _, ok := live.dirs[name]; !ok && !s.dirHasDocument(filepath.Join(dirPath, name), absRoot, false) {
 					continue // subtree holds no listable documents
 				}
@@ -479,10 +469,8 @@ func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, er
 			filtered = append(filtered, e)
 			continue
 		}
-		// Index fast path: a live indexed doc is a document by construction
-		// (the index is built from resolvable current versions). The nil map
-		// in the include-archived view simply misses, falling through to the
-		// disk checks.
+		// Index fast path: a live indexed doc is a document by construction;
+		// the include-archived view's nil map misses into the disk checks.
 		if _, ok := live.files[name]; ok {
 			filtered = append(filtered, e)
 			continue
@@ -498,17 +486,9 @@ func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, er
 	return filtered, nil
 }
 
-// docCandidates answers "is this file entry a served document?" for one
-// directory (SPEC 9.8): its per-doc directory holds at least one version, so
-// Get would serve it. A symlink is not trusted on its own — a hand-placed or
-// orphaned current pointer without versions must not be listed (a listing
-// never names an entry FETCH refuses, SPEC 6.2). The candidate set (one
-// ReadDir of versions/) is memoized on first use, so a directory of N
-// non-documents costs one syscall instead of N probes and a fully indexed
-// listing never loads it; the per-candidate confirm keeps an empty
-// crash-artifact directory unlisted. The set is built from Lstat-level entry
-// types, a strict subset of what the confirm would accept: a symlinked
-// per-doc directory is deliberately not a candidate.
+// docCandidates answers "is this file entry a served document?" (SPEC 9.8):
+// its per-doc dir holds a version, so Get would serve it; a symlink earns no
+// trust on its own (SPEC 6.2). Memoizes one versions/ ReadDir per listing.
 type docCandidates struct {
 	dirAbs string
 	bases  map[string]bool
@@ -522,10 +502,9 @@ func (s *Store) docCandidates(dirAbs string) *docCandidates {
 func (dc *docCandidates) isDocument(name string) bool {
 	if !dc.loaded {
 		dc.loaded = true
-		// A failed ReadDir leaves an empty set for the whole listing —
-		// deliberately, matching dirHasDocument and highestPerDocVersion:
-		// an inaccessible versions/ hides its documents rather than serving
-		// them broken, and heals when the permission problem does.
+		// A failed ReadDir leaves an empty set: an inaccessible versions/
+		// hides its documents rather than serving them broken (same
+		// trade-off as dirHasDocument and highestPerDocVersion).
 		entries, err := os.ReadDir(filepath.Join(dc.dirAbs, "versions"))
 		if err != nil {
 			return false
@@ -601,15 +580,9 @@ func hasHiddenSegment(rel string) bool {
 	return false
 }
 
-// dirHasDocument reports whether the directory subtree rooted at dirAbs
-// holds at least one document the listing view would show: any document when
-// includeArchived (the recovery/audit view), else a non-archived one. A
-// directory of only non-document files is excluded in both views (SPEC 11.9).
-// It is the slow-path complement to liveChildren: only consulted for child
-// directories the index does not already name, so an indexed (common-case)
-// live-view directory never pays for a disk walk. Returns false on an
-// unreadable directory so an inaccessible subtree is pruned rather than
-// shown empty.
+// dirHasDocument reports whether the subtree holds a document the listing
+// view would show (SPEC 11.9); liveChildren's slow-path complement, walked
+// only for unindexed children. Unreadable dirs prune rather than show empty.
 func (s *Store) dirHasDocument(dirAbs, absRoot string, includeArchived bool) bool {
 	entries, err := os.ReadDir(dirAbs)
 	if err != nil {
@@ -794,11 +767,9 @@ func (s *Store) CurrentVersion(reqPath string) int {
 	return highestPerDocVersion(versionsDir, filepath.Base(cleaned))
 }
 
-// highestPerDocVersion returns the highest version number in base's per-doc
-// directory, or 0 when it has none. Names-only: no per-file stats. An
-// unreadable per-doc directory also reports 0 — deliberately, matching
-// dirHasDocument: an inaccessible document is hidden rather than served
-// broken, and heals when the permission problem does.
+// highestPerDocVersion returns the highest version in base's per-doc dir,
+// or 0 (names-only, no stats). An unreadable dir is also 0: an inaccessible
+// doc hides rather than serves broken, and heals with the permission.
 func highestPerDocVersion(versionsDir, base string) int {
 	entries, err := os.ReadDir(filepath.Join(versionsDir, base))
 	if err != nil {
@@ -814,10 +785,8 @@ func highestPerDocVersion(versionsDir, base string) int {
 }
 
 // perDocVersionNumber parses a per-doc version filename ("v{N}", N >= 1),
-// returning 0 for any other name. Regular files only: version files are
-// store-written and immutable, so a symlink (or anything else) planted in a
-// per-doc directory is never counted as a version, anywhere the store
-// answers version questions.
+// 0 otherwise. Regular files only: a planted symlink is never a version,
+// anywhere the store answers version questions.
 func perDocVersionNumber(e os.DirEntry) int {
 	if !e.Type().IsRegular() {
 		return 0
@@ -1215,10 +1184,8 @@ func (s *Store) pruneVersions(versionsDir, base string, current, keep int) *Prun
 	return res
 }
 
-// prepareExistingDoc handles pre-write checks for existing documents:
-// rejects archived documents and returns ErrNotModified if content is
-// unchanged.
-// Returns (nil, nil) when the caller should proceed with writing a new version.
+// prepareExistingDoc rejects archived documents and returns ErrNotModified
+// on unchanged content; (nil, nil) means proceed with a new version.
 func (s *Store) prepareExistingDoc(versionsDir, base string, next int, content []byte, meta map[string]string) (*Document, error) {
 	archived, err := s.isCurrentArchived(versionsDir, base, next-1)
 	if err != nil {
@@ -1698,12 +1665,9 @@ func extractBody(data []byte) []byte {
 	return data[4+end+5:]
 }
 
-// migrateLegacyLayout migrates every legacy flat-layout document
-// (versions/{base}.v{N}) under the content root to the per-document
-// subdirectory layout (versions/{base}/v{N}) and repairs current pointers.
-// Runs once from Open, before the store serves or writes anything.
-// Idempotent; a store with no legacy version files performs no writes.
-// TODO(v1): remove once no pre-per-doc stores remain.
+// migrateLegacyLayout moves legacy versions/{base}.v{N} files to the
+// per-doc layout and repairs current pointers. Idempotent; runs from Open
+// before any serving. TODO(v1): remove once no pre-per-doc stores remain.
 func (s *Store) migrateLegacyLayout() error {
 	return filepath.WalkDir(s.root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -1726,10 +1690,9 @@ func (s *Store) migrateLegacyLayout() error {
 	})
 }
 
-// legacyFile is one legacy flat-layout version file: its on-disk name and
-// parsed version. The name travels with the number because the two can
-// diverge ("doc.md.v01" parses to 1); a reconstructed name would miss the
-// file and abort the migration.
+// legacyFile pairs a legacy version file's on-disk name with its parsed
+// version: the two can diverge ("doc.md.v01" parses to 1), and a
+// reconstructed name would miss the file and abort the migration.
 type legacyFile struct {
 	name string
 	n    int
@@ -1743,10 +1706,9 @@ func (s *Store) migrateLegacyVersionsDir(versionsDir string) error {
 	if err != nil {
 		return fmt.Errorf("read %s: %w", versionsDir, err)
 	}
-	// byVersion picks one filename per (base, n). Names can collide on the
-	// normalized version ("doc.md.v01" vs "doc.md.v1"); the canonical
-	// (unpadded) name wins deliberately and the loser is left on disk as an
-	// unserved stray, so a collision never deletes content or blocks Open.
+	// One filename per (base, n): normalized collisions ("doc.md.v01" vs
+	// "doc.md.v1") resolve to the canonical name; the loser stays on disk
+	// as an unserved stray, never deleted, never blocking Open.
 	byVersion := make(map[string]map[int]string)
 	for _, e := range entries {
 		// Regular files only: a symlink named like a version would otherwise
@@ -1779,12 +1741,9 @@ func (s *Store) migrateLegacyVersionsDir(versionsDir string) error {
 	return nil
 }
 
-// legacyVersion parses a legacy flat-layout version filename ({base}.v{N})
-// into its document basename and version, or ok=false for any other name.
-// Only visible markdown basenames qualify: the protocol never publishes
-// anything else (ErrInvalidPath), and a stray name like "..v1" (base ".")
-// would otherwise aim the migration's current-pointer at the directory
-// itself.
+// legacyVersion parses a legacy version filename ({base}.v{N}). Visible
+// markdown basenames only: the protocol publishes nothing else, and a stray
+// "..v1" (base ".") would aim the current-pointer at the directory itself.
 func legacyVersion(name string) (base string, n int, ok bool) {
 	i := strings.LastIndex(name, ".v")
 	if i <= 0 {
@@ -1801,11 +1760,9 @@ func legacyVersion(name string) (base string, n int, ok bool) {
 	return base, n, true
 }
 
-// migrateToPerDocDir moves the given legacy flat-layout versions of base
-// (versions/{base}.v{N}) into the per-document subdirectory and points the
-// current symlink at the highest version present after the move (a crashed
-// earlier migration may have left versions split across both layouts).
-// TODO(v1): remove with migrateLegacyLayout.
+// migrateToPerDocDir moves base's legacy version files into its per-doc dir
+// and points the current symlink at the highest version present after the
+// move (a crash may have split layouts). TODO(v1): remove with migration.
 func (s *Store) migrateToPerDocDir(versionsDir, base, currentFile string, files []legacyFile) error {
 	// Create per-document subdirectory.
 	docDir := filepath.Join(versionsDir, base)

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -478,13 +478,19 @@ func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, er
 			filtered = append(filtered, e)
 			continue
 		}
+		// Index fast path: a live indexed doc is a document by construction
+		// (the index is built from resolvable current versions). The nil map
+		// in the include-archived view simply misses, falling through to the
+		// disk checks.
+		if _, ok := live.files[name]; ok {
+			filtered = append(filtered, e)
+			continue
+		}
 		if !s.isDocumentEntry(dirPath, e) {
 			continue
 		}
-		if !includeArchived {
-			if _, ok := live.files[name]; !ok && entryArchived(filepath.Join(dirPath, name), absRoot) {
-				continue
-			}
+		if !includeArchived && entryArchived(filepath.Join(dirPath, name), absRoot) {
+			continue
 		}
 		filtered = append(filtered, e)
 	}
@@ -492,14 +498,12 @@ func (s *Store) ListDir(reqPath string, includeArchived bool) ([]os.DirEntry, er
 }
 
 // isDocumentEntry reports whether a file entry in dirAbs is a document a
-// listing may show: a current-version symlink, or a regular file (legacy
-// current pointer) with per-doc version history. Anything else never passed
-// PUBLISH and is not a document (SPEC 9.8) — the single definition ListDir
-// and the directory walks share.
+// listing may show: it has per-doc version history, so Get would serve it
+// (SPEC 9.8) — the single definition ListDir and the directory walks share.
+// A symlink is not trusted on its own: a hand-placed or orphaned current
+// pointer without versions must not be listed (a listing never names an
+// entry FETCH refuses, SPEC 6.2).
 func (s *Store) isDocumentEntry(dirAbs string, e os.DirEntry) bool {
-	if e.Type()&os.ModeSymlink != 0 {
-		return true
-	}
 	return highestPerDocVersion(filepath.Join(dirAbs, "versions"), e.Name()) > 0
 }
 
@@ -751,7 +755,10 @@ func (s *Store) CurrentVersion(reqPath string) int {
 }
 
 // highestPerDocVersion returns the highest version number in base's per-doc
-// directory, or 0 when it has none. Names-only: no per-file stats.
+// directory, or 0 when it has none. Names-only: no per-file stats. An
+// unreadable per-doc directory also reports 0 — deliberately, matching
+// dirHasDocument: an inaccessible document is hidden rather than served
+// broken, and heals when the permission problem does.
 func highestPerDocVersion(versionsDir, base string) int {
 	entries, err := os.ReadDir(filepath.Join(versionsDir, base))
 	if err != nil {
@@ -1676,26 +1683,35 @@ func (s *Store) migrateLegacyLayout() error {
 	})
 }
 
+// legacyFile is one legacy flat-layout version file: its on-disk name and
+// parsed version. The name travels with the number because the two can
+// diverge ("doc.md.v01" parses to 1); a reconstructed name would miss the
+// file and abort the migration.
+type legacyFile struct {
+	name string
+	n    int
+}
+
 // migrateLegacyVersionsDir migrates every legacy-layout document in one
-// versions directory. A single ReadDir groups version numbers by document;
+// versions directory. A single ReadDir groups version files by document;
 // the per-base worker gets the list so nothing rescans the directory.
 func (s *Store) migrateLegacyVersionsDir(versionsDir string) error {
 	entries, err := os.ReadDir(versionsDir)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", versionsDir, err)
 	}
-	docs := make(map[string][]int)
+	docs := make(map[string][]legacyFile)
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
 		}
 		if base, n, ok := legacyVersion(e.Name()); ok {
-			docs[base] = append(docs[base], n)
+			docs[base] = append(docs[base], legacyFile{e.Name(), n})
 		}
 	}
-	for base, versions := range docs {
+	for base, files := range docs {
 		currentFile := filepath.Join(filepath.Dir(versionsDir), base)
-		if err := s.migrateToPerDocDir(versionsDir, base, currentFile, versions); err != nil {
+		if err := s.migrateToPerDocDir(versionsDir, base, currentFile, files); err != nil {
 			return fmt.Errorf("migrate %s: %w", currentFile, err)
 		}
 	}
@@ -1729,25 +1745,33 @@ func legacyVersion(name string) (base string, n int, ok bool) {
 // current symlink at the highest version present after the move (a crashed
 // earlier migration may have left versions split across both layouts).
 // TODO(v1): remove with migrateLegacyLayout.
-func (s *Store) migrateToPerDocDir(versionsDir, base, currentFile string, versions []int) error {
+func (s *Store) migrateToPerDocDir(versionsDir, base, currentFile string, files []legacyFile) error {
 	// Create per-document subdirectory.
 	docDir := filepath.Join(versionsDir, base)
 	if err := os.MkdirAll(docDir, 0o755); err != nil {
 		return fmt.Errorf("create per-doc dir for migration: %w", err)
 	}
 
-	for _, num := range versions {
-		oldPath := filepath.Join(versionsDir, fmt.Sprintf("%s.v%d", base, num))
-		newPath := newVersionFilePath(versionsDir, base, num)
+	for _, f := range files {
+		oldPath := filepath.Join(versionsDir, f.name)
+		newPath := newVersionFilePath(versionsDir, base, f.n)
 
-		// Skip if already migrated (e.g. concurrent migration).
+		// Skip if already migrated (e.g. by a concurrent opener). Best-effort
+		// removal: a leftover duplicate is re-skipped on the next open.
 		if _, err := os.Stat(newPath); err == nil {
 			_ = os.Remove(oldPath)
 			continue
 		}
 
 		if err := os.Rename(oldPath, newPath); err != nil {
-			return fmt.Errorf("migrate version %d: %w", num, err)
+			// A concurrent opener can win the rename between the Stat above
+			// and here; the version arriving is success, not failure.
+			if errors.Is(err, os.ErrNotExist) {
+				if _, statErr := os.Stat(newPath); statErr == nil {
+					continue
+				}
+			}
+			return fmt.Errorf("migrate version %d: %w", f.n, err)
 		}
 	}
 

--- a/protocol/store/store_test.go
+++ b/protocol/store/store_test.go
@@ -29,21 +29,19 @@ func TestGet_FlatFileRejected(t *testing.T) {
 	}
 }
 
-// TODO(v1): update this test to use per-doc layout once flat layout support is removed.
 func TestGet_VersionedFile(t *testing.T) {
 	root := t.TempDir()
-	versionsDir := filepath.Join(root, "versions")
-	if err := os.Mkdir(versionsDir, 0o755); err != nil {
+	docDir := filepath.Join(root, "versions", "doc.md")
+	if err := os.MkdirAll(docDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(versionsDir, "doc.md.v1"), []byte("# V1"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(docDir, "v1"), []byte("# V1"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(versionsDir, "doc.md.v2"), []byte("# V2"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(docDir, "v2"), []byte("# V2"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// Current file (would be a symlink in production)
-	if err := os.WriteFile(filepath.Join(root, "doc.md"), []byte("# V2"), 0o644); err != nil {
+	if err := os.Symlink(filepath.Join("versions", "doc.md", "v2"), filepath.Join(root, "doc.md")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -143,24 +141,28 @@ func TestIsDir(t *testing.T) {
 
 func TestListDir(t *testing.T) {
 	root := t.TempDir()
-	for _, f := range []struct{ name, content string }{
-		{"a.md", "a"}, {"b.md", "b"}, {".hidden", "hidden"},
-	} {
-		if err := os.WriteFile(filepath.Join(root, f.name), []byte(f.content), 0o644); err != nil {
+	s := New(root)
+	for _, p := range []string{"/a.md", "/b.md"} {
+		if _, err := s.Write(p, []byte("# "+p+"\n"), nil); err != nil {
+			t.Fatalf("Write %s: %v", p, err)
+		}
+	}
+	// Excluded regardless of view: dot-files, versions/, and a versionless
+	// flat file (not a document, SPEC 9.8).
+	for _, name := range []string{".hidden", "flat.md"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("x"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := os.Mkdir(filepath.Join(root, "versions"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 
-	s := New(root)
-	entries, err := s.ListDir("/", false)
-	if err != nil {
-		t.Fatalf("ListDir: %v", err)
-	}
-	if len(entries) != 2 {
-		t.Errorf("entries = %d, want 2 (excluding .hidden and versions)", len(entries))
+	for _, includeArchived := range []bool{false, true} {
+		entries, err := s.ListDir("/", includeArchived)
+		if err != nil {
+			t.Fatalf("ListDir(includeArchived=%v): %v", includeArchived, err)
+		}
+		if len(entries) != 2 {
+			t.Errorf("includeArchived=%v: entries = %d, want 2 (excluding .hidden, versions, flat.md)", includeArchived, len(entries))
+		}
 	}
 }
 
@@ -182,9 +184,8 @@ func TestListDir_HidesArchived(t *testing.T) {
 	if err := s.Archive("/attic/old.md", true); err != nil {
 		t.Fatalf("Archive /attic/old.md: %v", err)
 	}
-	// A directory holding only a regular (unversioned, legacy/flat) file:
-	// pathIdx never tracks it, but the listing shows such files, so the
-	// directory must not be pruned.
+	// A directory holding only a versionless flat file: not a document
+	// (SPEC 9.8), so the directory holds nothing listable and is pruned.
 	if err := os.MkdirAll(filepath.Join(root, "flatdir"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -219,11 +220,12 @@ func TestListDir_HidesArchived(t *testing.T) {
 	if !h["nested"] {
 		t.Errorf("hide: want nested/ kept (live doc several levels down), got %v", h)
 	}
-	if !h["flatdir"] {
-		t.Errorf("hide: want flatdir/ kept (visible unversioned file, unindexed), got %v", h)
+	if h["flatdir"] {
+		t.Errorf("hide: want document-free flatdir/ pruned, got %v", h)
 	}
 
-	// include-archived: everything current is listed, including attic/.
+	// include-archived: every document is listed, including attic/; a
+	// document-free directory stays excluded even in the audit view.
 	shown, err := s.ListDir("/", true)
 	if err != nil {
 		t.Fatalf("ListDir show: %v", err)
@@ -233,6 +235,9 @@ func TestListDir_HidesArchived(t *testing.T) {
 		if !sh[want] {
 			t.Errorf("show: want %s present, got %v", want, sh)
 		}
+	}
+	if sh["flatdir"] {
+		t.Errorf("show: want document-free flatdir/ excluded, got %v", sh)
 	}
 
 	// Non-canonical request paths must behave identically — the index fast
@@ -303,22 +308,23 @@ func TestVersions_FlatFileRejected(t *testing.T) {
 	}
 }
 
-// TODO(v1): update this test to use per-doc layout once flat layout support is removed.
 func TestVersions_MultipleVersions(t *testing.T) {
 	root := t.TempDir()
-	versionsDir := filepath.Join(root, "versions")
-	if err := os.Mkdir(versionsDir, 0o755); err != nil {
+	docDir := filepath.Join(root, "versions", "doc.md")
+	if err := os.MkdirAll(docDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	for _, f := range []struct{ name, content string }{
-		{filepath.Join(root, "doc.md"), "current"},
-		{filepath.Join(versionsDir, "doc.md.v1"), "v1"},
-		{filepath.Join(versionsDir, "doc.md.v2"), "v2"},
-		{filepath.Join(versionsDir, "doc.md.v3"), "v3"},
+		{filepath.Join(docDir, "v1"), "v1"},
+		{filepath.Join(docDir, "v2"), "v2"},
+		{filepath.Join(docDir, "v3"), "v3"},
 	} {
 		if err := os.WriteFile(f.name, []byte(f.content), 0o644); err != nil {
 			t.Fatal(err)
 		}
+	}
+	if err := os.Symlink(filepath.Join("versions", "doc.md", "v3"), filepath.Join(root, "doc.md")); err != nil {
+		t.Fatal(err)
 	}
 
 	s := New(root)
@@ -959,8 +965,62 @@ func TestVerifyChain_Tampered(t *testing.T) {
 	}
 }
 
-// TODO(v1): remove this test once flat layout support and migration code are removed.
-func TestWrite_MigratesOldLayoutToPerDoc(t *testing.T) {
+// TODO(v1): remove this test with migrateLegacyLayout.
+func TestListDir_LegacyLayoutVisibility(t *testing.T) {
+	root := t.TempDir()
+	s := New(root)
+
+	// A legacy-layout doc (regular current pointer, flat-layout version
+	// history) is invisible until migrateLegacyLayout converts it; after
+	// migration it is listed and keeps its unindexed parent visible.
+	legacyDir := filepath.Join(root, "legacy")
+	if err := os.MkdirAll(filepath.Join(legacyDir, "versions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	v1 := []byte("---\nversion: 1\narchived: false\n---\n# legacy\n")
+	if err := os.WriteFile(filepath.Join(legacyDir, "versions", "old.md.v1"), v1, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyDir, "old.md"), v1, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	names := func(entries []os.DirEntry) map[string]bool {
+		m := map[string]bool{}
+		for _, e := range entries {
+			m[e.Name()] = true
+		}
+		return m
+	}
+
+	preMigrate, err := s.ListDir("/", false)
+	if err != nil {
+		t.Fatalf("ListDir / before migration: %v", err)
+	}
+	if r := names(preMigrate); r["legacy"] {
+		t.Errorf("unmigrated legacy/ dir listed: %v", r)
+	}
+	if err := s.migrateLegacyLayout(); err != nil {
+		t.Fatalf("migrateLegacyLayout: %v", err)
+	}
+	inLegacy, err := s.ListDir("/legacy", false)
+	if err != nil {
+		t.Fatalf("ListDir /legacy: %v", err)
+	}
+	if l := names(inLegacy); !l["old.md"] {
+		t.Errorf("migrated legacy-layout doc not listed: %v", l)
+	}
+	atRoot, err := s.ListDir("/", false)
+	if err != nil {
+		t.Fatalf("ListDir / after migration: %v", err)
+	}
+	if r := names(atRoot); !r["legacy"] {
+		t.Errorf("legacy/ dir pruned despite holding a migrated doc: %v", r)
+	}
+}
+
+// TODO(v1): remove this test with migrateLegacyLayout.
+func TestMigrateLegacyLayout(t *testing.T) {
 	root := t.TempDir()
 
 	// Set up old flat layout manually: versions/doc.md.v1 and versions/doc.md.v2.
@@ -986,16 +1046,25 @@ func TestWrite_MigratesOldLayoutToPerDoc(t *testing.T) {
 
 	s := New(root)
 
-	// Reads should work with old layout.
+	// Unmigrated legacy layout is invisible to the read path.
+	if _, err := s.Get("/doc.md", 0); err == nil {
+		t.Fatal("Get before migration should fail: read path is per-doc only")
+	}
+
+	if err := s.migrateLegacyLayout(); err != nil {
+		t.Fatalf("migrateLegacyLayout: %v", err)
+	}
+
+	// Reads work after migration.
 	doc, err := s.Get("/doc.md", 0)
 	if err != nil {
-		t.Fatalf("Get before migration: %v", err)
+		t.Fatalf("Get after migration: %v", err)
 	}
 	if doc.Version != 2 {
 		t.Errorf("version = %d, want 2", doc.Version)
 	}
 
-	// Write v3, which should trigger migration.
+	// Writes continue the chain.
 	doc, err = s.Write("/doc.md", []byte("# V3\n"), nil)
 	if err != nil {
 		t.Fatalf("Write v3: %v", err)
@@ -1032,6 +1101,46 @@ func TestWrite_MigratesOldLayoutToPerDoc(t *testing.T) {
 	// Hash chain should be valid across the migration boundary.
 	if err := s.VerifyChain("/doc.md"); err != nil {
 		t.Errorf("chain verification failed after migration: %v", err)
+	}
+
+	// Idempotent: a second run performs no work and breaks nothing.
+	if err := s.migrateLegacyLayout(); err != nil {
+		t.Fatalf("second migrateLegacyLayout: %v", err)
+	}
+}
+
+// TODO(v1): remove this test with migrateLegacyLayout.
+func TestMigrateLegacyLayout_SkipsStrayFiles(t *testing.T) {
+	root := t.TempDir()
+	versionsDir := filepath.Join(root, "versions")
+	if err := os.MkdirAll(versionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Junk seen in the wild: "..v1" (an old bug publishing base "."), a
+	// non-markdown name, and a hidden name. None may derive a migration
+	// target; "..v1" would otherwise aim the current pointer at root itself.
+	for _, name := range []string{"..v1", "data.txt.v1", ".hidden.md.v1"} {
+		if err := os.WriteFile(filepath.Join(versionsDir, name), []byte("junk"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(versionsDir, "real.md.v1"), []byte("---\nversion: 1\n---\n# real\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := New(root)
+	if err := s.migrateLegacyLayout(); err != nil {
+		t.Fatalf("migrateLegacyLayout: %v", err)
+	}
+
+	// The real doc migrated and serves; the junk stayed put, untouched.
+	if _, err := s.Get("/real.md", 0); err != nil {
+		t.Errorf("migrated real.md not served: %v", err)
+	}
+	for _, name := range []string{"..v1", "data.txt.v1", ".hidden.md.v1"} {
+		if _, err := os.Stat(filepath.Join(versionsDir, name)); err != nil {
+			t.Errorf("stray %s was moved or deleted: %v", name, err)
+		}
 	}
 }
 
@@ -1114,7 +1223,7 @@ func TestWrite_SubdirectoryPerDocLayout(t *testing.T) {
 	}
 }
 
-func TestWrite_SubdirectoryMigration(t *testing.T) {
+func TestMigrateLegacyLayout_Subdirectory(t *testing.T) {
 	root := t.TempDir()
 
 	// Set up old flat layout in a subdirectory.
@@ -1133,17 +1242,20 @@ func TestWrite_SubdirectoryMigration(t *testing.T) {
 	}
 
 	s := New(root)
+	if err := s.migrateLegacyLayout(); err != nil {
+		t.Fatalf("migrateLegacyLayout: %v", err)
+	}
 
-	// Read should work with old layout.
+	// Read works after migration.
 	doc, err := s.Get("/docs/guides/setup.md", 0)
 	if err != nil {
-		t.Fatalf("Get before migration: %v", err)
+		t.Fatalf("Get after migration: %v", err)
 	}
 	if doc.Version != 1 {
 		t.Errorf("version = %d, want 1", doc.Version)
 	}
 
-	// Write v2 triggers migration.
+	// Write v2 continues the chain.
 	doc, err = s.Write("/docs/guides/setup.md", []byte("# Updated Guide\n"), nil)
 	if err != nil {
 		t.Fatalf("Write v2: %v", err)
@@ -1972,7 +2084,7 @@ func TestPruneVersions_AbortsOnError(t *testing.T) {
 	}
 }
 
-func TestWrite_RetentionMigratesFlatLayoutThenPrunes(t *testing.T) {
+func TestWrite_RetentionAfterLegacyMigrationPrunes(t *testing.T) {
 	root := t.TempDir()
 	versionsDir := filepath.Join(root, "versions")
 	if err := os.Mkdir(versionsDir, 0o755); err != nil {
@@ -1988,6 +2100,9 @@ func TestWrite_RetentionMigratesFlatLayoutThenPrunes(t *testing.T) {
 	}
 
 	s := New(root)
+	if err := s.migrateLegacyLayout(); err != nil {
+		t.Fatalf("migrateLegacyLayout: %v", err)
+	}
 	doc, err := s.Write("/doc.md", []byte("# V3"), map[string]string{"retention": "1"})
 	if err != nil {
 		t.Fatalf("write: %v", err)

--- a/protocol/store/store_test.go
+++ b/protocol/store/store_test.go
@@ -1255,6 +1255,14 @@ func TestMigrateLegacyLayout_NormalizedCollisionKeepsBoth(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(versionsDir, "doc.md.v1")); !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("canonical flat file should have been moved: %v", err)
 	}
+	// The repaired current pointer makes the document fetchable end to end.
+	doc, err := s.Get("/doc.md", 0)
+	if err != nil {
+		t.Fatalf("Get after migration: %v", err)
+	}
+	if doc.Version != 1 || string(doc.Content) != "# canonical\n" {
+		t.Errorf("Get = v%d %q, want v1 with the canonical content", doc.Version, doc.Content)
+	}
 }
 
 func TestWrite_SubdirectoryPerDocLayout(t *testing.T) {

--- a/protocol/store/store_test.go
+++ b/protocol/store/store_test.go
@@ -2291,10 +2291,8 @@ func TestPruneVersions_SymlinkedDocDirCannotEscape(t *testing.T) {
 }
 
 func TestPruneVersions_SymlinkVersionFileNotFollowed(t *testing.T) {
-	// A symlink planted at a version slot is not a version
-	// (perDocVersionNumber counts regular files only): pruning neither
-	// follows nor deletes it, and the link target outside the store
-	// survives untouched.
+	// A planted symlink at a version slot is not a version: pruning
+	// neither follows nor deletes it, and its target survives untouched.
 	root := t.TempDir()
 	outsideFile := filepath.Join(t.TempDir(), "victim.md")
 	if err := os.WriteFile(outsideFile, []byte("victim"), 0o644); err != nil {

--- a/protocol/store/store_test.go
+++ b/protocol/store/store_test.go
@@ -1191,6 +1191,72 @@ func TestMigrateLegacyLayout_SkipsStrayFiles(t *testing.T) {
 	}
 }
 
+// TODO(v1): remove this test with migrateLegacyLayout.
+func TestMigrateLegacyLayout_SkipsSymlinkVersion(t *testing.T) {
+	root := t.TempDir()
+	versionsDir := filepath.Join(root, "versions")
+	if err := os.MkdirAll(versionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(t.TempDir(), "outside.md")
+	if err := os.WriteFile(target, []byte("outside"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A symlink named like a legacy version must not be migrated into the
+	// per-doc dir, where name-only detection would serve it as a version.
+	if err := os.Symlink(target, filepath.Join(versionsDir, "doc.md.v1")); err != nil {
+		t.Fatal(err)
+	}
+
+	s := New(root)
+	if err := s.migrateLegacyLayout(); err != nil {
+		t.Fatalf("migrateLegacyLayout: %v", err)
+	}
+	if fi, err := os.Lstat(filepath.Join(versionsDir, "doc.md.v1")); err != nil || fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("symlink version was moved or replaced: %v %v", fi, err)
+	}
+	if _, err := os.Stat(filepath.Join(versionsDir, "doc.md", "v1")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("symlink migrated into per-doc dir: %v", err)
+	}
+}
+
+// TODO(v1): remove this test with migrateLegacyLayout.
+func TestMigrateLegacyLayout_NormalizedCollisionKeepsBoth(t *testing.T) {
+	root := t.TempDir()
+	versionsDir := filepath.Join(root, "versions")
+	if err := os.MkdirAll(versionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Both names normalize to v1. The canonical (unpadded) name wins the
+	// slot deliberately; the padded loser survives on disk as a stray.
+	contents := map[string]string{"doc.md.v1": "# canonical\n", "doc.md.v01": "# padded\n"}
+	for name, body := range contents {
+		if err := os.WriteFile(filepath.Join(versionsDir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s := New(root)
+	if err := s.migrateLegacyLayout(); err != nil {
+		t.Fatalf("migrateLegacyLayout: %v", err)
+	}
+
+	migrated, err := os.ReadFile(filepath.Join(versionsDir, "doc.md", "v1"))
+	if err != nil {
+		t.Fatalf("no migrated v1: %v", err)
+	}
+	if string(migrated) != "# canonical\n" {
+		t.Errorf("migrated v1 = %q, want the canonical name's content", migrated)
+	}
+	stray, err := os.ReadFile(filepath.Join(versionsDir, "doc.md.v01"))
+	if err != nil || string(stray) != "# padded\n" {
+		t.Errorf("collision loser doc.md.v01 = %q (err %v), want untouched stray", stray, err)
+	}
+	if _, err := os.Stat(filepath.Join(versionsDir, "doc.md.v1")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("canonical flat file should have been moved: %v", err)
+	}
+}
+
 func TestWrite_SubdirectoryPerDocLayout(t *testing.T) {
 	root := t.TempDir()
 	s := New(root)
@@ -2217,8 +2283,10 @@ func TestPruneVersions_SymlinkedDocDirCannotEscape(t *testing.T) {
 }
 
 func TestPruneVersions_SymlinkVersionFileNotFollowed(t *testing.T) {
-	// A version file that is itself a symlink is unlinked, never followed:
-	// the link target outside the store must survive the prune.
+	// A symlink planted at a version slot is not a version
+	// (perDocVersionNumber counts regular files only): pruning neither
+	// follows nor deletes it, and the link target outside the store
+	// survives untouched.
 	root := t.TempDir()
 	outsideFile := filepath.Join(t.TempDir(), "victim.md")
 	if err := os.WriteFile(outsideFile, []byte("victim"), 0o644); err != nil {
@@ -2239,11 +2307,13 @@ func TestPruneVersions_SymlinkVersionFileNotFollowed(t *testing.T) {
 	if res == nil || res.Err != nil {
 		t.Fatalf("prune result = %+v, want clean prune", res)
 	}
-	if res.From != 1 || res.To != 2 {
-		t.Errorf("prune range = %d-%d, want 1-2", res.From, res.To)
+	// The planted symlink is invisible to version enumeration, so only the
+	// real v2 is pruned.
+	if res.From != 2 || res.To != 2 {
+		t.Errorf("prune range = %d-%d, want 2-2", res.From, res.To)
 	}
-	if _, err := os.Lstat(v1); !errors.Is(err, os.ErrNotExist) {
-		t.Errorf("v1 symlink should be removed, Lstat err = %v", err)
+	if fi, err := os.Lstat(v1); err != nil || fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("planted symlink should remain untouched, Lstat = %v %v", fi, err)
 	}
 	if data, err := os.ReadFile(outsideFile); err != nil || string(data) != "victim" {
 		t.Errorf("symlink target outside the store was touched: data=%q err=%v", data, err)

--- a/protocol/store/store_test.go
+++ b/protocol/store/store_test.go
@@ -155,13 +155,28 @@ func TestListDir(t *testing.T) {
 		}
 	}
 
+	// A doc published under a "versions" path segment must not surface the
+	// root versions/ directory in listings either.
+	if _, err := s.Write("/versions/doc.md", []byte("# in versions\n"), nil); err != nil {
+		t.Fatalf("Write /versions/doc.md: %v", err)
+	}
+
 	for _, includeArchived := range []bool{false, true} {
 		entries, err := s.ListDir("/", includeArchived)
 		if err != nil {
 			t.Fatalf("ListDir(includeArchived=%v): %v", includeArchived, err)
 		}
-		if len(entries) != 2 {
-			t.Errorf("includeArchived=%v: entries = %d, want 2 (excluding .hidden, versions, flat.md)", includeArchived, len(entries))
+		got := map[string]bool{}
+		for _, e := range entries {
+			got[e.Name()] = true
+		}
+		if !got["a.md"] || !got["b.md"] || len(got) != 2 {
+			t.Errorf("includeArchived=%v: entries = %v, want exactly a.md and b.md", includeArchived, got)
+		}
+		for _, hidden := range []string{".hidden", "versions", "flat.md"} {
+			if got[hidden] {
+				t.Errorf("includeArchived=%v: %s must not be listed", includeArchived, hidden)
+			}
 		}
 	}
 }
@@ -1106,6 +1121,38 @@ func TestMigrateLegacyLayout(t *testing.T) {
 	// Idempotent: a second run performs no work and breaks nothing.
 	if err := s.migrateLegacyLayout(); err != nil {
 		t.Fatalf("second migrateLegacyLayout: %v", err)
+	}
+}
+
+// TODO(v1): remove this test with migrateLegacyLayout.
+func TestOpen_MigratesLegacyLayout(t *testing.T) {
+	root := t.TempDir()
+	versionsDir := filepath.Join(root, "versions")
+	if err := os.MkdirAll(versionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A leading-zero name parses to the same version number but must be
+	// moved under its on-disk name — a reconstructed "doc.md.v1" would
+	// ENOENT and block Open on every start.
+	if err := os.WriteFile(filepath.Join(versionsDir, "doc.md.v01"), []byte("---\nversion: 1\n---\n# v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Open(root)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	doc, err := s.Get("/doc.md", 0)
+	if err != nil {
+		t.Fatalf("Get after Open: %v", err)
+	}
+	if doc.Version != 1 {
+		t.Errorf("version = %d, want 1", doc.Version)
+	}
+
+	// Open on a fresh root is a no-op.
+	if _, err := Open(t.TempDir()); err != nil {
+		t.Fatalf("Open on fresh root: %v", err)
 	}
 }
 

--- a/scripts/check-comment-length.sh
+++ b/scripts/check-comment-length.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Enforces the 1-3 line comment rule (CLAUDE.md) on comment blocks touched by
+# the current change: committed on this branch since main, or uncommitted.
+# Pre-existing long blocks elsewhere are left alone; tighten on touch.
+set -euo pipefail
+
+base=$(git merge-base main HEAD 2>/dev/null || git rev-parse HEAD)
+status=0
+
+while IFS= read -r file; do
+  [ -f "$file" ] || continue
+  added=$(git diff -U0 "$base" -- "$file" | awk '
+    /^@@/ {
+      if (match($0, /\+[0-9]+(,[0-9]+)?/)) {
+        split(substr($0, RSTART + 1, RLENGTH - 1), a, ",")
+        len = (a[2] == "" ? 1 : a[2])
+        for (i = 0; i < len; i++) printf "%d ", a[1] + i
+      }
+    }')
+  [ -n "${added// /}" ] || continue
+
+  out=$(awk -v added="$added" '
+    BEGIN { n = split(added, arr, " "); for (i = 1; i <= n; i++) isadd[arr[i]] = 1 }
+    # A block directly above a package clause is the package doc comment;
+    # godoc convention allows length there.
+    function flush(cur) {
+      if (run > 3 && touched && cur !~ /^package /)
+        print FILENAME ":" startln ": comment block of " run " lines (max 3; move deep rationale to a doc)"
+      run = 0; touched = 0
+    }
+    {
+      t = $0; sub(/^[ \t]+/, "", t)
+      if (t ~ /^\/\// && t !~ /^\/\/go:/ && t !~ /^\/\/nolint/) {
+        if (run == 0) startln = NR
+        run++
+        if (isadd[NR]) touched = 1
+        next
+      }
+      flush(t)
+    }
+    END { flush("") }
+  ' "$file")
+
+  if [ -n "$out" ]; then
+    echo "$out"
+    status=1
+  fi
+done < <(git diff --name-only "$base" -- '*.go' | sort -u)
+
+exit $status

--- a/scripts/check-comment-length.sh
+++ b/scripts/check-comment-length.sh
@@ -4,36 +4,45 @@
 # Pre-existing long blocks elsewhere are left alone; tighten on touch.
 set -euo pipefail
 
-base=$(git merge-base main HEAD 2>/dev/null || git rev-parse HEAD)
+# Fail closed: an unresolvable base would silently skip committed changes.
+if ! base=$(git merge-base main HEAD 2>/dev/null); then
+  echo "check-comment-length: cannot resolve merge-base with main" >&2
+  exit 1
+fi
+
+files=$(git diff --name-only "$base" -- '*.go' | sort -u)
 status=0
 
-while IFS= read -r file; do
+for file in $files; do
   [ -f "$file" ] || continue
-  added=$(git diff -U0 "$base" -- "$file" | awk '
+  # Touched lines in the new file: added lines, plus the line at (and after)
+  # each deletion-only hunk so shrunk-but-still-long blocks are checked too.
+  touched=$(git diff -U0 "$base" -- "$file" | awk '
     /^@@/ {
       if (match($0, /\+[0-9]+(,[0-9]+)?/)) {
         split(substr($0, RSTART + 1, RLENGTH - 1), a, ",")
         len = (a[2] == "" ? 1 : a[2])
+        if (len == 0) { printf "%d %d ", (a[1] < 1 ? 1 : a[1]), a[1] + 1 }
         for (i = 0; i < len; i++) printf "%d ", a[1] + i
       }
     }')
-  [ -n "${added// /}" ] || continue
+  [ -n "${touched// /}" ] || continue
 
-  out=$(awk -v added="$added" '
-    BEGIN { n = split(added, arr, " "); for (i = 1; i <= n; i++) isadd[arr[i]] = 1 }
+  out=$(awk -v touched="$touched" '
+    BEGIN { n = split(touched, arr, " "); for (i = 1; i <= n; i++) hit[arr[i]] = 1 }
     # A block directly above a package clause is the package doc comment;
     # godoc convention allows length there.
     function flush(cur) {
-      if (run > 3 && touched && cur !~ /^package /)
+      if (run > 3 && marked && cur !~ /^package /)
         print FILENAME ":" startln ": comment block of " run " lines (max 3; move deep rationale to a doc)"
-      run = 0; touched = 0
+      run = 0; marked = 0
     }
     {
       t = $0; sub(/^[ \t]+/, "", t)
       if (t ~ /^\/\// && t !~ /^\/\/go:/ && t !~ /^\/\/nolint/) {
         if (run == 0) startln = NR
         run++
-        if (isadd[NR]) touched = 1
+        if (hit[NR]) marked = 1
         next
       }
       flush(t)
@@ -45,6 +54,6 @@ while IFS= read -r file; do
     echo "$out"
     status=1
   fi
-done < <(git diff --name-only "$base" -- '*.go' | sort -u)
+done
 
 exit $status

--- a/server/cmd/demarkus-server/main.go
+++ b/server/cmd/demarkus-server/main.go
@@ -179,7 +179,13 @@ func main() {
 		// LOOKUP is DB-backed; a per-process index would diverge across pods.
 		docStore, cat = ps, ps
 	case "file":
-		s := store.New(cfg.ContentDir)
+		// Open migrates any legacy-layout version files; serving an
+		// unmigrated root would hide every legacy document, so failure is fatal.
+		s, err := store.Open(cfg.ContentDir)
+		if err != nil {
+			logger.Error("store open failed", "error", err)
+			os.Exit(1)
+		}
 		// BuildHashIndex clears the index before walking; continuing after a
 		// failure would serve hash-based FETCHes from an empty or partial
 		// index, so a broken walk is fatal.

--- a/tools/demarkus-publish/main.go
+++ b/tools/demarkus-publish/main.go
@@ -86,7 +86,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	s := store.New(*root)
+	// Open migrates any legacy layout; writing an unmigrated legacy doc
+	// would restart its version numbering and orphan its history.
+	s, err := store.Open(*root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
 	doc, err := s.Write(*path, content, nil)
 	if err != nil {
 		if errors.Is(err, store.ErrNotModified) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directory listings now exclude non-document files, empty directories, and unrelated subtrees.
  * Publishing to a versionless file path replaces it with a new document version instead of importing its contents.

* **Improvements**
  * Legacy document layouts are migrated automatically when the server or publishing tool starts.
  * Versioned documents now use a consistent per-document layout with improved migration recovery and retention handling.

* **Documentation**
  * Updated design and protocol documentation to clarify versioning, migration, publishing, and listing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->