### PR TITLE
refactor(client): add NodeURL so graph identity is built in one place

### DIFF
--- a/client/cmd/demarkus-mcp/explore.go
+++ b/client/cmd/demarkus-mcp/explore.go
@@ -86,7 +86,7 @@ func (h *handler) markExplore(_ context.Context, req mcp.CallToolRequest) (*mcp.
 	}
 
 	h.seedGraph(host)
-	h.writeBacklinksSection(&b, "mark://"+host+path)
+	h.writeBacklinksSection(&b, links.NodeURL(host, path))
 	h.writeSiblingsSection(&b, host, path, token)
 
 	fmt.Fprintf(&b, "\nfetch %s#<anchor> for a section; mark_fetch force=true for the full body\n", docURL)

--- a/client/cmd/demarkus-mcp/explore_test.go
+++ b/client/cmd/demarkus-mcp/explore_test.go
@@ -117,7 +117,9 @@ func TestHandlerMarkExplore_BacklinksFromStore(t *testing.T) {
 	h := &handler{client: exploreStub(), graphStore: gs}
 	text := exploreText(t, h, "mark://host:6309/hub.md")
 
-	if !strings.Contains(text, "## Backlinks (1)") || !strings.Contains(text, "[Page A](mark://host:6309/a.md)") {
+	// The card shows node identity, which omits the default port (ADR 0005),
+	// even though the caller addressed the document by its dial address.
+	if !strings.Contains(text, "## Backlinks (1)") || !strings.Contains(text, "[Page A](mark://host/a.md)") {
 		t.Errorf("expected enriched backlink in card:\n%s", text)
 	}
 }

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -1360,9 +1360,8 @@ func (h *handler) markBacklinks(_ context.Context, req mcp.CallToolRequest) (*mc
 		return mcp.NewToolResultError("url is required"), nil
 	}
 
-	// Canonicalize (default port included) so the lookup key matches both
-	// crawled and seeded rows: the hub's /graph.md aggregate stores
-	// canonical mark://host:port URLs.
+	// Key on node identity, which omits the default port (ADR 0005), so the
+	// lookup matches both crawled and seeded rows.
 	host, path, err := h.resolveURL(rawURL)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", err)), nil

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/latebit-io/demarkus/client/internal/cache"
 	"github.com/latebit-io/demarkus/client/internal/listwalk"
 	"github.com/latebit-io/demarkus/client/internal/tokens"
+	"github.com/latebit-io/demarkus/client/links"
 	"github.com/latebit-io/demarkus/client/mdoutline"
 	"github.com/latebit-io/demarkus/client/merge"
 	"github.com/latebit-io/demarkus/protocol"
@@ -1270,9 +1271,9 @@ func (h *handler) markGraph(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", err)), nil
 	}
-	// Canonical start URL (default port included) so crawled rows share the
-	// key form of the hub's /graph.md aggregate and backlink lookups.
-	startURL := "mark://" + host + path
+	// Node identity omits the default port (ADR 0005), so crawled rows share
+	// the key form of the hub's /graph.md aggregate and backlink lookups.
+	startURL := links.NodeURL(host, path)
 
 	if h.graphStore == nil {
 		return mcp.NewToolResultError("graph store not available"), nil
@@ -1366,7 +1367,7 @@ func (h *handler) markBacklinks(_ context.Context, req mcp.CallToolRequest) (*mc
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", err)), nil
 	}
-	fullURL := "mark://" + host + path
+	fullURL := links.NodeURL(host, path)
 
 	if h.graphStore == nil {
 		return mcp.NewToolResultError("graph store not available"), nil

--- a/client/cmd/demarkus-mcp/main_test.go
+++ b/client/cmd/demarkus-mcp/main_test.go
@@ -1202,7 +1202,7 @@ func TestHandlerMarkBacklinks_HappyPath(t *testing.T) {
 	if !strings.Contains(text.Text, "Page B") {
 		t.Errorf("expected backlink title 'Page B' in output: %s", text.Text)
 	}
-	if !strings.Contains(text.Text, "mark://host:6309/a.md") {
+	if !strings.Contains(text.Text, "mark://host/a.md") {
 		t.Errorf("expected backlink URL in output: %s", text.Text)
 	}
 }
@@ -1248,7 +1248,7 @@ func TestHandlerMarkGraphExport(t *testing.T) {
 	if !strings.Contains(text.Text, "# Document Graph") {
 		t.Error("expected markdown title in output")
 	}
-	if !strings.Contains(text.Text, "mark://host:6309/a.md") {
+	if !strings.Contains(text.Text, "mark://host/a.md") {
 		t.Error("expected node URL in output")
 	}
 	if !strings.Contains(text.Text, "## Edges") {
@@ -1348,7 +1348,7 @@ func TestHandlerMarkGraphPublish(t *testing.T) {
 	if !strings.Contains(publishedBody, "# Document Graph") {
 		t.Error("published body should contain graph export")
 	}
-	if !strings.Contains(publishedBody, "mark://host:6309/a.md") {
+	if !strings.Contains(publishedBody, "mark://host/a.md") {
 		t.Error("published body should contain node URLs")
 	}
 }

--- a/client/cmd/demarkus-mcp/seed_test.go
+++ b/client/cmd/demarkus-mcp/seed_test.go
@@ -66,7 +66,7 @@ func TestSeedGraph_ColdStoreAnswersBacklinks(t *testing.T) {
 		t.Fatalf("unexpected tool error: %v", res.Content)
 	}
 	text := resultText(t, res)
-	if !strings.Contains(text, "Page A") || !strings.Contains(text, "mark://host:6309/a.md") {
+	if !strings.Contains(text, "Page A") || !strings.Contains(text, "mark://host/a.md") {
 		t.Errorf("seeded backlink missing from output: %s", text)
 	}
 	if gotPath != "/graph.md" {

--- a/client/graph/crawl.go
+++ b/client/graph/crawl.go
@@ -55,6 +55,9 @@ type RelRef struct {
 // Malformed refs (empty, internal whitespace) and self-references are skipped
 // silently: bad metadata must never fail a crawl.
 func RelEdges(docURL string, metadata map[string]string) []RelRef {
+	// Callers may pass a dial address (fedcrawl does); compare like with like
+	// so a self-reference is not mistaken for an edge to a different node.
+	docURL = links.CanonicalURL(docURL)
 	var refs []RelRef
 	for key, val := range metadata {
 		pred, ok := strings.CutPrefix(key, "rel-")

--- a/client/graph/crawl.go
+++ b/client/graph/crawl.go
@@ -66,7 +66,7 @@ func RelEdges(docURL string, metadata map[string]string) []RelRef {
 			if ref == "" || strings.IndexFunc(ref, unicode.IsSpace) >= 0 {
 				continue
 			}
-			resolved := links.Resolve(docURL, ref)
+			resolved := links.CanonicalURL(links.Resolve(docURL, ref))
 			if resolved == docURL {
 				continue
 			}
@@ -85,6 +85,10 @@ func RelEdges(docURL string, metadata map[string]string) []RelRef {
 func Crawl(ctx context.Context, startURL string, fetcher Fetcher, parseURL func(string) (string, string, error), opts CrawlOptions) (*Graph, error) {
 	opts.applyDefaults()
 	g := New()
+
+	// Node identity is canonical from the first key onward (ADR 0005), so a
+	// caller passing a dial address cannot fork the graph into two key spaces.
+	startURL = links.CanonicalURL(startURL)
 
 	queue := make(chan crawlItem, 1000)
 	var wg sync.WaitGroup
@@ -172,7 +176,7 @@ func Crawl(ctx context.Context, startURL string, fetcher Fetcher, parseURL func(
 						}
 
 						for _, l := range anchored {
-							resolved := links.Resolve(item.url, l.Dest)
+							resolved := links.CanonicalURL(links.Resolve(item.url, l.Dest))
 							g.AddEdgeInfo(Edge{From: item.url, To: resolved, Label: l.Label, Anchor: l.Anchor, Count: 1})
 							enqueue(resolved)
 						}

--- a/client/graph/crawl_test.go
+++ b/client/graph/crawl_test.go
@@ -61,6 +61,12 @@ func mockParseURL(raw string) (host, path string, err error) {
 // withDefaultPort mirrors fetch.ParseMarkURL: a dial address needs a port even
 // though the canonical identity omits the default one (ADR 0005).
 func withDefaultPort(host string) string {
+	if strings.HasPrefix(host, "[") {
+		if strings.HasSuffix(host, "]") { // bracketed IPv6, no port
+			return host + ":6309"
+		}
+		return host
+	}
 	if strings.Contains(host, ":") {
 		return host
 	}
@@ -365,5 +371,45 @@ func TestCrawlSkipsMalformedRelRefs(t *testing.T) {
 	}
 	if g.EdgeCount() != 0 {
 		t.Errorf("EdgeCount = %d, want 0: %+v", g.EdgeCount(), g.GetEdges())
+	}
+}
+
+// A rel- target that points back at the document is a self-reference even when
+// the caller addressed the document by its dial address. fedcrawl does exactly
+// that, so comparing raw strings would emit a bogus self-edge.
+func TestRelEdgesSkipsSelfReferenceAcrossURLForms(t *testing.T) {
+	for _, docURL := range []string{"mark://host:6309/doc.md", "mark://host/doc.md"} {
+		refs := RelEdges(docURL, map[string]string{"rel-supersedes": "/doc.md, /other.md"})
+		if len(refs) != 1 {
+			t.Fatalf("RelEdges(%q) = %+v, want only the non-self target", docURL, refs)
+		}
+		if refs[0].Target != "mark://host/other.md" {
+			t.Errorf("target = %q, want mark://host/other.md", refs[0].Target)
+		}
+	}
+}
+
+// A bracketed IPv6 authority carries the default port for dialing and drops it
+// for identity, the same as any other host.
+func TestCrawlIPv6Identity(t *testing.T) {
+	f := newMockFetcher()
+	f.add("[::1]:6309", "/doc.md", "# Doc\n\n[Other](/other.md)\n")
+	f.add("[::1]:6309", "/other.md", "# Other\n")
+
+	g, err := Crawl(context.Background(), "mark://[::1]/doc.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
+	if err != nil {
+		t.Fatalf("Crawl() error: %v", err)
+	}
+	n := g.GetNode("mark://[::1]/doc.md")
+	if n == nil || n.Status != "ok" {
+		t.Fatalf("node = %+v, want an ok node under the identity key", n)
+	}
+	if g.GetNode("mark://[::1]/other.md") == nil {
+		t.Error("linked IPv6 node missing under its identity key")
+	}
+	for _, e := range g.GetEdges() {
+		if strings.Contains(e.From, ":6309") || strings.Contains(e.To, ":6309") {
+			t.Errorf("edge %s -> %s kept the dial port", e.From, e.To)
+		}
 	}
 }

--- a/client/graph/crawl_test.go
+++ b/client/graph/crawl_test.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -39,7 +40,7 @@ func (m *mockFetcher) Fetch(host, path string) (FetchResult, error) {
 }
 
 func mockParseURL(raw string) (host, path string, err error) {
-	// Minimal parser for mark://host:6309/path
+	// Minimal parser for mark://host/path
 	if len(raw) < 7 || raw[:7] != "mark://" {
 		return "", "", fmt.Errorf("not a mark URL: %s", raw)
 	}
@@ -52,16 +53,25 @@ func mockParseURL(raw string) (host, path string, err error) {
 		}
 	}
 	if slashIdx < 0 {
-		return rest, "/", nil
+		return withDefaultPort(rest), "/", nil
 	}
-	return rest[:slashIdx], rest[slashIdx:], nil
+	return withDefaultPort(rest[:slashIdx]), rest[slashIdx:], nil
+}
+
+// withDefaultPort mirrors fetch.ParseMarkURL: a dial address needs a port even
+// though the canonical identity omits the default one (ADR 0005).
+func withDefaultPort(host string) string {
+	if strings.Contains(host, ":") {
+		return host
+	}
+	return host + ":6309"
 }
 
 func TestCrawlSinglePage(t *testing.T) {
 	f := newMockFetcher()
 	f.add("host:6309", "/index.md", "# Home\n\nNo links here.")
 
-	g, err := Crawl(context.Background(), "mark://host:6309/index.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
+	g, err := Crawl(context.Background(), "mark://host/index.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
 	if err != nil {
 		t.Fatalf("Crawl() error: %v", err)
 	}
@@ -69,7 +79,7 @@ func TestCrawlSinglePage(t *testing.T) {
 	if g.NodeCount() != 1 {
 		t.Fatalf("NodeCount() = %d, want 1", g.NodeCount())
 	}
-	n := g.GetNode("mark://host:6309/index.md")
+	n := g.GetNode("mark://host/index.md")
 	if n == nil {
 		t.Fatal("start node not found")
 	}
@@ -89,7 +99,7 @@ func TestCrawlFollowsLinks(t *testing.T) {
 	f.add("host:6309", "/index.md", "# Home\n\nGo to [about](about.md).")
 	f.add("host:6309", "/about.md", "# About\n\nBack to [home](index.md).")
 
-	g, err := Crawl(context.Background(), "mark://host:6309/index.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
+	g, err := Crawl(context.Background(), "mark://host/index.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
 	if err != nil {
 		t.Fatalf("Crawl() error: %v", err)
 	}
@@ -101,7 +111,7 @@ func TestCrawlFollowsLinks(t *testing.T) {
 		t.Fatalf("EdgeCount() = %d, want 2", g.EdgeCount())
 	}
 
-	about := g.GetNode("mark://host:6309/about.md")
+	about := g.GetNode("mark://host/about.md")
 	if about == nil {
 		t.Fatal("about node not found")
 	}
@@ -117,24 +127,24 @@ func TestCrawlRespectsDepthLimit(t *testing.T) {
 	f.add("host:6309", "/c.md", "# C\n\n[d](d.md)")
 	f.add("host:6309", "/d.md", "# D\n\nEnd.")
 
-	g, err := Crawl(context.Background(), "mark://host:6309/a.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
+	g, err := Crawl(context.Background(), "mark://host/a.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
 	if err != nil {
 		t.Fatalf("Crawl() error: %v", err)
 	}
 
 	// a(0) -> b(1) -> c(2) -> d would be depth 3, should not be crawled
-	if g.GetNode("mark://host:6309/a.md") == nil {
+	if g.GetNode("mark://host/a.md") == nil {
 		t.Error("a not found")
 	}
-	if g.GetNode("mark://host:6309/b.md") == nil {
+	if g.GetNode("mark://host/b.md") == nil {
 		t.Error("b not found")
 	}
-	if g.GetNode("mark://host:6309/c.md") == nil {
+	if g.GetNode("mark://host/c.md") == nil {
 		t.Error("c not found")
 	}
 	// d should not be fetched (depth 3), but it may exist as an unfetched node
 	// since c links to it — however c is at depth 2 so its links are NOT followed
-	if n := g.GetNode("mark://host:6309/d.md"); n != nil {
+	if n := g.GetNode("mark://host/d.md"); n != nil {
 		t.Errorf("d should not be discovered, but found with status %q", n.Status)
 	}
 }
@@ -144,12 +154,12 @@ func TestCrawlHandlesNotFound(t *testing.T) {
 	f.add("host:6309", "/index.md", "# Home\n\n[missing](missing.md)")
 	// missing.md is not added, so it returns not-found
 
-	g, err := Crawl(context.Background(), "mark://host:6309/index.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
+	g, err := Crawl(context.Background(), "mark://host/index.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
 	if err != nil {
 		t.Fatalf("Crawl() error: %v", err)
 	}
 
-	missing := g.GetNode("mark://host:6309/missing.md")
+	missing := g.GetNode("mark://host/missing.md")
 	if missing == nil {
 		t.Fatal("missing node not found in graph")
 	}
@@ -162,7 +172,7 @@ func TestCrawlExternalLinksNotCrawled(t *testing.T) {
 	f := newMockFetcher()
 	f.add("host:6309", "/index.md", "# Home\n\n[ext](https://example.com)")
 
-	g, err := Crawl(context.Background(), "mark://host:6309/index.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
+	g, err := Crawl(context.Background(), "mark://host/index.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
 	if err != nil {
 		t.Fatalf("Crawl() error: %v", err)
 	}
@@ -188,7 +198,7 @@ func TestCrawlCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
-	g, err := Crawl(ctx, "mark://host:6309/a.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
+	g, err := Crawl(ctx, "mark://host/a.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
 	if err != nil {
 		t.Fatalf("Crawl() error: %v", err)
 	}
@@ -213,7 +223,7 @@ func TestCrawlOnNodeCallback(t *testing.T) {
 		mu.Unlock()
 	}
 
-	g, err := Crawl(context.Background(), "mark://host:6309/a.md", f, mockParseURL, CrawlOptions{MaxDepth: 2, OnNode: onNode})
+	g, err := Crawl(context.Background(), "mark://host/a.md", f, mockParseURL, CrawlOptions{MaxDepth: 2, OnNode: onNode})
 	if err != nil {
 		t.Fatalf("Crawl() error: %v", err)
 	}
@@ -230,7 +240,7 @@ func TestCrawlNoCycles(t *testing.T) {
 	f.add("host:6309", "/b.md", "# B\n\n[c](c.md)")
 	f.add("host:6309", "/c.md", "# C\n\n[a](a.md)")
 
-	g, err := Crawl(context.Background(), "mark://host:6309/a.md", f, mockParseURL, CrawlOptions{MaxDepth: 10})
+	g, err := Crawl(context.Background(), "mark://host/a.md", f, mockParseURL, CrawlOptions{MaxDepth: 10})
 	if err != nil {
 		t.Fatalf("Crawl() error: %v", err)
 	}
@@ -261,12 +271,12 @@ func TestCrawlRecordsLabelAndAnchor(t *testing.T) {
 	f.add("host:6309", "/index.md", "# Home\n\n## Section\n\nSee [About page](about.md).")
 	f.add("host:6309", "/about.md", "# About\n")
 
-	g, err := Crawl(context.Background(), "mark://host:6309/index.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
+	g, err := Crawl(context.Background(), "mark://host/index.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
 	if err != nil {
 		t.Fatalf("Crawl() error: %v", err)
 	}
 
-	e := findEdge(t, g, "mark://host:6309/index.md", "mark://host:6309/about.md", "")
+	e := findEdge(t, g, "mark://host/index.md", "mark://host/about.md", "")
 	if e.Label != "About page" || e.Anchor != "section" || e.Count != 1 {
 		t.Errorf("edge = %+v, want Label=About page Anchor=section Count=1", e)
 	}
@@ -277,12 +287,12 @@ func TestCrawlRecordsLinkInsideInlineFormatting(t *testing.T) {
 	f.add("host:6309", "/index.md", "# Home\n\n## Section\n\n**[Bold link](about.md)**")
 	f.add("host:6309", "/about.md", "# About\n")
 
-	g, err := Crawl(context.Background(), "mark://host:6309/index.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
+	g, err := Crawl(context.Background(), "mark://host/index.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
 	if err != nil {
 		t.Fatalf("Crawl() error: %v", err)
 	}
 
-	e := findEdge(t, g, "mark://host:6309/index.md", "mark://host:6309/about.md", "")
+	e := findEdge(t, g, "mark://host/index.md", "mark://host/about.md", "")
 	if e.Label != "Bold link" || e.Anchor != "section" {
 		t.Errorf("edge = %+v, want Label=Bold link Anchor=section", e)
 	}
@@ -293,19 +303,19 @@ func TestCrawlAggregatesRepeatedLinks(t *testing.T) {
 	f.add("host:6309", "/index.md", "# Home\n\n[first](about.md) then [second](about.md)")
 	f.add("host:6309", "/about.md", "# About\n")
 
-	g, err := Crawl(context.Background(), "mark://host:6309/index.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
+	g, err := Crawl(context.Background(), "mark://host/index.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
 	if err != nil {
 		t.Fatalf("Crawl() error: %v", err)
 	}
 
-	e := findEdge(t, g, "mark://host:6309/index.md", "mark://host:6309/about.md", "")
+	e := findEdge(t, g, "mark://host/index.md", "mark://host/about.md", "")
 	if e.Count != 2 {
 		t.Errorf("Count = %d, want 2", e.Count)
 	}
 	if e.Label != "first" {
 		t.Errorf("Label = %q, want first (first label wins)", e.Label)
 	}
-	if n := g.GetNode("mark://host:6309/index.md"); n.LinkCount != 2 {
+	if n := g.GetNode("mark://host/index.md"); n.LinkCount != 2 {
 		t.Errorf("LinkCount = %d, want 2", n.LinkCount)
 	}
 }
@@ -319,13 +329,13 @@ func TestCrawlIngestsRelMetadata(t *testing.T) {
 	f.add("host:6309", "/adr/0002.md", "# ADR 0002\n")
 	f.add("host:6309", "/adr/0003.md", "# ADR 0003\n")
 
-	g, err := Crawl(context.Background(), "mark://host:6309/adr/0004.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
+	g, err := Crawl(context.Background(), "mark://host/adr/0004.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
 	if err != nil {
 		t.Fatalf("Crawl() error: %v", err)
 	}
 
-	for _, target := range []string{"mark://host:6309/adr/0002.md", "mark://host:6309/adr/0003.md"} {
-		e := findEdge(t, g, "mark://host:6309/adr/0004.md", target, "supersedes")
+	for _, target := range []string{"mark://host/adr/0002.md", "mark://host/adr/0003.md"} {
+		e := findEdge(t, g, "mark://host/adr/0004.md", target, "supersedes")
 		if e.Count != 1 || e.Label != "" {
 			t.Errorf("edge = %+v, want Count=1 empty Label", e)
 		}
@@ -336,7 +346,7 @@ func TestCrawlIngestsRelMetadata(t *testing.T) {
 	}
 
 	// rel- edges do not count as body links.
-	if n := g.GetNode("mark://host:6309/adr/0004.md"); n.LinkCount != 0 {
+	if n := g.GetNode("mark://host/adr/0004.md"); n.LinkCount != 0 {
 		t.Errorf("LinkCount = %d, want 0", n.LinkCount)
 	}
 }
@@ -349,7 +359,7 @@ func TestCrawlSkipsMalformedRelRefs(t *testing.T) {
 		"rel-self":       "/doc.md",
 	})
 
-	g, err := Crawl(context.Background(), "mark://host:6309/doc.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
+	g, err := Crawl(context.Background(), "mark://host/doc.md", f, mockParseURL, CrawlOptions{MaxDepth: 2})
 	if err != nil {
 		t.Fatalf("Crawl() error: %v", err)
 	}

--- a/client/graphstore/store.go
+++ b/client/graphstore/store.go
@@ -22,10 +22,16 @@ import (
 	"github.com/latebit-io/demarkus/client/fetch"
 	"github.com/latebit-io/demarkus/client/graph"
 	"github.com/latebit-io/demarkus/client/internal/tokens"
+	"github.com/latebit-io/demarkus/client/links"
 )
 
 // schemaVersion is the on-disk format version. Increment on breaking changes.
-const schemaVersion = 1
+// v2 keys nodes by canonical identity, the authority without the default
+// port (ADR 0005); v1 files are migrated on load.
+const schemaVersion = 2
+
+// minSchemaVersion is the oldest on-disk format still readable.
+const minSchemaVersion = 1
 
 // StoredNode is a graph node with persistence metadata.
 type StoredNode struct {
@@ -125,18 +131,26 @@ func Load(path string) (*Store, error) {
 	if err := json.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("parse graph store %q: %w", path, err)
 	}
-	if doc.Version != schemaVersion {
-		return nil, fmt.Errorf("graph store %q: unsupported schema version %d (expected %d)", path, doc.Version, schemaVersion)
+	if doc.Version < minSchemaVersion || doc.Version > schemaVersion {
+		return nil, fmt.Errorf("graph store %q: unsupported schema version %d (expected %d..%d)", path, doc.Version, minSchemaVersion, schemaVersion)
 	}
 
+	// v1 keyed nodes by whatever the crawler was handed, so one document could
+	// appear under both mark://host/x and mark://host:6309/x. Canonicalizing on
+	// load merges those, keeping the more recently crawled copy.
 	for i := range doc.Nodes {
 		n := doc.Nodes[i]
+		n.URL = links.CanonicalURL(n.URL)
+		if prev := s.nodes[n.URL]; prev != nil && prev.CrawledAt.After(n.CrawledAt) {
+			continue
+		}
 		s.nodes[n.URL] = &n
 	}
 	for _, e := range doc.Edges {
 		if e.Count < 1 {
 			e.Count = 1 // legacy rows predate Count; an edge on disk means one occurrence
 		}
+		e.From, e.To = links.CanonicalURL(e.From), links.CanonicalURL(e.To)
 		if _, exists := s.edgeIdx[e.key()]; !exists {
 			s.edgeIdx[e.key()] = len(s.edges)
 			s.edges = append(s.edges, e)
@@ -213,6 +227,7 @@ func (s *Store) Merge(g *graph.Graph, etags map[string]string) int {
 	refreshed := make(map[string]bool)
 
 	for _, n := range g.AllNodes() {
+		n.URL = links.CanonicalURL(n.URL)
 		if !observedStatus(n.Status) {
 			// Failed fetch: we learned nothing about this node. Keep the
 			// stored copy untouched (its CrawledAt keeps it authoritative
@@ -247,7 +262,7 @@ func (s *Store) Merge(g *graph.Graph, etags map[string]string) int {
 	s.dropEdgesFromLocked(refreshed)
 
 	for _, e := range g.GetEdges() {
-		se := StoredEdge{From: e.From, To: e.To, Rel: e.Rel, Label: e.Label, Anchor: e.Anchor, Count: max(e.Count, 1)}
+		se := StoredEdge{From: links.CanonicalURL(e.From), To: links.CanonicalURL(e.To), Rel: e.Rel, Label: e.Label, Anchor: e.Anchor, Count: max(e.Count, 1)}
 		s.upsertEdgeLocked(&se)
 	}
 
@@ -319,6 +334,9 @@ func (s *Store) SeedFromExport(nodes []StoredNode, edges []StoredEdge) int {
 
 	added := 0
 	for _, n := range nodes {
+		// Another producer's export may predate ADR 0005 or address its worlds
+		// differently; normalize before it reaches a stored key.
+		n.URL = links.CanonicalURL(n.URL)
 		if s.authoritativeLocked(n.URL) {
 			continue
 		}
@@ -341,9 +359,11 @@ func (s *Store) SeedFromExport(nodes []StoredNode, edges []StoredEdge) int {
 			seeded[n.URL] = true
 		}
 	}
-	for _, e := range edges {
-		if !s.authoritativeLocked(e.From) {
-			seeded[e.From] = true
+	for i := range edges {
+		edges[i].From = links.CanonicalURL(edges[i].From)
+		edges[i].To = links.CanonicalURL(edges[i].To)
+		if !s.authoritativeLocked(edges[i].From) {
+			seeded[edges[i].From] = true
 		}
 	}
 	s.dropEdgesFromLocked(seeded)
@@ -376,6 +396,7 @@ func (s *Store) SetSeedEtag(host, etag string) {
 // Backlinks returns all URLs that link to the given URL, sorted alphabetically.
 // A source appears once even when it carries several edges (plain plus typed).
 func (s *Store) Backlinks(url string) []string {
+	url = links.CanonicalURL(url)
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -406,6 +427,7 @@ type BacklinkEntry struct {
 // title/status and edge provenance. One entry per edge, so a source appears
 // once per relation. Sorted by URL then Rel.
 func (s *Store) BacklinksEnriched(url string) []BacklinkEntry {
+	url = links.CanonicalURL(url)
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -444,6 +466,7 @@ func (s *Store) AllNodes() []StoredNode {
 
 // GetNode returns the stored node for a URL, or nil if not found.
 func (s *Store) GetNode(url string) *StoredNode {
+	url = links.CanonicalURL(url)
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	n := s.nodes[url]
@@ -502,7 +525,8 @@ func (f *EtagFetcher) Fetch(host, path string) (graph.FetchResult, error) {
 		return graph.FetchResult{}, err
 	}
 	if etag := res.Metadata["etag"]; etag != "" {
-		url := "mark://" + host + path
+		// host carries the dial port; the etag map is keyed by node identity.
+		url := links.NodeURL(host, path)
 		f.mu.Lock()
 		f.etags[url] = etag
 		f.mu.Unlock()
@@ -553,18 +577,11 @@ func (s *Store) CrawlAndPersist(
 	parseURL func(string) (string, string, error),
 	opts CrawlOptions,
 ) (*graph.Graph, error) {
-	// Canonical mark://host:port/path is the node-identity contract shared by
-	// stored keys, the etag map, and /graph.md. Only mark:// URLs are parsed;
-	// Crawl records anything else as an external node without a parser.
-	if strings.HasPrefix(startURL, "mark://") {
-		if parseURL == nil {
-			// Crawl would dereference the nil parser inside a worker goroutine,
-			// panicking the process where a caller cannot recover.
-			return nil, fmt.Errorf("crawl %s: parseURL is required for mark:// URLs", startURL)
-		}
-		if host, path, parseErr := parseURL(startURL); parseErr == nil {
-			startURL = "mark://" + host + path
-		}
+	// Crawl canonicalizes the start itself, but a nil parser would only be
+	// dereferenced inside a worker goroutine, panicking the process where no
+	// caller can recover. Fail here instead.
+	if strings.HasPrefix(startURL, "mark://") && parseURL == nil {
+		return nil, fmt.Errorf("crawl %s: parseURL is required for mark:// URLs", startURL)
 	}
 
 	fetcher := NewEtagFetcher(fetchFunc)

--- a/client/graphstore/store_test.go
+++ b/client/graphstore/store_test.go
@@ -43,13 +43,13 @@ func TestSaveLoad(t *testing.T) {
 	}
 
 	g := graph.New()
-	g.AddNode(&graph.Node{URL: "mark://a:6309/index.md", Title: "Home", Status: "ok", LinkCount: 2})
-	g.AddNode(&graph.Node{URL: "mark://a:6309/about.md", Title: "About", Status: "ok", LinkCount: 0})
-	g.AddEdge("mark://a:6309/index.md", "mark://a:6309/about.md")
+	g.AddNode(&graph.Node{URL: "mark://a/index.md", Title: "Home", Status: "ok", LinkCount: 2})
+	g.AddNode(&graph.Node{URL: "mark://a/about.md", Title: "About", Status: "ok", LinkCount: 0})
+	g.AddEdge("mark://a/index.md", "mark://a/about.md")
 
 	etags := map[string]string{
-		"mark://a:6309/index.md": "etag-1",
-		"mark://a:6309/about.md": "etag-2",
+		"mark://a/index.md": "etag-1",
+		"mark://a/about.md": "etag-2",
 	}
 	count := s.Merge(g, etags)
 	if count != 2 {
@@ -71,7 +71,7 @@ func TestSaveLoad(t *testing.T) {
 		t.Errorf("EdgeCount = %d, want 1", s2.EdgeCount())
 	}
 
-	n := s2.GetNode("mark://a:6309/index.md")
+	n := s2.GetNode("mark://a/index.md")
 	if n == nil {
 		t.Fatal("GetNode returned nil")
 	}
@@ -94,17 +94,17 @@ func TestMergeUpdatesNode(t *testing.T) {
 	}
 
 	g1 := graph.New()
-	g1.AddNode(&graph.Node{URL: "mark://a:6309/doc.md", Title: "Old", Status: "ok"})
+	g1.AddNode(&graph.Node{URL: "mark://a/doc.md", Title: "Old", Status: "ok"})
 	s.Merge(g1, nil)
 
 	g2 := graph.New()
-	g2.AddNode(&graph.Node{URL: "mark://a:6309/doc.md", Title: "New", Status: "ok"})
+	g2.AddNode(&graph.Node{URL: "mark://a/doc.md", Title: "New", Status: "ok"})
 	s.Merge(g2, nil)
 
 	if s.NodeCount() != 1 {
 		t.Errorf("NodeCount = %d, want 1", s.NodeCount())
 	}
-	n := s.GetNode("mark://a:6309/doc.md")
+	n := s.GetNode("mark://a/doc.md")
 	if n.Title != "New" {
 		t.Errorf("Title = %q, want %q", n.Title, "New")
 	}
@@ -118,17 +118,17 @@ func TestMergeAddsEdges(t *testing.T) {
 	}
 
 	g1 := graph.New()
-	g1.AddNode(&graph.Node{URL: "mark://a:6309/a.md"})
-	g1.AddNode(&graph.Node{URL: "mark://a:6309/b.md"})
-	g1.AddEdge("mark://a:6309/a.md", "mark://a:6309/b.md")
+	g1.AddNode(&graph.Node{URL: "mark://a/a.md"})
+	g1.AddNode(&graph.Node{URL: "mark://a/b.md"})
+	g1.AddEdge("mark://a/a.md", "mark://a/b.md")
 	s.Merge(g1, nil)
 
 	g2 := graph.New()
-	g2.AddNode(&graph.Node{URL: "mark://a:6309/a.md"})
-	g2.AddNode(&graph.Node{URL: "mark://a:6309/b.md"})
-	g2.AddNode(&graph.Node{URL: "mark://a:6309/c.md"})
-	g2.AddEdge("mark://a:6309/a.md", "mark://a:6309/b.md") // duplicate
-	g2.AddEdge("mark://a:6309/a.md", "mark://a:6309/c.md") // new
+	g2.AddNode(&graph.Node{URL: "mark://a/a.md"})
+	g2.AddNode(&graph.Node{URL: "mark://a/b.md"})
+	g2.AddNode(&graph.Node{URL: "mark://a/c.md"})
+	g2.AddEdge("mark://a/a.md", "mark://a/b.md") // duplicate
+	g2.AddEdge("mark://a/a.md", "mark://a/c.md") // new
 	s.Merge(g2, nil)
 
 	if s.EdgeCount() != 2 {
@@ -144,7 +144,7 @@ func TestMergeEnrichedEdgeIdempotent(t *testing.T) {
 	}
 
 	g := graph.New()
-	g.AddEdgeInfo(graph.Edge{From: "mark://a:6309/a.md", To: "mark://a:6309/b.md", Label: "B doc", Anchor: "intro", Count: 3})
+	g.AddEdgeInfo(graph.Edge{From: "mark://a/a.md", To: "mark://a/b.md", Label: "B doc", Anchor: "intro", Count: 3})
 	s.Merge(g, nil)
 	s.Merge(g, nil) // re-merging the same crawl must not inflate counts
 
@@ -166,22 +166,22 @@ func TestMergeReplacesRefreshedSourceEdges(t *testing.T) {
 	}
 
 	g1 := graph.New()
-	g1.AddNode(&graph.Node{URL: "mark://a:6309/a.md", Status: "ok", LinkCount: 1})
-	g1.AddEdgeInfo(graph.Edge{From: "mark://a:6309/a.md", To: "mark://a:6309/b.md"})
-	g1.AddEdgeInfo(graph.Edge{From: "mark://a:6309/a.md", To: "mark://a:6309/old.md", Rel: "supersedes"})
+	g1.AddNode(&graph.Node{URL: "mark://a/a.md", Status: "ok", LinkCount: 1})
+	g1.AddEdgeInfo(graph.Edge{From: "mark://a/a.md", To: "mark://a/b.md"})
+	g1.AddEdgeInfo(graph.Edge{From: "mark://a/a.md", To: "mark://a/old.md", Rel: "supersedes"})
 	s.Merge(g1, nil)
 
 	// The doc dropped the link to old.md and its rel- key; a refreshed crawl
 	// must replace the whole outgoing set, not just upsert.
 	g2 := graph.New()
-	g2.AddNode(&graph.Node{URL: "mark://a:6309/a.md", Status: "ok", LinkCount: 1})
-	g2.AddEdgeInfo(graph.Edge{From: "mark://a:6309/a.md", To: "mark://a:6309/b.md"})
+	g2.AddNode(&graph.Node{URL: "mark://a/a.md", Status: "ok", LinkCount: 1})
+	g2.AddEdgeInfo(graph.Edge{From: "mark://a/a.md", To: "mark://a/b.md"})
 	s.Merge(g2, nil)
 
 	if s.EdgeCount() != 1 {
 		t.Fatalf("EdgeCount = %d, want 1: %+v", s.EdgeCount(), s.edges)
 	}
-	if bl := s.Backlinks("mark://a:6309/old.md"); len(bl) != 0 {
+	if bl := s.Backlinks("mark://a/old.md"); len(bl) != 0 {
 		t.Errorf("stale backlink survived refresh: %v", bl)
 	}
 }
@@ -194,14 +194,14 @@ func TestMergeKeepsEdgesOfUnfetchedSources(t *testing.T) {
 	}
 
 	g1 := graph.New()
-	g1.AddNode(&graph.Node{URL: "mark://a:6309/x.md", Status: "ok", LinkCount: 1})
-	g1.AddEdgeInfo(graph.Edge{From: "mark://a:6309/x.md", To: "mark://a:6309/y.md"})
+	g1.AddNode(&graph.Node{URL: "mark://a/x.md", Status: "ok", LinkCount: 1})
+	g1.AddEdgeInfo(graph.Edge{From: "mark://a/x.md", To: "mark://a/y.md"})
 	s.Merge(g1, nil)
 
 	// A later crawl that only saw x.md as an error must not drop the edges
 	// recorded when it was last read successfully.
 	g2 := graph.New()
-	g2.AddNode(&graph.Node{URL: "mark://a:6309/x.md", Status: "error"})
+	g2.AddNode(&graph.Node{URL: "mark://a/x.md", Status: "error"})
 	s.Merge(g2, nil)
 
 	if s.EdgeCount() != 1 {
@@ -216,15 +216,15 @@ func TestMergePreservesResolvedNodeOnFailedRecrawl(t *testing.T) {
 	s := New()
 
 	g1 := graph.New()
-	g1.AddNode(&graph.Node{URL: "mark://a:6309/doc.md", Title: "Doc", Status: "ok", LinkCount: 2})
-	s.Merge(g1, map[string]string{"mark://a:6309/doc.md": "etag-1"})
-	firstCrawledAt := s.GetNode("mark://a:6309/doc.md").CrawledAt
+	g1.AddNode(&graph.Node{URL: "mark://a/doc.md", Title: "Doc", Status: "ok", LinkCount: 2})
+	s.Merge(g1, map[string]string{"mark://a/doc.md": "etag-1"})
+	firstCrawledAt := s.GetNode("mark://a/doc.md").CrawledAt
 
 	g2 := graph.New()
-	g2.AddNode(&graph.Node{URL: "mark://a:6309/doc.md", Status: "error"})
+	g2.AddNode(&graph.Node{URL: "mark://a/doc.md", Status: "error"})
 	s.Merge(g2, nil)
 
-	n := s.GetNode("mark://a:6309/doc.md")
+	n := s.GetNode("mark://a/doc.md")
 	if n.Title != "Doc" || n.Status != "ok" || n.LinkCount != 2 || n.Etag != "etag-1" {
 		t.Errorf("failed re-crawl clobbered resolved node: %+v", n)
 	}
@@ -233,8 +233,8 @@ func TestMergePreservesResolvedNodeOnFailedRecrawl(t *testing.T) {
 	}
 
 	// Still authoritative: a subsequent seed must not overwrite it either.
-	s.SeedFromExport([]StoredNode{{URL: "mark://a:6309/doc.md", Title: "Hub Doc", Status: "ok"}}, nil)
-	if n := s.GetNode("mark://a:6309/doc.md"); n.Title != "Doc" {
+	s.SeedFromExport([]StoredNode{{URL: "mark://a/doc.md", Title: "Hub Doc", Status: "ok"}}, nil)
+	if n := s.GetNode("mark://a/doc.md"); n.Title != "Doc" {
 		t.Errorf("seed overwrote node preserved through a failed re-crawl: %+v", n)
 	}
 }
@@ -244,14 +244,14 @@ func TestMergeRecordsNewUnfetchedNodes(t *testing.T) {
 
 	g := graph.New()
 	g.AddNode(&graph.Node{URL: "https://example.com/page", Status: "external"})
-	g.AddNode(&graph.Node{URL: "mark://a:6309/down.md", Status: "error"})
+	g.AddNode(&graph.Node{URL: "mark://a/down.md", Status: "error"})
 	if count := s.Merge(g, nil); count != 2 {
 		t.Errorf("Merge count = %d, want 2 (never-seen nodes still recorded)", count)
 	}
 	if n := s.GetNode("https://example.com/page"); n == nil || n.Status != "external" {
 		t.Errorf("external node not recorded: %+v", n)
 	}
-	if n := s.GetNode("mark://a:6309/down.md"); n == nil || n.Status != "error" {
+	if n := s.GetNode("mark://a/down.md"); n == nil || n.Status != "error" {
 		t.Errorf("error node not recorded: %+v", n)
 	}
 }
@@ -264,8 +264,8 @@ func TestMergeKeepsDistinctRels(t *testing.T) {
 	}
 
 	g := graph.New()
-	g.AddEdgeInfo(graph.Edge{From: "mark://a:6309/a.md", To: "mark://a:6309/b.md"})
-	g.AddEdgeInfo(graph.Edge{From: "mark://a:6309/a.md", To: "mark://a:6309/b.md", Rel: "supersedes"})
+	g.AddEdgeInfo(graph.Edge{From: "mark://a/a.md", To: "mark://a/b.md"})
+	g.AddEdgeInfo(graph.Edge{From: "mark://a/a.md", To: "mark://a/b.md", Rel: "supersedes"})
 	s.Merge(g, nil)
 
 	if s.EdgeCount() != 2 {
@@ -275,7 +275,7 @@ func TestMergeKeepsDistinctRels(t *testing.T) {
 
 func TestLoadLegacyEdgesDefaultsCount(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "graph.json")
-	legacy := `{"version":1,"nodes":[{"url":"mark://a:6309/a.md","title":"A","status":"ok","link_count":1,"crawled_at":"2026-01-01T00:00:00Z"}],"edges":[{"from":"mark://a:6309/a.md","to":"mark://a:6309/b.md"}]}`
+	legacy := `{"version":1,"nodes":[{"url":"mark://a/a.md","title":"A","status":"ok","link_count":1,"crawled_at":"2026-01-01T00:00:00Z"}],"edges":[{"from":"mark://a/a.md","to":"mark://a/b.md"}]}`
 	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
@@ -296,13 +296,53 @@ func TestLoadLegacyEdgesDefaultsCount(t *testing.T) {
 
 func TestLoadRejectsSchemaVersionMismatch(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "graph.json")
-	if err := os.WriteFile(path, []byte(`{"version":2,"nodes":[],"edges":[]}`), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(`{"version":3,"nodes":[],"edges":[]}`), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
 	_, err := Load(path)
 	if err == nil || !strings.Contains(err.Error(), "unsupported schema version") {
 		t.Fatalf("Load = %v, want unsupported schema version error", err)
+	}
+}
+
+// A v1 store keyed nodes by whatever the crawler was handed, so one document
+// could sit under both spellings. Load migrates to identity keys (ADR 0005)
+// and keeps the more recently crawled copy of a merged pair.
+func TestLoadMigratesV1KeysToIdentity(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.json")
+	v1 := `{"version":1,"nodes":[
+		{"url":"mark://a:6309/index.md","title":"stale","status":"ok","crawled_at":"2026-01-01T00:00:00Z"},
+		{"url":"mark://a/index.md","title":"fresh","status":"ok","crawled_at":"2026-06-01T00:00:00Z"},
+		{"url":"mark://a:7000/other.md","title":"other world","status":"ok","crawled_at":"2026-06-01T00:00:00Z"}
+	],"edges":[
+		{"from":"mark://a:6309/index.md","to":"mark://a/about.md"},
+		{"from":"mark://a/index.md","to":"mark://a:6309/about.md"}
+	]}`
+	if err := os.WriteFile(path, []byte(v1), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load v1: %v", err)
+	}
+
+	if s.NodeCount() != 2 {
+		t.Errorf("NodeCount = %d, want 2 (the two spellings merge)", s.NodeCount())
+	}
+	n := s.GetNode("mark://a/index.md")
+	if n == nil || n.Title != "fresh" {
+		t.Errorf("merged node = %+v, want the more recently crawled copy", n)
+	}
+	if s.GetNode("mark://a:7000/other.md") == nil {
+		t.Error("non-default port dropped; it names a different server")
+	}
+	if len(s.edges) != 1 {
+		t.Errorf("edges = %+v, want the two spellings deduped to 1", s.edges)
+	}
+	if bl := s.Backlinks("mark://a/about.md"); len(bl) != 1 || bl[0] != "mark://a/index.md" {
+		t.Errorf("Backlinks = %v, want [mark://a/index.md]", bl)
 	}
 }
 
@@ -314,22 +354,22 @@ func TestBacklinks(t *testing.T) {
 	}
 
 	g := graph.New()
-	g.AddNode(&graph.Node{URL: "mark://a:6309/a.md", Title: "A"})
-	g.AddNode(&graph.Node{URL: "mark://a:6309/b.md", Title: "B"})
-	g.AddNode(&graph.Node{URL: "mark://a:6309/c.md", Title: "C"})
-	g.AddEdge("mark://a:6309/a.md", "mark://a:6309/c.md")
-	g.AddEdge("mark://a:6309/b.md", "mark://a:6309/c.md")
+	g.AddNode(&graph.Node{URL: "mark://a/a.md", Title: "A"})
+	g.AddNode(&graph.Node{URL: "mark://a/b.md", Title: "B"})
+	g.AddNode(&graph.Node{URL: "mark://a/c.md", Title: "C"})
+	g.AddEdge("mark://a/a.md", "mark://a/c.md")
+	g.AddEdge("mark://a/b.md", "mark://a/c.md")
 	s.Merge(g, nil)
 
-	backlinks := s.Backlinks("mark://a:6309/c.md")
+	backlinks := s.Backlinks("mark://a/c.md")
 	if len(backlinks) != 2 {
 		t.Fatalf("len(backlinks) = %d, want 2", len(backlinks))
 	}
-	if backlinks[0] != "mark://a:6309/a.md" {
-		t.Errorf("backlinks[0] = %q, want %q", backlinks[0], "mark://a:6309/a.md")
+	if backlinks[0] != "mark://a/a.md" {
+		t.Errorf("backlinks[0] = %q, want %q", backlinks[0], "mark://a/a.md")
 	}
-	if backlinks[1] != "mark://a:6309/b.md" {
-		t.Errorf("backlinks[1] = %q, want %q", backlinks[1], "mark://a:6309/b.md")
+	if backlinks[1] != "mark://a/b.md" {
+		t.Errorf("backlinks[1] = %q, want %q", backlinks[1], "mark://a/b.md")
 	}
 }
 
@@ -340,7 +380,7 @@ func TestBacklinksNone(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	backlinks := s.Backlinks("mark://a:6309/unknown.md")
+	backlinks := s.Backlinks("mark://a/unknown.md")
 	if len(backlinks) != 0 {
 		t.Errorf("len(backlinks) = %d, want 0", len(backlinks))
 	}
@@ -354,9 +394,9 @@ func TestToGraph(t *testing.T) {
 	}
 
 	g := graph.New()
-	g.AddNode(&graph.Node{URL: "mark://a:6309/a.md", Title: "A", Status: "ok", LinkCount: 1})
-	g.AddNode(&graph.Node{URL: "mark://a:6309/b.md", Title: "B", Status: "ok"})
-	g.AddEdge("mark://a:6309/a.md", "mark://a:6309/b.md")
+	g.AddNode(&graph.Node{URL: "mark://a/a.md", Title: "A", Status: "ok", LinkCount: 1})
+	g.AddNode(&graph.Node{URL: "mark://a/b.md", Title: "B", Status: "ok"})
+	g.AddEdge("mark://a/a.md", "mark://a/b.md")
 	s.Merge(g, nil)
 
 	g2 := s.ToGraph()
@@ -367,7 +407,7 @@ func TestToGraph(t *testing.T) {
 		t.Errorf("EdgeCount = %d, want 1", g2.EdgeCount())
 	}
 
-	n := g2.GetNode("mark://a:6309/a.md")
+	n := g2.GetNode("mark://a/a.md")
 	if n == nil {
 		t.Fatal("GetNode returned nil")
 	}
@@ -388,7 +428,7 @@ func TestSaveAtomic(t *testing.T) {
 	}
 
 	g := graph.New()
-	g.AddNode(&graph.Node{URL: "mark://a:6309/a.md"})
+	g.AddNode(&graph.Node{URL: "mark://a/a.md"})
 	s.Merge(g, nil)
 
 	if err := s.Save(); err != nil {
@@ -414,20 +454,20 @@ func TestBacklinksEnriched(t *testing.T) {
 	}
 
 	g := graph.New()
-	g.AddNode(&graph.Node{URL: "mark://a:6309/a.md", Title: "A", Status: "ok"})
-	g.AddNode(&graph.Node{URL: "mark://a:6309/b.md", Title: "B", Status: "ok"})
-	g.AddNode(&graph.Node{URL: "mark://a:6309/c.md", Title: "C", Status: "ok"})
-	g.AddEdgeInfo(graph.Edge{From: "mark://a:6309/a.md", To: "mark://a:6309/c.md", Label: "see C", Anchor: "notes", Count: 2})
-	g.AddEdgeInfo(graph.Edge{From: "mark://a:6309/a.md", To: "mark://a:6309/c.md", Rel: "supersedes"})
-	g.AddEdge("mark://a:6309/b.md", "mark://a:6309/c.md")
+	g.AddNode(&graph.Node{URL: "mark://a/a.md", Title: "A", Status: "ok"})
+	g.AddNode(&graph.Node{URL: "mark://a/b.md", Title: "B", Status: "ok"})
+	g.AddNode(&graph.Node{URL: "mark://a/c.md", Title: "C", Status: "ok"})
+	g.AddEdgeInfo(graph.Edge{From: "mark://a/a.md", To: "mark://a/c.md", Label: "see C", Anchor: "notes", Count: 2})
+	g.AddEdgeInfo(graph.Edge{From: "mark://a/a.md", To: "mark://a/c.md", Rel: "supersedes"})
+	g.AddEdge("mark://a/b.md", "mark://a/c.md")
 	s.Merge(g, nil)
 
-	entries := s.BacklinksEnriched("mark://a:6309/c.md")
+	entries := s.BacklinksEnriched("mark://a/c.md")
 	if len(entries) != 3 {
 		t.Fatalf("len = %d, want 3", len(entries))
 	}
 	// Sorted by URL then Rel: a.md plain, a.md supersedes, b.md.
-	if entries[0].URL != "mark://a:6309/a.md" || entries[0].Rel != "" {
+	if entries[0].URL != "mark://a/a.md" || entries[0].Rel != "" {
 		t.Errorf("entries[0] = %+v, want a.md plain", entries[0])
 	}
 	if entries[0].Title != "A" {
@@ -439,10 +479,10 @@ func TestBacklinksEnriched(t *testing.T) {
 	if entries[0].Label != "see C" || entries[0].Anchor != "notes" || entries[0].Count != 2 {
 		t.Errorf("entries[0] = %+v, want Label=see C Anchor=notes Count=2", entries[0])
 	}
-	if entries[1].URL != "mark://a:6309/a.md" || entries[1].Rel != "supersedes" {
+	if entries[1].URL != "mark://a/a.md" || entries[1].Rel != "supersedes" {
 		t.Errorf("entries[1] = %+v, want a.md supersedes", entries[1])
 	}
-	if entries[2].URL != "mark://a:6309/b.md" {
+	if entries[2].URL != "mark://a/b.md" {
 		t.Errorf("entries[2].URL = %q, want b.md", entries[2].URL)
 	}
 }
@@ -455,11 +495,11 @@ func TestBacklinksDedupesMultiEdgeSources(t *testing.T) {
 	}
 
 	g := graph.New()
-	g.AddEdgeInfo(graph.Edge{From: "mark://a:6309/a.md", To: "mark://a:6309/c.md"})
-	g.AddEdgeInfo(graph.Edge{From: "mark://a:6309/a.md", To: "mark://a:6309/c.md", Rel: "supersedes"})
+	g.AddEdgeInfo(graph.Edge{From: "mark://a/a.md", To: "mark://a/c.md"})
+	g.AddEdgeInfo(graph.Edge{From: "mark://a/a.md", To: "mark://a/c.md", Rel: "supersedes"})
 	s.Merge(g, nil)
 
-	backlinks := s.Backlinks("mark://a:6309/c.md")
+	backlinks := s.Backlinks("mark://a/c.md")
 	if len(backlinks) != 1 {
 		t.Fatalf("len = %d, want 1 (source deduped across its edges)", len(backlinks))
 	}
@@ -472,7 +512,7 @@ func TestBacklinksEnrichedNone(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	entries := s.BacklinksEnriched("mark://a:6309/unknown.md")
+	entries := s.BacklinksEnriched("mark://a/unknown.md")
 	if len(entries) != 0 {
 		t.Errorf("len = %d, want 0", len(entries))
 	}
@@ -490,8 +530,8 @@ func TestAllNodes(t *testing.T) {
 	}
 
 	g := graph.New()
-	g.AddNode(&graph.Node{URL: "mark://a:6309/a.md", Title: "A", Status: "ok"})
-	g.AddNode(&graph.Node{URL: "mark://a:6309/b.md", Title: "B", Status: "ok"})
+	g.AddNode(&graph.Node{URL: "mark://a/a.md", Title: "A", Status: "ok"})
+	g.AddNode(&graph.Node{URL: "mark://a/b.md", Title: "B", Status: "ok"})
 	s.Merge(g, nil)
 
 	nodes := s.AllNodes()
@@ -503,7 +543,7 @@ func TestAllNodes(t *testing.T) {
 	for _, n := range nodes {
 		urls[n.URL] = true
 	}
-	if !urls["mark://a:6309/a.md"] || !urls["mark://a:6309/b.md"] {
+	if !urls["mark://a/a.md"] || !urls["mark://a/b.md"] {
 		t.Errorf("missing expected URLs: %v", urls)
 	}
 }
@@ -530,20 +570,8 @@ func TestCrawlAndPersist(t *testing.T) {
 		return graph.FetchResult{Status: "ok", Body: p.body, Metadata: map[string]string{"etag": p.etag}}, nil
 	}
 
-	parseURL := func(raw string) (string, string, error) {
-		if len(raw) > 7 && raw[:7] == "mark://" {
-			rest := raw[7:]
-			for i := range len(rest) {
-				if rest[i] == '/' {
-					return rest[:i], rest[i:], nil
-				}
-			}
-		}
-		return "", "", fmt.Errorf("invalid URL: %s", raw)
-	}
-
 	var nodeCount atomic.Int32
-	g, err := s.CrawlAndPersist(context.Background(), "mark://host:6309/index.md", fetchFunc, parseURL, CrawlOptions{
+	g, err := s.CrawlAndPersist(context.Background(), "mark://host:6309/index.md", fetchFunc, canonicalizingParseURL, CrawlOptions{
 		MaxDepth: 2,
 		MaxNodes: 100,
 		OnNode: func(_ *graph.Node) {
@@ -644,27 +672,29 @@ func crawlTwoPageSite(t *testing.T, startURL string) *Store {
 	return s
 }
 
-// A portless start URL must still key nodes canonically: the CLI passed the
-// raw address through, forking the store into two key spaces and leaving every
-// etag unattached, since EtagFetcher keys etags canonically.
+// A start URL carrying the default port must still key nodes by identity
+// (ADR 0005): the CLI passed the raw address through, forking the store into
+// two key spaces and leaving every etag unattached.
 func TestCrawlAndPersistCanonicalizesStartURL(t *testing.T) {
-	s := crawlTwoPageSite(t, "mark://host/index.md")
+	s := crawlTwoPageSite(t, "mark://host:6309/index.md")
 
-	if n := s.GetNode("mark://host/index.md"); n != nil {
-		t.Errorf("node stored under non-canonical key %q", n.URL)
+	for url := range s.nodes {
+		if strings.Contains(url, ":6309") {
+			t.Errorf("node stored under a dial address, not an identity: %q", url)
+		}
 	}
-	n := s.GetNode("mark://host:6309/index.md")
+	n := s.GetNode("mark://host/index.md")
 	if n == nil {
-		t.Fatal("no node under canonical key mark://host:6309/index.md")
+		t.Fatal("no node under canonical key mark://host/index.md")
 	}
 	if n.Etag != "etag-1" {
-		t.Errorf("Etag = %q, want %q (etag map is keyed canonically)", n.Etag, "etag-1")
+		t.Errorf("Etag = %q, want %q (etag map is keyed by identity)", n.Etag, "etag-1")
 	}
-	if s.GetNode("mark://host:6309/about.md") == nil {
+	if s.GetNode("mark://host/about.md") == nil {
 		t.Error("linked node not stored under a canonical key")
 	}
 	for _, e := range s.edges {
-		if !strings.HasPrefix(e.From, "mark://host:6309/") || !strings.HasPrefix(e.To, "mark://host:6309/") {
+		if !strings.HasPrefix(e.From, "mark://host/") || !strings.HasPrefix(e.To, "mark://host/") {
 			t.Errorf("edge %s -> %s is not canonical", e.From, e.To)
 		}
 	}
@@ -733,11 +763,11 @@ func TestSeedFromExportEmptyStore(t *testing.T) {
 	s := New()
 
 	nodes := []StoredNode{
-		{URL: "mark://a:6309/a.md", Title: "A", Status: "ok", LinkCount: 1},
-		{URL: "mark://a:6309/b.md", Title: "B", Status: "ok"},
+		{URL: "mark://a/a.md", Title: "A", Status: "ok", LinkCount: 1},
+		{URL: "mark://a/b.md", Title: "B", Status: "ok"},
 	}
 	edges := []StoredEdge{
-		{From: "mark://a:6309/a.md", To: "mark://a:6309/b.md", Rel: "", Label: "B", Anchor: "intro", Count: 2},
+		{From: "mark://a/a.md", To: "mark://a/b.md", Rel: "", Label: "B", Anchor: "intro", Count: 2},
 	}
 
 	added := s.SeedFromExport(nodes, edges)
@@ -747,10 +777,10 @@ func TestSeedFromExportEmptyStore(t *testing.T) {
 	if s.EdgeCount() != 1 {
 		t.Errorf("EdgeCount = %d, want 1", s.EdgeCount())
 	}
-	if bl := s.Backlinks("mark://a:6309/b.md"); len(bl) != 1 || bl[0] != "mark://a:6309/a.md" {
-		t.Errorf("Backlinks = %v, want [mark://a:6309/a.md]", bl)
+	if bl := s.Backlinks("mark://a/b.md"); len(bl) != 1 || bl[0] != "mark://a/a.md" {
+		t.Errorf("Backlinks = %v, want [mark://a/a.md]", bl)
 	}
-	n := s.GetNode("mark://a:6309/a.md")
+	n := s.GetNode("mark://a/a.md")
 	if n == nil {
 		t.Fatal("seeded node missing")
 	}
@@ -764,29 +794,29 @@ func TestSeedFromExportLocalWins(t *testing.T) {
 
 	// Local crawl: a.md links to b.md.
 	g := graph.New()
-	g.AddNode(&graph.Node{URL: "mark://a:6309/a.md", Title: "Local A", Status: "ok", LinkCount: 1})
-	g.AddEdgeInfo(graph.Edge{From: "mark://a:6309/a.md", To: "mark://a:6309/b.md"})
+	g.AddNode(&graph.Node{URL: "mark://a/a.md", Title: "Local A", Status: "ok", LinkCount: 1})
+	g.AddEdgeInfo(graph.Edge{From: "mark://a/a.md", To: "mark://a/b.md"})
 	s.Merge(g, nil)
 
 	// Seed claims a.md has a different title and links only to c.md.
-	nodes := []StoredNode{{URL: "mark://a:6309/a.md", Title: "Hub A", Status: "ok", LinkCount: 1}}
-	edges := []StoredEdge{{From: "mark://a:6309/a.md", To: "mark://a:6309/c.md", Count: 1}}
+	nodes := []StoredNode{{URL: "mark://a/a.md", Title: "Hub A", Status: "ok", LinkCount: 1}}
+	edges := []StoredEdge{{From: "mark://a/a.md", To: "mark://a/c.md", Count: 1}}
 	added := s.SeedFromExport(nodes, edges)
 
 	if added != 0 {
 		t.Errorf("added = %d, want 0 (authoritative node must not be seeded)", added)
 	}
-	n := s.GetNode("mark://a:6309/a.md")
+	n := s.GetNode("mark://a/a.md")
 	if n.Title != "Local A" {
 		t.Errorf("Title = %q, want %q", n.Title, "Local A")
 	}
 	if n.CrawledAt.IsZero() {
 		t.Error("authoritative node lost its CrawledAt")
 	}
-	if bl := s.Backlinks("mark://a:6309/c.md"); len(bl) != 0 {
+	if bl := s.Backlinks("mark://a/c.md"); len(bl) != 0 {
 		t.Errorf("seed edges leaked past authoritative source: %v", bl)
 	}
-	if bl := s.Backlinks("mark://a:6309/b.md"); len(bl) != 1 {
+	if bl := s.Backlinks("mark://a/b.md"); len(bl) != 1 {
 		t.Errorf("local edge dropped by seed: %v", bl)
 	}
 }
@@ -796,15 +826,15 @@ func TestSeedFromExportOverwritesNonAuthoritative(t *testing.T) {
 
 	// A locally crawled "error" node is not authoritative; seed may replace it.
 	g := graph.New()
-	g.AddNode(&graph.Node{URL: "mark://a:6309/a.md", Status: "error"})
+	g.AddNode(&graph.Node{URL: "mark://a/a.md", Status: "error"})
 	s.Merge(g, nil)
 
-	nodes := []StoredNode{{URL: "mark://a:6309/a.md", Title: "A", Status: "ok", LinkCount: 1}}
+	nodes := []StoredNode{{URL: "mark://a/a.md", Title: "A", Status: "ok", LinkCount: 1}}
 	added := s.SeedFromExport(nodes, nil)
 	if added != 1 {
 		t.Errorf("added = %d, want 1", added)
 	}
-	n := s.GetNode("mark://a:6309/a.md")
+	n := s.GetNode("mark://a/a.md")
 	if n.Status != "ok" || n.Title != "A" {
 		t.Errorf("node = %+v, want seeded ok/A", n)
 	}
@@ -816,27 +846,27 @@ func TestSeedFromExportOverwritesNonAuthoritative(t *testing.T) {
 func TestSeedThenCrawlFlipsAuthoritative(t *testing.T) {
 	s := New()
 
-	nodes := []StoredNode{{URL: "mark://a:6309/a.md", Title: "A", Status: "ok", LinkCount: 1}}
-	edges := []StoredEdge{{From: "mark://a:6309/a.md", To: "mark://a:6309/hub-only.md", Count: 1}}
+	nodes := []StoredNode{{URL: "mark://a/a.md", Title: "A", Status: "ok", LinkCount: 1}}
+	edges := []StoredEdge{{From: "mark://a/a.md", To: "mark://a/hub-only.md", Count: 1}}
 	s.SeedFromExport(nodes, edges)
 
 	// Local crawl of a.md observes a different outgoing set; Merge's refresh
 	// logic must replace the seeded edges.
 	g := graph.New()
-	g.AddNode(&graph.Node{URL: "mark://a:6309/a.md", Title: "A", Status: "ok", LinkCount: 1})
-	g.AddEdgeInfo(graph.Edge{From: "mark://a:6309/a.md", To: "mark://a:6309/b.md"})
+	g.AddNode(&graph.Node{URL: "mark://a/a.md", Title: "A", Status: "ok", LinkCount: 1})
+	g.AddEdgeInfo(graph.Edge{From: "mark://a/a.md", To: "mark://a/b.md"})
 	s.Merge(g, nil)
 
-	if bl := s.Backlinks("mark://a:6309/hub-only.md"); len(bl) != 0 {
+	if bl := s.Backlinks("mark://a/hub-only.md"); len(bl) != 0 {
 		t.Errorf("stale seeded edge survived local crawl: %v", bl)
 	}
-	if bl := s.Backlinks("mark://a:6309/b.md"); len(bl) != 1 {
+	if bl := s.Backlinks("mark://a/b.md"); len(bl) != 1 {
 		t.Errorf("crawled edge missing: %v", bl)
 	}
 
 	// Now authoritative: a re-seed must not touch it.
 	s.SeedFromExport(nodes, edges)
-	if bl := s.Backlinks("mark://a:6309/hub-only.md"); len(bl) != 0 {
+	if bl := s.Backlinks("mark://a/hub-only.md"); len(bl) != 0 {
 		t.Errorf("re-seed overwrote authoritative source: %v", bl)
 	}
 }
@@ -844,17 +874,17 @@ func TestSeedThenCrawlFlipsAuthoritative(t *testing.T) {
 func TestSeedRefreshReplacesSeededEdges(t *testing.T) {
 	s := New()
 
-	first := []StoredEdge{{From: "mark://a:6309/a.md", To: "mark://a:6309/old.md", Count: 1}}
-	s.SeedFromExport([]StoredNode{{URL: "mark://a:6309/a.md", Status: "ok"}}, first)
+	first := []StoredEdge{{From: "mark://a/a.md", To: "mark://a/old.md", Count: 1}}
+	s.SeedFromExport([]StoredNode{{URL: "mark://a/a.md", Status: "ok"}}, first)
 
 	// The hub aggregate no longer carries the old.md link.
-	second := []StoredEdge{{From: "mark://a:6309/a.md", To: "mark://a:6309/new.md", Count: 1}}
-	s.SeedFromExport([]StoredNode{{URL: "mark://a:6309/a.md", Status: "ok"}}, second)
+	second := []StoredEdge{{From: "mark://a/a.md", To: "mark://a/new.md", Count: 1}}
+	s.SeedFromExport([]StoredNode{{URL: "mark://a/a.md", Status: "ok"}}, second)
 
-	if bl := s.Backlinks("mark://a:6309/old.md"); len(bl) != 0 {
+	if bl := s.Backlinks("mark://a/old.md"); len(bl) != 0 {
 		t.Errorf("stale seeded backlink survived re-seed: %v", bl)
 	}
-	if bl := s.Backlinks("mark://a:6309/new.md"); len(bl) != 1 {
+	if bl := s.Backlinks("mark://a/new.md"); len(bl) != 1 {
 		t.Errorf("refreshed seed edge missing: %v", bl)
 	}
 }
@@ -862,16 +892,16 @@ func TestSeedRefreshReplacesSeededEdges(t *testing.T) {
 func TestSeedRefreshDropsEdgesOfEmptiedSource(t *testing.T) {
 	s := New()
 
-	nodes := []StoredNode{{URL: "mark://a:6309/a.md", Status: "ok", LinkCount: 1}}
-	edges := []StoredEdge{{From: "mark://a:6309/a.md", To: "mark://a:6309/old.md", Count: 1}}
+	nodes := []StoredNode{{URL: "mark://a/a.md", Status: "ok", LinkCount: 1}}
+	edges := []StoredEdge{{From: "mark://a/a.md", To: "mark://a/old.md", Count: 1}}
 	s.SeedFromExport(nodes, edges)
 
 	// The aggregate now says a.md has no outgoing links at all: the node row
 	// is present (observed) but no edge rows remain. The stale seeded edge
 	// must drop even with an empty edge set.
-	s.SeedFromExport([]StoredNode{{URL: "mark://a:6309/a.md", Status: "ok"}}, nil)
+	s.SeedFromExport([]StoredNode{{URL: "mark://a/a.md", Status: "ok"}}, nil)
 
-	if bl := s.Backlinks("mark://a:6309/old.md"); len(bl) != 0 {
+	if bl := s.Backlinks("mark://a/old.md"); len(bl) != 0 {
 		t.Errorf("stale seeded edge survived zero-edge re-seed: %v", bl)
 	}
 }
@@ -880,16 +910,16 @@ func TestSeedKeepsEdgesOfUnobservedSeedNode(t *testing.T) {
 	s := New()
 
 	s.SeedFromExport(
-		[]StoredNode{{URL: "mark://a:6309/a.md", Status: "ok", LinkCount: 1}},
-		[]StoredEdge{{From: "mark://a:6309/a.md", To: "mark://a:6309/b.md", Count: 1}},
+		[]StoredNode{{URL: "mark://a/a.md", Status: "ok", LinkCount: 1}},
+		[]StoredEdge{{From: "mark://a/a.md", To: "mark://a/b.md", Count: 1}},
 	)
 
 	// A later seed carries a.md only as an error node with no edges: the
 	// aggregate did not read it, so its recorded edge set says nothing and
 	// the earlier seeded edges must survive.
-	s.SeedFromExport([]StoredNode{{URL: "mark://a:6309/a.md", Status: "error"}}, nil)
+	s.SeedFromExport([]StoredNode{{URL: "mark://a/a.md", Status: "error"}}, nil)
 
-	if bl := s.Backlinks("mark://a:6309/b.md"); len(bl) != 1 {
+	if bl := s.Backlinks("mark://a/b.md"); len(bl) != 1 {
 		t.Errorf("unobserved seed node dropped edges it knew nothing about: %v", bl)
 	}
 }
@@ -949,21 +979,21 @@ func TestSeedFromLegacyExport(t *testing.T) {
 
 | URL | Title | Status | Links |
 |-----|-------|--------|-------|
-| [mark://a:6309/a.md](mark://a:6309/a.md) | A | ok | 1 |
-| [mark://a:6309/b.md](mark://a:6309/b.md) | B | ok | 0 |
+| [mark://a/a.md](mark://a/a.md) | A | ok | 1 |
+| [mark://a/b.md](mark://a/b.md) | B | ok | 0 |
 
 ## Edges
 
 | From | To |
 |------|----|
-| mark://a:6309/a.md | mark://a:6309/b.md |
+| mark://a/a.md | mark://a/b.md |
 `
 	nodes, edges := ParseExport(body)
 	s := New()
 	if added := s.SeedFromExport(nodes, edges); added != 2 {
 		t.Errorf("added = %d, want 2", added)
 	}
-	if bl := s.Backlinks("mark://a:6309/b.md"); len(bl) != 1 || bl[0] != "mark://a:6309/a.md" {
-		t.Errorf("Backlinks = %v, want [mark://a:6309/a.md]", bl)
+	if bl := s.Backlinks("mark://a/b.md"); len(bl) != 1 || bl[0] != "mark://a/a.md" {
+		t.Errorf("Backlinks = %v, want [mark://a/a.md]", bl)
 	}
 }

--- a/client/internal/fedcrawl/contract_test.go
+++ b/client/internal/fedcrawl/contract_test.go
@@ -66,10 +66,14 @@ func TestGraphExportContract(t *testing.T) {
 		t.Errorf("agent /graph.md export drifted from the contract golden.\nIf intentional, regenerate with -update and re-run the broker suite (it consumes this file).\ngot:\n%s\nwant:\n%s", got, want)
 	}
 
-	// Contract facts the consumer relies on, pinned independently of bytes:
-	// rows key on the internal dial address, and non-mark targets never enter.
-	if !strings.Contains(got, "mark://"+host+"/a.md") {
-		t.Error("export lost the internal dial-address URL form")
+	// Contract facts pinned independently of bytes: rows key on the internal
+	// address in identity form with the dial port removed (ADR 0005), and
+	// non-mark targets never enter. The broker canonicalizes to match.
+	if !strings.Contains(got, "mark://team-a.team-a.svc.cluster.local/a.md") {
+		t.Error("export lost the internal address URL form")
+	}
+	if strings.Contains(got, host) {
+		t.Errorf("export carries a dial address, not a node identity: %s", host)
 	}
 	if strings.Contains(got, "https://example.com/ext") || strings.Contains(got, "localhost") {
 		t.Error("external or loopback target leaked into the federation export")

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -630,7 +630,7 @@ func TestCrawlerGraphExportFiltersLoopbackAndNormalizesPorts(t *testing.T) {
 			t.Errorf("graph export must not contain %q\n---\n%s", bad, exp)
 		}
 	}
-	// the external target is kept, port-normalized to the canonical :6309 form.
+	// the external target is kept, normalized to identity form (ADR 0005).
 	if !containsMiddle(exp, "mark://a.example.com/index.md | mark://ext.example.com/page.md") {
 		t.Errorf("graph export missing normalized external edge\n---\n%s", exp)
 	}

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -578,9 +578,9 @@ func TestCrawlerGraphExportAndPublish(t *testing.T) {
 		"# Document Graph",
 		"## Edges",
 		// intra-server edge (relative link resolved)
-		"mark://a.example.com:6309/index.md | mark://a.example.com:6309/notes.md",
+		"mark://a.example.com/index.md | mark://a.example.com/notes.md",
 		// cross-server edge — the connection that makes a portal/edge on the floor
-		"mark://a.example.com:6309/index.md | mark://b.example.com:6309/page.md",
+		"mark://a.example.com/index.md | mark://b.example.com/page.md",
 	} {
 		if !contains(exp, want) {
 			t.Errorf("graph export missing %q\n---\n%s", want, exp)
@@ -631,7 +631,7 @@ func TestCrawlerGraphExportFiltersLoopbackAndNormalizesPorts(t *testing.T) {
 		}
 	}
 	// the external target is kept, port-normalized to the canonical :6309 form.
-	if !containsMiddle(exp, "mark://a.example.com:6309/index.md | mark://ext.example.com:6309/page.md") {
+	if !containsMiddle(exp, "mark://a.example.com/index.md | mark://ext.example.com/page.md") {
 		t.Errorf("graph export missing normalized external edge\n---\n%s", exp)
 	}
 }
@@ -761,9 +761,9 @@ func TestCrawlerRecordsTypedAndProvenancedEdges(t *testing.T) {
 	exp := crawler.GraphExport()
 	for _, want := range []string{
 		// body link with label and source anchor
-		"| mark://a.example.com:6309/index.md | mark://a.example.com:6309/notes.md |  | the notes | guide | 1 |",
+		"| mark://a.example.com/index.md | mark://a.example.com/notes.md |  | the notes | guide | 1 |",
 		// typed relation from rel-supersedes metadata, resolved against the doc URL
-		"| mark://a.example.com:6309/index.md | mark://a.example.com:6309/old.md | supersedes |  |  | 1 |",
+		"| mark://a.example.com/index.md | mark://a.example.com/old.md | supersedes |  |  | 1 |",
 	} {
 		if !contains(exp, want) {
 			t.Errorf("graph export missing %q\n---\n%s", want, exp)

--- a/client/internal/fedcrawl/testdata/graph-export-incluster.md
+++ b/client/internal/fedcrawl/testdata/graph-export-incluster.md
@@ -8,14 +8,14 @@
 
 | URL | Title | Status | Links |
 |-----|-------|--------|-------|
-| [mark://team-a.team-a.svc.cluster.local:6309/a.md](mark://team-a.team-a.svc.cluster.local:6309/a.md) | Applications | ok | 1 |
-| [mark://team-a.team-a.svc.cluster.local:6309/b.md](mark://team-a.team-a.svc.cluster.local:6309/b.md) | B doc | ok | 0 |
-| [mark://team-a.team-a.svc.cluster.local:6309/index.md](mark://team-a.team-a.svc.cluster.local:6309/index.md) | Team A hub | ok | 1 |
+| [mark://team-a.team-a.svc.cluster.local/a.md](mark://team-a.team-a.svc.cluster.local/a.md) | Applications | ok | 1 |
+| [mark://team-a.team-a.svc.cluster.local/b.md](mark://team-a.team-a.svc.cluster.local/b.md) | B doc | ok | 0 |
+| [mark://team-a.team-a.svc.cluster.local/index.md](mark://team-a.team-a.svc.cluster.local/index.md) | Team A hub | ok | 1 |
 
 ## Edges
 
 | From | To | Rel | Label | Anchor | Count |
 |------|----|-----|-------|--------|-------|
-| mark://team-a.team-a.svc.cluster.local:6309/a.md | mark://team-a.team-a.svc.cluster.local:6309/b.md |  | B doc | links | 1 |
-| mark://team-a.team-a.svc.cluster.local:6309/b.md | mark://team-a.team-a.svc.cluster.local:6309/a.md | supersedes |  |  | 1 |
-| mark://team-a.team-a.svc.cluster.local:6309/index.md | mark://team-a.team-a.svc.cluster.local:6309/a.md |  | Applications | services | 1 |
+| mark://team-a.team-a.svc.cluster.local/a.md | mark://team-a.team-a.svc.cluster.local/b.md |  | B doc | links | 1 |
+| mark://team-a.team-a.svc.cluster.local/b.md | mark://team-a.team-a.svc.cluster.local/a.md | supersedes |  |  | 1 |
+| mark://team-a.team-a.svc.cluster.local/index.md | mark://team-a.team-a.svc.cluster.local/a.md |  | Applications | services | 1 |

--- a/client/links/links.go
+++ b/client/links/links.go
@@ -3,12 +3,20 @@ package links
 
 import (
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/text"
+
+	"github.com/latebit-io/demarkus/protocol"
 )
+
+const markScheme = "mark://"
+
+// defaultPort is protocol.DefaultPort as a string, for URL port comparison.
+var defaultPort = strconv.Itoa(protocol.DefaultPort)
 
 // Extract parses body as markdown and returns all link destinations,
 // excluding fragment-only links. Fragments are stripped from destinations
@@ -36,6 +44,44 @@ func Resolve(baseURL, dest string) string {
 		return dest
 	}
 	return base.ResolveReference(ref).String()
+}
+
+// CanonicalURL returns the graph-identity form of a mark:// URL: the authority
+// with the default port removed (ADR 0005). A dial address keeps its port; an
+// identity does not. Anything else is returned unchanged.
+func CanonicalURL(raw string) string {
+	if !strings.HasPrefix(raw, markScheme) {
+		return raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	host := u.Hostname()
+	if host == "" {
+		return raw
+	}
+	if strings.Contains(host, ":") {
+		host = "[" + host + "]" // IPv6 literal; Hostname() strips the brackets
+	}
+	if port := u.Port(); port != "" && port != defaultPort {
+		host += ":" + port
+	}
+	path := u.EscapedPath()
+	if path == "" {
+		path = "/"
+	}
+	return markScheme + host + path
+}
+
+// NodeURL builds a graph node identity from a parsed host and path. host may
+// carry a dial port; identity drops the default one. Build identities with
+// this rather than concatenating, so the rule lives in exactly one place.
+func NodeURL(host, path string) string {
+	if path == "" {
+		path = "/"
+	}
+	return CanonicalURL(markScheme + host + path)
 }
 
 // LinkInfo describes a link extracted from markdown, including its position in the source.

--- a/client/links/links_test.go
+++ b/client/links/links_test.go
@@ -1,6 +1,7 @@
 package links
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -260,5 +261,61 @@ func TestExtractTitle(t *testing.T) {
 				t.Errorf("ExtractTitle() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCanonicalURL(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"default port stripped", "mark://host:6309/x.md", "mark://host/x.md"},
+		{"already canonical", "mark://host/x.md", "mark://host/x.md"},
+		{"non-default port kept", "mark://host:7000/x.md", "mark://host:7000/x.md"},
+		{"broker world untouched", "mark://servicing/x.md", "mark://servicing/x.md"},
+		{"broker world with default port", "mark://servicing:6309/x.md", "mark://servicing/x.md"},
+		{"empty path becomes root", "mark://host:6309", "mark://host/"},
+		{"directory path kept", "mark://host:6309/plans/", "mark://host/plans/"},
+		{"ipv6 default port", "mark://[::1]:6309/x.md", "mark://[::1]/x.md"},
+		{"ipv6 non-default port", "mark://[::1]:7000/x.md", "mark://[::1]:7000/x.md"},
+		{"external untouched", "https://example.com/x", "https://example.com/x"},
+		{"relative untouched", "/plans/x.md", "/plans/x.md"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CanonicalURL(tt.in)
+			if got != tt.want {
+				t.Errorf("CanonicalURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+			if again := CanonicalURL(got); again != got {
+				t.Errorf("not idempotent: CanonicalURL(%q) = %q", got, again)
+			}
+		})
+	}
+}
+
+// NodeURL and CanonicalURL must not drift: one builds identity from parsed
+// parts, the other normalizes a whole URL, and both encode the same rule.
+func TestNodeURLMatchesCanonicalURL(t *testing.T) {
+	cases := []struct{ host, path string }{
+		{"host:6309", "/x.md"},
+		{"host", "/x.md"},
+		{"host:7000", "/x.md"},
+		{"servicing", "/x.md"},
+		{"host:6309", "/plans/"},
+		{"[::1]:6309", "/x.md"},
+		{"host:6309", ""},
+	}
+	for _, c := range cases {
+		got := NodeURL(c.host, c.path)
+		path := c.path
+		if path == "" {
+			path = "/"
+		}
+		if want := CanonicalURL("mark://" + c.host + path); got != want {
+			t.Errorf("NodeURL(%q, %q) = %q, want %q", c.host, c.path, got, want)
+		}
+		if strings.HasSuffix(c.host, ":6309") && strings.Contains(got, ":6309") {
+			t.Errorf("NodeURL(%q, %q) = %q, kept the default port", c.host, c.path, got)
+		}
 	}
 }

--- a/docs/adr/0005-node-identity-default-port.md
+++ b/docs/adr/0005-node-identity-default-port.md
@@ -1,0 +1,129 @@
+# ADR 0005 — Node identity omits the default port
+
+Status: proposed (2026-08-17)
+
+## Context
+
+A graph node is identified by its URL string and compared exactly: the store
+looks up `s.nodes[url]` and matches backlinks with `e.To != url`, with no
+normalization anywhere. Identity is therefore whatever spelling the writer
+used, and two spellings of one document are two documents.
+
+Today the intended canonical form is `mark://host:port/path` with the default
+port filled in, because `fetch.ParseMarkURL` supplies `protocol.DefaultPort`
+when the address omits one. That intent was never enforced. `demarkus-mcp`
+rebuilt the canonical form explicitly before crawling; the CLI, TUI, and broker
+passed through whatever the caller typed. PR #318 closed the crawl entry by
+canonicalizing inside `graphstore.CrawlAndPersist`, using the caller's own
+`parseURL` so each transport keeps its own rule.
+
+The damage was real before that fix. A rebuild of the demarkus-soul graph
+produced 388 nodes for 192 documents, 204 keyed `mark://soul.demarkus.io/...`
+and 167 keyed `mark://soul.demarkus.io:6309/...`. A second symptom rode along:
+`EtagFetcher` keys etags canonically while nodes were keyed raw, so `Merge`
+never attached an etag from a portless crawl and every conditional re-crawl
+silently degraded to a full refetch.
+
+Three doors remain open after PR #318:
+
+- `SeedFromExport` ingests rows from another producer's `/graph.md` verbatim.
+- The read paths (`GetNode`, `Backlinks`, `BacklinksEnriched`) trust the
+  caller's key. The broker's `handleMarkBacklinks` validates the URL shape and
+  then queries with the agent's raw string, so a near-miss returns "no
+  backlinks" rather than an error.
+- `links.Resolve` returns any destination containing `://` untouched, so an
+  absolute body link written without a port creates a second node even under a
+  canonical crawl.
+
+Two further facts shape the decision. The system already separates identity
+from dial address: `mark_worlds` returns a world's name and its dial address as
+distinct columns, and the broker addresses worlds as `mark://{worldName}/{path}`
+with no port at all, rejecting a port outright as an operator typo. And humans
+and agents naturally write `mark://host/doc.md`, which today is the wrong
+spelling.
+
+## Decision
+
+**Node identity is the authority with the default port omitted.**
+
+- `mark://host/path` when the server listens on `protocol.DefaultPort`.
+- `mark://host:7000/path` when it does not. A non-default port stays part of
+  identity because it names a different server.
+- The broker's `mark://{worldName}/{path}` form is unchanged. It is already
+  portless, so both transports now follow one rule rather than two.
+
+### Identity is not the dial address
+
+`fetch.ParseMarkURL` keeps filling in the default port. Dialing needs a port;
+identity does not. These are separate functions with separate jobs, and
+conflating them is what produced the original bug. Canonicalization for
+identity gets its own exported helper, and the transport keeps its own.
+
+### Normalize at every keyed door, not just the crawl
+
+The store takes an injected canonicalizer, following the existing `parseURL`
+pattern so the store never hardcodes a rule that is wrong for the broker.
+Hardcoding "strip 6309" inside `graphstore` would rewrite `mark://servicing/x`
+as `mark://servicing:6309/x` and corrupt every brokered world key.
+
+It is applied on ingest (`Merge`, `SeedFromExport`, the crawl entry) and on
+read (`GetNode`, `Backlinks`, `BacklinksEnriched`). Read-side normalization is
+not redundant with ingest: a mismatch on read returns an empty result, which is
+indistinguishable from a document that genuinely has no backlinks, and a silent
+wrong answer is the failure mode this whole class of bug keeps producing.
+
+### Accept both forms forever
+
+Ingest accepts either spelling and stores the stripped one. Published graphs
+written under the old rule keep parsing, and their rows are stripped on the way
+in. `graph.json` bumps `schemaVersion` from 1 to 2 and strips keys on load, so
+existing stores migrate instead of being rejected by the version check.
+
+There is no flag day and no coordinated release. Hub aggregates can be
+republished whenever it suits.
+
+## Consequences
+
+- The spelling people naturally type becomes the correct one, which closes the
+  absolute-body-link hole by making the common case canonical rather than
+  wrong.
+- Identity matches RFC 3986 section 6.2.3, which removes a scheme's default
+  port during normalization, and matches the broker's existing split between a
+  world's name and its dial address.
+- `/graph.md` row shape changes. Producers are the `demarkus-agent` federation
+  crawler, which publishes hub aggregates, and `mark_graph_publish`. Consumers
+  are the MCP seed path, the broker seed path, and the library floor, which has
+  broken once before on an export format change. Accept-both keeps every one of
+  them working across the transition.
+- Moving a world off the default port changes the identity of every node it
+  serves. This is already true and is not a regression, but it means a port
+  remains load-bearing whenever it is not the default.
+- Tests that pin the old rule change with it: the fedcrawl producer-consumer
+  contract test, the MCP and broker seed tests, and
+  `TestCrawlAndPersistCanonicalizesStartURL`, whose expectation inverts.
+  `TestCrawlAndPersistKeysMatchAcrossURLForms` survives untouched, because it
+  asserts that the two spellings agree rather than which one wins. That is the
+  test carrying the real invariant.
+
+## Alternatives rejected
+
+- **Keep the port always.** Internally consistent, and it is what the current
+  data already looks like. Rejected because it leaves the natural spelling
+  permanently wrong, keeps two identity rules across the two transports, and
+  does nothing about absolute body links.
+- **Normalize on read only.** Cheaper, and it would answer queries correctly
+  today. Rejected because stored data stays forked on disk, so every export and
+  every seed keeps propagating both spellings.
+- **Hardcode the rule inside `graphstore`.** Rejected as wrong for the broker,
+  as above.
+- **Reject non-canonical input.** Honest, and it surfaces the problem instead
+  of hiding it. Rejected because a store seeded from another world's `/graph.md`
+  cannot control what that producer wrote, and refusing to seed is worse than
+  normalizing.
+
+## Deferred
+
+- Whether the LOOKUP catalog and the OKF export should adopt the same identity
+  rule. They key by path within a world today and are unaffected.
+- Case normalization of the authority. `mark://Host/x` and `mark://host/x`
+  remain distinct until there is evidence anyone writes the former.

--- a/docs/adr/0005-node-identity-default-port.md
+++ b/docs/adr/0005-node-identity-default-port.md
@@ -1,6 +1,9 @@
 # ADR 0005 — Node identity omits the default port
 
-Status: proposed (2026-08-17)
+Status: proposed (2026-08-17), amended the same day after implementing it on
+`feat/node-identity-default-port`. Three claims below were wrong as first
+written and are corrected in place; the amendments section records what
+changed and why.
 
 ## Context
 
@@ -61,10 +64,18 @@ identity gets its own exported helper, and the transport keeps its own.
 
 ### Normalize at every keyed door, not just the crawl
 
-The store takes an injected canonicalizer, following the existing `parseURL`
-pattern so the store never hardcodes a rule that is wrong for the broker.
-Hardcoding "strip 6309" inside `graphstore` would rewrite `mark://servicing/x`
-as `mark://servicing:6309/x` and corrupt every brokered world key.
+One package-level function, `links.CanonicalURL`, is enough. Stripping a
+default port is correct for both transports: a brokered world name carries no
+port, so the rule is a no-op there. Injection was specified in the first draft
+out of caution and proved unnecessary. The caution was real but belonged to the
+*old* rule: hardcoding "add 6309" would have rewritten `mark://servicing/x` as
+`mark://servicing:6309/x` and corrupted every brokered world key. Direction
+matters, and only one direction is safe to hardcode.
+
+Identity is built in one place too. `links.NodeURL(host, path)` constructs it
+from parsed parts, so no caller assembles an identity by concatenation. A test
+pins `NodeURL(h, p) == CanonicalURL("mark://" + h + p)` so the constructor and
+the normalizer cannot drift.
 
 It is applied on ingest (`Merge`, `SeedFromExport`, the crawl entry) and on
 read (`GetNode`, `Backlinks`, `BacklinksEnriched`). Read-side normalization is
@@ -79,8 +90,13 @@ written under the old rule keep parsing, and their rows are stripped on the way
 in. `graph.json` bumps `schemaVersion` from 1 to 2 and strips keys on load, so
 existing stores migrate instead of being rejected by the version check.
 
-There is no flag day and no coordinated release. Hub aggregates can be
-republished whenever it suits.
+Accept-both is what removes the flag day, and it has to, because the published
+`/graph.md` changes shape the moment this ships. The agent's export is rendered
+from a `graphstore`, so canonicalizing the store necessarily canonicalizes the
+export. The wire format is not a separate decision that can be sequenced later.
+What accept-both buys is that no consumer has to upgrade in lockstep: an old
+export lands correctly in a new store, and a new export lands correctly in any
+consumer that canonicalizes on ingest.
 
 ## Consequences
 
@@ -105,6 +121,35 @@ republished whenever it suits.
   asserts that the two spellings agree rather than which one wins. That is the
   test carrying the real invariant.
 
+## What implementation changed
+
+Amended 2026-08-17 after building this on `feat/node-identity-default-port`.
+
+- **The wire format is not sequenceable.** The first draft said hub aggregates
+  could be republished at leisure. They cannot: the agent renders `/graph.md`
+  from a `graphstore`, so canonicalizing the store canonicalizes the export in
+  the same commit. Accept-both stopped being a convenience and became the
+  mechanism that makes the change survivable.
+- **Injection was unnecessary.** See the decision section. One package-level
+  function serves both transports because only one direction of normalization
+  is safe to hardcode.
+- **The etag coupling bit a second time.** `EtagFetcher` keyed etags by
+  `"mark://" + host + path` with the dial port, so under the new rule they
+  missed exactly as they had under the old one, silently turning conditional
+  re-crawl back into a full refetch. Two different rules, same bug, because
+  identity was being assembled by hand in more than one place. That is what
+  motivated `links.NodeURL`.
+- **The broker needed a matching change, and a subtle one.** Its seed
+  translation keyed world prefixes on dial addresses with ports, so portless
+  export rows stopped translating and every seeded row became unreachable.
+  Canonicalizing both sides fixed it, but `CanonicalURL` normalizes an empty
+  path to `/`, which broke the bare-authority prefix match until the trailing
+  slash was trimmed. The cross-module contract test caught both.
+- **Fedcrawl was deliberately left alone.** Its crawl state and hash-index
+  entries key on dial addresses by design, and its graph is normalized at the
+  `graphstore.Merge` boundary anyway. Forcing identity there would break
+  `state.GetURL` and the index contract for no gain.
+
 ## Alternatives rejected
 
 - **Keep the port always.** Internally consistent, and it is what the current
@@ -114,8 +159,11 @@ republished whenever it suits.
 - **Normalize on read only.** Cheaper, and it would answer queries correctly
   today. Rejected because stored data stays forked on disk, so every export and
   every seed keeps propagating both spellings.
-- **Hardcode the rule inside `graphstore`.** Rejected as wrong for the broker,
-  as above.
+- **Hardcode the old rule inside `graphstore`.** Adding the default port in
+  the store would have corrupted every brokered world key. Stripping it, the
+  rule chosen here, is safe to hardcode because it is a no-op on a world name.
+  The asymmetry is the point: normalization may only ever remove information
+  that the scheme already implies.
 - **Reject non-canonical input.** Honest, and it surfaces the problem instead
   of hiding it. Rejected because a store seeded from another world's `/graph.md`
   cannot control what that producer wrote, and refusing to seed is worse than
@@ -125,5 +173,9 @@ republished whenever it suits.
 
 - Whether the LOOKUP catalog and the OKF export should adopt the same identity
   rule. They key by path within a world today and are unaffected.
+- A distinct `NodeURL` type so the compiler rejects a hand-built identity.
+  `links.NodeURL` puts the rule in one place but cannot stop a future caller
+  from concatenating a fifth one. Making it a named type touches every
+  signature that carries a node URL, so it wants its own change.
 - Case normalization of the authority. `mark://Host/x` and `mark://host/x`
   remain distinct until there is evidence anyone writes the former.

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
@@ -140,22 +140,26 @@ func (g *mcpGateway) seedWorldGraph(worldName string) {
 	}
 }
 
-// translateSeedURLs rewrites URLs on configured world dial addresses to
-// mark://{worldName}/... form; gateway queries key on world names, so
-// untranslated rows are unreachable. Unknown hosts are labels, kept as-is.
+// translateSeedURLs rewrites world dial addresses to mark://{worldName}/...;
+// gateway queries key on world names, so untranslated rows are unreachable.
+// Unknown hosts stay as labels. Both sides canonicalize (ADR 0005).
 func (g *mcpGateway) translateSeedURLs(nodes []graphstore.StoredNode, edges []graphstore.StoredEdge) {
 	worlds := g.srv.cfg.Worlds
 	byAddr := make(map[string]string, len(worlds))
 	for i := range worlds {
-		byAddr["mark://"+resolveWorldAddress(&worlds[i])] = "mark://" + worlds[i].Name
+		// CanonicalURL normalizes an empty path to "/"; the prefix match wants a
+		// bare authority, so trim it back off.
+		addr := strings.TrimSuffix(links.CanonicalURL("mark://"+resolveWorldAddress(&worlds[i])), "/")
+		byAddr[addr] = "mark://" + worlds[i].Name
 	}
 	translate := func(rawURL string) string {
+		canon := links.CanonicalURL(rawURL)
 		for prefix, world := range byAddr {
-			if rest, ok := strings.CutPrefix(rawURL, prefix); ok && (rest == "" || rest[0] == '/') {
+			if rest, ok := strings.CutPrefix(canon, prefix); ok && (rest == "" || rest[0] == '/') {
 				return world + rest
 			}
 		}
-		return rawURL
+		return canon
 	}
 	for i := range nodes {
 		nodes[i].URL = translate(nodes[i].URL)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized graph and backlink URLs by removing default ports from node identities.
  * Improved consistency across crawled links, graph exports, federation data, and seed imports.
  * Preserved non-default ports and correctly handled IPv6 addresses and root paths.
  * Migrated existing graph data to the canonical URL format.

* **Documentation**
  * Added guidance on node identity and default-port normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->