### PR TITLE
test(server): run pgstore in CI and add a file/postgres differential

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,11 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.server == 'true'
     runs-on: ubuntu-latest
-    # Backend parity is a core invariant: the pgstore conformance and
-    # differential suites must run here, not skip. DEMARKUS_TEST_PG_REQUIRED
-    # turns the DSN-missing skip into a failure so a broken service wiring
-    # cannot silently drop Postgres coverage.
+    # Backend parity is a core invariant, so pgstore tests must run here, not
+    # skip: DEMARKUS_TEST_PG_REQUIRED turns a missing DSN into a failure.
     services:
       postgres:
-        image: postgres:16-alpine
+        image: postgres:16-alpine@sha256:cf78e76683b9ca8c5733cbbdce6c9262b45b6767934dd0a95e671f9a0fc20685
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: demarkus_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,26 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.server == 'true'
     runs-on: ubuntu-latest
+    # Backend parity is a core invariant: the pgstore conformance and
+    # differential suites must run here, not skip. DEMARKUS_TEST_PG_REQUIRED
+    # turns the DSN-missing skip into a failure so a broken service wiring
+    # cannot silently drop Postgres coverage.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: demarkus_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DEMARKUS_TEST_PG_DSN: postgres://postgres:postgres@localhost:5432/demarkus_test
+      DEMARKUS_TEST_PG_REQUIRED: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/protocol/store/format.go
+++ b/protocol/store/format.go
@@ -132,3 +132,7 @@ func PrepareAppendMeta(reqPath string, base, req map[string]string) map[string]s
 // adds to stored version bytes; backends bound stored size by
 // protocol.MaxBodyLength + MaxStoreFrontmatter.
 const MaxStoreFrontmatter = maxStoreFrontmatter
