### PR TITLE
feat(tools): Add document history migration API and demarkus-migrate CLI

### DIFF
--- a/protocol/store/migrate.go
+++ b/protocol/store/migrate.go
@@ -166,20 +166,21 @@ func (s *Store) ImportDoc(ctx context.Context, reqPath string, versions []Stored
 		return fmt.Errorf("import %s: %w", reqPath, err)
 	}
 
-	// The per-doc versions dir must not pre-exist either (orphaned tree):
-	// version files are permanent and the failure cleanup below must never
-	// widen into files this call did not write.
+	// Mkdir (not MkdirAll) claims the per-doc versions dir atomically: a
+	// pre-existing dir (orphaned tree, concurrent import) refuses, so the
+	// failure cleanup below can never widen into files this call did not write.
 	firstFile, err := s.VersionFilePath(reqPath, versions[0].Version)
 	if err != nil {
 		return err
 	}
 	docDir := filepath.Dir(firstFile)
-	if _, err := os.Lstat(docDir); err == nil {
-		return fmt.Errorf("import %s: version directory already exists: %w", reqPath, os.ErrExist)
-	} else if !os.IsNotExist(err) {
+	if err := os.MkdirAll(filepath.Dir(docDir), 0o755); err != nil {
 		return fmt.Errorf("import %s: %w", reqPath, err)
 	}
-	if err := s.importVersionFiles(reqPath, docDir, versions); err != nil {
+	if err := os.Mkdir(docDir, 0o755); err != nil {
+		return fmt.Errorf("import %s: version directory: %w", reqPath, err)
+	}
+	if err := s.importVersionFiles(ctx, reqPath, versions); err != nil {
 		// Guarded above: the dir is exclusively this call's work. Removal is
 		// best-effort; the import error is what the caller must see.
 		_ = os.RemoveAll(docDir)
@@ -187,6 +188,10 @@ func (s *Store) ImportDoc(ctx context.Context, reqPath string, versions []Stored
 	}
 	newest := versions[len(versions)-1]
 	base := filepath.Base(rel)
+	if err := ctx.Err(); err != nil {
+		_ = os.RemoveAll(docDir)
+		return err
+	}
 	if err := os.Symlink(newVersionSymlinkTarget(base, newest.Version), currentFile); err != nil {
 		// Same guarantee as above: remove only what this call created.
 		_ = os.RemoveAll(docDir)
@@ -201,12 +206,12 @@ func (s *Store) ImportDoc(ctx context.Context, reqPath string, versions []Stored
 }
 
 // importVersionFiles writes the version files byte-for-byte with their
-// original modified times.
-func (s *Store) importVersionFiles(reqPath, docDir string, versions []StoredVersion) error {
-	if err := os.MkdirAll(docDir, 0o755); err != nil {
-		return fmt.Errorf("import %s: %w", reqPath, err)
-	}
+// original modified times, honoring cancellation between files.
+func (s *Store) importVersionFiles(ctx context.Context, reqPath string, versions []StoredVersion) error {
 	for _, v := range versions {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		vFile, err := s.VersionFilePath(reqPath, v.Version)
 		if err != nil {
 			return err

--- a/protocol/store/migrate.go
+++ b/protocol/store/migrate.go
@@ -5,12 +5,15 @@ package store
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/latebit-io/demarkus/protocol"
 )
 
 // StoredVersion is one version's raw stored bytes plus its modified time,
@@ -22,15 +25,17 @@ type StoredVersion struct {
 	Modified time.Time
 }
 
-// Migrator is the backend-neutral migration contract every store implements.
+// Migrator is the backend-neutral migration contract; the caller owns the
+// cancellation policy via ctx. The ExportDocs callback may retain versions,
+// so implementations must hand each document a fresh backing array.
 type Migrator interface {
-	ExportDocs(fn func(reqPath string, versions []StoredVersion) error) error
-	ImportDoc(reqPath string, versions []StoredVersion) error
+	ExportDocs(ctx context.Context, fn func(reqPath string, versions []StoredVersion) error) error
+	ImportDoc(ctx context.Context, reqPath string, versions []StoredVersion) error
 }
 
 // ValidateImport checks the shared ImportDoc preconditions and returns the
 // storage-relative path: a document path, at least one version, versions
-// strictly ascending (a pruned history may start past 1).
+// strictly ascending (a pruned history may start past 1), none oversized.
 func ValidateImport(reqPath string, versions []StoredVersion) (string, error) {
 	rel, err := RelPath(reqPath)
 	if err != nil {
@@ -42,9 +47,12 @@ func ValidateImport(reqPath string, versions []StoredVersion) (string, error) {
 	if len(versions) == 0 {
 		return "", fmt.Errorf("import %s: no versions", reqPath)
 	}
-	for i := 1; i < len(versions); i++ {
-		if versions[i].Version <= versions[i-1].Version {
+	for i, v := range versions {
+		if i > 0 && v.Version <= versions[i-1].Version {
 			return "", fmt.Errorf("import %s: versions not strictly ascending", reqPath)
+		}
+		if int64(len(v.Stored)) > int64(protocol.MaxBodyLength+maxStoreFrontmatter) {
+			return "", fmt.Errorf("import %s v%d: %w", reqPath, v.Version, ErrSizeLimit)
 		}
 	}
 	return rel, nil
@@ -83,14 +91,17 @@ func DiffExports(want, got map[string][]StoredVersion) error {
 
 // ExportDocs visits every document, archived included, with its history
 // oldest-first and stored bytes verbatim. Unreadable documents are hard
-// errors; non-symlink entries are not documents (walkCurrentFiles agrees).
-func (s *Store) ExportDocs(fn func(reqPath string, versions []StoredVersion) error) error {
+// errors; only symlink entries outside versions dirs count as documents.
+func (s *Store) ExportDocs(ctx context.Context, fn func(reqPath string, versions []StoredVersion) error) error {
 	root, err := s.resolvedRoot()
 	if err != nil {
 		return err
 	}
 	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 		if d.IsDir() {
@@ -140,9 +151,12 @@ func (s *Store) exportVersions(reqPath string) ([]StoredVersion, error) {
 // ImportDoc writes a document's version files byte-for-byte, restores their
 // modified times, and points the current symlink at the newest version. The
 // document must not exist; versions must be non-empty, strictly ascending.
-func (s *Store) ImportDoc(reqPath string, versions []StoredVersion) error {
+func (s *Store) ImportDoc(ctx context.Context, reqPath string, versions []StoredVersion) error {
 	rel, err := ValidateImport(reqPath, versions)
 	if err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
 		return err
 	}
 	currentFile := filepath.Join(s.root, rel)
@@ -152,21 +166,29 @@ func (s *Store) ImportDoc(reqPath string, versions []StoredVersion) error {
 		return fmt.Errorf("import %s: %w", reqPath, err)
 	}
 
-	// The per-doc versions dir, derived from the layout's one owner.
+	// The per-doc versions dir must not pre-exist either (orphaned tree):
+	// version files are permanent and the failure cleanup below must never
+	// widen into files this call did not write.
 	firstFile, err := s.VersionFilePath(reqPath, versions[0].Version)
 	if err != nil {
 		return err
 	}
 	docDir := filepath.Dir(firstFile)
+	if _, err := os.Lstat(docDir); err == nil {
+		return fmt.Errorf("import %s: version directory already exists: %w", reqPath, os.ErrExist)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("import %s: %w", reqPath, err)
+	}
 	if err := s.importVersionFiles(reqPath, docDir, versions); err != nil {
-		// The document did not exist, so its per-doc dir is all ours to
-		// remove: a failed import must not leave partial state behind.
+		// Guarded above: the dir is exclusively this call's work. Removal is
+		// best-effort; the import error is what the caller must see.
 		_ = os.RemoveAll(docDir)
 		return err
 	}
 	newest := versions[len(versions)-1]
 	base := filepath.Base(rel)
 	if err := os.Symlink(newVersionSymlinkTarget(base, newest.Version), currentFile); err != nil {
+		// Same guarantee as above: remove only what this call created.
 		_ = os.RemoveAll(docDir)
 		return fmt.Errorf("import %s: %w", reqPath, err)
 	}
@@ -195,6 +217,7 @@ func (s *Store) importVersionFiles(reqPath, docDir string, versions []StoredVers
 			return fmt.Errorf("import %s v%d: %w", reqPath, v.Version, err)
 		}
 		if _, err := f.Write(v.Stored); err != nil {
+			// Close error is moot; the write error is what matters.
 			_ = f.Close()
 			return fmt.Errorf("import %s v%d: %w", reqPath, v.Version, err)
 		}

--- a/protocol/store/migrate.go
+++ b/protocol/store/migrate.go
@@ -1,0 +1,210 @@
+package store
+
+// Migration surface: export and import a document's raw version history so a
+// world can move between store backends with byte-identical stored files.
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// StoredVersion is one version's raw stored bytes plus its modified time,
+// the complete migration unit: current version and archived flag are both
+// derivable (newest version; archived flag lives in the tip's frontmatter).
+type StoredVersion struct {
+	Version  int
+	Stored   []byte
+	Modified time.Time
+}
+
+// Migrator is the backend-neutral migration contract every store implements.
+type Migrator interface {
+	ExportDocs(fn func(reqPath string, versions []StoredVersion) error) error
+	ImportDoc(reqPath string, versions []StoredVersion) error
+}
+
+// ValidateImport checks the shared ImportDoc preconditions and returns the
+// storage-relative path: a document path, at least one version, versions
+// strictly ascending (a pruned history may start past 1).
+func ValidateImport(reqPath string, versions []StoredVersion) (string, error) {
+	rel, err := RelPath(reqPath)
+	if err != nil {
+		return "", err
+	}
+	if rel == "" || strings.HasSuffix(reqPath, "/") {
+		return "", fmt.Errorf("import %s: not a document path", reqPath)
+	}
+	if len(versions) == 0 {
+		return "", fmt.Errorf("import %s: no versions", reqPath)
+	}
+	for i := 1; i < len(versions); i++ {
+		if versions[i].Version <= versions[i-1].Version {
+			return "", fmt.Errorf("import %s: versions not strictly ascending", reqPath)
+		}
+	}
+	return rel, nil
+}
+
+// DiffExports is the one definition of export equality: same documents and
+// version numbers, byte-identical stored files, modified equal to the second
+// (the precision the protocol exposes via RFC3339 in VERSIONS).
+func DiffExports(want, got map[string][]StoredVersion) error {
+	if len(got) != len(want) {
+		return fmt.Errorf("document count: got %d, want %d", len(got), len(want))
+	}
+	for path, wv := range want {
+		gv, ok := got[path]
+		if !ok {
+			return fmt.Errorf("%s: missing", path)
+		}
+		if len(gv) != len(wv) {
+			return fmt.Errorf("%s: %d versions, want %d", path, len(gv), len(wv))
+		}
+		for i := range wv {
+			if gv[i].Version != wv[i].Version {
+				return fmt.Errorf("%s[%d]: version %d, want %d", path, i, gv[i].Version, wv[i].Version)
+			}
+			if !bytes.Equal(gv[i].Stored, wv[i].Stored) {
+				return fmt.Errorf("%s v%d: stored bytes differ", path, wv[i].Version)
+			}
+			w := wv[i].Modified.UTC().Truncate(time.Second)
+			if !gv[i].Modified.UTC().Truncate(time.Second).Equal(w) {
+				return fmt.Errorf("%s v%d: modified differs", path, wv[i].Version)
+			}
+		}
+	}
+	return nil
+}
+
+// ExportDocs visits every document, archived included, with its history
+// oldest-first and stored bytes verbatim. Unreadable documents are hard
+// errors; non-symlink entries are not documents (walkCurrentFiles agrees).
+func (s *Store) ExportDocs(fn func(reqPath string, versions []StoredVersion) error) error {
+	root, err := s.resolvedRoot()
+	if err != nil {
+		return err
+	}
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == "versions" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Type()&os.ModeSymlink == 0 {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		reqPath := "/" + filepath.ToSlash(rel)
+		versions, err := s.exportVersions(reqPath)
+		if err != nil {
+			return fmt.Errorf("export %s: %w", reqPath, err)
+		}
+		return fn(reqPath, versions)
+	})
+}
+
+// exportVersions reads a document's version files oldest-first.
+func (s *Store) exportVersions(reqPath string) ([]StoredVersion, error) {
+	infos, err := s.Versions(reqPath)
+	if err != nil {
+		return nil, err
+	}
+	versions := make([]StoredVersion, 0, len(infos))
+	// Versions returns newest-first; walk it backwards for oldest-first.
+	for i := len(infos) - 1; i >= 0; i-- {
+		vFile, err := s.VersionFilePath(reqPath, infos[i].Version)
+		if err != nil {
+			return nil, err
+		}
+		stored, err := os.ReadFile(vFile)
+		if err != nil {
+			return nil, err
+		}
+		versions = append(versions, StoredVersion{Version: infos[i].Version, Stored: stored, Modified: infos[i].Modified})
+	}
+	return versions, nil
+}
+
+// ImportDoc writes a document's version files byte-for-byte, restores their
+// modified times, and points the current symlink at the newest version. The
+// document must not exist; versions must be non-empty, strictly ascending.
+func (s *Store) ImportDoc(reqPath string, versions []StoredVersion) error {
+	rel, err := ValidateImport(reqPath, versions)
+	if err != nil {
+		return err
+	}
+	currentFile := filepath.Join(s.root, rel)
+	if _, err := os.Lstat(currentFile); err == nil {
+		return fmt.Errorf("import %s: %w", reqPath, os.ErrExist)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("import %s: %w", reqPath, err)
+	}
+
+	// The per-doc versions dir, derived from the layout's one owner.
+	firstFile, err := s.VersionFilePath(reqPath, versions[0].Version)
+	if err != nil {
+		return err
+	}
+	docDir := filepath.Dir(firstFile)
+	if err := s.importVersionFiles(reqPath, docDir, versions); err != nil {
+		// The document did not exist, so its per-doc dir is all ours to
+		// remove: a failed import must not leave partial state behind.
+		_ = os.RemoveAll(docDir)
+		return err
+	}
+	newest := versions[len(versions)-1]
+	base := filepath.Base(rel)
+	if err := os.Symlink(newVersionSymlinkTarget(base, newest.Version), currentFile); err != nil {
+		_ = os.RemoveAll(docDir)
+		return fmt.Errorf("import %s: %w", reqPath, err)
+	}
+	if IsArchived(newest.Stored) {
+		s.RemoveHashEntry(reqPath)
+	} else {
+		s.UpdateHashIndex(reqPath, ExtractBody(newest.Stored))
+	}
+	return nil
+}
+
+// importVersionFiles writes the version files byte-for-byte with their
+// original modified times.
+func (s *Store) importVersionFiles(reqPath, docDir string, versions []StoredVersion) error {
+	if err := os.MkdirAll(docDir, 0o755); err != nil {
+		return fmt.Errorf("import %s: %w", reqPath, err)
+	}
+	for _, v := range versions {
+		vFile, err := s.VersionFilePath(reqPath, v.Version)
+		if err != nil {
+			return err
+		}
+		// O_EXCL: version files are immutable; never overwrite one.
+		f, err := os.OpenFile(vFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+		if err != nil {
+			return fmt.Errorf("import %s v%d: %w", reqPath, v.Version, err)
+		}
+		if _, err := f.Write(v.Stored); err != nil {
+			_ = f.Close()
+			return fmt.Errorf("import %s v%d: %w", reqPath, v.Version, err)
+		}
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("import %s v%d: %w", reqPath, v.Version, err)
+		}
+		// Version modified times are read from file mtime; restore them.
+		if err := os.Chtimes(vFile, v.Modified, v.Modified); err != nil {
+			return fmt.Errorf("import %s v%d: %w", reqPath, v.Version, err)
+		}
+	}
+	return nil
+}

--- a/server/cmd/demarkus-migrate/main.go
+++ b/server/cmd/demarkus-migrate/main.go
@@ -1,0 +1,164 @@
+// demarkus-migrate copies a world's full version history between store
+// backends, byte-for-byte: file -> postgres or postgres -> file. The
+// destination must be empty; a verify pass re-exports the destination and
+// checks every stored version against hashes recorded during the copy.
+//
+// Usage:
+//
+//	demarkus-migrate -from file -to postgres -root /srv/site -pg-dsn "$DSN"
+//	demarkus-migrate -from postgres -to file -root /srv/new -pg-dsn "$DSN"
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/latebit-io/demarkus/protocol/store"
+	"github.com/latebit-io/demarkus/server/internal/logging"
+	"github.com/latebit-io/demarkus/server/internal/pgstore"
+)
+
+func main() {
+	from := flag.String("from", "", "source backend: file or postgres")
+	to := flag.String("to", "", "destination backend: file or postgres")
+	root := flag.String("root", "", "content directory for the file side (overrides DEMARKUS_ROOT)")
+	pgDSN := flag.String("pg-dsn", "", "Postgres connection string for the postgres side (overrides DEMARKUS_PG_DSN)")
+	verify := flag.Bool("verify", true, "after copying, re-export the destination and compare every stored version")
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: demarkus-migrate -from file|postgres -to file|postgres [options]\n\n")
+		fmt.Fprintf(os.Stderr, "Copy a world's full version history between store backends, byte-for-byte.\n")
+		fmt.Fprintf(os.Stderr, "The destination must be empty. Stop the server before migrating.\n\n")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	logger := logging.New(os.Getenv("DEMARKUS_LOG_FORMAT"), os.Getenv("DEMARKUS_LOG_LEVEL"), nil)
+	if err := run(*from, *to, *root, *pgDSN, *verify, logger); err != nil {
+		logger.Error("migration failed", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run(from, to, root, pgDSN string, verify bool, logger *slog.Logger) error {
+	if from == to || !validBackend(from) || !validBackend(to) {
+		return fmt.Errorf("need -from and -to as file|postgres and different (got %q -> %q)", from, to)
+	}
+	if root == "" {
+		root = os.Getenv("DEMARKUS_ROOT")
+	}
+	if pgDSN == "" {
+		pgDSN = os.Getenv("DEMARKUS_PG_DSN")
+	}
+	if root == "" {
+		return fmt.Errorf("-root (or DEMARKUS_ROOT) is required for the file side")
+	}
+	if pgDSN == "" {
+		return fmt.Errorf("-pg-dsn (or DEMARKUS_PG_DSN) is required for the postgres side")
+	}
+
+	fs, err := store.Open(root)
+	if err != nil {
+		return fmt.Errorf("open file store: %w", err)
+	}
+	pg, err := pgstore.Open(pgDSN, logger)
+	if err != nil {
+		return fmt.Errorf("open postgres store: %w", err)
+	}
+	defer func() {
+		if err := pg.Close(); err != nil {
+			logger.Warn("postgres close failed", "error", err)
+		}
+	}()
+
+	backends := map[string]store.Migrator{"file": fs, "postgres": pg}
+	src, dst := backends[from], backends[to]
+
+	if err := requireEmpty(dst, to); err != nil {
+		return err
+	}
+
+	logger.Info("copying", "from", from, "to", to)
+	// Per-version summaries recorded during the copy: the verify pass then
+	// reads only the destination, and memory stays ~50 bytes per version.
+	want := map[string][]versionSummary{}
+	var docs, versions int
+	if err := src.ExportDocs(func(p string, vs []store.StoredVersion) error {
+		docs++
+		versions += len(vs)
+		if verify {
+			want[p] = summarize(vs)
+		}
+		return dst.ImportDoc(p, vs)
+	}); err != nil {
+		return fmt.Errorf("copy: %w", err)
+	}
+	logger.Info("copied", "documents", docs, "versions", versions)
+
+	if verify {
+		if err := verifyDst(dst, want); err != nil {
+			return fmt.Errorf("verify: %w", err)
+		}
+		logger.Info("verified", "documents", docs, "versions", versions)
+	}
+	return nil
+}
+
+func validBackend(b string) bool { return b == "file" || b == "postgres" }
+
+// errNonEmpty aborts the emptiness probe on the first exported document.
+var errNonEmpty = fmt.Errorf("destination is not empty; migrate into a fresh root/database")
+
+func requireEmpty(dst store.Migrator, name string) error {
+	err := dst.ExportDocs(func(string, []store.StoredVersion) error { return errNonEmpty })
+	if err != nil {
+		return fmt.Errorf("%s: %w", name, err)
+	}
+	return nil
+}
+
+// versionSummary is what verify holds per version instead of raw bytes.
+type versionSummary struct {
+	version  int
+	hash     string
+	modified time.Time
+}
+
+func summarize(vs []store.StoredVersion) []versionSummary {
+	out := make([]versionSummary, len(vs))
+	for i, v := range vs {
+		out[i] = versionSummary{v.Version, store.ContentHash(v.Stored), v.Modified.UTC().Truncate(time.Second)}
+	}
+	return out
+}
+
+// verifyDst re-exports the destination and compares every stored version's
+// hash and modified time (to the second, the protocol's precision) against
+// the summaries recorded from the source during the copy.
+func verifyDst(dst store.Migrator, want map[string][]versionSummary) error {
+	if err := dst.ExportDocs(func(p string, vs []store.StoredVersion) error {
+		wv, ok := want[p]
+		if !ok {
+			return fmt.Errorf("%s: not in source", p)
+		}
+		delete(want, p)
+		got := summarize(vs)
+		if len(got) != len(wv) {
+			return fmt.Errorf("%s: %d versions, want %d", p, len(got), len(wv))
+		}
+		for i := range wv {
+			if got[i] != wv[i] {
+				return fmt.Errorf("%s v%d: stored bytes or modified differ", p, wv[i].version)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	if len(want) != 0 {
+		return fmt.Errorf("%d source documents missing from destination", len(want))
+	}
+	return nil
+}

--- a/server/cmd/demarkus-migrate/main.go
+++ b/server/cmd/demarkus-migrate/main.go
@@ -11,12 +11,13 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -128,15 +129,16 @@ func requireEmpty(ctx context.Context, dst store.Migrator, name string) error {
 	return nil
 }
 
-// docDigest folds a document's history into one hash: version numbers,
-// stored-bytes hashes, and modified times to the second (the protocol's
-// precision). Version order within a document is ascending on every backend.
+// docDigest folds a document's history into one hash, streamed record by
+// record: version numbers, stored-bytes hashes, and modified times to the
+// second. Version order within a document is ascending on every backend.
 func docDigest(vs []store.StoredVersion) string {
-	var sb strings.Builder
+	h := sha256.New()
 	for _, v := range vs {
-		fmt.Fprintf(&sb, "%d|%s|%d\n", v.Version, store.ContentHash(v.Stored), v.Modified.UTC().Truncate(time.Second).Unix())
+		// hash.Hash.Write never returns an error.
+		_, _ = fmt.Fprintf(h, "%d|%s|%d\n", v.Version, store.ContentHash(v.Stored), v.Modified.UTC().Truncate(time.Second).Unix())
 	}
-	return store.ContentHash([]byte(sb.String()))
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // verifyDst re-exports the destination and compares each document's digest

--- a/server/cmd/demarkus-migrate/main.go
+++ b/server/cmd/demarkus-migrate/main.go
@@ -10,6 +10,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -30,7 +31,8 @@ func main() {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: demarkus-migrate -from file|postgres -to file|postgres [options]\n\n")
 		fmt.Fprintf(os.Stderr, "Copy a world's full version history between store backends, byte-for-byte.\n")
-		fmt.Fprintf(os.Stderr, "The destination must be empty. Stop the server before migrating.\n\n")
+		fmt.Fprintf(os.Stderr, "The destination must be empty. Stop the server before migrating.\n")
+		fmt.Fprintf(os.Stderr, "A failed run leaves partial state; wipe the destination before retrying.\n\n")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
@@ -76,29 +78,33 @@ func run(from, to, root, pgDSN string, verify bool, logger *slog.Logger) error {
 	backends := map[string]store.Migrator{"file": fs, "postgres": pg}
 	src, dst := backends[from], backends[to]
 
-	if err := requireEmpty(dst, to); err != nil {
+	// The tool owns the cancellation policy: a bulk migration runs
+	// unbounded, interruptible only by the operator.
+	ctx := context.Background()
+	if err := requireEmpty(ctx, dst, to); err != nil {
 		return err
 	}
 
 	logger.Info("copying", "from", from, "to", to)
 	// Per-version summaries recorded during the copy: the verify pass then
-	// reads only the destination, and memory stays ~50 bytes per version.
+	// reads only the destination, holding ~120 bytes per version instead of
+	// the stored bytes.
 	want := map[string][]versionSummary{}
 	var docs, versions int
-	if err := src.ExportDocs(func(p string, vs []store.StoredVersion) error {
+	if err := src.ExportDocs(ctx, func(p string, vs []store.StoredVersion) error {
 		docs++
 		versions += len(vs)
 		if verify {
 			want[p] = summarize(vs)
 		}
-		return dst.ImportDoc(p, vs)
+		return dst.ImportDoc(ctx, p, vs)
 	}); err != nil {
 		return fmt.Errorf("copy: %w", err)
 	}
 	logger.Info("copied", "documents", docs, "versions", versions)
 
 	if verify {
-		if err := verifyDst(dst, want); err != nil {
+		if err := verifyDst(ctx, dst, want); err != nil {
 			return fmt.Errorf("verify: %w", err)
 		}
 		logger.Info("verified", "documents", docs, "versions", versions)
@@ -111,8 +117,8 @@ func validBackend(b string) bool { return b == "file" || b == "postgres" }
 // errNonEmpty aborts the emptiness probe on the first exported document.
 var errNonEmpty = fmt.Errorf("destination is not empty; migrate into a fresh root/database")
 
-func requireEmpty(dst store.Migrator, name string) error {
-	err := dst.ExportDocs(func(string, []store.StoredVersion) error { return errNonEmpty })
+func requireEmpty(ctx context.Context, dst store.Migrator, name string) error {
+	err := dst.ExportDocs(ctx, func(string, []store.StoredVersion) error { return errNonEmpty })
 	if err != nil {
 		return fmt.Errorf("%s: %w", name, err)
 	}
@@ -137,8 +143,8 @@ func summarize(vs []store.StoredVersion) []versionSummary {
 // verifyDst re-exports the destination and compares every stored version's
 // hash and modified time (to the second, the protocol's precision) against
 // the summaries recorded from the source during the copy.
-func verifyDst(dst store.Migrator, want map[string][]versionSummary) error {
-	if err := dst.ExportDocs(func(p string, vs []store.StoredVersion) error {
+func verifyDst(ctx context.Context, dst store.Migrator, want map[string][]versionSummary) error {
+	if err := dst.ExportDocs(ctx, func(p string, vs []store.StoredVersion) error {
 		wv, ok := want[p]
 		if !ok {
 			return fmt.Errorf("%s: not in source", p)

--- a/server/cmd/demarkus-migrate/main.go
+++ b/server/cmd/demarkus-migrate/main.go
@@ -15,6 +15,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
+	"strings"
+	"syscall"
 	"time"
 
 	"github.com/latebit-io/demarkus/protocol/store"
@@ -38,13 +41,16 @@ func main() {
 	flag.Parse()
 
 	logger := logging.New(os.Getenv("DEMARKUS_LOG_FORMAT"), os.Getenv("DEMARKUS_LOG_LEVEL"), nil)
-	if err := run(*from, *to, *root, *pgDSN, *verify, logger); err != nil {
+	// Interrupt/terminate cancels the migration between documents.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	if err := run(ctx, *from, *to, *root, *pgDSN, *verify, logger); err != nil {
 		logger.Error("migration failed", "error", err)
 		os.Exit(1)
 	}
 }
 
-func run(from, to, root, pgDSN string, verify bool, logger *slog.Logger) error {
+func run(ctx context.Context, from, to, root, pgDSN string, verify bool, logger *slog.Logger) error {
 	if from == to || !validBackend(from) || !validBackend(to) {
 		return fmt.Errorf("need -from and -to as file|postgres and different (got %q -> %q)", from, to)
 	}
@@ -78,24 +84,21 @@ func run(from, to, root, pgDSN string, verify bool, logger *slog.Logger) error {
 	backends := map[string]store.Migrator{"file": fs, "postgres": pg}
 	src, dst := backends[from], backends[to]
 
-	// The tool owns the cancellation policy: a bulk migration runs
-	// unbounded, interruptible only by the operator.
-	ctx := context.Background()
 	if err := requireEmpty(ctx, dst, to); err != nil {
 		return err
 	}
 
 	logger.Info("copying", "from", from, "to", to)
-	// Per-version summaries recorded during the copy: the verify pass then
-	// reads only the destination, holding ~120 bytes per version instead of
-	// the stored bytes.
-	want := map[string][]versionSummary{}
+	// One digest per document recorded during the copy: the verify pass then
+	// reads only the destination, and memory grows with documents, not
+	// versions or stored bytes.
+	want := map[string]string{}
 	var docs, versions int
 	if err := src.ExportDocs(ctx, func(p string, vs []store.StoredVersion) error {
 		docs++
 		versions += len(vs)
 		if verify {
-			want[p] = summarize(vs)
+			want[p] = docDigest(vs)
 		}
 		return dst.ImportDoc(ctx, p, vs)
 	}); err != nil {
@@ -125,39 +128,28 @@ func requireEmpty(ctx context.Context, dst store.Migrator, name string) error {
 	return nil
 }
 
-// versionSummary is what verify holds per version instead of raw bytes.
-type versionSummary struct {
-	version  int
-	hash     string
-	modified time.Time
-}
-
-func summarize(vs []store.StoredVersion) []versionSummary {
-	out := make([]versionSummary, len(vs))
-	for i, v := range vs {
-		out[i] = versionSummary{v.Version, store.ContentHash(v.Stored), v.Modified.UTC().Truncate(time.Second)}
+// docDigest folds a document's history into one hash: version numbers,
+// stored-bytes hashes, and modified times to the second (the protocol's
+// precision). Version order within a document is ascending on every backend.
+func docDigest(vs []store.StoredVersion) string {
+	var sb strings.Builder
+	for _, v := range vs {
+		fmt.Fprintf(&sb, "%d|%s|%d\n", v.Version, store.ContentHash(v.Stored), v.Modified.UTC().Truncate(time.Second).Unix())
 	}
-	return out
+	return store.ContentHash([]byte(sb.String()))
 }
 
-// verifyDst re-exports the destination and compares every stored version's
-// hash and modified time (to the second, the protocol's precision) against
-// the summaries recorded from the source during the copy.
-func verifyDst(ctx context.Context, dst store.Migrator, want map[string][]versionSummary) error {
+// verifyDst re-exports the destination and compares each document's digest
+// against the one recorded from the source during the copy.
+func verifyDst(ctx context.Context, dst store.Migrator, want map[string]string) error {
 	if err := dst.ExportDocs(ctx, func(p string, vs []store.StoredVersion) error {
-		wv, ok := want[p]
+		wd, ok := want[p]
 		if !ok {
 			return fmt.Errorf("%s: not in source", p)
 		}
 		delete(want, p)
-		got := summarize(vs)
-		if len(got) != len(wv) {
-			return fmt.Errorf("%s: %d versions, want %d", p, len(got), len(wv))
-		}
-		for i := range wv {
-			if got[i] != wv[i] {
-				return fmt.Errorf("%s v%d: stored bytes or modified differ", p, wv[i].version)
-			}
+		if docDigest(vs) != wd {
+			return fmt.Errorf("%s: version history differs from source", p)
 		}
 		return nil
 	}); err != nil {

--- a/server/internal/pgstore/migrate.go
+++ b/server/internal/pgstore/migrate.go
@@ -16,17 +16,16 @@ import (
 )
 
 // ExportDocs visits every document, archived included, in path order with
-// its full version history oldest-first and stored bytes verbatim. reqPath
-// is the request spelling ("/dir/doc.md"), matching the file store's export.
-func (s *Store) ExportDocs(fn func(reqPath string, versions []store.StoredVersion) error) error {
-	// No queryTimeout: streaming a whole world legitimately outlives the
-	// per-op budget, and migration is an operator-driven bulk read.
-	rows, err := s.db.QueryContext(context.Background(), `
+// its history oldest-first and stored bytes verbatim, bounded by the
+// caller's ctx. reqPath is the request spelling, matching the file store.
+func (s *Store) ExportDocs(ctx context.Context, fn func(reqPath string, versions []store.StoredVersion) error) error {
+	rows, err := s.db.QueryContext(ctx, `
 		SELECT path, version, stored, modified FROM versions
 		ORDER BY path, version`)
 	if err != nil {
 		return fmt.Errorf("export versions: %w", err)
 	}
+	// Close error is redundant: rows.Err() below reports iteration failures.
 	defer func() { _ = rows.Close() }()
 
 	var curPath string
@@ -36,6 +35,8 @@ func (s *Store) ExportDocs(fn func(reqPath string, versions []store.StoredVersio
 			return nil
 		}
 		err := fn("/"+curPath, cur)
+		// The callback may retain the slice (Migrator contract); start a
+		// fresh backing array for the next document.
 		cur = nil
 		return err
 	}
@@ -59,21 +60,21 @@ func (s *Store) ExportDocs(fn func(reqPath string, versions []store.StoredVersio
 	return flush()
 }
 
-// ImportDoc inserts a document's rows byte-for-byte in one transaction:
-// versions verbatim, the documents row derived (current = newest, archived
-// from the tip), and the catalog row from the tip, as a live write would.
-func (s *Store) ImportDoc(reqPath string, versions []store.StoredVersion) error {
+// ImportDoc inserts a document's rows byte-for-byte in one transaction,
+// bounded by the caller's ctx: versions verbatim, the documents row and the
+// catalog row derived from the tip, as a live write would.
+func (s *Store) ImportDoc(ctx context.Context, reqPath string, versions []store.StoredVersion) error {
 	p, err := store.ValidateImport(reqPath, versions)
 	if err != nil {
 		return err
 	}
 
-	ctx, cancel := opCtx()
-	defer cancel()
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin import: %w", err)
 	}
+	// No-op (ErrTxDone) after a successful Commit; the safety net for every
+	// early return below.
 	defer func() { _ = tx.Rollback() }()
 
 	newest := versions[len(versions)-1]
@@ -95,6 +96,7 @@ func (s *Store) ImportDoc(reqPath string, versions []store.StoredVersion) error 
 	if err != nil {
 		return fmt.Errorf("import %s: %w", reqPath, err)
 	}
+	// Statement lives on the tx; Rollback/Commit releases it either way.
 	defer func() { _ = stmt.Close() }()
 	for _, v := range versions {
 		if _, err := stmt.ExecContext(ctx, p, v.Version, v.Stored,

--- a/server/internal/pgstore/migrate.go
+++ b/server/internal/pgstore/migrate.go
@@ -1,0 +1,115 @@
+package pgstore
+
+// Migration surface: the Postgres half of store.Migrator (see
+// protocol/store/migrate.go), moving raw stored bytes between backends.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/latebit-io/demarkus/protocol/store"
+	"github.com/latebit-io/demarkus/server/internal/catalog"
+)
+
+// ExportDocs visits every document, archived included, in path order with
+// its full version history oldest-first and stored bytes verbatim. reqPath
+// is the request spelling ("/dir/doc.md"), matching the file store's export.
+func (s *Store) ExportDocs(fn func(reqPath string, versions []store.StoredVersion) error) error {
+	// No queryTimeout: streaming a whole world legitimately outlives the
+	// per-op budget, and migration is an operator-driven bulk read.
+	rows, err := s.db.QueryContext(context.Background(), `
+		SELECT path, version, stored, modified FROM versions
+		ORDER BY path, version`)
+	if err != nil {
+		return fmt.Errorf("export versions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var curPath string
+	var cur []store.StoredVersion
+	flush := func() error {
+		if len(cur) == 0 {
+			return nil
+		}
+		err := fn("/"+curPath, cur)
+		cur = nil
+		return err
+	}
+	for rows.Next() {
+		var v store.StoredVersion
+		var p string
+		if err := rows.Scan(&p, &v.Version, &v.Stored, &v.Modified); err != nil {
+			return fmt.Errorf("export scan: %w", err)
+		}
+		if p != curPath {
+			if err := flush(); err != nil {
+				return err
+			}
+			curPath = p
+		}
+		cur = append(cur, v)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("export rows: %w", err)
+	}
+	return flush()
+}
+
+// ImportDoc inserts a document's rows byte-for-byte in one transaction:
+// versions verbatim, the documents row derived (current = newest, archived
+// from the tip), and the catalog row from the tip, as a live write would.
+func (s *Store) ImportDoc(reqPath string, versions []store.StoredVersion) error {
+	p, err := store.ValidateImport(reqPath, versions)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := opCtx()
+	defer cancel()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin import: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	newest := versions[len(versions)-1]
+	// The documents PK doubles as the exists check: a duplicate import
+	// surfaces as a unique violation, folded into ErrExist.
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO documents (path, current_version, archived) VALUES ($1, $2, $3)`,
+		p, newest.Version, store.IsArchived(newest.Stored)); err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
+			return fmt.Errorf("import %s: %w", reqPath, os.ErrExist)
+		}
+		return fmt.Errorf("import %s: %w", reqPath, err)
+	}
+
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO versions (path, version, stored, body_hash, modified)
+		VALUES ($1, $2, $3, $4, $5)`)
+	if err != nil {
+		return fmt.Errorf("import %s: %w", reqPath, err)
+	}
+	defer func() { _ = stmt.Close() }()
+	for _, v := range versions {
+		if _, err := stmt.ExecContext(ctx, p, v.Version, v.Stored,
+			store.ContentHash(store.ExtractBody(v.Stored)), v.Modified); err != nil {
+			return fmt.Errorf("import %s v%d: %w", reqPath, v.Version, err)
+		}
+	}
+
+	tipMeta := store.ExtractMetadata(newest.Stored)
+	entry := catalog.FromDocument("/"+p, tipMeta, store.ExtractBody(newest.Stored), newest.Modified.UTC())
+	if err := upsertCatalogRow(ctx, tx, p, entry); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit import %s: %w", reqPath, err)
+	}
+	return nil
+}

--- a/server/internal/pgstore/migrate_test.go
+++ b/server/internal/pgstore/migrate_test.go
@@ -1,0 +1,55 @@
+package pgstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/latebit-io/demarkus/protocol/store"
+	"github.com/latebit-io/demarkus/server/internal/catalog"
+	"github.com/latebit-io/demarkus/server/internal/storetest"
+)
+
+// TestPostgresMigrationRoundTrip runs the shared migration gate against
+// Postgres, then checks the pg-only surfaces of the imported world: in-tx
+// catalog rows, hash index, unarchive visibility, duplicate-refusal atomicity.
+func TestPostgresMigrationRoundTrip(t *testing.T) {
+	s := openStore(t)
+	storetest.RunMigrationRoundTrip(t, func(_ *testing.T) storetest.MigrationBackend {
+		return storetest.MigrationBackend{Migrator: s, Store: s}
+	})
+
+	// LOOKUP works straight off the import: catalog rows rode the import tx.
+	assertLookupCount(t, s, "unicode", 1)
+	if _, ok := s.LookupHash(store.ContentHash([]byte("# Deep\n"))); !ok {
+		t.Error("LookupHash: imported body not found")
+	}
+
+	// The refused duplicate import (run inside the shared suite) was
+	// transactional: no partial version rows behind it.
+	if got := s.CurrentVersion("/a.md"); got != 3 {
+		t.Errorf("after refused import: current = %d, want 3", got)
+	}
+	if vs, err := s.Versions("/a.md"); err != nil || len(vs) != 3 {
+		t.Errorf("after refused import: %d versions (err %v), want 3", len(vs), err)
+	}
+
+	// The archived document's catalog row was imported too: unarchive
+	// restores it to LOOKUP without a write.
+	if err := s.Archive("/arch.md", false); err != nil {
+		t.Fatalf("unarchive: %v", err)
+	}
+	rs, err := s.Lookup("archived", catalog.Options{})
+	if err != nil {
+		t.Fatalf("lookup after unarchive: %v", err)
+	}
+	if len(rs) != 1 {
+		t.Errorf("lookup after unarchive: %d results, want 1 (title match)", len(rs))
+	}
+
+	// A later Init must not disturb the imported catalog (backfill is
+	// insert-if-absent).
+	if err := s.Init(context.Background()); err != nil {
+		t.Fatalf("init after import: %v", err)
+	}
+	assertLookupCount(t, s, "unicode", 1)
+}

--- a/server/internal/storetest/filestore_test.go
+++ b/server/internal/storetest/filestore_test.go
@@ -1,7 +1,13 @@
 package storetest
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/latebit-io/demarkus/protocol/store"
 	"github.com/latebit-io/demarkus/server/internal/handler"
@@ -48,4 +54,38 @@ func TestFileStoreMigrationRoundTrip(t *testing.T) {
 
 func BenchmarkFileHandler(b *testing.B) {
 	RunHandlerBenchmarks(b, FileBackend)
+}
+
+// TestFileStoreImportRefusesOrphanedVersionDir pins the failure-cleanup
+// guard: an import onto a leftover version tree (no current symlink) must
+// refuse with ErrExist and leave the pre-existing version files untouched.
+func TestFileStoreImportRefusesOrphanedVersionDir(t *testing.T) {
+	s := store.New(t.TempDir())
+	if _, err := s.WriteVersion("/x.md", 0, []byte("# X\n"), nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	vFile, err := s.VersionFilePath("/x.md", 1)
+	if err != nil {
+		t.Fatalf("version path: %v", err)
+	}
+	before, err := os.ReadFile(vFile)
+	if err != nil {
+		t.Fatalf("read v1: %v", err)
+	}
+	// Orphan the tree: remove the current symlink, keep the version files.
+	if err := os.Remove(filepath.Join(s.Root(), "x.md")); err != nil {
+		t.Fatalf("orphan: %v", err)
+	}
+
+	err = s.ImportDoc(context.Background(), "/x.md", []store.StoredVersion{{Version: 1, Stored: []byte("# other\n"), Modified: time.Now()}})
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("import onto orphaned tree: err = %v, want ErrExist", err)
+	}
+	after, err := os.ReadFile(vFile)
+	if err != nil {
+		t.Fatalf("orphaned version file gone after refused import: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Error("orphaned version file modified by refused import")
+	}
 }

--- a/server/internal/storetest/filestore_test.go
+++ b/server/internal/storetest/filestore_test.go
@@ -37,6 +37,15 @@ func TestFileStoreHandlerDifferentialSelf(t *testing.T) {
 	RunHandlerDifferential(t, factory, factory, DifferentialConfig{Seeds: []int64{1, 2}, Ops: 80})
 }
 
+// TestFileStoreMigrationRoundTrip runs the shared migration gate with the
+// file store as the backend under test (file -> file -> file).
+func TestFileStoreMigrationRoundTrip(t *testing.T) {
+	RunMigrationRoundTrip(t, func(t *testing.T) MigrationBackend {
+		s := store.New(t.TempDir())
+		return MigrationBackend{Migrator: s, Store: s}
+	})
+}
+
 func BenchmarkFileHandler(b *testing.B) {
 	RunHandlerBenchmarks(b, FileBackend)
 }

--- a/server/internal/storetest/migrate.go
+++ b/server/internal/storetest/migrate.go
@@ -1,0 +1,138 @@
+package storetest
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/latebit-io/demarkus/protocol/store"
+	"github.com/latebit-io/demarkus/server/internal/handler"
+)
+
+// MigrationBackend pairs a backend's migration surface with its read surface
+// so the imported world can be checked behaviorally, not just byte-wise.
+type MigrationBackend struct {
+	Migrator store.Migrator
+	Store    handler.DocumentStore
+}
+
+// RunMigrationRoundTrip migrates a seeded file store into the backend under
+// test and back into a fresh file root; every stored version must survive
+// both hops byte-for-byte. The imported world stays for caller assertions.
+func RunMigrationRoundTrip(t *testing.T, newBackend func(t *testing.T) MigrationBackend) {
+	src := store.New(t.TempDir())
+	paths := seedMigrationDocs(t, src)
+	srcExport := exportDocs(t, src)
+
+	b := newBackend(t)
+	copyDocs(t, "src->backend", src, b.Migrator)
+	if err := store.DiffExports(srcExport, exportDocs(t, b.Migrator)); err != nil {
+		t.Fatalf("backend export differs from source: %v", err)
+	}
+
+	// The imported world behaves: chains verify and reads match the source.
+	for _, p := range paths {
+		if err := b.Store.VerifyChain(p); err != nil {
+			t.Errorf("VerifyChain(%s): %v", p, err)
+		}
+		want, err := src.Get(p, 0)
+		if err != nil {
+			t.Fatalf("src Get(%s): %v", p, err)
+		}
+		got, err := b.Store.Get(p, 0)
+		if err != nil {
+			t.Fatalf("backend Get(%s): %v", p, err)
+		}
+		if !bytes.Equal(got.Content, want.Content) || got.Version != want.Version || got.Archived != want.Archived {
+			t.Errorf("Get(%s): got v%d archived=%v, want v%d archived=%v", p, got.Version, got.Archived, want.Version, want.Archived)
+		}
+	}
+
+	// The pruned document's history starts past v1 and must survive as-is.
+	vs, err := b.Store.Versions("/pruned.md")
+	if err != nil || len(vs) != 2 || vs[0].Version != 4 || vs[1].Version != 3 {
+		t.Errorf("pruned versions: %v (err %v), want [4 3]", vs, err)
+	}
+
+	// Back into a fresh file root: byte-identical to the original.
+	dst := store.New(t.TempDir())
+	copyDocs(t, "backend->file", b.Migrator, dst)
+	if err := store.DiffExports(srcExport, exportDocs(t, dst)); err != nil {
+		t.Fatalf("round-tripped export differs from source: %v", err)
+	}
+	for _, p := range paths {
+		if err := dst.VerifyChain(p); err != nil {
+			t.Errorf("dst VerifyChain(%s): %v", p, err)
+		}
+	}
+
+	// Re-importing an existing document must refuse, not overwrite.
+	if err := b.Migrator.ImportDoc("/a.md", srcExport["/a.md"]); !errors.Is(err, os.ErrExist) {
+		t.Errorf("double import: err = %v, want ErrExist", err)
+	}
+	// Invalid imports must refuse on every backend.
+	for name, bad := range map[string]struct {
+		path     string
+		versions []store.StoredVersion
+	}{
+		"no versions":    {"/new.md", nil},
+		"not ascending":  {"/new.md", []store.StoredVersion{srcExport["/a.md"][1], srcExport["/a.md"][0]}},
+		"directory path": {"/dir/", srcExport["/a.md"]},
+	} {
+		if err := b.Migrator.ImportDoc(bad.path, bad.versions); err == nil {
+			t.Errorf("import %s: expected error", name)
+		}
+	}
+}
+
+// seedMigrationDocs writes a world exercising every migration-relevant shape:
+// multi-version, append, nested path, unicode, archived doc, pruned history.
+func seedMigrationDocs(t *testing.T, s *store.Store) []string {
+	t.Helper()
+	mustWrite := func(path string, version int, body string, meta map[string]string) {
+		t.Helper()
+		if _, err := s.WriteVersion(path, version, []byte(body), meta); err != nil {
+			t.Fatalf("seed write %s: %v", path, err)
+		}
+	}
+	mustWrite("/a.md", 0, "# A v1\n", map[string]string{"tags": "go,auth", "importance": "0.7"})
+	mustWrite("/a.md", 1, "# A v2\n", map[string]string{"tags": "go,auth", "importance": "0.7"})
+	if _, err := s.Append("/a.md", 2, []byte("appended\n"), nil); err != nil {
+		t.Fatalf("seed append: %v", err)
+	}
+	mustWrite("/dir/deep.md", 0, "# Deep\n", nil)
+	mustWrite("/uni.md", 0, "# Ünïcode ☃ 日本語\n", map[string]string{"tags": "unicode"})
+	mustWrite("/arch.md", 0, "# Archived\n", nil)
+	if err := s.Archive("/arch.md", true); err != nil {
+		t.Fatalf("seed archive: %v", err)
+	}
+	for i := range 4 {
+		mustWrite("/pruned.md", i, fmt.Sprintf("# P v%d\n", i+1), map[string]string{"retention": "2"})
+	}
+	return []string{"/a.md", "/dir/deep.md", "/uni.md", "/arch.md", "/pruned.md"}
+}
+
+// exportDocs collects a migrator's full export keyed by path.
+func exportDocs(t *testing.T, m store.Migrator) map[string][]store.StoredVersion {
+	t.Helper()
+	out := map[string][]store.StoredVersion{}
+	if err := m.ExportDocs(func(p string, vs []store.StoredVersion) error {
+		out[p] = vs
+		return nil
+	}); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	return out
+}
+
+// copyDocs migrates every document from src to dst.
+func copyDocs(t *testing.T, label string, src, dst store.Migrator) {
+	t.Helper()
+	if err := src.ExportDocs(func(p string, vs []store.StoredVersion) error {
+		return dst.ImportDoc(p, vs)
+	}); err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+}

--- a/server/internal/storetest/migrate.go
+++ b/server/internal/storetest/migrate.go
@@ -2,11 +2,13 @@ package storetest
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"testing"
 
+	"github.com/latebit-io/demarkus/protocol"
 	"github.com/latebit-io/demarkus/protocol/store"
 	"github.com/latebit-io/demarkus/server/internal/handler"
 )
@@ -26,6 +28,7 @@ func RunMigrationRoundTrip(t *testing.T, newBackend func(t *testing.T) Migration
 	paths := seedMigrationDocs(t, src)
 	srcExport := exportDocs(t, src)
 
+	ctx := context.Background()
 	b := newBackend(t)
 	copyDocs(t, "src->backend", src, b.Migrator)
 	if err := store.DiffExports(srcExport, exportDocs(t, b.Migrator)); err != nil {
@@ -69,7 +72,7 @@ func RunMigrationRoundTrip(t *testing.T, newBackend func(t *testing.T) Migration
 	}
 
 	// Re-importing an existing document must refuse, not overwrite.
-	if err := b.Migrator.ImportDoc("/a.md", srcExport["/a.md"]); !errors.Is(err, os.ErrExist) {
+	if err := b.Migrator.ImportDoc(ctx, "/a.md", srcExport["/a.md"]); !errors.Is(err, os.ErrExist) {
 		t.Errorf("double import: err = %v, want ErrExist", err)
 	}
 	// Invalid imports must refuse on every backend.
@@ -77,11 +80,16 @@ func RunMigrationRoundTrip(t *testing.T, newBackend func(t *testing.T) Migration
 		path     string
 		versions []store.StoredVersion
 	}{
-		"no versions":    {"/new.md", nil},
-		"not ascending":  {"/new.md", []store.StoredVersion{srcExport["/a.md"][1], srcExport["/a.md"][0]}},
-		"directory path": {"/dir/", srcExport["/a.md"]},
+		// Distinct paths: a wrongly accepted case must not mask the next
+		// one behind ErrExist (map order is random).
+		"no versions":    {"/inv-empty.md", nil},
+		"not ascending":  {"/inv-order.md", []store.StoredVersion{srcExport["/a.md"][1], srcExport["/a.md"][0]}},
+		"directory path": {"/inv-dir/", srcExport["/a.md"]},
+		"oversized": {"/inv-big.md", []store.StoredVersion{{
+			Version: 1, Stored: make([]byte, protocol.MaxBodyLength+store.MaxStoreFrontmatter+1),
+		}}},
 	} {
-		if err := b.Migrator.ImportDoc(bad.path, bad.versions); err == nil {
+		if err := b.Migrator.ImportDoc(ctx, bad.path, bad.versions); err == nil {
 			t.Errorf("import %s: expected error", name)
 		}
 	}
@@ -118,7 +126,7 @@ func seedMigrationDocs(t *testing.T, s *store.Store) []string {
 func exportDocs(t *testing.T, m store.Migrator) map[string][]store.StoredVersion {
 	t.Helper()
 	out := map[string][]store.StoredVersion{}
-	if err := m.ExportDocs(func(p string, vs []store.StoredVersion) error {
+	if err := m.ExportDocs(context.Background(), func(p string, vs []store.StoredVersion) error {
 		out[p] = vs
 		return nil
 	}); err != nil {
@@ -130,8 +138,9 @@ func exportDocs(t *testing.T, m store.Migrator) map[string][]store.StoredVersion
 // copyDocs migrates every document from src to dst.
 func copyDocs(t *testing.T, label string, src, dst store.Migrator) {
 	t.Helper()
-	if err := src.ExportDocs(func(p string, vs []store.StoredVersion) error {
-		return dst.ImportDoc(p, vs)
+	ctx := context.Background()
+	if err := src.ExportDocs(ctx, func(p string, vs []store.StoredVersion) error {
+		return dst.ImportDoc(ctx, p, vs)
 	}); err != nil {
 		t.Fatalf("%s: %v", label, err)
 	}


### PR DESCRIPTION
…nd-parity harness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added migration support for transferring complete document histories between file and PostgreSQL storage.
  - Preserves document versions, archived history, content, and modification timestamps.
  - Added the `demarkus-migrate` command with configuration validation, progress reporting, and optional verification.
  - Detects differences in versions, content, or timestamps after migration.

- **Bug Fixes**
  - Prevents partial imports and safely rejects duplicate or malformed document data.

- **Tests**
  - Added round-trip coverage for file and PostgreSQL storage, including archived and pruned histories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->