### PR TITLE
fix(server): filter configwatch sibling events; move managed server log

### DIFF
--- a/server/internal/configwatch/watcher.go
+++ b/server/internal/configwatch/watcher.go
@@ -57,6 +57,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 	}
 
 	dir := filepath.Dir(w.Target)
+	cleanTarget := filepath.Clean(w.Target)
 	fw, err := fsnotify.NewWatcher()
 	if err != nil {
 		return fmt.Errorf("configwatch: create watcher: %w", err)
@@ -89,9 +90,12 @@ func (w *Watcher) Run(ctx context.Context) error {
 				return nil
 			}
 			w.Logger.Warn("configwatch: error", "target", w.Target, "error", err)
-		case _, ok := <-fw.Events:
+		case ev, ok := <-fw.Events:
 			if !ok {
 				return nil
+			}
+			if !eventRelevant(ev, cleanTarget) {
+				continue
 			}
 			if armed && !timer.Stop() {
 				select {
@@ -110,6 +114,16 @@ func (w *Watcher) Run(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+// eventRelevant drops Write/Chmod events on sibling files (a co-located log
+// once fed the watcher its own "reloaded" lines forever, #289). The target
+// itself and structural ops (create/rename/remove: swaps) still reload.
+func eventRelevant(ev fsnotify.Event, cleanTarget string) bool {
+	if ev.Name == "" || filepath.Clean(ev.Name) == cleanTarget {
+		return true
+	}
+	return ev.Op&(fsnotify.Create|fsnotify.Rename|fsnotify.Remove) != 0
 }
 
 // reloadWithRetry calls reload and retries once on a transient ErrNotExist,

--- a/server/internal/configwatch/watcher_test.go
+++ b/server/internal/configwatch/watcher_test.go
@@ -3,6 +3,7 @@ package configwatch
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -53,14 +54,14 @@ func waitForCount(counter *atomic.Int32, want int32, deadline time.Duration) int
 	return counter.Load()
 }
 
-// awaitWatchLive touches a sentinel until a reload proves the watch is
-// registered (fsnotify misses pre-registration events; a single touch would
-// lose that same race), then drains stragglers and resets the counter.
+// awaitWatchLive creates fresh sentinels until a reload proves the watch is
+// registered (fsnotify misses pre-registration events; sibling Writes are
+// filtered, so only a Create proves liveness), then resets the counter.
 func awaitWatchLive(t *testing.T, dir string, calls *atomic.Int32, debounce time.Duration) {
 	t.Helper()
-	sentinel := filepath.Join(dir, "watch-live.sentinel")
 	deadline := time.Now().Add(10 * time.Second)
-	for {
+	for i := 0; ; i++ {
+		sentinel := filepath.Join(dir, fmt.Sprintf("watch-live-%d.sentinel", i))
 		if err := os.WriteFile(sentinel, []byte("x"), 0o600); err != nil {
 			t.Fatal(err)
 		}
@@ -247,6 +248,50 @@ func TestDebounceCoalescesBurst(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 	if got := calls.Load(); got != 1 {
 		t.Fatalf("expected no further reloads after the burst, got %d", got)
+	}
+}
+
+// TestSiblingWritesDoNotTriggerReload is the #289 regression: a log file in
+// the watched directory being appended to must not cause reloads, or a server
+// logging "reloaded" into that file feeds the watcher forever.
+func TestSiblingWritesDoNotTriggerReload(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "tokens.toml")
+	if err := os.WriteFile(target, []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sibling := filepath.Join(dir, ".log")
+	lf, err := os.OpenFile(sibling, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := lf.Close(); err != nil {
+			t.Errorf("close sibling log: %v", err)
+		}
+	}()
+
+	var calls atomic.Int32
+	w := Watcher{
+		Target:   target,
+		Reload:   func() error { calls.Add(1); return nil },
+		Debounce: 20 * time.Millisecond,
+		Logger:   discardLogger(),
+	}
+	runInBackground(t, &w)
+
+	awaitWatchLive(t, dir, &calls, w.Debounce)
+	for range 10 {
+		if _, err := lf.WriteString("configwatch: reloaded\n"); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// A full debounce window plus slack with zero reloads proves the filter.
+	time.Sleep(2*w.Debounce + 200*time.Millisecond)
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("expected 0 reloads from sibling writes, got %d", got)
 	}
 }
 

--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -751,7 +751,7 @@ func signalReload(pid int) error {
 	case err == nil:
 		logf("sent SIGHUP to server (pid=%d) to reload tokens", pid)
 		return nil
-	case errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH):
+	case alreadyExited(err):
 		return nil
 	default:
 		return fmt.Errorf("SIGHUP to server pid %d: %w", pid, err)
@@ -953,14 +953,18 @@ func stopStaleManagedServer(runningPID int, soulDir string) error {
 		return nil
 	}
 	logf("restarting managed demarkus-server onto upgraded binary (target=%s)", serverVersion)
-	_ = signalPID(runningPID, syscall.SIGTERM)
+	if err := signalPID(runningPID, syscall.SIGTERM); err != nil && !alreadyExited(err) {
+		warnf("SIGTERM to managed server pid %d: %v", runningPID, err)
+	}
 	// Bounded wait for exit (~3s), then escalate to SIGKILL so the respawn
 	// can bind the freed UDP port.
 	for waited := 0; waited < 30 && pidAlive(runningPID); waited++ {
 		time.Sleep(100 * time.Millisecond)
 	}
 	if pidAlive(runningPID) {
-		_ = signalPID(runningPID, syscall.SIGKILL) // escalation; exit confirmed below
+		if err := signalPID(runningPID, syscall.SIGKILL); err != nil && !alreadyExited(err) {
+			warnf("SIGKILL to managed server pid %d: %v", runningPID, err)
+		}
 		for waited := 0; waited < 10 && pidAlive(runningPID); waited++ {
 			time.Sleep(100 * time.Millisecond)
 		}
@@ -1584,6 +1588,12 @@ func pidAlive(pid int) bool {
 	}
 	err = p.Signal(syscall.Signal(0))
 	return err == nil || err == syscall.EPERM
+}
+
+// alreadyExited reports a signal failure that just means the process is gone,
+// which is the outcome the stop sequence wants, not a warning.
+func alreadyExited(err error) bool {
+	return errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH)
 }
 
 func signalPID(pid int, sig syscall.Signal) error {

--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -137,6 +137,85 @@ func binPath(name string) (string, error) {
 	return filepath.Join(d, name), nil
 }
 
+// soulID is a stable per-soul identifier: basename for readability plus a
+// path hash for uniqueness across souls.
+func soulID(soulDir string) string {
+	sum := sha256.Sum256([]byte(soulDir))
+	return filepath.Base(soulDir) + "-" + hex.EncodeToString(sum[:4])
+}
+
+// managedServerLogPath places the managed server's log under ~/.demarkus/logs,
+// never inside soulDir, which the server watches for tokens.toml changes (#289).
+func managedServerLogPath(soulDir string) (string, error) {
+	return underHome(filepath.Join("logs", "server-"+soulID(soulDir)+".log"))
+}
+
+// managedTokensPath is the out-of-root tokens.toml for soulDir's managed
+// server: token data does not belong inside the served content root (#289
+// follow-up). Managed modes only; reuse mode keeps <root>/tokens.toml.
+func managedTokensPath(soulDir string) (string, error) {
+	return underHome(filepath.Join("tokens", soulID(soulDir), "tokens.toml"))
+}
+
+// tokensPathFor resolves the live tokens.toml for soulDir: the out-of-root
+// path once migrated, a legacy <soulDir>/tokens.toml until then (the running
+// server's -tokens flag still points there), the new path on fresh installs.
+func tokensPathFor(soulDir string) (string, error) {
+	newPath, err := managedTokensPath(soulDir)
+	if err != nil {
+		return "", err
+	}
+	if fileExists(newPath) {
+		return newPath, nil
+	}
+	// TODO: drop the legacy branch once released installs have migrated.
+	if legacy := filepath.Join(soulDir, "tokens.toml"); fileExists(legacy) {
+		return legacy, nil
+	}
+	return newPath, nil
+}
+
+// migrateManagedTokens moves a legacy <soulDir>/tokens.toml to the out-of-root
+// path and returns the final path. Only call with the managed server stopped:
+// a live server reads the legacy path.
+func migrateManagedTokens(soulDir string) (string, error) {
+	newPath, err := managedTokensPath(soulDir)
+	if err != nil {
+		return "", err
+	}
+	cur, err := tokensPathFor(soulDir)
+	if err != nil {
+		return "", err
+	}
+	if cur == newPath {
+		return newPath, nil // migrated already, or fresh: ensureTokenEntry populates it
+	}
+	if err := os.MkdirAll(filepath.Dir(newPath), 0o700); err != nil {
+		return "", err
+	}
+	if err := os.Rename(cur, newPath); err != nil {
+		// Cross-device fallback: project souls can sit on another volume.
+		if err := installFile(cur, newPath, 0o600); err != nil {
+			return "", fmt.Errorf("migrate tokens.toml out of soul root: %w", err)
+		}
+		if err := os.Remove(cur); err != nil {
+			warnf("remove legacy tokens.toml %s after copy: %v", cur, err)
+		}
+	}
+	logf("moved tokens.toml out of the soul root (%s)", newPath)
+	return newPath, nil
+}
+
+// ensureManagedTokenEntry mints the plugin token against the resolved managed
+// tokens path for soul.
+func ensureManagedTokenEntry(soul string) error {
+	tokensTOML, err := tokensPathFor(soul)
+	if err != nil {
+		return err
+	}
+	return ensureTokenEntry(soul, tokensTOML)
+}
+
 // --- detectPlatform (lib.sh detect_platform) ---------------------------------
 
 // detectPlatform maps GOOS/GOARCH onto the release artifact suffix, e.g.
@@ -407,7 +486,7 @@ func ensureBinaries() (replaced bool, err error) {
 
 	// Install 0755 to the bin dir (bash install -m 0755).
 	for _, name := range []string{"demarkus-server", "demarkus-token", "demarkus-mcp"} {
-		if err := installFile(filepath.Join(tmp, name), filepath.Join(binDir, name)); err != nil {
+		if err := installFile(filepath.Join(tmp, name), filepath.Join(binDir, name), 0o755); err != nil {
 			return false, fmt.Errorf("install %s: %w", name, err)
 		}
 	}
@@ -515,15 +594,15 @@ func extractTarGz(archive, destDir string) error {
 	return nil
 }
 
-// installFile copies src to dst with mode 0755 (atomic via temp + rename).
-func installFile(src, dst string) error {
+// installFile copies src to dst with the given mode (atomic via temp + rename).
+func installFile(src, dst string, mode os.FileMode) error {
 	in, err := os.Open(src)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = in.Close() }()
 	tmp := dst + ".tmp"
-	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o755)
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
 	if err != nil {
 		return err
 	}
@@ -536,7 +615,7 @@ func installFile(src, dst string) error {
 		_ = os.Remove(tmp)
 		return err
 	}
-	if err := os.Chmod(tmp, 0o755); err != nil {
+	if err := os.Chmod(tmp, mode); err != nil {
 		_ = os.Remove(tmp)
 		return err
 	}
@@ -545,10 +624,10 @@ func installFile(src, dst string) error {
 
 // --- token (lib.sh ensure_token_entry) ---------------------------------------
 
-// ensureTokenEntry mints the plugin token (raw to plugin-memory.token, entry to
-// tokensTOML). Idempotent when both exist with a current scope; stale state
-// (missing token file, or a legacy-scope entry) is revoked and reminted.
-func ensureTokenEntry(tokensTOML string) error {
+// ensureTokenEntry mints the plugin token (raw to plugin-memory.token, entry
+// to tokensTOML, which may live outside root, the server root used to find a
+// live server to reload). Idempotent when current; stale state is reminted.
+func ensureTokenEntry(root, tokensTOML string) error {
 	tokenFile, err := pluginToken()
 	if err != nil {
 		return err
@@ -619,7 +698,7 @@ func ensureTokenEntry(tokensTOML string) error {
 	// pre-remint table, and committing only after a successful reload keeps the
 	// gate's invariant — a matching token file implies the server loaded it, so
 	// any failure here self-heals via a remint on the next run.
-	if pid := findServerAtRoot(filepath.Dir(tokensTOML)); pid > 0 {
+	if pid := findServerAtRoot(root); pid > 0 {
 		if err := reloadServer(pid); err != nil {
 			_ = os.Remove(tmpTok) // best-effort; a leftover .tmp never satisfies the gate
 			return fmt.Errorf("reload reminted token: %w", err)
@@ -863,7 +942,6 @@ func managedServerCurrent(pidFile, versionFile, root string) bool {
 func ensureManagedServer(soulDir string, port int) error {
 	pidFile := filepath.Join(soulDir, ".pid")
 	versionFile := filepath.Join(soulDir, ".server-version")
-	logFile := filepath.Join(soulDir, ".log")
 
 	if managedServerCurrent(pidFile, versionFile, soulDir) {
 		return nil
@@ -888,13 +966,30 @@ func ensureManagedServer(soulDir string, port int) error {
 	}
 	_ = os.Remove(pidFile)
 	_ = os.Remove(versionFile)
+	// Pre-#289 the log sat at <soulDir>/.log, inside the server's tokens-watch
+	// directory, feeding the watcher its own output. Remove it on migration.
+	legacyLog := filepath.Join(soulDir, ".log")
+	if err := os.Remove(legacyLog); err != nil && !os.IsNotExist(err) {
+		warnf("remove legacy server log %s: %v", legacyLog, err)
+	}
 
 	if err := os.MkdirAll(soulDir, 0o755); err != nil {
+		return err
+	}
+	tokensPath, err := migrateManagedTokens(soulDir)
+	if err != nil {
 		return err
 	}
 
 	serverBin, err := binPath("demarkus-server")
 	if err != nil {
+		return err
+	}
+	logFile, err := managedServerLogPath(soulDir)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(logFile), 0o755); err != nil {
 		return err
 	}
 	lf, err := os.OpenFile(logFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
@@ -906,7 +1001,7 @@ func ensureManagedServer(soulDir string, port int) error {
 	cmd := exec.Command(serverBin,
 		"-root", soulDir,
 		"-port", strconv.Itoa(port),
-		"-tokens", filepath.Join(soulDir, "tokens.toml"),
+		"-tokens", tokensPath,
 	)
 	cmd.Stdout = lf
 	cmd.Stderr = lf
@@ -1286,7 +1381,7 @@ func doDefault() error {
 	if err != nil {
 		return err
 	}
-	if err := ensureTokenEntry(filepath.Join(soul, "tokens.toml")); err != nil {
+	if err := ensureManagedTokenEntry(soul); err != nil {
 		return err
 	}
 	if err := ensureManagedServer(soul, defaultPort); err != nil {
@@ -1311,7 +1406,7 @@ func doIsolated() error {
 	if err != nil {
 		return err
 	}
-	if err := ensureTokenEntry(filepath.Join(soul, "tokens.toml")); err != nil {
+	if err := ensureManagedTokenEntry(soul); err != nil {
 		return err
 	}
 	if err := ensureManagedServer(soul, port); err != nil {
@@ -1331,7 +1426,9 @@ func doReuse(port int, root string) error {
 	if _, err := ensureBinaries(); err != nil {
 		return err
 	}
-	if err := ensureTokenEntry(filepath.Join(root, "tokens.toml")); err != nil {
+	// Adopted external server: its -tokens flag conventionally points at
+	// <root>/tokens.toml; that file is not ours to relocate.
+	if err := ensureTokenEntry(root, filepath.Join(root, "tokens.toml")); err != nil {
 		return err
 	}
 

--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -183,23 +183,30 @@ func migrateManagedTokens(soulDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cur, err := tokensPathFor(soulDir)
-	if err != nil {
-		return "", err
+	legacy := filepath.Join(soulDir, "tokens.toml")
+	if fileExists(newPath) {
+		// Retry a legacy cleanup that failed after a successful copy on a
+		// prior run; a leftover copy keeps token material in the content root.
+		if fileExists(legacy) {
+			if err := os.Remove(legacy); err != nil {
+				return "", fmt.Errorf("remove leftover legacy tokens.toml: %w", err)
+			}
+		}
+		return newPath, nil
 	}
-	if cur == newPath {
-		return newPath, nil // migrated already, or fresh: ensureTokenEntry populates it
+	if !fileExists(legacy) {
+		return newPath, nil // fresh install: ensureTokenEntry populates it
 	}
 	if err := os.MkdirAll(filepath.Dir(newPath), 0o700); err != nil {
 		return "", err
 	}
-	if err := os.Rename(cur, newPath); err != nil {
+	if err := os.Rename(legacy, newPath); err != nil {
 		// Cross-device fallback: project souls can sit on another volume.
-		if err := installFile(cur, newPath, 0o600); err != nil {
+		if err := installFile(legacy, newPath, 0o600); err != nil {
 			return "", fmt.Errorf("migrate tokens.toml out of soul root: %w", err)
 		}
-		if err := os.Remove(cur); err != nil {
-			warnf("remove legacy tokens.toml %s after copy: %v", cur, err)
+		if err := os.Remove(legacy); err != nil {
+			return "", fmt.Errorf("remove legacy tokens.toml after copy: %w", err)
 		}
 	}
 	logf("moved tokens.toml out of the soul root (%s)", newPath)
@@ -600,7 +607,11 @@ func installFile(src, dst string, mode os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = in.Close() }()
+	defer func() {
+		if err := in.Close(); err != nil {
+			warnf("close %s after copy: %v", src, err)
+		}
+	}()
 	tmp := dst + ".tmp"
 	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
 	if err != nil {
@@ -931,6 +942,35 @@ func managedServerCurrent(pidFile, versionFile, root string) bool {
 	return strings.TrimSpace(string(ver)) == serverVersion
 }
 
+// stopStaleManagedServer stops a live-but-stale managed server and confirms it
+// exited: the caller's token migration moves the file the old server reads. A
+// live PID that is not our server for soulDir is left untouched (kill safety).
+func stopStaleManagedServer(runningPID int, soulDir string) error {
+	if !pidIsServerAtRoot(runningPID, soulDir) {
+		if runningPID > 0 && pidAlive(runningPID) {
+			warnf("recorded pid %d is live but is not the demarkus-server for %s (stale .pid, reused PID); leaving it alone and clearing our bookkeeping", runningPID, soulDir)
+		}
+		return nil
+	}
+	logf("restarting managed demarkus-server onto upgraded binary (target=%s)", serverVersion)
+	_ = signalPID(runningPID, syscall.SIGTERM)
+	// Bounded wait for exit (~3s), then escalate to SIGKILL so the respawn
+	// can bind the freed UDP port.
+	for waited := 0; waited < 30 && pidAlive(runningPID); waited++ {
+		time.Sleep(100 * time.Millisecond)
+	}
+	if pidAlive(runningPID) {
+		_ = signalPID(runningPID, syscall.SIGKILL) // escalation; exit confirmed below
+		for waited := 0; waited < 10 && pidAlive(runningPID); waited++ {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	if pidAlive(runningPID) {
+		return fmt.Errorf("prior managed server (pid %d) still alive after SIGKILL; aborting respawn", runningPID)
+	}
+	return nil
+}
+
 // ensureManagedServer spawns a demarkus-server for soulDir on port if ours isn't
 // already running and current. Writes the PID to <soulDir>/.pid and the spawned
 // binary's version to <soulDir>/.server-version. For default/isolated modes only.
@@ -949,20 +989,8 @@ func ensureManagedServer(soulDir string, port int) error {
 
 	// Not reusable. Stop a live-but-stale managed server before respawning — but
 	// only after confirming it is genuinely ours for this root.
-	runningPID := readPID(pidFile)
-	if pidIsServerAtRoot(runningPID, soulDir) {
-		logf("restarting managed demarkus-server onto upgraded binary (target=%s)", serverVersion)
-		_ = signalPID(runningPID, syscall.SIGTERM)
-		// Bounded wait for exit (~3s), then escalate to SIGKILL so the respawn
-		// can bind the freed UDP port.
-		for waited := 0; waited < 30 && pidAlive(runningPID); waited++ {
-			time.Sleep(100 * time.Millisecond)
-		}
-		if pidAlive(runningPID) {
-			_ = signalPID(runningPID, syscall.SIGKILL)
-		}
-	} else if runningPID > 0 && pidAlive(runningPID) {
-		warnf("recorded pid %d is live but is not the demarkus-server for %s (stale .pid, reused PID); leaving it alone and clearing our bookkeeping", runningPID, soulDir)
+	if err := stopStaleManagedServer(readPID(pidFile), soulDir); err != nil {
+		return err
 	}
 	_ = os.Remove(pidFile)
 	_ = os.Remove(versionFile)

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -506,7 +506,7 @@ func TestEnsureTokenEntryScope(t *testing.T) {
 
 	// Fresh install mints with the recursive scope.
 	log := phaseLog(func() {
-		if err := ensureTokenEntry(tokensTOML); err != nil {
+		if err := ensureTokenEntry(soul, tokensTOML); err != nil {
 			t.Fatalf("fresh mint: %v", err)
 		}
 	})
@@ -516,7 +516,7 @@ func TestEnsureTokenEntryScope(t *testing.T) {
 
 	// Provisioned-and-current is a no-op: no further binary invocations.
 	log = phaseLog(func() {
-		if err := ensureTokenEntry(tokensTOML); err != nil {
+		if err := ensureTokenEntry(soul, tokensTOML); err != nil {
 			t.Fatalf("idempotent rerun: %v", err)
 		}
 	})
@@ -529,7 +529,7 @@ func TestEnsureTokenEntryScope(t *testing.T) {
 		t.Fatal(err)
 	}
 	log = phaseLog(func() {
-		if err := ensureTokenEntry(tokensTOML); err != nil {
+		if err := ensureTokenEntry(soul, tokensTOML); err != nil {
 			t.Fatalf("stale-scope remint: %v", err)
 		}
 	})
@@ -556,7 +556,7 @@ func TestEnsureTokenEntryScope(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("FAKE_REVOKE_FAIL", "1")
-	if err := ensureTokenEntry(tokensTOML); err == nil {
+	if err := ensureTokenEntry(soul, tokensTOML); err == nil {
 		t.Error("revoke failure did not surface an error")
 	}
 	t.Setenv("FAKE_REVOKE_FAIL", "")
@@ -567,7 +567,7 @@ func TestEnsureTokenEntryScope(t *testing.T) {
 	if err := os.WriteFile(tokensTOML, []byte(malformed), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := ensureTokenEntry(tokensTOML); err == nil {
+	if err := ensureTokenEntry(soul, tokensTOML); err == nil {
 		t.Error("malformed tokens.toml did not surface an error")
 	}
 
@@ -576,7 +576,7 @@ func TestEnsureTokenEntryScope(t *testing.T) {
 	if err := os.Remove(tokensTOML); err != nil { // clear the malformed file
 		t.Fatal(err)
 	}
-	if err := ensureTokenEntry(tokensTOML); err != nil {
+	if err := ensureTokenEntry(soul, tokensTOML); err != nil {
 		t.Fatalf("re-mint after malformed: %v", err)
 	}
 	tokenFile, err := pluginToken()
@@ -587,7 +587,7 @@ func TestEnsureTokenEntryScope(t *testing.T) {
 		t.Fatal(err)
 	}
 	log = phaseLog(func() {
-		if err := ensureTokenEntry(tokensTOML); err != nil {
+		if err := ensureTokenEntry(soul, tokensTOML); err != nil {
 			t.Fatalf("mismatched-raw remint: %v", err)
 		}
 	})
@@ -620,7 +620,7 @@ func TestEnsureTokenEntryReload(t *testing.T) {
 	reloads := 0
 	reloadServer = func(int) error { reloads++; return errors.New("injected reload failure") }
 
-	if err := ensureTokenEntry(tokensTOML); err == nil {
+	if err := ensureTokenEntry(soul, tokensTOML); err == nil {
 		t.Fatal("failed reload did not surface an error")
 	}
 	if reloads != 1 {
@@ -632,7 +632,7 @@ func TestEnsureTokenEntryReload(t *testing.T) {
 
 	// The next run retries: mint again, reload succeeds, token file commits.
 	reloadServer = func(int) error { reloads++; return nil }
-	if err := ensureTokenEntry(tokensTOML); err != nil {
+	if err := ensureTokenEntry(soul, tokensTOML); err != nil {
 		t.Fatalf("retry after failed reload: %v", err)
 	}
 	if reloads != 2 {
@@ -640,6 +640,64 @@ func TestEnsureTokenEntryReload(t *testing.T) {
 	}
 	if !fileExists(tokenFile) {
 		t.Error("token file missing after successful retry")
+	}
+}
+
+// TestManagedTokensMigration pins the #289 follow-up: tokens.toml moves out of
+// the content root on respawn; resolution prefers legacy until migrated.
+func TestManagedTokensMigration(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	soul := filepath.Join(home, "soul")
+	if err := os.MkdirAll(soul, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	newPath, err := managedTokensPath(soul)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.HasPrefix(newPath, soul+string(os.PathSeparator)) {
+		t.Fatalf("managed tokens path %s is inside the soul root", newPath)
+	}
+
+	// Fresh install: nothing on disk resolves to the new path.
+	if got, err := tokensPathFor(soul); err != nil || got != newPath {
+		t.Fatalf("fresh tokensPathFor = %q, %v; want %q", got, err, newPath)
+	}
+
+	// A legacy file wins resolution until migrated: the running server's
+	// -tokens flag still points there.
+	legacy := filepath.Join(soul, "tokens.toml")
+	if err := os.WriteFile(legacy, []byte("[tokens]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := tokensPathFor(soul); err != nil || got != legacy {
+		t.Fatalf("unmigrated tokensPathFor = %q, %v; want %q", got, err, legacy)
+	}
+
+	// Migration moves the file, preserving content; resolution flips.
+	migrated, err := migrateManagedTokens(soul)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if migrated != newPath {
+		t.Fatalf("migrateManagedTokens = %q, want %q", migrated, newPath)
+	}
+	data, err := os.ReadFile(newPath)
+	if err != nil || string(data) != "[tokens]\n" {
+		t.Fatalf("migrated content = %q, %v; want original body", data, err)
+	}
+	if fileExists(legacy) {
+		t.Error("legacy tokens.toml still present after migration")
+	}
+	if got, err := tokensPathFor(soul); err != nil || got != newPath {
+		t.Fatalf("post-migration tokensPathFor = %q, %v; want %q", got, err, newPath)
+	}
+
+	// Idempotent rerun leaves the migrated file alone.
+	if again, err := migrateManagedTokens(soul); err != nil || again != newPath {
+		t.Fatalf("rerun migrateManagedTokens = %q, %v; want %q", again, err, newPath)
 	}
 }
 

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -699,6 +699,21 @@ func TestManagedTokensMigration(t *testing.T) {
 	if again, err := migrateManagedTokens(soul); err != nil || again != newPath {
 		t.Fatalf("rerun migrateManagedTokens = %q, %v; want %q", again, err, newPath)
 	}
+
+	// A leftover legacy file (failed removal after a prior copy) is cleaned up
+	// on the next run without touching the migrated file.
+	if err := os.WriteFile(legacy, []byte("leftover"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := migrateManagedTokens(soul); err != nil || got != newPath {
+		t.Fatalf("leftover-cleanup migrateManagedTokens = %q, %v; want %q", got, err, newPath)
+	}
+	if fileExists(legacy) {
+		t.Error("leftover legacy tokens.toml not removed on rerun")
+	}
+	if data, err := os.ReadFile(newPath); err != nil || string(data) != "[tokens]\n" {
+		t.Fatalf("migrated file changed by leftover cleanup: %q, %v", data, err)
+	}
 }
 
 // TestSignalReload covers the nil paths: live owned child, then vanished pid.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unrelated writes to sibling log files from triggering unnecessary configuration reloads.
  * Improved detection of relevant file changes, including creation, renaming, and removal.

* **Improvements**
  * Managed server logs and authentication tokens are now stored outside the soul directory.
  * Existing token files are migrated automatically while preserving their contents.
  * Legacy in-directory logs are cleaned up during migration.
  * Provisioning and server reload behavior is more reliable across repeated setup attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->