### PR TITLE
fix(server): migrate legacy versions under hidden directories

### DIFF
--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -1676,11 +1676,10 @@ func (s *Store) migrateLegacyLayout() error {
 		if !d.IsDir() {
 			return nil
 		}
-		name := d.Name()
-		if path != s.root && strings.HasPrefix(name, ".") {
-			return filepath.SkipDir
-		}
-		if name != "versions" {
+		// Hidden directories are walked too: FETCH serves explicit hidden
+		// paths (/.well-known/agent-manifest.md), so their legacy versions
+		// must migrate; skipping them broke the manifest on soul.demarkus.io.
+		if d.Name() != "versions" {
 			return nil
 		}
 		if merr := s.migrateLegacyVersionsDir(path); merr != nil {

--- a/protocol/store/store_test.go
+++ b/protocol/store/store_test.go
@@ -1157,6 +1157,35 @@ func TestOpen_MigratesLegacyLayout(t *testing.T) {
 }
 
 // TODO(v1): remove this test with migrateLegacyLayout.
+func TestMigrateLegacyLayout_HiddenDirDocuments(t *testing.T) {
+	root := t.TempDir()
+	wkDir := filepath.Join(root, ".well-known", "versions")
+	if err := os.MkdirAll(wkDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// FETCH serves explicit hidden paths (the agent manifest), so legacy
+	// versions under hidden directories must migrate like any other.
+	if err := os.WriteFile(filepath.Join(wkDir, "agent-manifest.md.v1"), []byte("---\nversion: 1\n---\n# manifest\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("versions", "agent-manifest.md.v1"), filepath.Join(root, ".well-known", "agent-manifest.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Open(root)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	doc, err := s.Get("/.well-known/agent-manifest.md", 0)
+	if err != nil {
+		t.Fatalf("Get manifest after migration: %v", err)
+	}
+	if doc.Version != 1 {
+		t.Errorf("version = %d, want 1", doc.Version)
+	}
+}
+
+// TODO(v1): remove this test with migrateLegacyLayout.
 func TestMigrateLegacyLayout_SkipsStrayFiles(t *testing.T) {
 	root := t.TempDir()
 	versionsDir := filepath.Join(root, "versions")

--- a/protocol/store/store_test.go
+++ b/protocol/store/store_test.go
@@ -1183,6 +1183,15 @@ func TestMigrateLegacyLayout_HiddenDirDocuments(t *testing.T) {
 	if doc.Version != 1 {
 		t.Errorf("version = %d, want 1", doc.Version)
 	}
+
+	// Explicit-version retrieval (getVersion) must reach it too.
+	doc, err = s.Get("/.well-known/agent-manifest.md", 1)
+	if err != nil {
+		t.Fatalf("Get manifest v1: %v", err)
+	}
+	if !bytes.Contains(doc.Content, []byte("# manifest")) {
+		t.Errorf("v1 content = %q, want the manifest body", doc.Content)
+	}
 }
 
 // TODO(v1): remove this test with migrateLegacyLayout.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy versioned documents stored in hidden directories are now migrated correctly.
  * Documents under paths such as `.well-known` remain accessible after migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->