+
+// ValidateWrite checks the size, metadata, and encoding of a write request
+// in the order every backend applies before reading any state.
+func ValidateWrite(content []byte, meta map[string]string) error { return validateWrite(content, meta) }

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -34,6 +34,7 @@ import (
 	"os"
 	slashpath "path"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -177,10 +178,10 @@ func newVersionSymlinkTarget(base string, version int) string {
 type Store struct {
 	root   string
 	hashMu sync.RWMutex
-	// hashIdx: content hash → canonical request paths whose current body has
-	// that hash. LookupHash picks the smallest path, as pgstore's ORDER BY
-	// path does, so backends and a rebuilt index agree on shared bodies.
-	hashIdx map[string]map[string]struct{}
+	// hashIdx: content hash → sorted canonical request paths whose current
+	// body has that hash. LookupHash answers the smallest, as pgstore's ORDER
+	// BY path does, so backends and a rebuilt index agree on shared bodies.
+	hashIdx map[string][]string
 	// pathIdx: canonical request path → content hash. liveChildren also reads
 	// membership as "current, non-archived doc" for ListDir filtering, so
 	// keep membership semantics exact; a miss only degrades to a disk scan.
@@ -192,7 +193,7 @@ type Store struct {
 func New(root string) *Store {
 	return &Store{
 		root:    root,
-		hashIdx: make(map[string]map[string]struct{}),
+		hashIdx: make(map[string][]string),
 		pathIdx: make(map[string]string),
 	}
 }
@@ -273,7 +274,7 @@ func (s *Store) BuildHashIndex() error {
 	s.hashMu.Lock()
 	defer s.hashMu.Unlock()
 
-	s.hashIdx = make(map[string]map[string]struct{})
+	s.hashIdx = make(map[string][]string)
 	s.pathIdx = make(map[string]string)
 
 	return s.walkCurrentFiles(func(reqPath string, data []byte, _ time.Time) error {
@@ -286,12 +287,9 @@ func (s *Store) BuildHashIndex() error {
 // earlier hash it was indexed under. Caller holds hashMu.
 func (s *Store) indexLocked(reqPath, hash string) {
 	s.unindexLocked(reqPath)
-	paths, ok := s.hashIdx[hash]
-	if !ok {
-		paths = make(map[string]struct{})
-		s.hashIdx[hash] = paths
-	}
-	paths[reqPath] = struct{}{}
+	paths := s.hashIdx[hash]
+	i, _ := slices.BinarySearch(paths, reqPath)
+	s.hashIdx[hash] = slices.Insert(paths, i, reqPath)
 	s.pathIdx[reqPath] = hash
 }
 
@@ -302,11 +300,14 @@ func (s *Store) unindexLocked(reqPath string) {
 		return
 	}
 	delete(s.pathIdx, reqPath)
-	if paths := s.hashIdx[hash]; paths != nil {
-		delete(paths, reqPath)
-		if len(paths) == 0 {
-			delete(s.hashIdx, hash)
-		}
+	paths := s.hashIdx[hash]
+	if i, found := slices.BinarySearch(paths, reqPath); found {
+		paths = slices.Delete(paths, i, i+1)
+	}
+	if len(paths) == 0 {
+		delete(s.hashIdx, hash)
+	} else {
+		s.hashIdx[hash] = paths
 	}
 }
 
@@ -341,13 +342,10 @@ func (s *Store) WalkCurrent(fn func(CurrentDoc) error) error {
 func (s *Store) LookupHash(hash string) (string, bool) {
 	s.hashMu.RLock()
 	defer s.hashMu.RUnlock()
-	best := ""
-	for p := range s.hashIdx[hash] {
-		if best == "" || p < best {
-			best = p
-		}
+	if paths := s.hashIdx[hash]; len(paths) > 0 {
+		return paths[0], true
 	}
-	return best, best != ""
+	return "", false
 }
 
 // UpdateHashIndex adds or updates the hash index entry for a document.
@@ -795,11 +793,10 @@ func (s *Store) resolve(reqPath string) (string, error) {
 // CurrentVersion returns the latest version number for a document.
 // Returns 0 if no version history exists.
 func (s *Store) CurrentVersion(reqPath string) int {
-	if ContainsDotDot(reqPath) {
+	cleaned, err := RelPath(reqPath)
+	if err != nil {
 		return 0
 	}
-	cleaned := filepath.Clean(reqPath)
-	cleaned = strings.TrimLeft(cleaned, "/")
 	versionsDir := filepath.Join(s.root, filepath.Dir(cleaned), "versions")
 	return highestPerDocVersion(versionsDir, filepath.Base(cleaned))
 }
@@ -880,12 +877,10 @@ func (s *Store) findVersionsPerDoc(versionsDir, base string) []VersionInfo {
 // getVersion retrieves a specific version of a document from the versions directory.
 // Uses resolve() for path validation — same security as all other path access.
 func (s *Store) getVersion(reqPath string, version int) (*Document, error) {
-	// filepath.Join below would clean ".." away; reject it like resolve does.
-	if ContainsDotDot(reqPath) {
-		return nil, os.ErrNotExist
+	cleaned, err := RelPath(reqPath)
+	if err != nil {
+		return nil, err
 	}
-	cleaned := filepath.Clean(reqPath)
-	cleaned = strings.TrimLeft(cleaned, "/")
 	base := filepath.Base(cleaned)
 
 	dir := filepath.Dir(cleaned)
@@ -1010,23 +1005,25 @@ func (s *Store) Write(reqPath string, content []byte, meta map[string]string) (*
 	if err := validateWrite(content, meta); err != nil {
 		return nil, err
 	}
-	if ContainsDotDot(reqPath) {
-		return nil, os.ErrNotExist
-	}
+	return s.write(reqPath, content, meta)
+}
 
-	cleaned := filepath.Clean(reqPath)
-	cleaned = strings.TrimLeft(cleaned, "/")
+// write is the validated core shared by Write and WriteVersion.
+func (s *Store) write(reqPath string, content []byte, meta map[string]string) (*Document, error) {
+	cleaned, err := RelPath(reqPath)
+	if err != nil {
+		return nil, err
+	}
 	base := filepath.Base(cleaned)
 	dir := filepath.Dir(cleaned)
 
-	// Writing beneath a document is a topology collision, reported the same
-	// way as writing over a directory (pgstore.checkPathTopology agrees).
-	if anc := s.documentAncestor(cleaned); anc != "" {
-		return nil, fmt.Errorf("cannot publish %s: a document exists at ancestor /%s", reqPath, anc)
-	}
-
 	// Validate path stays within the store root (resolve handles traversal + symlinks).
 	if _, err := s.resolve(reqPath); err != nil {
+		if errors.Is(err, errUnderDocument) {
+			// Topology collision, same class as writing over a directory
+			// (pgstore.checkPathTopology agrees).
+			return nil, fmt.Errorf("cannot publish %s: a document exists at an ancestor", reqPath)
+		}
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, os.ErrNotExist
 		}
@@ -1285,7 +1282,7 @@ func (s *Store) WriteVersion(reqPath string, expectedVersion int, content []byte
 		return nil, os.ErrNotExist
 	}
 	if expectedVersion < 0 {
-		return s.Write(reqPath, content, meta)
+		return s.write(reqPath, content, meta)
 	}
 
 	current := s.CurrentVersion(reqPath)
@@ -1293,7 +1290,7 @@ func (s *Store) WriteVersion(reqPath string, expectedVersion int, content []byte
 		return &Document{Version: current}, ErrConflict
 	}
 
-	doc, err := s.Write(reqPath, content, meta)
+	doc, err := s.write(reqPath, content, meta)
 	if err != nil {
 		if errors.Is(err, ErrVersionExists) {
 			// Lost the O_EXCL race: another writer created the expected
@@ -1446,21 +1443,34 @@ func resolveNonExistent(path string) (string, error) {
 		return filepath.Abs(path)
 	}
 	// A non-directory ancestor (a document's current pointer) cannot have
-	// children: the path addresses nothing. Report ErrNotExist here rather
-	// than letting a later stat surface ENOTDIR as an internal error.
+	// children; surface that as ErrNotExist rather than a later ENOTDIR.
 	if len(tail) > 0 {
 		if info, err := os.Stat(resolved); err == nil && !info.IsDir() {
-			return "", os.ErrNotExist
+			return "", errUnderDocument
 		}
 	}
 	return filepath.Join(append([]string{resolved}, tail...)...), nil
 }
+
+// errUnderDocument marks a path beneath a document. Readers see ErrNotExist;
+// write maps it to the topology collision error.
+var errUnderDocument = fmt.Errorf("%w: path is beneath a document", os.ErrNotExist)
 
 // CanonicalPath is the one spelling of a request path shared by every index
 // keyed on paths (hash index, catalog, pgstore rows): slash-cleaned, single
 // leading slash, root is "/". Callers reject traversal via ContainsDotDot.
 func CanonicalPath(reqPath string) string {
 	return slashpath.Clean("/" + reqPath)
+}
+
+// RelPath is the storage-relative form of a request path: CanonicalPath
+// without the leading slash, "" for the root. ".." is rejected with
+// os.ErrNotExist so traversal never reaches a backend.
+func RelPath(reqPath string) (string, error) {
+	if ContainsDotDot(reqPath) {
+		return "", os.ErrNotExist
+	}
+	return strings.TrimPrefix(CanonicalPath(reqPath), "/"), nil
 }
 
 // ContainsDotDot reports whether the path contains a ".." segment. Every
@@ -1621,19 +1631,6 @@ func validateWrite(content []byte, meta map[string]string) error {
 		return err
 	}
 	return ValidateBody(content)
-}
-
-// documentAncestor returns the nearest proper ancestor of cleaned (no leading
-// slash) that is a document, archived or not, or "" when none is.
-func (s *Store) documentAncestor(cleaned string) string {
-	parts := strings.Split(cleaned, "/")
-	for i := 1; i < len(parts); i++ {
-		anc := strings.Join(parts[:i], "/")
-		if s.CurrentVersion(anc) > 0 {
-			return anc
-		}
-	}
-	return ""
 }
 
 // validateMeta checks metadata is safe for frontmatter serialization. Defense

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -230,9 +230,12 @@ func (s *Store) walkCurrentFiles(fn func(reqPath string, data []byte, modified t
 	// Entries that cannot be indexed are skipped, never fatal: one broken
 	// symlink must not take the server down. They are reported as a
 	// PartialWalkError so the caller can surface the degradation.
-	var skipped []SkippedEntry
+	partial := &PartialWalkError{}
 	skip := func(path string, err error) error {
-		skipped = append(skipped, SkippedEntry{Path: path, Err: err})
+		partial.Total++
+		if len(partial.Skipped) < maxSkippedSample {
+			partial.Skipped = append(partial.Skipped, SkippedEntry{Path: path, Err: err})
+		}
 		return nil
 	}
 	walkErr := filepath.WalkDir(absRoot, func(path string, d os.DirEntry, err error) error {
@@ -284,11 +287,15 @@ func (s *Store) walkCurrentFiles(fn func(reqPath string, data []byte, modified t
 	if walkErr != nil {
 		return walkErr
 	}
-	if len(skipped) > 0 {
-		return &PartialWalkError{Skipped: skipped}
+	if partial.Total > 0 {
+		return partial
 	}
 	return nil
 }
+
+// maxSkippedSample bounds the entries a PartialWalkError retains; a badly
+// damaged root must not exhaust memory during startup.
+const maxSkippedSample = 32
 
 var errSymlinkEscapes = errors.New("current-version symlink escapes the content root")
 
@@ -300,13 +307,14 @@ type SkippedEntry struct {
 
 // PartialWalkError reports a walk that completed but skipped entries: the
 // derived index is missing them. Callers log it rather than treating the
-// build as whole or aborting.
+// build as whole or aborting. Skipped holds at most maxSkippedSample entries.
 type PartialWalkError struct {
+	Total   int
 	Skipped []SkippedEntry
 }
 
 func (e *PartialWalkError) Error() string {
-	return fmt.Sprintf("walk skipped %d entries (first %s: %v)", len(e.Skipped), e.Skipped[0].Path, e.Skipped[0].Err)
+	return fmt.Sprintf("walk skipped %d entries (first %s: %v)", e.Total, e.Skipped[0].Path, e.Skipped[0].Err)
 }
 
 // BuildHashIndex walks the content root and indexes current versions by content hash.

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -227,9 +227,17 @@ func (s *Store) walkCurrentFiles(fn func(reqPath string, data []byte, modified t
 		return err
 	}
 
-	return filepath.WalkDir(absRoot, func(path string, d os.DirEntry, err error) error {
+	// Entries that cannot be indexed are skipped, never fatal: one broken
+	// symlink must not take the server down. They are reported as a
+	// PartialWalkError so the caller can surface the degradation.
+	var skipped []SkippedEntry
+	skip := func(path string, err error) error {
+		skipped = append(skipped, SkippedEntry{Path: path, Err: err})
+		return nil
+	}
+	walkErr := filepath.WalkDir(absRoot, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			return nil // skip unreadable entries
+			return skip(path, err)
 		}
 		if d.IsDir() {
 			if d.Name() == "versions" {
@@ -244,28 +252,57 @@ func (s *Store) walkCurrentFiles(fn func(reqPath string, data []byte, modified t
 		// Resolve symlink and ensure target stays within the content root.
 		resolved, err := filepath.EvalSymlinks(path)
 		if err != nil {
-			return nil // skip broken symlinks
+			return skip(path, err)
 		}
 		if !isContained(resolved, absRoot) {
-			return nil // skip symlinks that escape the content root
+			return skip(path, errSymlinkEscapes)
 		}
 		info, err := os.Stat(resolved)
-		if err != nil || info.Size() > int64(protocol.MaxBodyLength+maxStoreFrontmatter) {
-			return nil // skip unreadable or oversized files
+		if err != nil {
+			return skip(path, err)
+		}
+		if info.Size() > int64(protocol.MaxBodyLength+maxStoreFrontmatter) {
+			return skip(path, ErrSizeLimit)
 		}
 		data, err := os.ReadFile(resolved)
 		if err != nil {
-			return nil // skip unreadable files
+			return skip(path, err)
 		}
 		if isArchived(data) {
 			return nil
 		}
 		rel, err := filepath.Rel(absRoot, path)
 		if err != nil {
-			return nil
+			return skip(path, err)
 		}
-		return fn("/"+rel, data, info.ModTime().UTC().Truncate(time.Second))
+		return fn("/"+filepath.ToSlash(rel), data, info.ModTime().UTC().Truncate(time.Second))
 	})
+	if walkErr != nil {
+		return walkErr
+	}
+	if len(skipped) > 0 {
+		return &PartialWalkError{Skipped: skipped}
+	}
+	return nil
+}
+
+var errSymlinkEscapes = errors.New("current-version symlink escapes the content root")
+
+// SkippedEntry is a content-root entry a walk could not index.
+type SkippedEntry struct {
+	Path string
+	Err  error
+}
+
+// PartialWalkError reports a walk that completed but skipped entries: the
+// derived index is missing them. Callers log it rather than treating the
+// build as whole or aborting.
+type PartialWalkError struct {
+	Skipped []SkippedEntry
+}
+
+func (e *PartialWalkError) Error() string {
+	return fmt.Sprintf("walk skipped %d entries (first %s: %v)", len(e.Skipped), e.Skipped[0].Path, e.Skipped[0].Err)
 }
 
 // BuildHashIndex walks the content root and indexes current versions by content hash.

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -175,14 +175,15 @@ func newVersionSymlinkTarget(base string, version int) string {
 
 // Store provides read access to a versioned document directory.
 type Store struct {
-	root    string
-	hashMu  sync.RWMutex
-	hashIdx map[string]string // content hash → request path
-	// pathIdx maps request path → content hash (reverse index). Beyond hash
-	// lookups, ListDir's archived-filtering treats membership as "current,
-	// non-archived versioned doc" (see liveChildren) — a change to what this
-	// index tracks changes listing behavior. A miss only degrades to a disk
-	// scan, but keep membership semantics exact.
+	root   string
+	hashMu sync.RWMutex
+	// hashIdx: content hash → canonical request paths whose current body has
+	// that hash. LookupHash picks the smallest path, as pgstore's ORDER BY
+	// path does, so backends and a rebuilt index agree on shared bodies.
+	hashIdx map[string]map[string]struct{}
+	// pathIdx: canonical request path → content hash. liveChildren also reads
+	// membership as "current, non-archived doc" for ListDir filtering, so
+	// keep membership semantics exact; a miss only degrades to a disk scan.
 	pathIdx map[string]string
 }
 
@@ -191,7 +192,7 @@ type Store struct {
 func New(root string) *Store {
 	return &Store{
 		root:    root,
-		hashIdx: make(map[string]string),
+		hashIdx: make(map[string]map[string]struct{}),
 		pathIdx: make(map[string]string),
 	}
 }
@@ -272,15 +273,41 @@ func (s *Store) BuildHashIndex() error {
 	s.hashMu.Lock()
 	defer s.hashMu.Unlock()
 
-	s.hashIdx = make(map[string]string)
+	s.hashIdx = make(map[string]map[string]struct{})
 	s.pathIdx = make(map[string]string)
 
 	return s.walkCurrentFiles(func(reqPath string, data []byte, _ time.Time) error {
-		hash := contentHash(extractBody(data))
-		s.hashIdx[hash] = reqPath
-		s.pathIdx[reqPath] = hash
+		s.indexLocked(reqPath, contentHash(extractBody(data)))
 		return nil
 	})
+}
+
+// indexLocked records reqPath (already canonical) under hash, dropping any
+// earlier hash it was indexed under. Caller holds hashMu.
+func (s *Store) indexLocked(reqPath, hash string) {
+	s.unindexLocked(reqPath)
+	paths, ok := s.hashIdx[hash]
+	if !ok {
+		paths = make(map[string]struct{})
+		s.hashIdx[hash] = paths
+	}
+	paths[reqPath] = struct{}{}
+	s.pathIdx[reqPath] = hash
+}
+
+// unindexLocked removes reqPath from both maps. Caller holds hashMu.
+func (s *Store) unindexLocked(reqPath string) {
+	hash, ok := s.pathIdx[reqPath]
+	if !ok {
+		return
+	}
+	delete(s.pathIdx, reqPath)
+	if paths := s.hashIdx[hash]; paths != nil {
+		delete(paths, reqPath)
+		if len(paths) == 0 {
+			delete(s.hashIdx, hash)
+		}
+	}
 }
 
 // CurrentDoc describes a current, non-archived document version surfaced by
@@ -309,42 +336,41 @@ func (s *Store) WalkCurrent(fn func(CurrentDoc) error) error {
 	})
 }
 
-// LookupHash returns the request path for a content hash, or false if not found.
+// LookupHash returns the request path for a content hash, or false if not
+// found. When several live documents share the body, the smallest path wins.
 func (s *Store) LookupHash(hash string) (string, bool) {
 	s.hashMu.RLock()
 	defer s.hashMu.RUnlock()
-	path, ok := s.hashIdx[hash]
-	return path, ok
+	best := ""
+	for p := range s.hashIdx[hash] {
+		if best == "" || p < best {
+			best = p
+		}
+	}
+	return best, best != ""
 }
 
 // UpdateHashIndex adds or updates the hash index entry for a document.
+// Keys are canonical so "/d/e/" and "/d/e" index one document, as
+// BuildHashIndex derives from the walk.
 func (s *Store) UpdateHashIndex(reqPath string, body []byte) {
-	hash := contentHash(body)
 	s.hashMu.Lock()
 	defer s.hashMu.Unlock()
-	// Remove old hash entry for this path (content changed)
-	if oldHash, ok := s.pathIdx[reqPath]; ok {
-		delete(s.hashIdx, oldHash)
-	}
-	s.hashIdx[hash] = reqPath
-	s.pathIdx[reqPath] = hash
+	s.indexLocked(CanonicalPath(reqPath), contentHash(body))
 }
 
 // RemoveHashEntry removes the hash index entry for a given request path.
 func (s *Store) RemoveHashEntry(reqPath string) {
 	s.hashMu.Lock()
 	defer s.hashMu.Unlock()
-	if hash, ok := s.pathIdx[reqPath]; ok {
-		delete(s.hashIdx, hash)
-		delete(s.pathIdx, reqPath)
-	}
+	s.unindexLocked(CanonicalPath(reqPath))
 }
 
-// HashIndexSize returns the number of entries in the hash index.
+// HashIndexSize returns the number of indexed documents.
 func (s *Store) HashIndexSize() int {
 	s.hashMu.RLock()
 	defer s.hashMu.RUnlock()
-	return len(s.hashIdx)
+	return len(s.pathIdx)
 }
 
 // Root returns the content directory path.
@@ -556,7 +582,7 @@ type liveChildren struct {
 // though the index tracks them: a listing never shows them, so counting one
 // as live would keep its parent visible as an empty shell.
 func (s *Store) liveChildren(dirReq string) liveChildren {
-	canon := slashpath.Clean("/" + strings.Trim(dirReq, "/"))
+	canon := CanonicalPath(dirReq)
 	prefix := strings.TrimRight(canon, "/") + "/"
 	out := liveChildren{files: make(map[string]struct{}), dirs: make(map[string]struct{})}
 	s.hashMu.RLock()
@@ -731,7 +757,7 @@ func (s *Store) resolve(reqPath string) (string, error) {
 	// Reject paths that contain .. segments. filepath.Clean collapses traversal
 	// attempts into valid-looking paths (e.g., /../etc/passwd → etc/passwd), so
 	// we check the original path for traversal intent as defense-in-depth.
-	if containsDotDot(reqPath) {
+	if ContainsDotDot(reqPath) {
 		return "", os.ErrNotExist
 	}
 
@@ -769,6 +795,9 @@ func (s *Store) resolve(reqPath string) (string, error) {
 // CurrentVersion returns the latest version number for a document.
 // Returns 0 if no version history exists.
 func (s *Store) CurrentVersion(reqPath string) int {
+	if ContainsDotDot(reqPath) {
+		return 0
+	}
 	cleaned := filepath.Clean(reqPath)
 	cleaned = strings.TrimLeft(cleaned, "/")
 	versionsDir := filepath.Join(s.root, filepath.Dir(cleaned), "versions")
@@ -851,6 +880,10 @@ func (s *Store) findVersionsPerDoc(versionsDir, base string) []VersionInfo {
 // getVersion retrieves a specific version of a document from the versions directory.
 // Uses resolve() for path validation — same security as all other path access.
 func (s *Store) getVersion(reqPath string, version int) (*Document, error) {
+	// filepath.Join below would clean ".." away; reject it like resolve does.
+	if ContainsDotDot(reqPath) {
+		return nil, os.ErrNotExist
+	}
 	cleaned := filepath.Clean(reqPath)
 	cleaned = strings.TrimLeft(cleaned, "/")
 	base := filepath.Base(cleaned)
@@ -974,14 +1007,22 @@ func (s *Store) Archive(reqPath string, archived bool) error {
 // The previous-hash is the SHA-256 of the raw on-disk bytes of version N-1,
 // forming a hash chain that allows chain integrity to be verified later.
 func (s *Store) Write(reqPath string, content []byte, meta map[string]string) (*Document, error) {
-	if int64(len(content)) > protocol.MaxBodyLength {
-		return nil, ErrSizeLimit
-	}
-	if err := validateMeta(meta); err != nil {
+	if err := validateWrite(content, meta); err != nil {
 		return nil, err
 	}
-	if err := ValidateBody(content); err != nil {
-		return nil, err
+	if ContainsDotDot(reqPath) {
+		return nil, os.ErrNotExist
+	}
+
+	cleaned := filepath.Clean(reqPath)
+	cleaned = strings.TrimLeft(cleaned, "/")
+	base := filepath.Base(cleaned)
+	dir := filepath.Dir(cleaned)
+
+	// Writing beneath a document is a topology collision, reported the same
+	// way as writing over a directory (pgstore.checkPathTopology agrees).
+	if anc := s.documentAncestor(cleaned); anc != "" {
+		return nil, fmt.Errorf("cannot publish %s: a document exists at ancestor /%s", reqPath, anc)
 	}
 
 	// Validate path stays within the store root (resolve handles traversal + symlinks).
@@ -991,11 +1032,6 @@ func (s *Store) Write(reqPath string, content []byte, meta map[string]string) (*
 		}
 		return nil, fmt.Errorf("resolve path: %w", err)
 	}
-
-	cleaned := filepath.Clean(reqPath)
-	cleaned = strings.TrimLeft(cleaned, "/")
-	base := filepath.Base(cleaned)
-	dir := filepath.Dir(cleaned)
 
 	versionsDir := filepath.Join(s.root, dir, "versions")
 	if err := os.MkdirAll(versionsDir, 0o755); err != nil {
@@ -1089,12 +1125,15 @@ func (s *Store) Write(reqPath string, content []byte, meta map[string]string) (*
 
 	s.UpdateHashIndex(reqPath, content)
 
+	// Metadata is the persisted form (what Get returns), not the request
+	// map: "alpha, beta" is stored as a tags list and reads back "alpha,beta",
+	// and the catalog must see one spelling whichever path populated it.
 	doc := &Document{
 		Content:  content,
 		Modified: info.ModTime().UTC().Truncate(time.Second),
 		Version:  next,
 		Archived: false,
-		Metadata: meta,
+		Metadata: extractMetadata(stored),
 	}
 	if keep := retentionValue(meta); keep > 0 {
 		doc.Prune = s.pruneVersions(versionsDir, base, next, keep)
@@ -1237,6 +1276,14 @@ func (s *Store) prepareExistingDoc(versionsDir, base string, next int, content [
 //
 // Returns ErrConflict if the expectation is violated.
 func (s *Store) WriteVersion(reqPath string, expectedVersion int, content []byte, meta map[string]string) (*Document, error) {
+	// Request-shaped checks come before any state read so an invalid write
+	// never masquerades as a conflict; pgstore orders its checks the same way.
+	if err := validateWrite(content, meta); err != nil {
+		return nil, err
+	}
+	if ContainsDotDot(reqPath) {
+		return nil, os.ErrNotExist
+	}
 	if expectedVersion < 0 {
 		return s.Write(reqPath, content, meta)
 	}
@@ -1295,7 +1342,7 @@ func (s *Store) Append(reqPath string, expectedVersion int, content []byte, meta
 	if err := validateMeta(meta); err != nil {
 		return nil, err
 	}
-	if containsDotDot(reqPath) {
+	if ContainsDotDot(reqPath) {
 		return nil, os.ErrNotExist
 	}
 
@@ -1398,11 +1445,28 @@ func resolveNonExistent(path string) (string, error) {
 	if err != nil {
 		return filepath.Abs(path)
 	}
+	// A non-directory ancestor (a document's current pointer) cannot have
+	// children: the path addresses nothing. Report ErrNotExist here rather
+	// than letting a later stat surface ENOTDIR as an internal error.
+	if len(tail) > 0 {
+		if info, err := os.Stat(resolved); err == nil && !info.IsDir() {
+			return "", os.ErrNotExist
+		}
+	}
 	return filepath.Join(append([]string{resolved}, tail...)...), nil
 }
 
-// containsDotDot reports whether the path contains a ".." segment.
-func containsDotDot(path string) bool {
+// CanonicalPath is the one spelling of a request path shared by every index
+// keyed on paths (hash index, catalog, pgstore rows): slash-cleaned, single
+// leading slash, root is "/". Callers reject traversal via ContainsDotDot.
+func CanonicalPath(reqPath string) string {
+	return slashpath.Clean("/" + reqPath)
+}
+
+// ContainsDotDot reports whether the path contains a ".." segment. Every
+// backend rejects such paths with os.ErrNotExist; exported so they share one
+// definition of traversal.
+func ContainsDotDot(path string) bool {
 	for seg := range strings.SplitSeq(path, "/") {
 		if seg == ".." {
 			return true
@@ -1546,6 +1610,30 @@ func ValidateBody(content []byte) error {
 		return ErrInvalidContent
 	}
 	return nil
+}
+
+// validateWrite checks the size, metadata, and encoding of a write request.
+func validateWrite(content []byte, meta map[string]string) error {
+	if int64(len(content)) > protocol.MaxBodyLength {
+		return ErrSizeLimit
+	}
+	if err := validateMeta(meta); err != nil {
+		return err
+	}
+	return ValidateBody(content)
+}
+
+// documentAncestor returns the nearest proper ancestor of cleaned (no leading
+// slash) that is a document, archived or not, or "" when none is.
+func (s *Store) documentAncestor(cleaned string) string {
+	parts := strings.Split(cleaned, "/")
+	for i := 1; i < len(parts); i++ {
+		anc := strings.Join(parts[:i], "/")
+		if s.CurrentVersion(anc) > 0 {
+			return anc
+		}
+	}
+	return ""
 }
 
 // validateMeta checks metadata is safe for frontmatter serialization. Defense

--- a/protocol/store/store.go
+++ b/protocol/store/store.go
@@ -237,6 +237,10 @@ func (s *Store) walkCurrentFiles(fn func(reqPath string, data []byte, modified t
 	}
 	walkErr := filepath.WalkDir(absRoot, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
+			if path == absRoot {
+				// An unreadable root is not a partial walk: nothing was indexed.
+				return fmt.Errorf("walk content root: %w", err)
+			}
 			return skip(path, err)
 		}
 		if d.IsDir() {

--- a/protocol/store/walkcurrent_test.go
+++ b/protocol/store/walkcurrent_test.go
@@ -88,3 +88,26 @@ func TestBuildHashIndex_ReportsSkippedEntries(t *testing.T) {
 		t.Errorf("LookupHash after partial walk = (%q, %v), want /good.md", p, ok)
 	}
 }
+
+// TestBuildHashIndex_UnreadableRootIsFatal pins that a root the walk cannot
+// open is a real error, not a partial walk with zero entries.
+func TestBuildHashIndex_UnreadableRootIsFatal(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory permissions")
+	}
+	root := t.TempDir()
+	s := New(root)
+	if _, err := s.Write("/doc.md", []byte("x"), nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(root, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(root, 0o755) })
+
+	err := s.BuildHashIndex()
+	var partial *PartialWalkError
+	if err == nil || errors.As(err, &partial) {
+		t.Fatalf("BuildHashIndex err = %v, want a non-partial error", err)
+	}
+}

--- a/protocol/store/walkcurrent_test.go
+++ b/protocol/store/walkcurrent_test.go
@@ -1,6 +1,9 @@
 package store
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -58,4 +61,30 @@ func keysOf(m map[string]CurrentDoc) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// TestBuildHashIndex_ReportsSkippedEntries pins that an unindexable entry
+// (here a dangling current-version symlink) is reported, not swallowed, and
+// does not prevent the rest of the root from being indexed.
+func TestBuildHashIndex_ReportsSkippedEntries(t *testing.T) {
+	root := t.TempDir()
+	s := New(root)
+	if _, err := s.Write("/good.md", []byte("good"), nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("versions/missing.md/v1", filepath.Join(root, "dangling.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := s.BuildHashIndex()
+	var partial *PartialWalkError
+	if !errors.As(err, &partial) {
+		t.Fatalf("BuildHashIndex err = %v, want *PartialWalkError", err)
+	}
+	if len(partial.Skipped) != 1 || filepath.Base(partial.Skipped[0].Path) != "dangling.md" {
+		t.Errorf("skipped = %+v, want the dangling symlink", partial.Skipped)
+	}
+	if p, ok := s.LookupHash(ContentHash([]byte("good"))); !ok || p != "/good.md" {
+		t.Errorf("LookupHash after partial walk = (%q, %v), want /good.md", p, ok)
+	}
 }

--- a/protocol/store/walkcurrent_test.go
+++ b/protocol/store/walkcurrent_test.go
@@ -89,25 +89,50 @@ func TestBuildHashIndex_ReportsSkippedEntries(t *testing.T) {
 	}
 }
 
-// TestBuildHashIndex_UnreadableRootIsFatal pins that a root the walk cannot
-// open is a real error, not a partial walk with zero entries.
-func TestBuildHashIndex_UnreadableRootIsFatal(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("root ignores directory permissions")
+// TestBuildHashIndex_RootFailureIsFatal pins that a root the walk cannot open
+// is a real error, not a partial walk with zero entries. The missing-root case
+// is deterministic everywhere; the permission case needs a non-root uid.
+func TestBuildHashIndex_RootFailureIsFatal(t *testing.T) {
+	newRoot := func(t *testing.T) (string, *Store) {
+		root := filepath.Join(t.TempDir(), "content")
+		if err := os.Mkdir(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		s := New(root)
+		if _, err := s.Write("/doc.md", []byte("x"), nil); err != nil {
+			t.Fatal(err)
+		}
+		return root, s
 	}
-	root := t.TempDir()
-	s := New(root)
-	if _, err := s.Write("/doc.md", []byte("x"), nil); err != nil {
-		t.Fatal(err)
+	assertFatal := func(t *testing.T, s *Store) {
+		t.Helper()
+		err := s.BuildHashIndex()
+		var partial *PartialWalkError
+		if err == nil || errors.As(err, &partial) {
+			t.Fatalf("BuildHashIndex err = %v, want a non-partial error", err)
+		}
 	}
-	if err := os.Chmod(root, 0o000); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(root, 0o755) })
 
-	err := s.BuildHashIndex()
-	var partial *PartialWalkError
-	if err == nil || errors.As(err, &partial) {
-		t.Fatalf("BuildHashIndex err = %v, want a non-partial error", err)
-	}
+	t.Run("missing root", func(t *testing.T) {
+		root, s := newRoot(t)
+		if err := os.RemoveAll(root); err != nil {
+			t.Fatal(err)
+		}
+		assertFatal(t, s)
+	})
+	t.Run("unreadable root", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root ignores directory permissions")
+		}
+		root, s := newRoot(t)
+		if err := os.Chmod(root, 0o000); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if err := os.Chmod(root, 0o755); err != nil {
+				t.Errorf("restore root permissions: %v", err)
+			}
+		})
+		assertFatal(t, s)
+	})
 }

--- a/server/cmd/demarkus-server/main.go
+++ b/server/cmd/demarkus-server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -37,15 +38,29 @@ type currentWalker interface {
 // table. A failed walk leaves an empty catalog rather than aborting startup.
 func buildCatalog(s currentWalker, logger *slog.Logger) *catalog.Catalog {
 	cat := catalog.New()
-	if err := s.WalkCurrent(func(d store.CurrentDoc) error {
+	err := s.WalkCurrent(func(d store.CurrentDoc) error {
 		cat.Set(catalog.FromDocument(d.Path, d.Metadata, d.Body, d.Modified))
 		return nil
-	}); err != nil {
+	})
+	if err != nil && !logPartialWalk(logger, "lookup catalog", err) {
 		logger.Warn("lookup catalog build failed", "error", err)
-	} else {
-		logger.Info("lookup catalog built", "entries", cat.Len())
+		return cat
 	}
+	logger.Info("lookup catalog built", "entries", cat.Len())
 	return cat
+}
+
+// logPartialWalk reports each entry a completed walk skipped and returns
+// true; any other error returns false for the caller to handle.
+func logPartialWalk(logger *slog.Logger, what string, err error) bool {
+	var partial *store.PartialWalkError
+	if !errors.As(err, &partial) {
+		return false
+	}
+	for _, e := range partial.Skipped {
+		logger.Warn(what+" skipped entry", "path", e.Path, "error", e.Err)
+	}
+	return true
 }
 
 // version is set at build time via -ldflags "-X main.version=...".
@@ -189,10 +204,9 @@ func main() {
 			logger.Error("store open failed", "error", err)
 			os.Exit(1)
 		}
-		// BuildHashIndex clears the index before walking; continuing after a
-		// failure would serve hash-based FETCHes from an empty or partial
-		// index, so a broken walk is fatal.
-		if err := s.BuildHashIndex(); err != nil {
+		// A broken walk is fatal (an empty index would fail every hash FETCH);
+		// a walk that merely skipped entries is logged per entry and served.
+		if err := s.BuildHashIndex(); err != nil && !logPartialWalk(logger, "hash index", err) {
 			logger.Error("hash index build failed", "error", err)
 			os.Exit(1)
 		}

--- a/server/cmd/demarkus-server/main.go
+++ b/server/cmd/demarkus-server/main.go
@@ -60,6 +60,9 @@ func logPartialWalk(logger *slog.Logger, what string, err error) bool {
 	for _, e := range partial.Skipped {
 		logger.Warn(what+" skipped entry", "path", e.Path, "error", e.Err)
 	}
+	if partial.Total > len(partial.Skipped) {
+		logger.Warn(what+" skipped more entries than listed", "total", partial.Total, "listed", len(partial.Skipped))
+	}
 	return true
 }
 

--- a/server/internal/catalog/catalog.go
+++ b/server/internal/catalog/catalog.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/latebit-io/demarkus/protocol/store"
 )
 
 // Entry is a single document's catalog record.
@@ -50,6 +52,7 @@ func New() *Catalog {
 // Set adds or replaces the entry for e.Path. The catalog takes ownership of e;
 // the caller must not mutate it afterward.
 func (c *Catalog) Set(e *Entry) {
+	e.Path = store.CanonicalPath(e.Path)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.entries[e.Path] = e
@@ -65,7 +68,7 @@ func (c *Catalog) Put(docPath string, meta map[string]string, body []byte, modif
 func (c *Catalog) Remove(docPath string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	delete(c.entries, docPath)
+	delete(c.entries, store.CanonicalPath(docPath))
 }
 
 // Len returns the number of cataloged documents.
@@ -101,7 +104,7 @@ func (c *Catalog) Lookup(query string, opts Options) ([]Result, error) {
 	if !matchAll && len(terms) == 0 {
 		return nil, nil
 	}
-	scope := normalizeScope(opts.Scope)
+	scope := NormalizeScope(opts.Scope)
 
 	c.mu.RLock()
 	var results []Result
@@ -179,9 +182,10 @@ func sortResults(rs []Result) {
 	})
 }
 
-// normalizeScope returns a leading-slashed, trailing-slash-trimmed scope, or
-// "/" for the whole-server scope.
-func normalizeScope(s string) string {
+// NormalizeScope returns a leading-slashed, trailing-slash-trimmed scope, or
+// "/" for the whole-server scope. Exported so every LookupCatalog backend
+// scopes identically; it deliberately does not clean the path.
+func NormalizeScope(s string) string {
 	if s == "" || s == "/" {
 		return "/"
 	}

--- a/server/internal/catalog/catalog.go
+++ b/server/internal/catalog/catalog.go
@@ -52,10 +52,11 @@ func New() *Catalog {
 // Set adds or replaces the entry for e.Path. The catalog takes ownership of e;
 // the caller must not mutate it afterward.
 func (c *Catalog) Set(e *Entry) {
-	e.Path = store.CanonicalPath(e.Path)
+	path := store.CanonicalPath(e.Path)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.entries[e.Path] = e
+	e.Path = path
+	c.entries[path] = e
 }
 
 // Put derives an entry from a written document and records it; body has

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -71,6 +71,8 @@ type DocumentStore interface {
 	IsDir(reqPath string) (bool, error)
 	Versions(reqPath string) ([]store.VersionInfo, error)
 	CurrentVersion(reqPath string) int
+	// LookupHash resolves a live document by body hash; when several share
+	// the body, the smallest path wins.
 	LookupHash(hash string) (string, bool)
 	VerifyChain(reqPath string) error
 	// Writes surface the sentinels the handlers map to protocol statuses:

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -127,7 +127,7 @@ func (h *Handler) HandleStream(stream Stream) {
 
 	// Reject path traversal attempts before any handler logic (including auth)
 	// to prevent scope bypass via paths like /allowed/../secret.md.
-	if containsDotDot(req.Path) {
+	if store.ContainsDotDot(req.Path) {
 		h.logger().Warn("path traversal attempt blocked", "path", sanitize(req.Path))
 		h.writeError(stream, protocol.StatusNotFound, req.Path+" not found")
 		return
@@ -1061,16 +1061,6 @@ func (h *Handler) writeResponse(w io.Writer, resp protocol.Response) {
 	if _, err := resp.WriteTo(w); err != nil {
 		h.logger().Error("write response failed", "error", err)
 	}
-}
-
-// containsDotDot reports whether the path contains a ".." segment.
-func containsDotDot(p string) bool {
-	for seg := range strings.SplitSeq(p, "/") {
-		if seg == ".." {
-			return true
-		}
-	}
-	return false
 }
 
 // sanitize strips control characters from a string for safe logging.

--- a/server/internal/pgstore/catalog.go
+++ b/server/internal/pgstore/catalog.go
@@ -207,10 +207,13 @@ func (s *Store) Lookup(query string, opts catalog.Options) ([]catalog.Result, er
 		JOIN documents d ON d.path = c.path
 		WHERE NOT d.archived`
 	args := []any{termsJSON}
-	if scope := canonical(opts.Scope); scope != "" {
-		prefix := scope + "/"
+	// Same scope normalization as the in-memory catalog, minus the leading
+	// slash stored paths lack; an uncleaned scope matches nothing on both.
+	if scope := catalog.NormalizeScope(opts.Scope); scope != "/" {
+		key := strings.TrimPrefix(scope, "/")
+		prefix := key + "/"
 		sel += ` AND (c.path = $2 OR (c.path >= $3 AND c.path < $4))`
-		args = append(args, scope, prefix, prefixUpperBound(prefix))
+		args = append(args, key, prefix, prefixUpperBound(prefix))
 	}
 	q := `SELECT * FROM (` + sel + `) m`
 	if !matchAll {

--- a/server/internal/pgstore/pgstore.go
+++ b/server/internal/pgstore/pgstore.go
@@ -727,6 +727,11 @@ func (s *Store) Append(reqPath string, expectedVersion int, content []byte, meta
 	if err := store.ValidateMeta(meta); err != nil {
 		return nil, err
 	}
+	// Reject traversal explicitly, as the file store does, rather than relying
+	// on the CurrentVersion fallback below reading 0 for an invalid path.
+	if _, err := store.RelPath(reqPath); err != nil {
+		return nil, err
+	}
 
 	baseDoc, err := s.Get(reqPath, expectedVersion)
 	if err != nil {

--- a/server/internal/pgstore/pgstore.go
+++ b/server/internal/pgstore/pgstore.go
@@ -146,20 +146,10 @@ func (s *Store) Reset(ctx context.Context) error {
 	return nil
 }
 
-// canonical normalizes a request path to the storage key: CanonicalPath
-// without the leading slash, "" for the root. ".." is rejected with
-// os.ErrNotExist rather than cleaned away, matching the file store.
-func canonical(reqPath string) (string, error) {
-	if store.ContainsDotDot(reqPath) {
-		return "", os.ErrNotExist
-	}
-	return strings.TrimPrefix(store.CanonicalPath(reqPath), "/"), nil
-}
-
 // Get retrieves a document. version 0 means current. Missing documents and
 // directory paths return os.ErrNotExist.
 func (s *Store) Get(reqPath string, version int) (*store.Document, error) {
-	p, err := canonical(reqPath)
+	p, err := store.RelPath(reqPath)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +186,7 @@ func (s *Store) Get(reqPath string, version int) (*store.Document, error) {
 // beneath it (and that is not the root) returns os.ErrNotExist, as does a
 // document path.
 func (s *Store) ListEntries(reqPath string, includeArchived bool) ([]store.DirEntry, error) {
-	p, err := canonical(reqPath)
+	p, err := store.RelPath(reqPath)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +283,7 @@ func hiddenName(name string) bool {
 // other path is a directory when documents exist beneath it. A document
 // path reports false; a missing path returns os.ErrNotExist.
 func (s *Store) IsDir(reqPath string) (bool, error) {
-	p, err := canonical(reqPath)
+	p, err := store.RelPath(reqPath)
 	if err != nil {
 		return false, err
 	}
@@ -328,7 +318,7 @@ func (s *Store) IsDir(reqPath string) (bool, error) {
 // Versions returns the version history newest first, or os.ErrNotExist for
 // a document with no history.
 func (s *Store) Versions(reqPath string) ([]store.VersionInfo, error) {
-	p, err := canonical(reqPath)
+	p, err := store.RelPath(reqPath)
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +353,7 @@ func (s *Store) Versions(reqPath string) ([]store.VersionInfo, error) {
 // database failure is logged before reporting absence; otherwise an outage
 // would be indistinguishable from a missing document.
 func (s *Store) CurrentVersion(reqPath string) int {
-	p, err := canonical(reqPath)
+	p, err := store.RelPath(reqPath)
 	if err != nil {
 		return 0
 	}
@@ -414,7 +404,7 @@ func (s *Store) LookupHash(hash string) (string, bool) {
 // VerifyChain checks previous-hash integrity across the retained versions,
 // oldest to newest, exactly as the file store does.
 func (s *Store) VerifyChain(reqPath string) error {
-	p, err := canonical(reqPath)
+	p, err := store.RelPath(reqPath)
 	if err != nil {
 		return err
 	}
@@ -479,7 +469,7 @@ func (s *Store) write(reqPath string, expectedVersion int, content []byte, meta 
 	if err := store.ValidateWrite(content, meta); err != nil {
 		return nil, err
 	}
-	p, err := canonical(reqPath)
+	p, err := store.RelPath(reqPath)
 	if err != nil {
 		return nil, err
 	}
@@ -768,7 +758,7 @@ func (s *Store) Append(reqPath string, expectedVersion int, content []byte, meta
 // stays valid because only successors hash their predecessor and the tip
 // has no successor yet.
 func (s *Store) Archive(reqPath string, archived bool) error {
-	p, err := canonical(reqPath)
+	p, err := store.RelPath(reqPath)
 	if err != nil {
 		return err
 	}

--- a/server/internal/pgstore/pgstore.go
+++ b/server/internal/pgstore/pgstore.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	gopath "path"
 	"sort"
 	"strings"
 	"time"
@@ -147,24 +146,29 @@ func (s *Store) Reset(ctx context.Context) error {
 	return nil
 }
 
-// canonical normalizes a request path to the storage key: cleaned, no
-// leading slash. "" is the root. ".." segments cannot survive path.Clean
-// of a rooted path, so traversal cannot escape the keyspace.
-func canonical(reqPath string) string {
-	p := gopath.Clean("/" + reqPath)
-	return strings.TrimPrefix(p, "/")
+// canonical normalizes a request path to the storage key: CanonicalPath
+// without the leading slash, "" for the root. ".." is rejected with
+// os.ErrNotExist rather than cleaned away, matching the file store.
+func canonical(reqPath string) (string, error) {
+	if store.ContainsDotDot(reqPath) {
+		return "", os.ErrNotExist
+	}
+	return strings.TrimPrefix(store.CanonicalPath(reqPath), "/"), nil
 }
 
 // Get retrieves a document. version 0 means current. Missing documents and
 // directory paths return os.ErrNotExist.
 func (s *Store) Get(reqPath string, version int) (*store.Document, error) {
-	p := canonical(reqPath)
+	p, err := canonical(reqPath)
+	if err != nil {
+		return nil, err
+	}
 	ctx, cancel := opCtx()
 	defer cancel()
 	var stored []byte
 	var modified time.Time
 	var ver int
-	err := s.db.QueryRowContext(ctx, `
+	err = s.db.QueryRowContext(ctx, `
 		SELECT v.stored, v.modified, v.version
 		FROM documents d
 		JOIN versions v ON v.path = d.path
@@ -192,7 +196,10 @@ func (s *Store) Get(reqPath string, version int) (*store.Document, error) {
 // beneath it (and that is not the root) returns os.ErrNotExist, as does a
 // document path.
 func (s *Store) ListEntries(reqPath string, includeArchived bool) ([]store.DirEntry, error) {
-	p := canonical(reqPath)
+	p, err := canonical(reqPath)
+	if err != nil {
+		return nil, err
+	}
 	prefix := ""
 	if p != "" {
 		prefix = p + "/"
@@ -286,7 +293,10 @@ func hiddenName(name string) bool {
 // other path is a directory when documents exist beneath it. A document
 // path reports false; a missing path returns os.ErrNotExist.
 func (s *Store) IsDir(reqPath string) (bool, error) {
-	p := canonical(reqPath)
+	p, err := canonical(reqPath)
+	if err != nil {
+		return false, err
+	}
 	if p == "" {
 		return true, nil
 	}
@@ -294,7 +304,7 @@ func (s *Store) IsDir(reqPath string) (bool, error) {
 	defer cancel()
 	prefix := p + "/"
 	var hasChildren bool
-	err := s.db.QueryRowContext(ctx, `
+	err = s.db.QueryRowContext(ctx, `
 		SELECT EXISTS (SELECT 1 FROM documents WHERE path >= $1 AND path < $2)`,
 		prefix, prefixUpperBound(prefix)).Scan(&hasChildren)
 	if err != nil {
@@ -318,7 +328,10 @@ func (s *Store) IsDir(reqPath string) (bool, error) {
 // Versions returns the version history newest first, or os.ErrNotExist for
 // a document with no history.
 func (s *Store) Versions(reqPath string) ([]store.VersionInfo, error) {
-	p := canonical(reqPath)
+	p, err := canonical(reqPath)
+	if err != nil {
+		return nil, err
+	}
 	ctx, cancel := opCtx()
 	defer cancel()
 	rows, err := s.db.QueryContext(ctx, `
@@ -350,11 +363,14 @@ func (s *Store) Versions(reqPath string) ([]store.VersionInfo, error) {
 // database failure is logged before reporting absence; otherwise an outage
 // would be indistinguishable from a missing document.
 func (s *Store) CurrentVersion(reqPath string) int {
-	p := canonical(reqPath)
+	p, err := canonical(reqPath)
+	if err != nil {
+		return 0
+	}
 	ctx, cancel := opCtx()
 	defer cancel()
 	var cur int
-	err := s.db.QueryRowContext(ctx, `
+	err = s.db.QueryRowContext(ctx, `
 		SELECT current_version FROM documents WHERE path = $1`, p).Scan(&cur)
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
@@ -398,7 +414,10 @@ func (s *Store) LookupHash(hash string) (string, bool) {
 // VerifyChain checks previous-hash integrity across the retained versions,
 // oldest to newest, exactly as the file store does.
 func (s *Store) VerifyChain(reqPath string) error {
-	p := canonical(reqPath)
+	p, err := canonical(reqPath)
+	if err != nil {
+		return err
+	}
 	ctx, cancel := opCtx()
 	defer cancel()
 	rows, err := s.db.QueryContext(ctx, `
@@ -457,16 +476,13 @@ func (s *Store) WriteVersion(reqPath string, expectedVersion int, content []byte
 }
 
 func (s *Store) write(reqPath string, expectedVersion int, content []byte, meta map[string]string) (*store.Document, error) {
-	if int64(len(content)) > protocol.MaxBodyLength {
-		return nil, store.ErrSizeLimit
-	}
-	if err := store.ValidateMeta(meta); err != nil {
+	if err := store.ValidateWrite(content, meta); err != nil {
 		return nil, err
 	}
-	if err := store.ValidateBody(content); err != nil {
+	p, err := canonical(reqPath)
+	if err != nil {
 		return nil, err
 	}
-	p := canonical(reqPath)
 	if p == "" {
 		return nil, os.ErrNotExist
 	}
@@ -549,8 +565,12 @@ func (s *Store) write(reqPath string, expectedVersion int, content []byte, meta 
 		return nil, fmt.Errorf("update current v%d: %w", next, err)
 	}
 
+	// Catalog row and returned Metadata use the persisted form, as the file
+	// store does; the request map may spell tags differently.
+	persisted := store.ExtractMetadata(stored)
+
 	// Catalog row rides the write tx: visible to every replica at commit.
-	if err := upsertCatalogRow(ctx, tx, p, catalog.FromDocument("/"+p, meta, content, now)); err != nil {
+	if err := upsertCatalogRow(ctx, tx, p, catalog.FromDocument("/"+p, persisted, content, now)); err != nil {
 		return nil, err
 	}
 
@@ -559,7 +579,7 @@ func (s *Store) write(reqPath string, expectedVersion int, content []byte, meta 
 		Modified: now,
 		Version:  next,
 		Archived: false,
-		Metadata: meta,
+		Metadata: persisted,
 	}
 
 	if err := s.applyRetention(ctx, tx, p, next, meta, doc); err != nil {
@@ -748,7 +768,10 @@ func (s *Store) Append(reqPath string, expectedVersion int, content []byte, meta
 // stays valid because only successors hash their predecessor and the tip
 // has no successor yet.
 func (s *Store) Archive(reqPath string, archived bool) error {
-	p := canonical(reqPath)
+	p, err := canonical(reqPath)
+	if err != nil {
+		return err
+	}
 	if p == "" {
 		return os.ErrNotExist
 	}

--- a/server/internal/pgstore/pgstore_test.go
+++ b/server/internal/pgstore/pgstore_test.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/latebit-io/demarkus/protocol"
+	"github.com/latebit-io/demarkus/protocol/store"
 	"github.com/latebit-io/demarkus/server/internal/auth"
 	"github.com/latebit-io/demarkus/server/internal/catalog"
 	"github.com/latebit-io/demarkus/server/internal/handler"
@@ -38,18 +39,23 @@ func TestPostgresConformance(t *testing.T) {
 	})
 }
 
-// testDSN returns the conformance database DSN or skips the test.
-func testDSN(t *testing.T) string {
+// testDSN returns the conformance database DSN or skips the test. CI sets
+// DEMARKUS_TEST_PG_REQUIRED so a missing DSN fails instead of skipping:
+// backend parity must be proven on every run, never silently dropped.
+func testDSN(t testing.TB) string {
 	t.Helper()
 	dsn := os.Getenv("DEMARKUS_TEST_PG_DSN")
 	if dsn == "" {
+		if os.Getenv("DEMARKUS_TEST_PG_REQUIRED") != "" {
+			t.Fatal("DEMARKUS_TEST_PG_DSN not set but DEMARKUS_TEST_PG_REQUIRED is; Postgres coverage is mandatory here")
+		}
 		t.Skip("DEMARKUS_TEST_PG_DSN not set; skipping Postgres test")
 	}
 	return dsn
 }
 
 // openStore opens a pgstore against the test database with a quiet logger.
-func openStore(t *testing.T) *pgstore.Store {
+func openStore(t testing.TB) *pgstore.Store {
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	s, err := pgstore.Open(testDSN(t), logger)
@@ -243,4 +249,36 @@ func assertLookupCount(t *testing.T, s *pgstore.Store, query string, want int) {
 	if len(rs) != want {
 		t.Errorf("lookup %q matched %d, want %d (results %+v)", query, len(rs), want, rs)
 	}
+}
+
+// TestPostgresDifferential is the primary parity gate: the file store is the
+// reference implementation and pgstore must be observably indistinguishable
+// from it over seeded random operation sequences.
+func TestPostgresDifferential(t *testing.T) {
+	s := openStore(t)
+	ref := func(t *testing.T) storetest.LookupBackend {
+		return storetest.LookupBackend{Store: store.New(t.TempDir()), Catalog: catalog.New()}
+	}
+	cand := func(t *testing.T) storetest.LookupBackend {
+		if err := s.Reset(context.Background()); err != nil {
+			t.Fatalf("reset: %v", err)
+		}
+		return storetest.LookupBackend{Store: s, Catalog: s}
+	}
+	storetest.RunDifferential(t, ref, cand, storetest.DifferentialConfig{})
+}
+
+// FuzzPostgresDifferential lets the fuzzer pick seeds for deeper runs. Fuzz
+// workers share one database, so: go test -run '^$' -fuzz FuzzPostgresDifferential -fuzztime 2m -parallel 1
+func FuzzPostgresDifferential(f *testing.F) {
+	s := openStore(f)
+	f.Add(int64(99))
+	f.Fuzz(func(t *testing.T, seed int64) {
+		if err := s.Reset(context.Background()); err != nil {
+			t.Fatalf("reset: %v", err)
+		}
+		ref := storetest.LookupBackend{Store: store.New(t.TempDir()), Catalog: catalog.New()}
+		cand := storetest.LookupBackend{Store: s, Catalog: s}
+		storetest.RunDifferentialSeed(t, ref, cand, seed, storetest.DifferentialConfig{Ops: 100})
+	})
 }

--- a/server/internal/pgstore/pgstore_test.go
+++ b/server/internal/pgstore/pgstore_test.go
@@ -16,7 +16,6 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/latebit-io/demarkus/protocol"
-	"github.com/latebit-io/demarkus/protocol/store"
 	"github.com/latebit-io/demarkus/server/internal/auth"
 	"github.com/latebit-io/demarkus/server/internal/catalog"
 	"github.com/latebit-io/demarkus/server/internal/handler"
@@ -70,12 +69,17 @@ func openStore(t testing.TB) *pgstore.Store {
 // is both halves of the backend pair (rows maintained by its write txs).
 func TestPostgresLookupConformance(t *testing.T) {
 	s := openStore(t)
-	storetest.RunLookupConformance(t, func(t *testing.T) storetest.LookupBackend {
-		if err := s.Reset(context.Background()); err != nil {
-			t.Fatalf("reset: %v", err)
-		}
-		return storetest.LookupBackend{Store: s, Catalog: s}
-	})
+	storetest.RunLookupConformance(t, func(t *testing.T) storetest.LookupBackend { return pgBackend(t, s) })
+}
+
+// pgBackend resets the shared store and returns it as both halves of the
+// lookup pair (catalog rows are maintained by its write transactions).
+func pgBackend(t testing.TB, s *pgstore.Store) storetest.LookupBackend {
+	t.Helper()
+	if err := s.Reset(context.Background()); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	return storetest.LookupBackend{Store: s, Catalog: s}
 }
 
 // mockStream is the minimal handler.Stream for driving requests in tests.
@@ -256,15 +260,8 @@ func assertLookupCount(t *testing.T, s *pgstore.Store, query string, want int) {
 // from it over seeded random operation sequences.
 func TestPostgresDifferential(t *testing.T) {
 	s := openStore(t)
-	ref := func(t *testing.T) storetest.LookupBackend {
-		return storetest.LookupBackend{Store: store.New(t.TempDir()), Catalog: catalog.New()}
-	}
-	cand := func(t *testing.T) storetest.LookupBackend {
-		if err := s.Reset(context.Background()); err != nil {
-			t.Fatalf("reset: %v", err)
-		}
-		return storetest.LookupBackend{Store: s, Catalog: s}
-	}
+	ref := func(t *testing.T) storetest.LookupBackend { return storetest.FileBackend(t) }
+	cand := func(t *testing.T) storetest.LookupBackend { return pgBackend(t, s) }
 	storetest.RunDifferential(t, ref, cand, storetest.DifferentialConfig{})
 }
 
@@ -274,11 +271,6 @@ func FuzzPostgresDifferential(f *testing.F) {
 	s := openStore(f)
 	f.Add(int64(99))
 	f.Fuzz(func(t *testing.T, seed int64) {
-		if err := s.Reset(context.Background()); err != nil {
-			t.Fatalf("reset: %v", err)
-		}
-		ref := storetest.LookupBackend{Store: store.New(t.TempDir()), Catalog: catalog.New()}
-		cand := storetest.LookupBackend{Store: s, Catalog: s}
-		storetest.RunDifferentialSeed(t, ref, cand, seed, storetest.DifferentialConfig{Ops: 100})
+		storetest.RunDifferentialSeed(t, storetest.FileBackend(t), pgBackend(t, s), seed, storetest.DifferentialConfig{Ops: 100})
 	})
 }

--- a/server/internal/storetest/conformance.go
+++ b/server/internal/storetest/conformance.go
@@ -41,6 +41,8 @@ func RunConformance(t *testing.T, factory Factory) {
 		{"MissingDocument", testMissingDocument},
 		{"PathCollisions", testPathCollisions},
 		{"RejectsBinaryBody", testRejectsBinaryBody},
+		{"SharedBodyHash", testSharedBodyHash},
+		{"BodySizeLimit", testBodySizeLimit},
 	}
 	for _, st := range subtests {
 		t.Run(st.name, func(t *testing.T) {
@@ -472,6 +474,60 @@ func testRejectsBinaryBody(t *testing.T, s handler.DocumentStore) {
 	}
 	if cur := s.CurrentVersion("/doc.md"); cur != 1 {
 		t.Errorf("rejected binary append advanced /doc.md to version %d, want 1", cur)
+	}
+}
+
+// testSharedBodyHash pins LookupHash when several live documents share a
+// body: the smallest path wins, and updating or archiving one never drops
+// the others.
+func testSharedBodyHash(t *testing.T, s handler.DocumentStore) {
+	hash := store.ContentHash([]byte("same"))
+	mustWrite(t, s, "/b.md", 0, "same")
+	mustWrite(t, s, "/a.md", 0, "same")
+	mustWrite(t, s, "/c.md", 0, "same")
+	if p, ok := s.LookupHash(hash); !ok || p != "/a.md" {
+		t.Errorf("LookupHash shared = (%q, %v), want smallest path /a.md", p, ok)
+	}
+	if err := s.Archive("/a.md", true); err != nil {
+		t.Fatal(err)
+	}
+	if p, ok := s.LookupHash(hash); !ok || p != "/b.md" {
+		t.Errorf("LookupHash after archiving /a.md = (%q, %v), want /b.md", p, ok)
+	}
+	mustWrite(t, s, "/b.md", 1, "changed")
+	if p, ok := s.LookupHash(hash); !ok || p != "/c.md" {
+		t.Errorf("LookupHash after rewriting /b.md = (%q, %v), want /c.md", p, ok)
+	}
+	if p, ok := s.LookupHash(store.ContentHash([]byte("changed"))); !ok || p != "/b.md" {
+		t.Errorf("LookupHash new body = (%q, %v), want /b.md", p, ok)
+	}
+	if err := s.Archive("/a.md", false); err != nil {
+		t.Fatal(err)
+	}
+	if p, ok := s.LookupHash(hash); !ok || p != "/a.md" {
+		t.Errorf("LookupHash after unarchiving /a.md = (%q, %v), want /a.md", p, ok)
+	}
+}
+
+// testBodySizeLimit pins the body boundary: exactly MaxBodyLength is stored,
+// one byte more is ErrSizeLimit, and an append whose joined content crosses
+// the limit is rejected without advancing the version.
+func testBodySizeLimit(t *testing.T, s handler.DocumentStore) {
+	atLimit := bytes.Repeat([]byte("x"), protocol.MaxBodyLength)
+	if _, err := s.WriteVersion("/max.md", 0, atLimit, nil); err != nil {
+		t.Fatalf("write at limit: %v", err)
+	}
+	if _, err := s.WriteVersion("/over.md", 0, append(atLimit, 'x'), nil); !errors.Is(err, store.ErrSizeLimit) {
+		t.Errorf("write over limit: err = %v, want ErrSizeLimit", err)
+	}
+	if cur := s.CurrentVersion("/over.md"); cur != 0 {
+		t.Errorf("over-limit write left version %d", cur)
+	}
+	if _, err := s.Append("/max.md", 1, []byte("y"), nil); !errors.Is(err, store.ErrSizeLimit) {
+		t.Errorf("append crossing limit: err = %v, want ErrSizeLimit", err)
+	}
+	if cur := s.CurrentVersion("/max.md"); cur != 1 {
+		t.Errorf("rejected append advanced /max.md to version %d, want 1", cur)
 	}
 }
 

--- a/server/internal/storetest/differential.go
+++ b/server/internal/storetest/differential.go
@@ -16,10 +16,12 @@ import (
 
 // DifferentialConfig tunes a differential run. Zero values take defaults.
 type DifferentialConfig struct {
-	Seeds         []int64 // one subtest per seed; default 12 fixed seeds
-	Ops           int     // operations per seed; default 200
-	SnapshotEvery int     // full-state comparison cadence in ops; default 10
+	Seeds []int64 // one subtest per seed; default 12 fixed seeds
+	Ops   int     // operations per seed; default 200
 }
+
+// snapshotEvery is the full-state comparison cadence in ops.
+const snapshotEvery = 10
 
 // RunDifferential drives one seeded random op sequence through a reference and
 // a candidate backend, comparing every return and periodically the full state.
@@ -42,22 +44,16 @@ func RunDifferentialSeed(t *testing.T, ref, cand LookupBackend, seed int64, cfg 
 	if cfg.Ops <= 0 {
 		cfg.Ops = 200
 	}
-	if cfg.SnapshotEvery <= 0 {
-		cfg.SnapshotEvery = 10
-	}
 	d := &differential{t: t, ref: ref, cand: cand, rng: rand.New(rand.NewSource(seed)), seed: seed}
 	for i := range cfg.Ops {
 		op := d.nextOp()
 		d.history = append(d.history, op.String())
 		d.apply(op)
+		if !t.Failed() && ((i+1)%snapshotEvery == 0 || i == cfg.Ops-1) {
+			d.compareSnapshots()
+		}
 		if t.Failed() {
 			return
-		}
-		if (i+1)%cfg.SnapshotEvery == 0 || i == cfg.Ops-1 {
-			d.compareSnapshots()
-			if t.Failed() {
-				return
-			}
 		}
 	}
 }
@@ -91,17 +87,15 @@ type op struct {
 	okf     bool
 }
 
+func (k opKind) String() string {
+	return [...]string{"write", "append", "archive", "unarchive"}[k]
+}
+
 func (o op) String() string {
-	switch o.kind {
-	case opWrite:
-		return fmt.Sprintf("write %s exp=%s body=%d meta=%d okf=%v", o.path, o.expMode, o.body, o.meta, o.okf)
-	case opAppend:
-		return fmt.Sprintf("append %s exp=%s body=%d meta=%d okf=%v", o.path, o.expMode, o.body, o.meta, o.okf)
-	case opArchive:
-		return "archive " + o.path
-	default:
-		return "unarchive " + o.path
+	if o.kind == opArchive || o.kind == opUnarchive {
+		return o.kind.String() + " " + o.path
 	}
+	return fmt.Sprintf("%s %s exp=%s body=%d meta=%d okf=%v", o.kind, o.path, o.expMode, o.body, o.meta, o.okf)
 }
 
 // Pools. Paths deliberately include collisions both ways, dot names, unicode,
@@ -169,9 +163,9 @@ func (d *differential) nextOp() op {
 		o.kind = opUnarchive
 	}
 	if o.kind == opWrite || o.kind == opAppend {
-		o.body = r.Intn(len(diffBodies) + 1) // +1 selects the oversized body
-		if o.body == len(diffBodies) && r.Intn(10) != 0 {
-			o.body = r.Intn(len(diffBodies))
+		o.body = r.Intn(len(diffBodies))
+		if r.Intn(100) == 0 {
+			o.body = len(diffBodies) // the oversized body, kept rare: 1 MiB per write
 		}
 		o.meta = r.Intn(len(diffMetas))
 		o.okf = r.Intn(2) == 0
@@ -202,11 +196,14 @@ func expectedFor(mode string, cur int) int {
 	case "create":
 		return 0
 	case "stale":
+		if cur == 0 {
+			return 1 // cur-1 would be -1, the skip-check sentinel
+		}
 		return cur - 1
 	case "ahead":
 		return cur + 1
 	case "far":
-		return 99
+		return cur + 50
 	default:
 		return cur
 	}
@@ -245,36 +242,16 @@ func (d *differential) apply(o op) {
 
 func (d *differential) applyOne(b LookupBackend, o op, cur int) string {
 	switch o.kind {
-	case opWrite, opAppend:
-		body, meta := d.bodyFor(o), d.metaFor(o)
-		expected := expectedFor(o.expMode, cur)
-		var doc *store.Document
-		var err error
-		if o.kind == opWrite {
-			doc, err = b.Store.WriteVersion(o.path, expected, body, meta)
-		} else {
-			doc, err = b.Store.Append(o.path, expected, body, meta)
-		}
-		if err == nil {
-			b.Catalog.Put(o.path, doc.Metadata, doc.Content, doc.Modified)
-		}
+	case opWrite:
+		doc, err := publishInto(b, o.path, expectedFor(o.expMode, cur), d.bodyFor(o), d.metaFor(o))
+		return errClass(err) + " " + describeDoc(doc)
+	case opAppend:
+		doc, err := appendInto(b, o.path, expectedFor(o.expMode, cur), d.bodyFor(o), d.metaFor(o))
 		return errClass(err) + " " + describeDoc(doc)
 	case opArchive:
-		err := b.Store.Archive(o.path, true)
-		if err == nil {
-			b.Catalog.Remove(o.path)
-		}
-		return errClass(err)
+		return errClass(archiveInto(b, o.path))
 	default:
-		err := b.Store.Archive(o.path, false)
-		if err == nil {
-			doc, gerr := b.Store.Get(o.path, 0)
-			if gerr != nil {
-				return "unarchive-get " + errClass(gerr)
-			}
-			b.Catalog.Put(o.path, doc.Metadata, doc.Content, doc.Modified)
-		}
-		return errClass(err)
+		return errClass(unarchiveInto(b, o.path))
 	}
 }
 
@@ -318,25 +295,10 @@ func describeDoc(doc *store.Document) string {
 		doc.Version, doc.Archived, !doc.Modified.IsZero(), doc.Content, describeMeta(doc.Metadata), prune)
 }
 
+// describeMeta renders metadata with sorted keys (fmt sorts map keys); nil
+// and empty both print as map[], which is the intended equivalence.
 func describeMeta(m map[string]string) string {
-	if len(m) == 0 {
-		return "{}"
-	}
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	var sb strings.Builder
-	sb.WriteString("{")
-	for i, k := range keys {
-		if i > 0 {
-			sb.WriteString(", ")
-		}
-		fmt.Fprintf(&sb, "%s=%q", k, m[k])
-	}
-	sb.WriteString("}")
-	return sb.String()
+	return fmt.Sprintf("%q", m)
 }
 
 // compareSnapshots renders the full observable state of both backends over

--- a/server/internal/storetest/differential.go
+++ b/server/internal/storetest/differential.go
@@ -21,11 +21,9 @@ type DifferentialConfig struct {
 	SnapshotEvery int     // full-state comparison cadence in ops; default 10
 }
 
-// RunDifferential drives the same seeded random operation sequence through a
-// reference backend and a candidate backend, comparing every return value and
-// periodically the full observable state. Conformance tests assert the
-// behaviors their author thought of; the differential catches the rest, so it
-// is the primary backend-parity gate: any divergence is a bug in one backend.
+// RunDifferential drives one seeded random op sequence through a reference and
+// a candidate backend, comparing every return and periodically the full state.
+// Conformance asserts what its author imagined; this catches the rest.
 func RunDifferential(t *testing.T, ref, cand LookupFactory, cfg DifferentialConfig) {
 	if len(cfg.Seeds) == 0 {
 		cfg.Seeds = []int64{1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233}
@@ -106,10 +104,8 @@ func (o op) String() string {
 	}
 }
 
-// Pools. Paths deliberately include collisions (document over directory and
-// under document), hidden dot names, unicode, OKF-exempt basenames, a
-// non-.md name, and traversal and unnormalized spellings, so the generator
-// reaches every branch the handler can hand a store.
+// Pools. Paths deliberately include collisions both ways, dot names, unicode,
+// OKF-exempt basenames, a non-.md name, traversal, and unnormalized spellings.
 var (
 	diffDocPaths = []string{
 		"/a.md", "/b.md", "/d/x.md", "/d/y.md", "/d/e/z.md",

--- a/server/internal/storetest/differential.go
+++ b/server/internal/storetest/differential.go
@@ -1,0 +1,454 @@
+package storetest
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/latebit-io/demarkus/protocol"
+	"github.com/latebit-io/demarkus/protocol/store"
+	"github.com/latebit-io/demarkus/server/internal/catalog"
+)
+
+// DifferentialConfig tunes a differential run. Zero values take defaults.
+type DifferentialConfig struct {
+	Seeds         []int64 // one subtest per seed; default 12 fixed seeds
+	Ops           int     // operations per seed; default 200
+	SnapshotEvery int     // full-state comparison cadence in ops; default 10
+}
+
+// RunDifferential drives the same seeded random operation sequence through a
+// reference backend and a candidate backend, comparing every return value and
+// periodically the full observable state. Conformance tests assert the
+// behaviors their author thought of; the differential catches the rest, so it
+// is the primary backend-parity gate: any divergence is a bug in one backend.
+func RunDifferential(t *testing.T, ref, cand LookupFactory, cfg DifferentialConfig) {
+	if len(cfg.Seeds) == 0 {
+		cfg.Seeds = []int64{1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233}
+	}
+	for _, seed := range cfg.Seeds {
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			RunDifferentialSeed(t, ref(t), cand(t), seed, cfg)
+		})
+	}
+}
+
+// RunDifferentialSeed runs one seeded sequence against already-constructed
+// backends. Exposed so a fuzz target can feed arbitrary seeds.
+func RunDifferentialSeed(t *testing.T, ref, cand LookupBackend, seed int64, cfg DifferentialConfig) {
+	t.Helper()
+	if cfg.Ops <= 0 {
+		cfg.Ops = 200
+	}
+	if cfg.SnapshotEvery <= 0 {
+		cfg.SnapshotEvery = 10
+	}
+	d := &differential{t: t, ref: ref, cand: cand, rng: rand.New(rand.NewSource(seed)), seed: seed}
+	for i := range cfg.Ops {
+		op := d.nextOp()
+		d.history = append(d.history, op.String())
+		d.apply(op)
+		if t.Failed() {
+			return
+		}
+		if (i+1)%cfg.SnapshotEvery == 0 || i == cfg.Ops-1 {
+			d.compareSnapshots()
+			if t.Failed() {
+				return
+			}
+		}
+	}
+}
+
+type differential struct {
+	t       *testing.T
+	ref     LookupBackend
+	cand    LookupBackend
+	rng     *rand.Rand
+	seed    int64
+	history []string
+}
+
+// opKind enumerates the mutating operations the generator emits. Reads are
+// covered by the snapshot, which exercises every read method over the pool.
+type opKind int
+
+const (
+	opWrite opKind = iota
+	opAppend
+	opArchive
+	opUnarchive
+)
+
+type op struct {
+	kind    opKind
+	path    string
+	expMode string
+	body    int // index into bodies
+	meta    int // index into metas
+	okf     bool
+}
+
+func (o op) String() string {
+	switch o.kind {
+	case opWrite:
+		return fmt.Sprintf("write %s exp=%s body=%d meta=%d okf=%v", o.path, o.expMode, o.body, o.meta, o.okf)
+	case opAppend:
+		return fmt.Sprintf("append %s exp=%s body=%d meta=%d okf=%v", o.path, o.expMode, o.body, o.meta, o.okf)
+	case opArchive:
+		return "archive " + o.path
+	default:
+		return "unarchive " + o.path
+	}
+}
+
+// Pools. Paths deliberately include collisions (document over directory and
+// under document), hidden dot names, unicode, OKF-exempt basenames, a
+// non-.md name, and traversal and unnormalized spellings, so the generator
+// reaches every branch the handler can hand a store.
+var (
+	diffDocPaths = []string{
+		"/a.md", "/b.md", "/d/x.md", "/d/y.md", "/d/e/z.md",
+		"/.h.md", "/d/.s.md", "/ü/ñ.md", "/index.md", "/d/log.md",
+		"/a.md/child.md", "/d", "/x", "/d/../b.md", "//a.md", "/d/e/", "/missing.md",
+	}
+	diffDirPaths = []string{
+		"/", "/d", "/d/e", "/ü", "/a.md", "/nope", "/.h.md", "/d/e/", "/d/../d", "",
+	}
+	diffBodies = [][]byte{
+		[]byte("# A\n"),
+		[]byte("# A\nline\n"),
+		[]byte("---\ntitle: own\n---\n# Doc\n"),
+		[]byte("x"),
+		[]byte(""),
+		[]byte("line1\nline2"),
+		[]byte("line1\nline2\n"),
+		[]byte(strings.Repeat("# Title with Words\n\nbody paragraph\n", 64)),
+		[]byte("# Üñí cödé\n"),
+		[]byte("no heading, just text"),
+		{0x89, 'P', 'N', 'G', 0xff, 0xfe, 0x00},
+	}
+	diffMetas = []map[string]string{
+		nil,
+		{},
+		{"tags": "alpha, beta", "importance": "0.9", "title": "Kept"},
+		{"tags": "Alpha"},
+		{"tags": "gamma, alpha", "importance": "0.5", "type": "Plan"},
+		{"tags": "beta", "importance": "0.5", "title": "Words Title"},
+		{"importance": "0.7"},
+		{"retention": "2"},
+		{"retention": "1", "tags": "x"},
+		{"retention": "abc"},
+		{"version": "3"},
+		{"agent": "claude"},
+		{"bad key": "v"},
+		{"tags": "nl\ninjected"},
+		{"tags": strings.Repeat("x", protocol.MaxMetaBytes+8)},
+		{"rel-depends-on": "/a.md, /b.md", "importance": "1"},
+	}
+	diffQueries = []string{"*", "alpha", "beta", "Alpha gamma", "words", "title", "kept words", "nothing", ""}
+	diffScopes  = []string{"", "/", "/d", "/d/", "/ü", "/a.md", "/nope"}
+	diffFilters = []string{"", "tag=alpha", "type=Plan", "modified-after=2000-01-01", "modified-before=2000-01-01", "tag=alpha,importance=0.9"}
+)
+
+// oversizedBody is shared so the 1 MiB+1 allocation happens once; it is
+// emitted rarely since writing it to Postgres is comparatively slow.
+var oversizedBody = []byte(strings.Repeat("y", protocol.MaxBodyLength+1))
+
+func (d *differential) nextOp() op {
+	r := d.rng
+	o := op{path: diffDocPaths[r.Intn(len(diffDocPaths))]}
+	switch n := r.Intn(100); {
+	case n < 50:
+		o.kind = opWrite
+	case n < 75:
+		o.kind = opAppend
+	case n < 88:
+		o.kind = opArchive
+	default:
+		o.kind = opUnarchive
+	}
+	if o.kind == opWrite || o.kind == opAppend {
+		o.body = r.Intn(len(diffBodies) + 1) // +1 selects the oversized body
+		if o.body == len(diffBodies) && r.Intn(10) != 0 {
+			o.body = r.Intn(len(diffBodies))
+		}
+		o.meta = r.Intn(len(diffMetas))
+		o.okf = r.Intn(2) == 0
+		switch n := r.Intn(100); {
+		case n < 35:
+			o.expMode = "cur"
+		case n < 60:
+			o.expMode = "any"
+		case n < 70:
+			o.expMode = "create"
+		case n < 80:
+			o.expMode = "stale"
+		case n < 90:
+			o.expMode = "ahead"
+		default:
+			o.expMode = "far"
+		}
+	}
+	return o
+}
+
+// expectedFor resolves the symbolic expected-version mode against a backend's
+// own current version so both backends are asked the same question.
+func expectedFor(mode string, cur int) int {
+	switch mode {
+	case "any":
+		return -1
+	case "create":
+		return 0
+	case "stale":
+		return cur - 1
+	case "ahead":
+		return cur + 1
+	case "far":
+		return 99
+	default:
+		return cur
+	}
+}
+
+func (d *differential) bodyFor(o op) []byte {
+	if o.body == len(diffBodies) {
+		return oversizedBody
+	}
+	return diffBodies[o.body]
+}
+
+func (d *differential) metaFor(o op) map[string]string {
+	m := diffMetas[o.meta]
+	if o.okf {
+		return store.ApplyOKFTypeDefault(o.path, m)
+	}
+	return m
+}
+
+// apply runs one op against both backends, mirroring the handler's catalog
+// maintenance, and compares the results.
+func (d *differential) apply(o op) {
+	refCur := d.ref.Store.CurrentVersion(o.path)
+	candCur := d.cand.Store.CurrentVersion(o.path)
+	if refCur != candCur {
+		d.fail("CurrentVersion(%s) before op: ref=%d cand=%d", o.path, refCur, candCur)
+		return
+	}
+	refRes := d.applyOne(d.ref, o, refCur)
+	candRes := d.applyOne(d.cand, o, candCur)
+	if refRes != candRes {
+		d.fail("op result differs\nref:  %s\ncand: %s", refRes, candRes)
+	}
+}
+
+func (d *differential) applyOne(b LookupBackend, o op, cur int) string {
+	switch o.kind {
+	case opWrite, opAppend:
+		body, meta := d.bodyFor(o), d.metaFor(o)
+		expected := expectedFor(o.expMode, cur)
+		var doc *store.Document
+		var err error
+		if o.kind == opWrite {
+			doc, err = b.Store.WriteVersion(o.path, expected, body, meta)
+		} else {
+			doc, err = b.Store.Append(o.path, expected, body, meta)
+		}
+		if err == nil {
+			b.Catalog.Put(o.path, doc.Metadata, doc.Content, doc.Modified)
+		}
+		return errClass(err) + " " + describeDoc(doc)
+	case opArchive:
+		err := b.Store.Archive(o.path, true)
+		if err == nil {
+			b.Catalog.Remove(o.path)
+		}
+		return errClass(err)
+	default:
+		err := b.Store.Archive(o.path, false)
+		if err == nil {
+			doc, gerr := b.Store.Get(o.path, 0)
+			if gerr != nil {
+				return "unarchive-get " + errClass(gerr)
+			}
+			b.Catalog.Put(o.path, doc.Metadata, doc.Content, doc.Modified)
+		}
+		return errClass(err)
+	}
+}
+
+// errClass maps an error to the sentinel the handler would act on. Backends
+// may wrap differently; what must agree is the class.
+func errClass(err error) string {
+	switch {
+	case err == nil:
+		return "ok"
+	case errors.Is(err, store.ErrConflict):
+		return "conflict"
+	case errors.Is(err, store.ErrNotModified):
+		return "not-modified"
+	case errors.Is(err, store.ErrArchived):
+		return "archived"
+	case errors.Is(err, store.ErrInvalidMeta):
+		return "invalid-meta"
+	case errors.Is(err, store.ErrInvalidContent):
+		return "invalid-content"
+	case errors.Is(err, store.ErrSizeLimit):
+		return "size-limit"
+	case errors.Is(err, os.ErrNotExist):
+		return "not-exist"
+	default:
+		return "error"
+	}
+}
+
+// describeDoc renders the backend-neutral parts of a Document. Modified is
+// wall-clock and differs between backends by construction, so only its
+// presence is compared.
+func describeDoc(doc *store.Document) string {
+	if doc == nil {
+		return "<nil>"
+	}
+	prune := "prune=nil"
+	if doc.Prune != nil {
+		prune = fmt.Sprintf("prune=%d-%d err=%v", doc.Prune.From, doc.Prune.To, doc.Prune.Err != nil)
+	}
+	return fmt.Sprintf("v=%d archived=%v modified=%v body=%q meta=%s %s",
+		doc.Version, doc.Archived, !doc.Modified.IsZero(), doc.Content, describeMeta(doc.Metadata), prune)
+}
+
+func describeMeta(m map[string]string) string {
+	if len(m) == 0 {
+		return "{}"
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var sb strings.Builder
+	sb.WriteString("{")
+	for i, k := range keys {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		fmt.Fprintf(&sb, "%s=%q", k, m[k])
+	}
+	sb.WriteString("}")
+	return sb.String()
+}
+
+// compareSnapshots renders the full observable state of both backends over
+// the path, body, and query pools and reports the first differing line.
+func (d *differential) compareSnapshots() {
+	ref := snapshot(d.ref)
+	cand := snapshot(d.cand)
+	for i := range ref {
+		if i >= len(cand) {
+			d.fail("snapshot: candidate shorter at line %d\nref: %s", i, ref[i])
+			return
+		}
+		if ref[i] != cand[i] {
+			d.fail("snapshot line %d differs\nref:  %s\ncand: %s", i, ref[i], cand[i])
+			return
+		}
+	}
+	if len(cand) > len(ref) {
+		d.fail("snapshot: candidate longer at line %d\ncand: %s", len(ref), cand[len(ref)])
+	}
+}
+
+func snapshot(b LookupBackend) []string {
+	var lines []string
+	add := func(format string, args ...any) { lines = append(lines, fmt.Sprintf(format, args...)) }
+
+	for _, p := range diffDocPaths {
+		cur := b.Store.CurrentVersion(p)
+		add("current %s = %d", p, cur)
+		doc, err := b.Store.Get(p, 0)
+		add("get %s = %s %s", p, errClass(err), describeDoc(doc))
+		vs, err := b.Store.Versions(p)
+		nums := make([]int, len(vs))
+		for i, v := range vs {
+			nums[i] = v.Version
+		}
+		add("versions %s = %s %v", p, errClass(err), nums)
+		for _, v := range nums {
+			vd, err := b.Store.Get(p, v)
+			add("get %s@%d = %s %s", p, v, errClass(err), describeDoc(vd))
+		}
+		_, err = b.Store.Get(p, cur+1)
+		add("get %s@next = %s", p, errClass(err))
+		add("chain %s = %s", p, errClass(b.Store.VerifyChain(p)))
+	}
+	for _, dir := range diffDirPaths {
+		ok, err := b.Store.IsDir(dir)
+		add("isdir %q = %v %s", dir, ok, errClass(err))
+		for _, includeArchived := range []bool{false, true} {
+			entries, err := b.Store.ListEntries(dir, includeArchived)
+			add("list %q archived=%v = %s %v", dir, includeArchived, errClass(err), entries)
+		}
+	}
+	for i, body := range diffBodies {
+		p, ok := b.Store.LookupHash(store.ContentHash(body))
+		add("hash body=%d = %q %v", i, p, ok)
+	}
+	// Queries x scopes unfiltered, then filters on the match-all query: the
+	// full cross product is mostly redundant and dominates snapshot cost.
+	lookup := func(q, scope, filter string) {
+		preds, perr := catalog.ParseFilter(filter)
+		if perr != nil {
+			add("filter %q parse error", filter)
+			return
+		}
+		rs, err := b.Catalog.Lookup(q, catalog.Options{Scope: scope, Filter: preds})
+		add("lookup q=%q scope=%q filter=%q = %s %s", q, scope, filter, errClass(err), describeResults(rs))
+	}
+	for _, q := range diffQueries {
+		for _, scope := range diffScopes {
+			lookup(q, scope, "")
+		}
+	}
+	for _, f := range diffFilters {
+		lookup("*", "", f)
+		lookup("alpha", "/d", f)
+	}
+	return lines
+}
+
+// describeResults renders lookup results in an order independent of the
+// modified-time tiebreak, which wall-clock skew between backends makes
+// non-deterministic. Score, importance, and path order are still asserted.
+func describeResults(rs []catalog.Result) string {
+	sorted := make([]catalog.Result, len(rs))
+	copy(sorted, rs)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		a, b := sorted[i], sorted[j]
+		if a.Score != b.Score {
+			return a.Score > b.Score
+		}
+		if a.Importance != b.Importance {
+			return a.Importance > b.Importance
+		}
+		return a.Path < b.Path
+	})
+	parts := make([]string, len(sorted))
+	for i, r := range sorted {
+		parts[i] = fmt.Sprintf("{%s score=%d imp=%g title=%q tags=%v meta=%s mod=%v}",
+			r.Path, r.Score, r.Importance, r.Title, r.Tags, describeMeta(r.Metadata), !r.Modified.IsZero())
+	}
+	return "[" + strings.Join(parts, " ") + "]"
+}
+
+func (d *differential) fail(format string, args ...any) {
+	d.t.Helper()
+	n := len(d.history)
+	from := max(0, n-12)
+	d.t.Errorf("seed %d, op %d: %s\nlast ops:\n  %s", d.seed, n, fmt.Sprintf(format, args...),
+		strings.Join(d.history[from:], "\n  "))
+}

--- a/server/internal/storetest/filestore_test.go
+++ b/server/internal/storetest/filestore_test.go
@@ -24,3 +24,13 @@ func TestFileStoreLookupConformance(t *testing.T) {
 		return LookupBackend{Store: store.New(t.TempDir()), Catalog: catalog.New()}
 	})
 }
+
+// TestFileStoreDifferentialSelf runs the differential harness with the file
+// store on both sides. It proves the harness itself is deterministic and
+// backend-neutral: a self-diff failure is a harness bug, not a store bug.
+func TestFileStoreDifferentialSelf(t *testing.T) {
+	factory := func(t *testing.T) LookupBackend {
+		return LookupBackend{Store: store.New(t.TempDir()), Catalog: catalog.New()}
+	}
+	RunDifferential(t, factory, factory, DifferentialConfig{Seeds: []int64{1, 2}, Ops: 80})
+}

--- a/server/internal/storetest/filestore_test.go
+++ b/server/internal/storetest/filestore_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/latebit-io/demarkus/protocol/store"
-	"github.com/latebit-io/demarkus/server/internal/catalog"
 	"github.com/latebit-io/demarkus/server/internal/handler"
 )
 
@@ -20,17 +19,13 @@ func TestFileStoreConformance(t *testing.T) {
 // the file backend's pairing: file store plus in-memory catalog, kept in
 // sync by the handler-mirroring helpers.
 func TestFileStoreLookupConformance(t *testing.T) {
-	RunLookupConformance(t, func(t *testing.T) LookupBackend {
-		return LookupBackend{Store: store.New(t.TempDir()), Catalog: catalog.New()}
-	})
+	RunLookupConformance(t, func(t *testing.T) LookupBackend { return FileBackend(t) })
 }
 
 // TestFileStoreDifferentialSelf runs the differential harness with the file
 // store on both sides. It proves the harness itself is deterministic and
 // backend-neutral: a self-diff failure is a harness bug, not a store bug.
 func TestFileStoreDifferentialSelf(t *testing.T) {
-	factory := func(t *testing.T) LookupBackend {
-		return LookupBackend{Store: store.New(t.TempDir()), Catalog: catalog.New()}
-	}
+	factory := func(t *testing.T) LookupBackend { return FileBackend(t) }
 	RunDifferential(t, factory, factory, DifferentialConfig{Seeds: []int64{1, 2}, Ops: 80})
 }

--- a/server/internal/storetest/lookup.go
+++ b/server/internal/storetest/lookup.go
@@ -1,9 +1,11 @@
 package storetest
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/latebit-io/demarkus/protocol/store"
 	"github.com/latebit-io/demarkus/server/internal/catalog"
 	"github.com/latebit-io/demarkus/server/internal/handler"
 )
@@ -202,39 +204,72 @@ func testLookupMaxCap(t *testing.T, b LookupBackend) {
 	assertLookup(t, b, "go", catalog.Options{Max: 0}, "/m1.md", "/m2.md", "/m3.md")
 }
 
-// catalogPublish writes a version and updates the catalog like the handler's
-// PUBLISH path.
-func catalogPublish(t *testing.T, b LookupBackend, path, body string, meta map[string]string) {
-	t.Helper()
-	doc, err := b.Store.WriteVersion(path, -1, []byte(body), meta)
-	if err != nil {
-		t.Fatalf("write %s: %v", path, err)
-	}
-	b.Catalog.Put(path, doc.Metadata, doc.Content, doc.Modified)
+// FileBackend is the file store paired with the in-memory catalog: the
+// reference backend every other one is compared against.
+func FileBackend(t testing.TB) LookupBackend {
+	return LookupBackend{Store: store.New(t.TempDir()), Catalog: catalog.New()}
 }
 
-// catalogArchive archives a document and updates the catalog like the
-// handler's ARCHIVE path.
-func catalogArchive(t *testing.T, b LookupBackend, path string) {
-	t.Helper()
+// The *Into helpers drive a backend exactly as the handler's write paths do
+// (store op, then catalog maintenance) and return the store's error; the
+// conformance and differential suites share them so they cannot drift.
+
+func publishInto(b LookupBackend, path string, expected int, body []byte, meta map[string]string) (*store.Document, error) {
+	doc, err := b.Store.WriteVersion(path, expected, body, meta)
+	if err == nil {
+		b.Catalog.Put(path, doc.Metadata, doc.Content, doc.Modified)
+	}
+	return doc, err
+}
+
+func appendInto(b LookupBackend, path string, expected int, body []byte, meta map[string]string) (*store.Document, error) {
+	doc, err := b.Store.Append(path, expected, body, meta)
+	if err == nil {
+		b.Catalog.Put(path, doc.Metadata, doc.Content, doc.Modified)
+	}
+	return doc, err
+}
+
+func archiveInto(b LookupBackend, path string) error {
 	if err := b.Store.Archive(path, true); err != nil {
-		t.Fatalf("archive %s: %v", path, err)
+		return err
 	}
 	b.Catalog.Remove(path)
+	return nil
 }
 
-// catalogUnarchive unarchives and re-registers a document like the handler's
-// empty-body PUBLISH path.
-func catalogUnarchive(t *testing.T, b LookupBackend, path string) {
-	t.Helper()
+// unarchiveInto mirrors the handler's empty-body PUBLISH path.
+func unarchiveInto(b LookupBackend, path string) error {
 	if err := b.Store.Archive(path, false); err != nil {
-		t.Fatalf("unarchive %s: %v", path, err)
+		return err
 	}
 	doc, err := b.Store.Get(path, 0)
 	if err != nil {
-		t.Fatalf("get after unarchive %s: %v", path, err)
+		return fmt.Errorf("get after unarchive: %w", err)
 	}
 	b.Catalog.Put(path, doc.Metadata, doc.Content, doc.Modified)
+	return nil
+}
+
+func catalogPublish(t *testing.T, b LookupBackend, path, body string, meta map[string]string) {
+	t.Helper()
+	if _, err := publishInto(b, path, -1, []byte(body), meta); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func catalogArchive(t *testing.T, b LookupBackend, path string) {
+	t.Helper()
+	if err := archiveInto(b, path); err != nil {
+		t.Fatalf("archive %s: %v", path, err)
+	}
+}
+
+func catalogUnarchive(t *testing.T, b LookupBackend, path string) {
+	t.Helper()
+	if err := unarchiveInto(b, path); err != nil {
+		t.Fatalf("unarchive %s: %v", path, err)
+	}
 }
 
 // mustLookup runs a lookup, failing the test on error.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved path normalization and traversal protection across storage and catalog operations.
  - Prevented writes beneath existing documents and rejected invalid content, metadata, and encoding.
  - Ensured stored metadata is accurately returned and reflected in catalog updates.
  - Made hash lookups deterministic when multiple paths share content.
  - Improved catalog scope filtering and invalid path handling.
  - Servers continue operating when individual filesystem entries cannot be indexed, while reporting skipped entries.

- **Tests**
  - Added differential testing across file and PostgreSQL storage.
  - PostgreSQL CI tests now use a provisioned PostgreSQL 16 database and fail when required configuration is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->