### PR TITLE
fix(server): type schemaLockID as int64 so 32-bit targets build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,21 @@ jobs:
           go vet -tags pg ./cmd/demarkus-server
           go build -tags pg -o /dev/null ./cmd/demarkus-server
           go build -o /dev/null ./cmd/demarkus-migrate
+      # The release builds 32-bit arm, where an untyped 64-bit constant is a
+      # compile error the amd64 build never sees (it shipped one: #338).
+      - name: Cross-compile the release targets
+        run: |
+          set -euo pipefail
+          cd server
+          for target in linux/amd64 linux/arm64 linux/arm/7 darwin/amd64 darwin/arm64; do
+            export GOOS="${target%%/*}" GOARM=""
+            rest="${target#*/}"
+            case "$rest" in */*) export GOARCH="${rest%%/*}" GOARM="${rest#*/}" ;; *) export GOARCH="$rest" ;; esac
+            CGO_ENABLED=0 go build -o /dev/null ./cmd/demarkus-server
+            CGO_ENABLED=0 go build -tags pg -o /dev/null ./cmd/demarkus-server
+            CGO_ENABLED=0 go build -o /dev/null ./cmd/demarkus-migrate
+            echo "ok $GOOS/$GOARCH${GOARM:+v$GOARM}"
+          done
 
   test-client:
     needs: detect-changes

--- a/server/internal/pgstore/pgstore.go
+++ b/server/internal/pgstore/pgstore.go
@@ -83,9 +83,10 @@ CREATE INDEX IF NOT EXISTS catalog_tags_lower_idx ON catalog USING GIN (tags_low
 CREATE INDEX IF NOT EXISTS catalog_title_trgm_idx ON catalog USING GIN (title_lower public.gin_trgm_ops);
 `
 
-// schemaLockID keys the advisory lock serializing extension DDL: CREATE
-// EXTENSION IF NOT EXISTS races with itself across concurrent startups.
-const schemaLockID = 0x64656d61726b7573 // "demarkus"
+// schemaLockID keys the advisory lock serializing startup DDL against
+// concurrent replica boots. Typed int64: pg_advisory_xact_lock takes bigint,
+// and an untyped constant this size overflows int on 32-bit targets.
+const schemaLockID int64 = 0x64656d61726b7573 // "demarkus"
 
 // queryTimeout bounds every store call. The DocumentStore interface carries
 // no context, so the deadline is applied here: a stalled Postgres fails the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded automated build checks across Linux and macOS architectures.
  - Verified both standard and PostgreSQL-enabled server builds, including migration binaries.

- **Bug Fixes**
  - Improved database startup locking reliability on 32-bit systems by preventing integer overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->