### PR TITLE
fix(tools): handle empty OpenCode update responses

### DIFF
--- a/plugins/opencode-knowledge/src/demarkus-knowledge.ts
+++ b/plugins/opencode-knowledge/src/demarkus-knowledge.ts
@@ -49,7 +49,7 @@ function reportFailure(operation: string, detail: string): void {
   console.error(`[demarkus-knowledge] ${message}`);
 }
 
-function runBin<T>(args: string[], payload?: unknown): Promise<T | null> {
+function runBin<T>(args: string[], payload?: unknown, emptyIsNull = false): Promise<T | null> {
   return new Promise((resolve) => {
     const operation = args[0] ?? "helper";
     if (!existsSync(BIN)) {
@@ -63,8 +63,14 @@ function runBin<T>(args: string[], payload?: unknown): Promise<T | null> {
         resolve(null);
         return;
       }
+      const output = (stdout || "").trim();
+      if (!output) {
+        if (!emptyIsNull) reportFailure(operation, "helper returned an empty response");
+        resolve(null);
+        return;
+      }
       try {
-        resolve(JSON.parse((stdout || "").trim()) as T);
+        resolve(JSON.parse(output) as T);
       } catch (error) {
         reportFailure(operation, `invalid helper response: ${error}`);
         resolve(null);
@@ -221,7 +227,7 @@ async function checkForUpdate(): Promise<string> {
     `${RAW_BASE}/package.json`,
     "--update-command",
     `curl -fsSL ${RAW_BASE}/install.sh | bash`,
-  ]);
+  ], undefined, true);
   return output?.message ?? "";
 }
 
@@ -232,7 +238,7 @@ export function loadCommand(file: string, commandsDir = COMMANDS_DIR): { descrip
   const body = (frontmatter ? raw.slice(frontmatter[0].length) : raw)
     .replace(/\$\{DEMARKUS_SCRIPTS\}/g, SCRIPTS_DIR)
     .trim();
-  return { description, template: `${body}\n\nUser arguments (may be empty): $ARGUMENTS` };
+  return { description, template: `${body}\n\nUser arguments (may be empty): $ARGUMENTS\n` };
 }
 
 export const DemarkusKnowledgePlugin = async ({ client, directory }: { client: ToastClient; directory: string }) => {

--- a/plugins/opencode-knowledge/tests/demarkus-knowledge.test.ts
+++ b/plugins/opencode-knowledge/tests/demarkus-knowledge.test.ts
@@ -90,6 +90,6 @@ test("loadCommand strips frontmatter and appends OpenCode arguments", () => {
 
   assert.deepEqual(loadCommand("knowledge.md", commands), {
     description: "Show knowledge",
-    template: "Do the work.\n\nUser arguments (may be empty): $ARGUMENTS",
+    template: "Do the work.\n\nUser arguments (may be empty): $ARGUMENTS\n",
   });
 });

--- a/plugins/opencode-memory/src/demarkus-memory.ts
+++ b/plugins/opencode-memory/src/demarkus-memory.ts
@@ -37,7 +37,7 @@ function reportFailure(operation: string, detail: string): void {
 
 // runBin pipes an optional JSON payload to a demarkus-plugin subcommand and
 // resolves parsed stdout, or null on any failure (missing binary, timeout, parse).
-function runBin<T>(args: string[], payload?: unknown): Promise<T | null> {
+function runBin<T>(args: string[], payload?: unknown, emptyIsNull = false): Promise<T | null> {
   return new Promise((resolve) => {
     const operation = args[0] ?? "helper";
     if (!existsSync(BIN)) {
@@ -51,8 +51,14 @@ function runBin<T>(args: string[], payload?: unknown): Promise<T | null> {
         resolve(null);
         return;
       }
+      const output = (stdout || "").trim();
+      if (!output) {
+        if (!emptyIsNull) reportFailure(operation, "helper returned an empty response");
+        resolve(null);
+        return;
+      }
       try {
-        resolve(JSON.parse((stdout || "").trim()) as T);
+        resolve(JSON.parse(output) as T);
       } catch (error) {
         reportFailure(operation, `invalid helper response: ${error}`);
         resolve(null);
@@ -142,7 +148,7 @@ async function checkForUpdate(): Promise<string> {
     "--installed", installed,
     "--manifest-url", `${RAW_BASE}/package.json`,
     "--update-command", `curl -fsSL ${RAW_BASE}/install.sh | bash`,
-  ]);
+  ], undefined, true);
   return out?.message ?? "";
 }
 
@@ -154,7 +160,7 @@ function loadCommand(file: string): { description: string; template: string } {
   const description = fm?.[1].match(/^description:\s*(.+)$/m)?.[1]?.trim() ?? "";
   const body = (fm ? raw.slice(fm[0].length) : raw).replace(/\$\{DEMARKUS_SCRIPTS\}/g, SCRIPTS_DIR).trim();
   // $ARGUMENTS lets the user pass arguments; harmless when empty.
-  const template = `${body}\n\nUser arguments (may be empty): $ARGUMENTS`;
+  const template = `${body}\n\nUser arguments (may be empty): $ARGUMENTS\n`;
   return { description, template };
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update checks so empty helper responses are handled silently instead of reported as failures.
  * Preserved proper handling of valid command output while distinguishing it from empty responses.

* **Improvements**
  * Command templates now consistently end with a trailing newline after user-provided arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->