### PR TITLE
feat(tools): notify-only update check for the opencode and pi plugins

### DIFF
--- a/plugins/opencode-memory/CHANGELOG.md
+++ b/plugins/opencode-memory/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.13.27
+
+- Update check on plugin init: `demarkus-plugin update-check` compares the installed version against the manifest on `main`, and the adapter toasts when a newer release exists (notify-only, never self-installing). Throttled to once per 24h by the binary, silent when offline, turned off with `DEMARKUS_UPDATE_CHECK=0` or `~/.demarkus/plugin.update-check`. Requires a tools release carrying `update-check`; until the pin moves, the check is a no-op.
+- `install.sh` installs `package.json` alongside the assets, so the plugin can read the version it was installed at.
+
 ## 0.13.8
 
 - Initial OpenCode port of the Claude Code `demarkus-memory` plugin (version tracks the plugin line for the shared pin-bump convention).

--- a/plugins/opencode-memory/README.md
+++ b/plugins/opencode-memory/README.md
@@ -32,11 +32,25 @@ demarkus/plugins/opencode-memory/install.sh
 
 This copies the plugin to `$XDG_CONFIG_HOME/opencode/plugins/demarkus-memory.ts` (default `~/.config/opencode/plugins/`), the skill to the sibling `skills/soul-memory/`, and the assets it reads to `~/.demarkus/opencode-memory/`. Start (or restart) OpenCode; the first session provisions the soul. Restart once after the first session so the newly-registered MCP server connects. Diagnose with `/soul-status`, reconfigure with `/soul-init`, remove with `install.sh --uninstall`.
 
