### PR TITLE
fix(tools): accept expected empty helper responses

### DIFF
--- a/plugins/opencode-knowledge/src/demarkus-knowledge.ts
+++ b/plugins/opencode-knowledge/src/demarkus-knowledge.ts
@@ -49,7 +49,7 @@ function reportFailure(operation: string, detail: string): void {
   console.error(`[demarkus-knowledge] ${message}`);
 }
 
-function runBin<T>(args: string[], payload?: unknown, emptyIsNull = false): Promise<T | null> {
+function runBin<T>(args: string[], payload?: unknown, allowEmpty = false): Promise<T | null> {
   return new Promise((resolve) => {
     const operation = args[0] ?? "helper";
     if (!existsSync(BIN)) {
@@ -65,7 +65,11 @@ function runBin<T>(args: string[], payload?: unknown, emptyIsNull = false): Prom
       }
       const output = (stdout || "").trim();
       if (!output) {
-        if (!emptyIsNull) reportFailure(operation, "helper returned an empty response");
+        if (allowEmpty) {
+          resolve({} as T);
+          return;
+        }
+        reportFailure(operation, "helper returned an empty response");
         resolve(null);
         return;
       }
@@ -86,7 +90,7 @@ async function callGate(toolName: string, input: Record<string, unknown>, cwd: s
 }
 
 async function callNudge(request: Record<string, unknown>): Promise<string> {
-  const output = await runBin<{ nudge?: string }>(["nudge"], request);
+  const output = await runBin<{ nudge?: string }>(["nudge"], request, true);
   return output?.nudge ?? "";
 }
 
@@ -97,7 +101,7 @@ async function callGuidance(): Promise<string | null> {
     "knowledge",
     "--guidance-file",
     GUIDANCE_FILE,
-  ]);
+  ], undefined, true);
   return output === null ? null : (output.context ?? "");
 }
 

--- a/plugins/opencode-memory/src/demarkus-memory.ts
+++ b/plugins/opencode-memory/src/demarkus-memory.ts
@@ -36,8 +36,8 @@ function reportFailure(operation: string, detail: string): void {
 }
 
 // runBin pipes an optional JSON payload to a demarkus-plugin subcommand and
-// resolves parsed stdout, or null on any failure (missing binary, timeout, parse).
-function runBin<T>(args: string[], payload?: unknown, emptyIsNull = false): Promise<T | null> {
+// resolves parsed stdout, {} for an allowed empty response, or null on failure.
+function runBin<T>(args: string[], payload?: unknown, allowEmpty = false): Promise<T | null> {
   return new Promise((resolve) => {
     const operation = args[0] ?? "helper";
     if (!existsSync(BIN)) {
@@ -53,7 +53,11 @@ function runBin<T>(args: string[], payload?: unknown, emptyIsNull = false): Prom
       }
       const output = (stdout || "").trim();
       if (!output) {
-        if (!emptyIsNull) reportFailure(operation, "helper returned an empty response");
+        if (allowEmpty) {
+          resolve({} as T);
+          return;
+        }
+        reportFailure(operation, "helper returned an empty response");
         resolve(null);
         return;
       }
@@ -76,13 +80,17 @@ async function callGate(toolName: string, input: Record<string, unknown>, cwd: s
 }
 
 async function callNudge(req: Record<string, unknown>): Promise<string> {
-  const o = await runBin<{ nudge?: string }>(["nudge"], req);
+  const o = await runBin<{ nudge?: string }>(["nudge"], req, true);
   return o?.nudge ?? "";
 }
 
 // null = binary unavailable/failed (caller retries next turn); "" = ran, nothing to say.
 async function callGuidance(): Promise<string | null> {
-  const o = await runBin<{ context?: string }>(["guidance", "--surface", "memory", "--guidance-file", GUIDANCE_FILE]);
+  const o = await runBin<{ context?: string }>(
+    ["guidance", "--surface", "memory", "--guidance-file", GUIDANCE_FILE],
+    undefined,
+    true,
+  );
   return o === null ? null : (o.context ?? "");
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty nudge and guidance responses are now handled successfully instead of being reported as failures.
  * Genuine execution and parsing errors continue to be reported appropriately.
  * Improved reliability when helper tools return no content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->