### PR TITLE
docs(adr): accept ADR 0005 now that node identity has shipped

### DIFF
--- a/docs/adr/0005-node-identity-default-port.md
+++ b/docs/adr/0005-node-identity-default-port.md
@@ -1,9 +1,10 @@
 # ADR 0005 — Node identity omits the default port
 
-Status: proposed (2026-08-17), amended the same day after implementing it on
-`feat/node-identity-default-port`. Three claims below were wrong as first
-written and are corrected in place; the amendments section records what
-changed and why.
+Status: accepted (2026-08-18). Shipped in PR #320 (`2964a35`); the managed
+binary pins that close the mixed-version window followed in #319 and #321.
+Amended before acceptance from what implementing it taught: three claims below
+were wrong as first written and are corrected in place, and the "What
+implementation changed" section records what moved and why.
 
 ## Context
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Node identities now use a consistent URL format, omitting the default port while preserving non-default ports.
  - Existing data and exported graph files continue to support both URL formats.
  - Graph exports now use schema version 2.

- **Documentation**
  - Added an accepted architecture decision record documenting URL normalization, compatibility handling, and migration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->