### PR TITLE
Fix punctuation in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Run a single personal server, or compose many into an organizational **knowledge
 
 ### Agent memory plugins (start here)
 
-The fastest way to try Demarkus: give your coding agent persistent, versioned memory. The plugins manage their own binaries — no separate install needed.
+The fastest way to try Demarkus: give your coding agent persistent, versioned memory. The plugins manage their own binaries no separate install needed.
 
 **Claude Code**
 


### PR DESCRIPTION
Removed a comma in the installation instructions for clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the agent memory plugin description with clearer punctuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->