-Update by re-running the one-liner (or `git pull` + `install.sh` from a checkout). `DEMARKUS_REF=<branch>` pins the git ref for the standalone install.
+### Update
+
+Re-run the installer; it is idempotent and stages before it commits, so a failed update leaves the previous install intact:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/latebit-io/demarkus/main/plugins/opencode-memory/install.sh | bash
+# or, from a checkout
+git -C demarkus pull && demarkus/plugins/opencode-memory/install.sh
+```
+
+`DEMARKUS_REF=<branch|tag|sha>` pins the git ref for the standalone install. Restart OpenCode afterwards; the managed binaries update themselves on the next session from the pins the new plugin carries.
+
+### Update check
+
+On plugin init the adapter reads its version from the `package.json` that `install.sh` copies into `~/.demarkus/opencode-memory/`, and hands it to `demarkus-plugin update-check` together with this plugin's manifest URL and update command; the binary compares against the manifest on `main` and the adapter toasts whatever it returns. Notify-only: nothing installs itself, since the plugin file is already loaded and a rewrite could not take effect until the next restart. The binary throttles to one check per 24h (stamp: `~/.demarkus/.update-check-demarkus-opencode-memory`), the call is fire-and-forget so it cannot delay startup, and it stays silent when offline or before provisioning has installed the binary. Turn it off with `DEMARKUS_UPDATE_CHECK=0` or by writing `0` to `~/.demarkus/plugin.update-check`. A `DEMARKUS_REF`-pinned install still compares against `main`, so a pinned older revision reports an update.
 
 ## Architecture
 
-- `src/demarkus-memory.ts` — the whole adapter, one self-contained file (OpenCode's plugin dir loads flat files). All gate/nudge/guidance logic lives in the shared `demarkus-plugin` binary; the adapter hands it normalized JSON and applies the result. Fails open when the binary is absent.
+- `src/demarkus-memory.ts` — the whole adapter, one self-contained file (OpenCode's plugin dir loads flat files). All gate/nudge/guidance/update-check logic lives in the shared `demarkus-plugin` binary; the adapter hands it normalized JSON and applies the result. Fails open when the binary is absent.
 - `scripts/bootstrap.sh` — pinned binary installer, reused verbatim from the Claude Code plugin (single source of truth for provisioning).
 - `commands/*.md` — slash-command prompt bodies, registered via the `config` hook.
 - `skills/soul-memory/` — the on-demand memory-routing skill, installed into OpenCode's native skills directory.

--- a/plugins/opencode-memory/install.sh
+++ b/plugins/opencode-memory/install.sh
@@ -56,7 +56,7 @@ if [[ ! -e "${SRC}/src/demarkus-memory.ts" ]]; then
   SRC="${tmpdir}/${topdir}/plugins/opencode-memory"
 fi
 
-for d in src/demarkus-memory.ts commands context scripts skills/soul-memory/SKILL.md; do
+for d in src/demarkus-memory.ts package.json commands context scripts skills/soul-memory/SKILL.md; do
   [[ -e "${SRC}/${d}" ]] || { echo "[demarkus-memory] install: missing ${d} in ${SRC}" >&2; exit 1; }
 done
 
@@ -69,9 +69,12 @@ for d in commands context scripts; do
   cp -R "${SRC}/${d}" "${staging}/assets/${d}"
 done
 chmod 0755 "${staging}/assets/scripts/"*.sh
+# The manifest travels with the assets: the update check reads its version, and
+# OpenCode's flat plugin file has nowhere else to carry one.
+install -m 0644 "${SRC}/package.json" "${staging}/assets/package.json"
 install -m 0644 "${SRC}/src/demarkus-memory.ts" "${staging}/demarkus-memory.ts"
 install -m 0644 "${SRC}/skills/soul-memory/SKILL.md" "${staging}/SKILL.md"
-for f in demarkus-memory.ts SKILL.md assets/commands assets/context assets/scripts/bootstrap.sh; do
+for f in demarkus-memory.ts SKILL.md assets/package.json assets/commands assets/context assets/scripts/bootstrap.sh; do
   [[ -s "${staging}/${f}" || -d "${staging}/${f}" ]] || { echo "[demarkus-memory] install: staging incomplete (${f})" >&2; exit 1; }
 done
 

--- a/plugins/opencode-memory/package.json
+++ b/plugins/opencode-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-opencode-memory",
-  "version": "0.13.26",
+  "version": "0.13.27",
   "description": "Local, versioned memory for OpenCode via demarkus. Provisions a local demarkus-server, auto-generates a token, wires the demarkus-memory MCP server, injects standing guidance so sessions self-document to the soul, and enforces a publish tag-gate plus a destination gate.",
   "author": "latebit",
   "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/opencode-memory",

--- a/plugins/opencode-memory/src/demarkus-memory.ts
+++ b/plugins/opencode-memory/src/demarkus-memory.ts
@@ -6,7 +6,7 @@
 
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -15,7 +15,10 @@ const ASSETS = join(homedir(), ".demarkus", "opencode-memory");
 const COMMANDS_DIR = join(ASSETS, "commands");
 const SCRIPTS_DIR = join(ASSETS, "scripts");
 const GUIDANCE_FILE = join(ASSETS, "context", "session-guidance.md");
+const MANIFEST = join(ASSETS, "package.json");
 const MCP_SERVER_NAME = "demarkus-memory";
+const PLUGIN_NAME = "demarkus-opencode-memory";
+const RAW_BASE = "https://raw.githubusercontent.com/latebit-io/demarkus/main/plugins/opencode-memory";
 
 interface GateDecision {
   decision: "allow" | "warn" | "block" | "ask";
@@ -26,6 +29,10 @@ interface GateDecision {
 // resolves parsed stdout, or null on any failure (missing binary, timeout, parse).
 function runBin<T>(args: string[], payload?: unknown): Promise<T | null> {
   return new Promise((resolve) => {
+    if (!existsSync(BIN)) {
+      resolve(null);
+      return;
+    }
     const child = execFile(BIN, args, { encoding: "utf8", timeout: 5000 }, (err, stdout) => {
       if (err) {
         resolve(null);
@@ -100,6 +107,31 @@ async function provision(): Promise<string> {
   return run(BIN, ["provision"], "provisioning", 600_000);
 }
 
+// Update notice. The binary owns the throttle, fetch, and comparison; the
+// adapter owns its release identity and where its version is recorded (the
+// manifest install.sh copied alongside the assets).
+async function checkForUpdate(): Promise<string> {
+  let installed = "";
+  try {
+    installed = (JSON.parse(readFileSync(MANIFEST, "utf8")) as { version?: string }).version ?? "";
+  } catch (e) {
+    // ENOENT = installed before the manifest was shipped; anything else is real.
+    if ((e as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      console.error(`[demarkus-memory] update check: unreadable manifest ${MANIFEST}: ${e}`);
+    }
+    return "";
+  }
+  if (!installed) return "";
+  const out = await runBin<{ message?: string }>([
+    "update-check",
+    "--plugin", PLUGIN_NAME,
+    "--installed", installed,
+    "--manifest-url", `${RAW_BASE}/package.json`,
+    "--update-command", `curl -fsSL ${RAW_BASE}/install.sh | bash`,
+  ]);
+  return out?.message ?? "";
+}
+
 // Load a command markdown: parse the frontmatter description, strip the fence,
 // resolve ${DEMARKUS_SCRIPTS} to the installed scripts dir.
 function loadCommand(file: string): { description: string; template: string } {
@@ -157,6 +189,12 @@ export const DemarkusMemoryPlugin = async ({ client, directory }: { client: Toas
       });
   };
   ensureProvisioned();
+
+  // Fire-and-forget alongside provisioning: an update notice must never delay
+  // startup or block on the network.
+  void checkForUpdate().then((message) => {
+    if (message) void toast(message);
+  });
 
   return {
     // Register the MCP servers and the slash commands by mutating the merged

--- a/plugins/pi-memory/CHANGELOG.md
+++ b/plugins/pi-memory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.27
+
+- Update check on session start: `demarkus-plugin update-check` compares the shipped `package.json` version against the manifest on the monorepo's `main`, and the extension notifies when a newer release exists (notify-only, never self-installing). Throttled to once per 24h by the binary, silent when offline, turned off with `DEMARKUS_UPDATE_CHECK=0` or `~/.demarkus/plugin.update-check`. Requires a tools release carrying `update-check`; until the pin moves, the check is a no-op.
+
 ## 0.13.0
 
 - `/soul-join` accepts a join URL (`mark://host#token=...`, as emitted by

--- a/plugins/pi-memory/README.md
+++ b/plugins/pi-memory/README.md
@@ -39,9 +39,27 @@ pi install git:github.com/latebit-io/demarkus-pi-memory
 
 On the next session the soul is provisioned automatically. Run `/mcp` (or restart pi) once after the first session to connect the newly-registered `demarkus-memory` server. Use `/soul-status` to diagnose, `/soul-init` to reconfigure (adopt an existing server, switch modes). Remove with `pi remove ./demarkus/plugins/pi-memory`.
 
+### Update
+
+The command depends on how it was installed:
+
+```bash
+# installed from a local checkout
+git -C demarkus pull && pi install ./demarkus/plugins/pi-memory
+
+# installed via the git: one-liner
+pi update git:github.com/latebit-io/demarkus-pi-memory
+```
+
+The standalone repo is mirrored from the monorepo on every push to `main`, so a `git:` update picks up a change once that mirror workflow has run. Restart pi (or run `/mcp`) after an update that changes the MCP wiring.
+
+### Update check
+
+On session start, after provisioning, the extension hands `demarkus-plugin update-check` its own `package.json` version along with this plugin's manifest URL and update command; the binary compares against the manifest on the monorepo's `main` branch and the extension notifies when a newer release exists. Notify-only: nothing installs itself, since pi owns the package lifecycle. The binary throttles to one check per 24h (stamp: `~/.demarkus/.update-check-demarkus-pi-memory`), the call is fire-and-forget so it cannot delay the session, and it stays silent when offline. Turn it off with `DEMARKUS_UPDATE_CHECK=0` or by writing `0` to `~/.demarkus/plugin.update-check`. It reads the monorepo (the source of truth), so a `git:`-installed copy can see the notice a workflow run before the mirror repo carries the new version.
+
 ## Architecture
 
-- `src/*.ts` — native TypeScript: config/registry readers, the publish + destination gates, nudges, session-start guidance, and MCP wiring (loaded directly by pi via `tsx`, no build step).
+- `src/*.ts` — native TypeScript: config/registry readers, the publish + destination gates, nudges, session-start guidance, the update check, and MCP wiring (loaded directly by pi via `tsx`, no build step).
 - `scripts/*.sh` — the demarkus binary/server lifecycle, reused verbatim from the Claude Code plugin (single source of truth for provisioning); `provision.sh` is the per-session entrypoint and `mcp-config.mjs` registers remote-soul MCP servers.
 - `commands/*.md` — slash-command prompt bodies, injected by the extension.
 - `skills/soul-memory/` — the on-demand memory-routing skill.

--- a/plugins/pi-memory/package.json
+++ b/plugins/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-pi-memory",
-  "version": "0.13.26",
+  "version": "0.13.27",
   "description": "Local, versioned memory for the pi coding agent via demarkus. Provisions a local demarkus-server, auto-generates a token, wires the demarkus-memory MCP server through pi-mcp-adapter, injects standing guidance so sessions self-document to the soul, and enforces a publish tag-gate plus a destination gate so documents stay findable and land on the right soul.",
   "author": "latebit",
   "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/pi-memory",

--- a/plugins/pi-memory/src/index.ts
+++ b/plugins/pi-memory/src/index.ts
@@ -2,7 +2,8 @@
 //
 // The pi port of the claude-code demarkus-memory plugin. Same behavior, mapped
 // onto pi's extension API:
-//   - session_start      → provision the managed server + wire the MCP entry
+//   - session_start      → provision the managed server + wire the MCP entry,
+//                          plus a notify-only update check (throttled, daily)
 //   - before_agent_start → inject standing guidance (once) + recall nudge
 //   - tool_call          → publish tag-gate + destination gate + promote nudge
 //   - session_shutdown   → journal nudge
@@ -17,7 +18,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { SessionActivity } from "./nudges.js";
-import { callGate, callGuidance, callNudge } from "./plugin.js";
+import { callGate, callGuidance, callNudge, callUpdateCheck } from "./plugin.js";
 import { ensureMcpServerEntry, provisionServer } from "./setup.js";
 
 // Minimal structural types — pi's ExtensionAPI is provided at runtime; we keep
@@ -69,6 +70,10 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const COMMANDS_DIR = join(HERE, "..", "commands");
 const SCRIPTS_DIR = join(HERE, "..", "scripts");
 const GUIDANCE_FILE = join(HERE, "..", "context", "session-guidance.md");
+const MANIFEST = join(HERE, "..", "package.json");
+const PLUGIN_NAME = "demarkus-pi-memory";
+const MANIFEST_URL = "https://raw.githubusercontent.com/latebit-io/demarkus/main/plugins/pi-memory/package.json";
+const UPDATE_COMMAND = "pi update git:github.com/latebit-io/demarkus-pi-memory (or re-run pi install from an updated checkout)";
 const CUSTOM = "demarkus-memory";
 
 // Slash commands → bundled skills. Each command injects its skill's body so the
@@ -122,6 +127,24 @@ function normalizeToolCall(event: ToolCallEvent): { toolName: string; input: Rec
   return { toolName, input };
 }
 
+// The plugin's own version, from the manifest pi installed alongside src/.
+async function checkForUpdate(): Promise<string> {
+  let installed = "";
+  try {
+    installed = (JSON.parse(readFileSync(MANIFEST, "utf8")) as { version?: string }).version ?? "";
+  } catch (e) {
+    console.error(`[demarkus-memory] update check: unreadable manifest ${MANIFEST}: ${e}`);
+    return "";
+  }
+  if (!installed) return "";
+  return callUpdateCheck({
+    plugin: PLUGIN_NAME,
+    installed,
+    manifestUrl: MANIFEST_URL,
+    updateCommand: UPDATE_COMMAND,
+  });
+}
+
 export default function demarkusMemoryExtension(pi: ExtensionAPI): void {
   let contextDelivered = false;
   let activity = new SessionActivity();
@@ -138,6 +161,12 @@ export default function demarkusMemoryExtension(pi: ExtensionAPI): void {
     if (mcp.status === "error") {
       ctx.ui.notify(`demarkus-memory: MCP registration failed: ${mcp.message}`, "warning");
     }
+
+    // After provisioning, which is what installs the binary this call needs.
+    // Fire-and-forget: a notice must never delay the session.
+    void checkForUpdate().then((message) => {
+      if (message) ctx.ui.notify(message);
+    });
   });
 
   pi.on("before_agent_start", async (event) => {

--- a/plugins/pi-memory/src/plugin.ts
+++ b/plugins/pi-memory/src/plugin.ts
@@ -72,3 +72,27 @@ export async function callGuidance(surface: "memory" | "knowledge", guidanceFile
   const o = await runBin<{ context?: string }>(["guidance", "--surface", surface, "--guidance-file", guidanceFile]);
   return o === null ? null : (o.context ?? "");
 }
+
+// callUpdateCheck asks `demarkus-plugin update-check` whether a newer release of
+// this plugin exists. The binary owns the throttle, fetch, and comparison; the
+// caller supplies its release identity. Resolves "" when current, throttled,
+// turned off, or the binary is unavailable.
+export async function callUpdateCheck(req: {
+  plugin: string;
+  installed: string;
+  manifestUrl: string;
+  updateCommand: string;
+}): Promise<string> {
+  const o = await runBin<{ message?: string }>([
+    "update-check",
+    "--plugin",
+    req.plugin,
+    "--installed",
+    req.installed,
+    "--manifest-url",
+    req.manifestUrl,
+    "--update-command",
+    req.updateCommand,
+  ]);
+  return o?.message ?? "";
+}

--- a/plugins/pi-memory/src/plugin.ts
+++ b/plugins/pi-memory/src/plugin.ts
@@ -73,9 +73,8 @@ export async function callGuidance(surface: "memory" | "knowledge", guidanceFile
   return o === null ? null : (o.context ?? "");
 }
 
-// callUpdateCheck asks `demarkus-plugin update-check` whether a newer release of
-// this plugin exists. The binary owns the throttle, fetch, and comparison; the
-// caller supplies its release identity. Resolves "" when current, throttled,
+// callUpdateCheck asks the binary whether a newer release of this plugin exists;
+// the caller supplies its release identity. Resolves "" when current, throttled,
 // turned off, or the binary is unavailable.
 export async function callUpdateCheck(req: {
   plugin: string;

--- a/tools/demarkus-plugin/internal/config/config.go
+++ b/tools/demarkus-plugin/internal/config/config.go
@@ -176,6 +176,32 @@ func RetentionStrictness() (Strictness, error) {
 	return validStrictness(s, Ask), nil
 }
 
+// UpdateCheckEnabled reports whether the plugin update check may run.
+// env override → plugin.update-check → on: a notice once a day is cheap, and a
+// user who wants it gone gets a file, not just an env var a GUI launch drops.
+func UpdateCheckEnabled() (bool, error) {
+	if v := os.Getenv("DEMARKUS_UPDATE_CHECK"); v != "" {
+		return !isOff(v), nil
+	}
+	p, err := path("plugin.update-check")
+	if err != nil {
+		return true, err
+	}
+	s, err := readTrimmed(p)
+	if err != nil {
+		return true, err
+	}
+	return !isOff(s), nil
+}
+
+func isOff(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "0", "off", "false", "no":
+		return true
+	}
+	return false
+}
+
 // KnowledgeStrictness env override → plugin-knowledge.strictness.<slug> → warn.
 func KnowledgeStrictness(slug string) (Strictness, error) {
 	if v := os.Getenv("DEMARKUS_KNOWLEDGE_STRICTNESS"); v != "" {

--- a/tools/demarkus-plugin/internal/update/update.go
+++ b/tools/demarkus-plugin/internal/update/update.go
@@ -1,0 +1,171 @@
+// Package update implements the plugin update check shared by every harness
+// adapter: compare the version a plugin was installed at against its published
+// manifest, and return the notice to surface. The adapters own their release
+// identity (manifest URL, update command); the throttle, fetch, comparison, and
+// message shape live here.
+//
+// Notify-only by design: the plugin is already loaded when the check runs, so
+// self-installing could not take effect before a restart.
+package update
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/latebit-io/demarkus/tools/demarkus-plugin/internal/config"
+)
+
+// Input is the calling plugin's release identity plus the version it runs.
+type Input struct {
+	Plugin        string // package name, e.g. demarkus-opencode-memory
+	Installed     string // version the adapter found locally
+	ManifestURL   string // JSON manifest carrying the published {"version":...}
+	UpdateCommand string // what the user runs to update this plugin
+}
+
+// Output carries the notice to surface; empty means nothing to say.
+type Output struct {
+	Message string `json:"message"`
+}
+
+// interval throttles the network call; httpTimeout stays under the adapters'
+// 5s subprocess bound so a slow GitHub never looks like a dead binary.
+const (
+	interval    = 24 * time.Hour
+	httpTimeout = 3 * time.Second
+)
+
+// Evaluate returns the update notice for the calling plugin, or an empty output
+// when it is current, throttled, or turned off.
+func Evaluate(in Input) (Output, error) {
+	if err := in.validate(); err != nil {
+		return Output{}, err
+	}
+	enabled, err := config.UpdateCheckEnabled()
+	if err != nil {
+		return Output{}, err
+	}
+	if !enabled {
+		return Output{}, nil
+	}
+
+	// One stamp per plugin: the plugins share a version line but are installed
+	// and updated independently.
+	stamp, err := config.StatePath(".update-check-" + in.Plugin)
+	if err != nil {
+		return Output{}, err
+	}
+	if !due(stamp) {
+		return Output{}, nil
+	}
+
+	latest, err := latestVersion(in.ManifestURL)
+	if err != nil {
+		// Offline or the host is down: no stamp is written, so the next session
+		// retries instead of going quiet for a day.
+		return Output{}, err
+	}
+	if err := writeStamp(stamp); err != nil {
+		return Output{}, err
+	}
+	if !isNewer(latest, in.Installed) {
+		return Output{}, nil
+	}
+	return Output{Message: fmt.Sprintf("%s %s available (installed %s). Update: %s",
+		in.Plugin, latest, in.Installed, in.UpdateCommand)}, nil
+}
+
+func (in Input) validate() error {
+	for _, f := range []struct{ name, value string }{
+		{"plugin", in.Plugin},
+		{"installed", in.Installed},
+		{"manifest-url", in.ManifestURL},
+		{"update-command", in.UpdateCommand},
+	} {
+		if strings.TrimSpace(f.value) == "" {
+			return errors.New("missing " + f.name)
+		}
+	}
+	return nil
+}
+
+// due reports whether the throttle window has elapsed. A missing stamp means
+// never checked; an unreadable or malformed one counts as due, since a corrupt
+// throttle must not disable the check forever.
+func due(stamp string) bool {
+	b, err := os.ReadFile(stamp)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			fmt.Fprintln(os.Stderr, "[demarkus-plugin] update-check: unreadable stamp, checking anyway: "+err.Error())
+		}
+		return true
+	}
+	secs, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
+	if err != nil {
+		return true
+	}
+	return time.Since(time.Unix(secs, 0)) >= interval
+}
+
+func writeStamp(stamp string) error {
+	if err := os.MkdirAll(filepath.Dir(stamp), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(stamp), err)
+	}
+	if err := os.WriteFile(stamp, []byte(strconv.FormatInt(time.Now().Unix(), 10)), 0o600); err != nil {
+		return fmt.Errorf("write stamp %s: %w", stamp, err)
+	}
+	return nil
+}
+
+func latestVersion(url string) (string, error) {
+	client := &http.Client{Timeout: httpTimeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("fetch %s: %w", url, err)
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			fmt.Fprintln(os.Stderr, "[demarkus-plugin] update-check: close body: "+cerr.Error())
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetch %s: HTTP %d", url, resp.StatusCode)
+	}
+	var manifest struct {
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&manifest); err != nil {
+		return "", fmt.Errorf("decode %s: %w", url, err)
+	}
+	if manifest.Version == "" {
+		return "", fmt.Errorf("manifest %s carried no version", url)
+	}
+	return manifest.Version, nil
+}
+
+// isNewer compares major.minor.patch numerically; the plugin line never ships
+// prereleases, and an unparseable version compares as 0.0.0.
+func isNewer(latest, installed string) bool {
+	a, b := parts(latest), parts(installed)
+	for i := range a {
+		if a[i] != b[i] {
+			return a[i] > b[i]
+		}
+	}
+	return false
+}
+
+func parts(v string) [3]int {
+	var out [3]int
+	if _, err := fmt.Sscanf(strings.TrimSpace(v), "%d.%d.%d", &out[0], &out[1], &out[2]); err != nil {
+		return [3]int{}
+	}
+	return out
+}

--- a/tools/demarkus-plugin/internal/update/update.go
+++ b/tools/demarkus-plugin/internal/update/update.go
@@ -1,11 +1,6 @@
-// Package update implements the plugin update check shared by every harness
-// adapter: compare the version a plugin was installed at against its published
-// manifest, and return the notice to surface. The adapters own their release
-// identity (manifest URL, update command); the throttle, fetch, comparison, and
-// message shape live here.
-//
-// Notify-only by design: the plugin is already loaded when the check runs, so
-// self-installing could not take effect before a restart.
+// Package update implements the plugin update check: the adapters own their
+// release identity, this owns the throttle, fetch, comparison, and message.
+// Notify-only; the plugin is already loaded, so installing could not take hold.
 package update
 
 import (
@@ -96,9 +91,9 @@ func (in Input) validate() error {
 	return nil
 }
 
-// due reports whether the throttle window has elapsed. A missing stamp means
-// never checked; an unreadable or malformed one counts as due, since a corrupt
-// throttle must not disable the check forever.
+// due reports whether the throttle window has elapsed. A missing, unreadable,
+// malformed, or future-dated stamp counts as due: a corrupt throttle must not
+// disable the check forever.
 func due(stamp string) bool {
 	b, err := os.ReadFile(stamp)
 	if err != nil {
@@ -109,9 +104,17 @@ func due(stamp string) bool {
 	}
 	secs, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
 	if err != nil {
+		fmt.Fprintln(os.Stderr, "[demarkus-plugin] update-check: malformed stamp, checking anyway: "+err.Error())
 		return true
 	}
-	return time.Since(time.Unix(secs, 0)) >= interval
+	// A stamp ahead of the clock (skew, or a correction since it was written)
+	// would otherwise throttle until that future time plus the interval.
+	elapsed := time.Since(time.Unix(secs, 0))
+	if elapsed < 0 {
+		fmt.Fprintln(os.Stderr, "[demarkus-plugin] update-check: stamp is in the future, checking anyway")
+		return true
+	}
+	return elapsed >= interval
 }
 
 func writeStamp(stamp string) error {

--- a/tools/demarkus-plugin/internal/update/update_test.go
+++ b/tools/demarkus-plugin/internal/update/update_test.go
@@ -135,6 +135,24 @@ func TestMalformedStampIsDue(t *testing.T) {
 	}
 }
 
+func TestFutureStampIsDue(t *testing.T) {
+	in, stamp := serve(t, `{"version":"0.14.0"}`, http.StatusOK)
+	if err := os.MkdirAll(filepath.Dir(stamp), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ahead := strconv.FormatInt(time.Now().Add(48*time.Hour).Unix(), 10)
+	if err := os.WriteFile(stamp, []byte(ahead), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err := Evaluate(in)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if out.Message == "" {
+		t.Error("a stamp ahead of the clock must not throttle the check")
+	}
+}
+
 func TestFetchFailureLeavesNoStamp(t *testing.T) {
 	in, stamp := serve(t, `{"version":"0.14.0"}`, http.StatusInternalServerError)
 	if _, err := Evaluate(in); err == nil {

--- a/tools/demarkus-plugin/internal/update/update_test.go
+++ b/tools/demarkus-plugin/internal/update/update_test.go
@@ -1,0 +1,210 @@
+package update
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testPlugin = "demarkus-test-memory"
+
+// serve returns an input pointed at a manifest server, plus its stamp path,
+// under a temp HOME.
+func serve(t *testing.T, manifest string, status int) (in Input, stamp string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DEMARKUS_UPDATE_CHECK", "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		if _, err := io.WriteString(w, manifest); err != nil {
+			t.Errorf("write manifest: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	in = Input{
+		Plugin:        testPlugin,
+		Installed:     "0.13.26",
+		ManifestURL:   srv.URL,
+		UpdateCommand: "pi update demarkus-test-memory",
+	}
+	return in, filepath.Join(home, ".demarkus", ".update-check-"+testPlugin)
+}
+
+func TestIsNewer(t *testing.T) {
+	tests := []struct {
+		latest, installed string
+		want              bool
+	}{
+		{"0.14.0", "0.13.26", true},
+		{"0.13.26", "0.13.26", false},
+		{"0.13.26", "0.14.0", false},
+		{"0.13.27", "0.13.26", true},
+		{"0.14.0", "0.13.99", true},
+		{"1.0.0", "0.99.99", true},
+		{"garbage", "0.13.26", false},
+		{"0.13.26", "garbage", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.latest+"_vs_"+tt.installed, func(t *testing.T) {
+			if got := isNewer(tt.latest, tt.installed); got != tt.want {
+				t.Errorf("isNewer(%q, %q) = %v, want %v", tt.latest, tt.installed, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvaluateMessageCarriesIdentity(t *testing.T) {
+	in, _ := serve(t, `{"version":"0.14.0"}`, http.StatusOK)
+	out, err := Evaluate(in)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	for _, want := range []string{in.Plugin, "0.14.0", in.Installed, in.UpdateCommand} {
+		if !strings.Contains(out.Message, want) {
+			t.Errorf("message %q missing %q", out.Message, want)
+		}
+	}
+}
+
+func TestEvaluateSilentWhenCurrent(t *testing.T) {
+	in, _ := serve(t, `{"version":"0.13.26"}`, http.StatusOK)
+	out, err := Evaluate(in)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if out.Message != "" {
+		t.Errorf("expected no notice when current, got %q", out.Message)
+	}
+}
+
+func TestThrottle(t *testing.T) {
+	in, stamp := serve(t, `{"version":"0.14.0"}`, http.StatusOK)
+
+	if _, err := Evaluate(in); err != nil {
+		t.Fatalf("first Evaluate: %v", err)
+	}
+	if _, err := os.Stat(stamp); err != nil {
+		t.Fatalf("stamp not written: %v", err)
+	}
+
+	out, err := Evaluate(in)
+	if err != nil {
+		t.Fatalf("second Evaluate: %v", err)
+	}
+	if out.Message != "" {
+		t.Errorf("expected the throttle to suppress the second check, got %q", out.Message)
+	}
+
+	// A stamp older than the interval re-opens the window.
+	old := strconv.FormatInt(time.Now().Add(-interval-time.Minute).Unix(), 10)
+	if err := os.WriteFile(stamp, []byte(old), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err = Evaluate(in)
+	if err != nil {
+		t.Fatalf("third Evaluate: %v", err)
+	}
+	if out.Message == "" {
+		t.Error("expected a notice once the throttle window elapsed")
+	}
+}
+
+func TestMalformedStampIsDue(t *testing.T) {
+	in, stamp := serve(t, `{"version":"0.14.0"}`, http.StatusOK)
+	if err := os.MkdirAll(filepath.Dir(stamp), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stamp, []byte("not-a-number"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err := Evaluate(in)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if out.Message == "" {
+		t.Error("a corrupt stamp must not disable the check")
+	}
+}
+
+func TestFetchFailureLeavesNoStamp(t *testing.T) {
+	in, stamp := serve(t, `{"version":"0.14.0"}`, http.StatusInternalServerError)
+	if _, err := Evaluate(in); err == nil {
+		t.Fatal("expected an error on HTTP 500")
+	}
+	if _, err := os.Stat(stamp); !os.IsNotExist(err) {
+		t.Errorf("stamp must not be written on a failed fetch (stat err: %v)", err)
+	}
+}
+
+func TestManifestWithoutVersion(t *testing.T) {
+	in, _ := serve(t, `{"name":"demarkus-test-memory"}`, http.StatusOK)
+	if _, err := Evaluate(in); err == nil {
+		t.Error("expected an error when the manifest carries no version")
+	}
+}
+
+func TestTurnedOff(t *testing.T) {
+	t.Run("env", func(t *testing.T) {
+		in, stamp := serve(t, `{"version":"0.14.0"}`, http.StatusOK)
+		t.Setenv("DEMARKUS_UPDATE_CHECK", "off")
+		out, err := Evaluate(in)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		if out.Message != "" {
+			t.Errorf("turned off, got %q", out.Message)
+		}
+		if _, err := os.Stat(stamp); !os.IsNotExist(err) {
+			t.Error("turned off: no stamp should be written")
+		}
+	})
+
+	t.Run("config file", func(t *testing.T) {
+		in, stamp := serve(t, `{"version":"0.14.0"}`, http.StatusOK)
+		dir := filepath.Dir(stamp)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "plugin.update-check"), []byte("0\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		out, err := Evaluate(in)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		if out.Message != "" {
+			t.Errorf("turned off by config file, got %q", out.Message)
+		}
+	})
+}
+
+func TestInputValidation(t *testing.T) {
+	base, _ := serve(t, `{"version":"0.14.0"}`, http.StatusOK)
+	for _, missing := range []string{"plugin", "installed", "manifest-url", "update-command"} {
+		t.Run(missing, func(t *testing.T) {
+			in := base
+			switch missing {
+			case "plugin":
+				in.Plugin = ""
+			case "installed":
+				in.Installed = "  "
+			case "manifest-url":
+				in.ManifestURL = ""
+			case "update-command":
+				in.UpdateCommand = ""
+			}
+			if _, err := Evaluate(in); err == nil {
+				t.Errorf("expected an error when %s is missing", missing)
+			}
+		})
+	}
+}

--- a/tools/demarkus-plugin/main.go
+++ b/tools/demarkus-plugin/main.go
@@ -141,7 +141,7 @@ func cmdUpdateCheck() {
 	installed := fs.String("installed", "", "version the plugin is running")
 	manifestURL := fs.String("manifest-url", "", "URL of the published JSON manifest carrying {\"version\":...}")
 	updateCommand := fs.String("update-command", "", "what the user runs to update this plugin")
-	_ = fs.Parse(os.Args[2:])
+	fs.Parse(os.Args[2:]) //nolint:errcheck // ExitOnError reports and exits
 
 	out, err := update.Evaluate(update.Input{
 		Plugin:        *plugin,

--- a/tools/demarkus-plugin/main.go
+++ b/tools/demarkus-plugin/main.go
@@ -9,8 +9,7 @@
 //	echo '{"tool":"...","input":{...},"cwd":"..."}' | demarkus-plugin gate
 //	demarkus-plugin version
 //
-// Subcommands beyond `gate` (nudge, guidance, registry, provision, mcp-serve)
-// are introduced in later phases.
+// Subcommands: gate, nudge, guidance, update-check, registry, provision, mcp-serve.
 package main
 
 import (
@@ -24,6 +23,7 @@ import (
 	"github.com/latebit-io/demarkus/tools/demarkus-plugin/internal/gate"
 	"github.com/latebit-io/demarkus/tools/demarkus-plugin/internal/guidance"
 	"github.com/latebit-io/demarkus/tools/demarkus-plugin/internal/nudge"
+	"github.com/latebit-io/demarkus/tools/demarkus-plugin/internal/update"
 )
 
 // version is set at build time via -ldflags "-X main.version=...".
@@ -41,6 +41,8 @@ func main() {
 		cmdNudge()
 	case "guidance":
 		cmdGuidance()
+	case "update-check":
+		cmdUpdateCheck()
 	case "registry":
 		cmdRegistry(os.Args[2:])
 	case "mcp-serve":
@@ -61,6 +63,7 @@ func printUsage() {
 	fmt.Fprintf(os.Stderr, "  gate      Decide whether a mark_publish/mark_append should proceed (reads JSON on stdin)\n")
 	fmt.Fprintf(os.Stderr, "  nudge     Decide a recall/promote/session-end nudge (reads JSON on stdin)\n")
 	fmt.Fprintf(os.Stderr, "  guidance  Emit the session-start context for a surface (memory|knowledge)\n")
+	fmt.Fprintf(os.Stderr, "  update-check  Report whether a newer release of the calling plugin exists\n")
 	fmt.Fprintf(os.Stderr, "  version   Print version and exit\n")
 }
 
@@ -124,6 +127,33 @@ func cmdNudge() {
 				"hookEventName": "UserPromptSubmit", "additionalContext": out.Nudge,
 			}})
 		}
+		return
+	}
+	printJSON(out)
+}
+
+// cmdUpdateCheck reports whether a newer release of the calling plugin exists:
+// {"message":...}, no output otherwise. The adapter supplies its own release
+// identity (only it knows its channel); fails silent on any error.
+func cmdUpdateCheck() {
+	fs := flag.NewFlagSet("update-check", flag.ExitOnError)
+	plugin := fs.String("plugin", "", "calling plugin's package name")
+	installed := fs.String("installed", "", "version the plugin is running")
+	manifestURL := fs.String("manifest-url", "", "URL of the published JSON manifest carrying {\"version\":...}")
+	updateCommand := fs.String("update-command", "", "what the user runs to update this plugin")
+	_ = fs.Parse(os.Args[2:])
+
+	out, err := update.Evaluate(update.Input{
+		Plugin:        *plugin,
+		Installed:     *installed,
+		ManifestURL:   *manifestURL,
+		UpdateCommand: *updateCommand,
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "[demarkus-plugin] update-check: "+err.Error())
+		return
+	}
+	if out.Message == "" {
 		return
 	}
 	printJSON(out)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added background update checks for both memory plugins.
  - Displays informational notifications when newer versions are available.
  - Checks are throttled, fail safely offline, and can be disabled through configuration.
  - Added an update-check command for plugin availability monitoring.

- **Bug Fixes**
  - Installations now validate that required package metadata is present before completing.

- **Documentation**
  - Added instructions for updating plugins, version pinning, restart requirements, and update-check behavior.

- **Chores**
  - Updated both plugin versions to 0.13.27.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->