### PR TITLE
feat(server): package and deploy read-only knowledge-server canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
             release_contract:
               - '.github/workflows/release.yml'
               - 'server/.goreleaser.yml'
+              - 'server/Dockerfile.knowledge'
             install:
               - 'install.sh'
               - 'install-stack.sh'
@@ -149,6 +150,8 @@ jobs:
             echo "default demarkus-server links an optional storage SDK" >&2
             exit 1
           fi
+          go build -o /tmp/demarkus-knowledge-server ./cmd/demarkus-knowledge-server
+          go build -o /tmp/demarkus-knowledge-bootstrap ./cmd/demarkus-knowledge-bootstrap
       - name: Build (postgres flavor)
         run: |
           set -euo pipefail
@@ -169,6 +172,8 @@ jobs:
             CGO_ENABLED=0 go build -o /dev/null ./cmd/demarkus-server
             CGO_ENABLED=0 go build -tags pg -o /dev/null ./cmd/demarkus-server
             CGO_ENABLED=0 go build -o /dev/null ./cmd/demarkus-migrate
+            CGO_ENABLED=0 go build -o /dev/null ./cmd/demarkus-knowledge-server
+            CGO_ENABLED=0 go build -o /dev/null ./cmd/demarkus-knowledge-bootstrap
             echo "ok $GOOS/$GOARCH${GOARM:+v$GOARM}"
           done
 
@@ -317,6 +322,12 @@ jobs:
             yq -e ".builds[] | select(.id == \"$id\")" server/.goreleaser.yml >/dev/null \
               || { echo "release.yml stages $id but server/.goreleaser.yml has no such build id" >&2; exit 1; }
           done
+          test "$(yq -r '.jobs."release-server".steps[] | select(.name == "Build + push demarkus-knowledge-server image") | .with.file' .github/workflows/release.yml)" = "server/Dockerfile.knowledge"
+          yq -e '.jobs."release-server".steps[] | select(.name == "Build + push demarkus-knowledge-server image") | .with.tags | contains("ghcr.io/latebit-io/demarkus-knowledge-server")' .github/workflows/release.yml >/dev/null
+          yq -e '.jobs."release-server".steps[] | select(.name == "Build + push demarkus-knowledge-server image") | .with.tags | contains("needs.semver-server.outputs.new_version")' .github/workflows/release.yml >/dev/null
+          yq -e '.jobs.detect-changes.steps[] | select(.id == "filter") | .with.filters | contains("deploy/helm/demarkus-knowledge-server/**")' .github/workflows/release.yml >/dev/null
+          yq -e '.jobs."semver-server".steps[] | select(.id == "semver") | .with.change_path | contains("deploy/helm/demarkus-knowledge-server/")' .github/workflows/release.yml >/dev/null
+          yq -e '.jobs."release-server".steps[] | select(.name == "Package + push server charts") | .run | contains("demarkus-knowledge-server")' .github/workflows/release.yml >/dev/null
 
   test-charts:
     needs: detect-changes
@@ -353,6 +364,8 @@ jobs:
         run: helm lint deploy/helm/demarkus-broker
       - name: Lint demarkus-agent chart
         run: helm lint deploy/helm/demarkus-agent
+      - name: Lint demarkus-knowledge-server chart
+        run: helm lint deploy/helm/demarkus-knowledge-server -f deploy/helm/demarkus-knowledge-server/tests/fixtures/valid-values.yaml
       # Helm never merges a library chart's values, so the two backend
       # charts must carry the same defaults; add deliberate divergences to
       # the del() list.
@@ -374,6 +387,8 @@ jobs:
         run: helm unittest deploy/helm/demarkus-server-pg
       - name: Unit test demarkus-broker chart
         run: helm unittest deploy/helm/demarkus-broker
+      - name: Unit test demarkus-knowledge-server chart
+        run: helm unittest deploy/helm/demarkus-knowledge-server
 
   test-charts-kind:
     needs: detect-changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
               - 'deploy/helm/demarkus-server/**'
               - 'deploy/helm/demarkus-server-pg/**'
               - 'deploy/helm/demarkus-server-common/**'
+              - 'deploy/helm/demarkus-knowledge-server/**'
             client:
               - 'client/**'
               - 'protocol/**'
@@ -66,6 +67,8 @@ jobs:
       - run: cd server && go test ./...
       - run: cd server && go vet ./...
       - run: cd server && go build -o /dev/null ./cmd/demarkus-server
+      - run: cd server && go build -o /dev/null ./cmd/demarkus-knowledge-server
+      - run: cd server && go build -o /dev/null ./cmd/demarkus-knowledge-bootstrap
 
   test-client:
     needs: detect-changes
@@ -148,7 +151,7 @@ jobs:
           # bump too. protocol/ is compiled in via replace directives, and
           # the image bundles the client CLI for chart exec probes: a fix
           # in either that skips this gate silently never ships (#295).
-          change_path: "server/ protocol/ client/ deploy/helm/demarkus-server/ deploy/helm/demarkus-server-pg/ deploy/helm/demarkus-server-common/"
+          change_path: "server/ protocol/ client/ deploy/helm/demarkus-server/ deploy/helm/demarkus-server-pg/ deploy/helm/demarkus-server-common/ deploy/helm/demarkus-knowledge-server/"
           bump_each_commit: false
           search_commit_body: true
       - name: Check if version changed
@@ -323,7 +326,7 @@ jobs:
 
           # demarkus-server-pg is the -tags pg flavor and demarkus-migrate
           # ships beside it; both feed server/Dockerfile.pg below.
-          for bin in demarkus-server demarkus-server-pg demarkus-migrate; do
+          for bin in demarkus-server demarkus-server-pg demarkus-migrate demarkus-knowledge-server; do
             for arch in amd64:amd64 arm64:arm64 arm_7:armv7; do
               cp dist/${bin}_linux_${arch%%:*}*/"$bin" "dist/docker/${arch##*:}/"
             done
@@ -367,6 +370,17 @@ jobs:
             ghcr.io/latebit-io/demarkus-server-pg:${{ needs.semver-server.outputs.new_version }}
             ghcr.io/latebit-io/demarkus-server-pg:latest
 
+      - name: Build + push demarkus-knowledge-server image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: server/Dockerfile.knowledge
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            ghcr.io/latebit-io/demarkus-knowledge-server:${{ needs.semver-server.outputs.new_version }}
+            ghcr.io/latebit-io/demarkus-knowledge-server:latest
+
       # Chart version + appVersion are pinned 1:1 to the server module
       # version so `helm install ghcr.io/.../charts/demarkus-server --version
       # X` resolves the image at the same tag. Helm 3.13+ reads ~/.docker/
@@ -375,12 +389,11 @@ jobs:
         with:
           version: v3.13.2
 
-      # Both charts vendor the shared library chart into their package, so
-      # consumers never need it separately; it is not pushed on its own.
+      # Dependency updates vendor library charts into each package.
       - name: Package + push server charts
         run: |
           VER="${{ needs.semver-server.outputs.new_version }}"
-          for chart in demarkus-server demarkus-server-pg; do
+          for chart in demarkus-server demarkus-server-pg demarkus-knowledge-server; do
             helm dependency update "deploy/helm/$chart"
             helm package "deploy/helm/$chart" --version "$VER" --app-version "$VER" --destination /tmp/charts
             helm push "/tmp/charts/${chart}-${VER}.tgz" oci://ghcr.io/latebit-io/charts

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all protocol server server-pg client tools image image-server-pg image-server image-broker image-agent test clean install help lint fmt vet deps
+.PHONY: all protocol server server-pg knowledge-server client tools image image-server-pg image-server image-knowledge-server image-broker image-agent test clean install help lint fmt vet deps
 
 VERSION ?= $(shell (git describe --tags --match 'v[0-9]*' --always --dirty 2>/dev/null || echo dev) | tr -cd 'a-zA-Z0-9._-')
 
@@ -8,14 +8,16 @@ all: protocol server client tools
 # Help target
 help:
 	@echo "Demarkus Build Targets:"
-	@echo "  all       - Build protocol, server, and client"
+	@echo "  all       - Build protocol, server, client, and tools"
 	@echo "  protocol  - Build protocol library"
 	@echo "  server    - Build demarkus-server (no external database deps)"
 	@echo "  server-pg - Build demarkus-server-pg + demarkus-migrate (Postgres backend)"
+	@echo "  knowledge-server - Build demarkus-knowledge-server (multi-world GCS backend)"
 	@echo "  client    - Build demarkus TUI client"
 	@echo "  tools     - Build broker, token, publish (tools/bin/)"
-	@echo "  image     - Build server + broker + agent container images (TAG overridable)"
+	@echo "  image     - Build runtime container images (TAG overridable)"
 	@echo "  image-server-pg - Build the Postgres-flavor server image"
+	@echo "  image-knowledge-server - Build the multi-world knowledge server image"
 	@echo "  test      - Run all tests"
 	@echo "  lint      - Run golangci-lint on all modules"
 	@echo "  clean     - Remove build artifacts"
@@ -48,6 +50,12 @@ server-pg: protocol
 	cd server && go build -o bin/demarkus-migrate ./cmd/demarkus-migrate
 	@echo "✓ Built: server/bin/demarkus-server-pg, server/bin/demarkus-migrate"
 
+knowledge-server: protocol
+	@echo "Building knowledge server tools..."
+	cd server && go build -ldflags "-X main.version=$(VERSION)" -o bin/demarkus-knowledge-server ./cmd/demarkus-knowledge-server
+	cd server && go build -ldflags "-X main.version=$(VERSION)" -o bin/demarkus-knowledge-bootstrap ./cmd/demarkus-knowledge-bootstrap
+	@echo "✓ Built: server/bin/demarkus-knowledge-{server,bootstrap}"
+
 # Build client
 client: protocol
 	@echo "Building demarkus client..."
@@ -78,7 +86,7 @@ IMAGE_REGISTRY ?= ghcr.io/latebit-io
 TAG            ?= dev
 HOST_ARCH      ?= $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/;s/armv7l/arm/')
 
-image: image-server image-broker image-agent
+image: image-server image-knowledge-server image-broker image-agent
 
 image-server:
 	@echo "Building $(IMAGE_REGISTRY)/demarkus-server:$(TAG) for linux/$(HOST_ARCH)..."
@@ -98,6 +106,13 @@ image-server-pg:
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(HOST_ARCH) go build -C client -ldflags "-s -w -X main.version=$(VERSION)" -o ../dist/docker/$(HOST_ARCH)/demarkus ./cmd/demarkus
 	docker build --build-arg TARGETARCH=$(HOST_ARCH) -f server/Dockerfile.pg -t $(IMAGE_REGISTRY)/demarkus-server-pg:$(TAG) .
 	@echo "✓ Image built: $(IMAGE_REGISTRY)/demarkus-server-pg:$(TAG)"
+
+image-knowledge-server:
+	@echo "Building $(IMAGE_REGISTRY)/demarkus-knowledge-server:$(TAG) for linux/$(HOST_ARCH)..."
+	@mkdir -p dist/docker/$(HOST_ARCH)
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(HOST_ARCH) go build -C server -ldflags "-s -w -X main.version=$(VERSION)" -o ../dist/docker/$(HOST_ARCH)/demarkus-knowledge-server ./cmd/demarkus-knowledge-server
+	docker build --build-arg TARGETARCH=$(HOST_ARCH) -f server/Dockerfile.knowledge -t $(IMAGE_REGISTRY)/demarkus-knowledge-server:$(TAG) .
+	@echo "✓ Image built: $(IMAGE_REGISTRY)/demarkus-knowledge-server:$(TAG)"
 
 image-broker:
 	@echo "Building $(IMAGE_REGISTRY)/demarkus-broker:$(TAG) for linux/$(HOST_ARCH)..."

--- a/deploy/helm/demarkus-knowledge-server/.helmignore
+++ b/deploy/helm/demarkus-knowledge-server/.helmignore
@@ -1,0 +1,11 @@
+.DS_Store
+.git/
+.gitignore
+.idea/
+.vscode/
+*.swp
+*.tmp
+*.bak
+*.orig
+/*.tgz
+tests/

--- a/deploy/helm/demarkus-knowledge-server/Chart.yaml
+++ b/deploy/helm/demarkus-knowledge-server/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: demarkus-knowledge-server
+description: Multi-world Demarkus knowledge server backed by Google Cloud Storage
+type: application
+version: 0.1.0
+appVersion: "0.25.0"
+keywords:
+  - demarkus
+  - mark-protocol
+  - knowledge-server
+  - gcs
+  - quic
+home: https://demarkus.io
+sources:
+  - https://github.com/latebit-io/demarkus
+maintainers:
+  - name: latebit-io
+    url: https://github.com/latebit-io

--- a/deploy/helm/demarkus-knowledge-server/README.md
+++ b/deploy/helm/demarkus-knowledge-server/README.md
@@ -30,6 +30,9 @@ serviceAccount:
   workloadIdentity:
     gsa: demarkus-knowledge@project.iam.gserviceaccount.com
 
+networkPolicy:
+  allowUnrestrictedHTTPS: true
+
 worlds:
   - name: team-a
     authorities:
@@ -68,8 +71,9 @@ blocked from direct clients until those CIDRs are set. Egress permits cluster
 DNS, TCP 443 for GCS, and GKE metadata-server endpoints.
 
 GCS egress cannot be restricted to stable CIDRs with standard Kubernetes
-NetworkPolicy. Use an egress proxy or CNI FQDN policy when destination-level
-restriction is required.
+NetworkPolicy. The built-in policy therefore requires explicit
+`allowUnrestrictedHTTPS: true`. Otherwise disable it and provide an egress proxy
+or CNI FQDN policy.
 
 Each world token Secret is projected read-only into a distinct path. TLS and
 configuration are also read-only. Pods run as UID/GID 65532 with a read-only

--- a/deploy/helm/demarkus-knowledge-server/README.md
+++ b/deploy/helm/demarkus-knowledge-server/README.md
@@ -1,0 +1,91 @@
+# demarkus-knowledge-server
+
+Production Helm chart for the multi-world `demarkus-knowledge-server`. One
+Deployment serves every configured authority over a shared UDP Service and
+stores each world in its own pre-provisioned GCS bucket.
+
+## Prerequisites
+
+- Kubernetes 1.25+
+- GKE Workload Identity, or an existing Kubernetes ServiceAccount with equivalent identity
+- One initialized GCS bucket and immutable world ID per world
+- One existing token Secret per world
+- One existing multi-SAN TLS Secret, or cert-manager and a suitable Issuer
+- Policy document at `/.well-known/demarkus/policy.md` in every bucket
+
+The chart never creates buckets, PVCs, token Secrets, or TLS Secrets. The
+optional `Certificate` asks cert-manager to populate the referenced TLS Secret.
+
+## Install
+
+```yaml
+tls:
+  certManager:
+    enabled: true
+    issuerRef:
+      kind: ClusterIssuer
+      name: internal-ca
+
+serviceAccount:
+  workloadIdentity:
+    gsa: demarkus-knowledge@project.iam.gserviceaccount.com
+
+worlds:
+  - name: team-a
+    authorities:
+      - team-a.example.com
+      - team-a.knowledge.svc.cluster.local
+    bucket:
+      url: gs://deployment-team-a
+      worldID: 52b471f7-8d38-4c89-b44a-6f4f8b1a4f48
+    tokenSecret:
+      name: team-a-tokens
+      key: tokens.toml
+```
+
+```sh
+helm upgrade --install knowledge ./deploy/helm/demarkus-knowledge-server \
+  --namespace demarkus-knowledge --create-namespace --values production.yaml
+```
+
+When installing from a source checkout, set `image.tag` to a published server
+release. Packaged OCI charts receive that release tag through `appVersion`.
+
+Use `tls.existingSecret` instead of `tls.certManager` when certificate lifecycle
+is managed elsewhere. The certificate must cover every configured authority.
+cert-manager mode derives one deduplicated multi-SAN certificate from those
+authorities.
+
+After Secret rotation, send `SIGHUP` to each pod or restart the Deployment. The
+projected files update automatically, but certificate reload is signal-driven.
+
+## Security
+
+Health endpoints listen on the private pod port only. No health Service is
+created. NetworkPolicy permits UDP ingress only from configured broker and agent
+namespace/pod selectors and optional `externalCIDRs`. A LoadBalancer remains
+blocked from direct clients until those CIDRs are set. Egress permits cluster
+DNS, TCP 443 for GCS, and GKE metadata-server endpoints.
+
+GCS egress cannot be restricted to stable CIDRs with standard Kubernetes
+NetworkPolicy. Use an egress proxy or CNI FQDN policy when destination-level
+restriction is required.
+
+Each world token Secret is projected read-only into a distinct path. TLS and
+configuration are also read-only. Pods run as UID/GID 65532 with a read-only
+root filesystem, dropped capabilities, RuntimeDefault seccomp, node and zone
+topology spread, rolling updates, and a default PDB.
+
+## Validation
+
+Template rendering fails for missing TLS, Workload Identity, world identity,
+authority, bucket, or token Secret values. It also rejects fewer than two
+replicas and duplicate world names, normalized authorities, buckets, world IDs,
+or token Secret names.
+
+```sh
+helm lint ./deploy/helm/demarkus-knowledge-server --values production.yaml
+helm unittest ./deploy/helm/demarkus-knowledge-server
+helm template knowledge ./deploy/helm/demarkus-knowledge-server \
+  --namespace demarkus-knowledge --values production.yaml
+```

--- a/deploy/helm/demarkus-knowledge-server/templates/_helpers.tpl
+++ b/deploy/helm/demarkus-knowledge-server/templates/_helpers.tpl
@@ -94,6 +94,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if or (empty .Values.networkPolicy.agent.namespace) (empty .Values.networkPolicy.agent.podLabels) -}}
 {{- fail "networkPolicy.agent.namespace and podLabels are required when NetworkPolicy is enabled" -}}
 {{- end -}}
+{{- if not .Values.networkPolicy.allowUnrestrictedHTTPS -}}
+{{- fail "networkPolicy.allowUnrestrictedHTTPS must be true when built-in NetworkPolicy is enabled; otherwise disable it and provide CNI or proxy egress controls" -}}
+{{- end -}}
 {{- if and .Values.networkPolicy.externalCIDRs (ne .Values.service.externalTrafficPolicy "Local") -}}
 {{- fail "service.externalTrafficPolicy must be Local when networkPolicy.externalCIDRs is set" -}}
 {{- end -}}

--- a/deploy/helm/demarkus-knowledge-server/templates/_helpers.tpl
+++ b/deploy/helm/demarkus-knowledge-server/templates/_helpers.tpl
@@ -158,6 +158,18 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- fail (printf "%s.bucket.url %q must contain valid GCS bucket components" $location $bucket.url) -}}
 {{- end -}}
 {{- end -}}
+{{- $bucketComponents := splitList "." $bucketName -}}
+{{- $dottedIPv4 := eq (len $bucketComponents) 4 -}}
+{{- if $dottedIPv4 -}}
+{{- range $component := $bucketComponents -}}
+{{- if or (not (regexMatch "^(0|[1-9][0-9]{0,2})$" $component)) (gt (atoi $component) 255) -}}
+{{- $dottedIPv4 = false -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if $dottedIPv4 -}}
+{{- fail (printf "%s.bucket.url %q must not use an IPv4 address as a bucket name" $location $bucket.url) -}}
+{{- end -}}
 {{- if or (hasPrefix "goog" $bucketName) (contains "google" $bucketName) (contains "g00gle" $bucketName) (contains "go0gle" $bucketName) (contains "g0ogle" $bucketName) -}}
 {{- fail (printf "%s.bucket.url %q uses a reserved GCS bucket name" $location $bucket.url) -}}
 {{- end -}}
@@ -169,7 +181,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- fail (printf "%s.bucket.worldID is required" $location) -}}
 {{- end -}}
 {{- if not (regexMatch "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" $bucket.worldID) -}}
-{{- fail (printf "%s.bucket.worldID %q must be a canonical lowercase RFC 4122 UUID" $location $bucket.worldID) -}}
+{{- fail (printf "%s.bucket.worldID %q must be a canonical lowercase UUID with RFC 4122 variant" $location $bucket.worldID) -}}
 {{- end -}}
 {{- if hasKey $worldIDs $bucket.worldID -}}
 {{- fail (printf "%s.bucket.worldID %q is duplicated" $location $bucket.worldID) -}}

--- a/deploy/helm/demarkus-knowledge-server/templates/_helpers.tpl
+++ b/deploy/helm/demarkus-knowledge-server/templates/_helpers.tpl
@@ -1,0 +1,189 @@
+{{- define "demarkus-knowledge-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "demarkus-knowledge-server.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "demarkus-knowledge-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "demarkus-knowledge-server.labels" -}}
+helm.sh/chart: {{ include "demarkus-knowledge-server.chart" . }}
+{{ include "demarkus-knowledge-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "demarkus-knowledge-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "demarkus-knowledge-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "demarkus-knowledge-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "demarkus-knowledge-server.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "demarkus-knowledge-server.configName" -}}
+{{- printf "%s-config" (include "demarkus-knowledge-server.fullname" . | trunc 56 | trimSuffix "-") -}}
+{{- end -}}
+
+{{- define "demarkus-knowledge-server.tlsSecretName" -}}
+{{- if .Values.tls.existingSecret -}}
+{{- .Values.tls.existingSecret -}}
+{{- else -}}
+{{- printf "%s-tls" (include "demarkus-knowledge-server.fullname" . | trunc 59 | trimSuffix "-") -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "demarkus-knowledge-server.validate" -}}
+{{- if lt (int .Values.replicaCount) 2 -}}
+{{- fail "replicaCount must be at least 2 for production availability" -}}
+{{- end -}}
+{{- $udpPort := int .Values.server.udpPort -}}
+{{- $healthPort := int .Values.server.healthPort -}}
+{{- if or (lt $udpPort 1) (gt $udpPort 65535) -}}
+{{- fail "server.udpPort must be between 1 and 65535" -}}
+{{- end -}}
+{{- if or (lt $healthPort 1) (gt $healthPort 65535) -}}
+{{- fail "server.healthPort must be between 1 and 65535" -}}
+{{- end -}}
+{{- if eq $udpPort $healthPort -}}
+{{- fail "server.healthPort must differ from server.udpPort" -}}
+{{- end -}}
+{{- if lt (int .Values.server.maxIncomingStreams) 1 -}}
+{{- fail "server.maxIncomingStreams must be positive" -}}
+{{- end -}}
+{{- if and .Values.tls.existingSecret .Values.tls.certManager.enabled -}}
+{{- fail "tls.existingSecret and tls.certManager.enabled are mutually exclusive; set exactly one" -}}
+{{- end -}}
+{{- if not (or .Values.tls.existingSecret .Values.tls.certManager.enabled) -}}
+{{- fail "tls.existingSecret or tls.certManager.enabled is required" -}}
+{{- end -}}
+{{- if and .Values.tls.certManager.enabled (empty .Values.tls.certManager.issuerRef.name) -}}
+{{- fail "tls.certManager.issuerRef.name is required when cert-manager is enabled" -}}
+{{- end -}}
+{{- if .Values.serviceAccount.create -}}
+{{- if empty .Values.serviceAccount.workloadIdentity.gsa -}}
+{{- fail "serviceAccount.workloadIdentity.gsa is required when serviceAccount.create is true" -}}
+{{- end -}}
+{{- else if empty .Values.serviceAccount.name -}}
+{{- fail "serviceAccount.name is required when serviceAccount.create is false" -}}
+{{- end -}}
+{{- if .Values.networkPolicy.enabled -}}
+{{- if or (empty .Values.networkPolicy.broker.namespace) (empty .Values.networkPolicy.broker.podLabels) -}}
+{{- fail "networkPolicy.broker.namespace and podLabels are required when NetworkPolicy is enabled" -}}
+{{- end -}}
+{{- if or (empty .Values.networkPolicy.agent.namespace) (empty .Values.networkPolicy.agent.podLabels) -}}
+{{- fail "networkPolicy.agent.namespace and podLabels are required when NetworkPolicy is enabled" -}}
+{{- end -}}
+{{- if and .Values.networkPolicy.externalCIDRs (ne .Values.service.externalTrafficPolicy "Local") -}}
+{{- fail "service.externalTrafficPolicy must be Local when networkPolicy.externalCIDRs is set" -}}
+{{- end -}}
+{{- end -}}
+{{- if empty .Values.worlds -}}
+{{- fail "worlds must contain at least one world" -}}
+{{- end -}}
+{{- $names := dict -}}
+{{- $authorities := dict -}}
+{{- $buckets := dict -}}
+{{- $worldIDs := dict -}}
+{{- $tokenSecrets := dict -}}
+{{- range $index, $configuredWorld := .Values.worlds -}}
+{{- $world := default dict $configuredWorld -}}
+{{- $bucket := default dict $world.bucket -}}
+{{- $tokenSecret := default dict $world.tokenSecret -}}
+{{- $location := printf "worlds[%d]" $index -}}
+{{- if empty $world.name -}}
+{{- fail (printf "%s.name is required" $location) -}}
+{{- end -}}
+{{- if or (gt (len $world.name) 63) (not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" $world.name)) -}}
+{{- fail (printf "%s.name must be a valid lowercase DNS label" $location) -}}
+{{- end -}}
+{{- if hasKey $names $world.name -}}
+{{- fail (printf "%s.name %q is duplicated" $location $world.name) -}}
+{{- end -}}
+{{- $_ := set $names $world.name true -}}
+{{- if empty $world.authorities -}}
+{{- fail (printf "%s.authorities must contain at least one authority" $location) -}}
+{{- end -}}
+{{- range $authorityIndex, $authority := $world.authorities -}}
+{{- if empty $authority -}}
+{{- fail (printf "%s.authorities[%d] is required" $location $authorityIndex) -}}
+{{- end -}}
+{{- $normalized := lower $authority -}}
+{{- if or (gt (len $normalized) 253) (not (regexMatch "^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$" $normalized)) (contains ".." $normalized) -}}
+{{- fail (printf "%s.authorities[%d] %q must be a DNS hostname without a port" $location $authorityIndex $authority) -}}
+{{- end -}}
+{{- range $label := splitList "." $normalized -}}
+{{- if or (gt (len $label) 63) (not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" $label)) -}}
+{{- fail (printf "%s.authorities[%d] %q must contain valid DNS labels" $location $authorityIndex $authority) -}}
+{{- end -}}
+{{- end -}}
+{{- if hasKey $authorities $normalized -}}
+{{- fail (printf "%s.authorities[%d] %q is duplicated after normalization" $location $authorityIndex $authority) -}}
+{{- end -}}
+{{- $_ := set $authorities $normalized true -}}
+{{- end -}}
+{{- if empty $bucket.url -}}
+{{- fail (printf "%s.bucket.url is required" $location) -}}
+{{- end -}}
+{{- $bucketName := trimPrefix "gs://" $bucket.url -}}
+{{- $maximumBucketLength := 63 -}}
+{{- if contains "." $bucketName -}}
+{{- $maximumBucketLength = 222 -}}
+{{- end -}}
+{{- if or (not (hasPrefix "gs://" $bucket.url)) (lt (len $bucketName) 3) (gt (len $bucketName) $maximumBucketLength) (not (regexMatch "^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$" $bucketName)) -}}
+{{- fail (printf "%s.bucket.url %q must be an exact lowercase gs://bucket URL" $location $bucket.url) -}}
+{{- end -}}
+{{- range $component := splitList "." $bucketName -}}
+{{- if or (gt (len $component) 63) (not (regexMatch "^[a-z0-9]([-_a-z0-9]*[a-z0-9])?$" $component)) -}}
+{{- fail (printf "%s.bucket.url %q must contain valid GCS bucket components" $location $bucket.url) -}}
+{{- end -}}
+{{- end -}}
+{{- if or (hasPrefix "goog" $bucketName) (contains "google" $bucketName) (contains "g00gle" $bucketName) (contains "go0gle" $bucketName) (contains "g0ogle" $bucketName) -}}
+{{- fail (printf "%s.bucket.url %q uses a reserved GCS bucket name" $location $bucket.url) -}}
+{{- end -}}
+{{- if hasKey $buckets $bucket.url -}}
+{{- fail (printf "%s.bucket.url %q is duplicated" $location $bucket.url) -}}
+{{- end -}}
+{{- $_ := set $buckets $bucket.url true -}}
+{{- if empty $bucket.worldID -}}
+{{- fail (printf "%s.bucket.worldID is required" $location) -}}
+{{- end -}}
+{{- if not (regexMatch "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" $bucket.worldID) -}}
+{{- fail (printf "%s.bucket.worldID %q must be a canonical lowercase RFC 4122 UUID" $location $bucket.worldID) -}}
+{{- end -}}
+{{- if hasKey $worldIDs $bucket.worldID -}}
+{{- fail (printf "%s.bucket.worldID %q is duplicated" $location $bucket.worldID) -}}
+{{- end -}}
+{{- $_ := set $worldIDs $bucket.worldID true -}}
+{{- if empty $tokenSecret.name -}}
+{{- fail (printf "%s.tokenSecret.name is required" $location) -}}
+{{- end -}}
+{{- if hasKey $tokenSecrets $tokenSecret.name -}}
+{{- fail (printf "%s.tokenSecret.name %q is duplicated" $location $tokenSecret.name) -}}
+{{- end -}}
+{{- $_ := set $tokenSecrets $tokenSecret.name true -}}
+{{- if empty $tokenSecret.key -}}
+{{- fail (printf "%s.tokenSecret.key is required" $location) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/demarkus-knowledge-server/templates/certificate.yaml
+++ b/deploy/helm/demarkus-knowledge-server/templates/certificate.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.tls.certManager.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "demarkus-knowledge-server.tlsSecretName" . }}
+  labels:
+    {{- include "demarkus-knowledge-server.labels" . | nindent 4 }}
+  {{- with .Values.tls.certManager.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  secretName: {{ include "demarkus-knowledge-server.tlsSecretName" . }}
+  issuerRef:
+    kind: {{ .Values.tls.certManager.issuerRef.kind }}
+    name: {{ .Values.tls.certManager.issuerRef.name }}
+  dnsNames:
+    {{- range .Values.worlds }}
+    {{- range .authorities }}
+    - {{ lower . | quote }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/demarkus-knowledge-server/templates/configmap.yaml
+++ b/deploy/helm/demarkus-knowledge-server/templates/configmap.yaml
@@ -1,0 +1,41 @@
+{{- include "demarkus-knowledge-server.validate" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "demarkus-knowledge-server.configName" . }}
+  labels:
+    {{- include "demarkus-knowledge-server.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    version: 1
+    listen:
+      address: {{ printf ":%d" (int .Values.server.udpPort) | quote }}
+      maxIncomingStreams: {{ .Values.server.maxIncomingStreams }}
+      idleTimeout: {{ .Values.server.idleTimeout | quote }}
+    health:
+      address: {{ printf ":%d" (int .Values.server.healthPort) | quote }}
+    tls:
+      certFile: /run/demarkus/tls/tls.crt
+      keyFile: /run/demarkus/tls/tls.key
+    worlds:
+      {{- range $index, $configuredWorld := .Values.worlds }}
+      {{- $world := mergeOverwrite (deepCopy $.Values.worldDefaults) (deepCopy $configuredWorld) }}
+      - name: {{ $world.name | quote }}
+        authorities:
+          {{- range $world.authorities }}
+          - {{ lower . | quote }}
+          {{- end }}
+        bucket:
+          url: {{ $world.bucket.url | quote }}
+          worldID: {{ $world.bucket.worldID | quote }}
+        auth:
+          tokensFile: {{ printf "/run/demarkus/worlds/%s/tokens.toml" $world.name | quote }}
+        policy:
+          path: /.well-known/demarkus/policy.md
+        readOnly: {{ $world.readOnly }}
+        limits:
+          maxConcurrentRequests: {{ $world.limits.maxConcurrentRequests }}
+          requestTimeout: {{ $world.limits.requestTimeout | quote }}
+          requestsPerSecond: {{ $world.limits.requestsPerSecond }}
+          burst: {{ $world.limits.burst }}
+      {{- end }}

--- a/deploy/helm/demarkus-knowledge-server/templates/deployment.yaml
+++ b/deploy/helm/demarkus-knowledge-server/templates/deployment.yaml
@@ -1,0 +1,136 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "demarkus-knowledge-server.fullname" . }}
+  labels:
+    {{- include "demarkus-knowledge-server.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      {{- include "demarkus-knowledge-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "demarkus-knowledge-server.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "demarkus-knowledge-server.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: knowledge-server
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["-config", "/etc/demarkus/config.yaml"]
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: mark
+              protocol: UDP
+              containerPort: {{ .Values.server.udpPort }}
+            - name: health
+              protocol: TCP
+              containerPort: {{ .Values.server.healthPort }}
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: health
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/demarkus
+              readOnly: true
+            - name: tls
+              mountPath: /run/demarkus/tls
+              readOnly: true
+            {{- range $index, $world := .Values.worlds }}
+            - name: {{ printf "world-token-%d" $index }}
+              mountPath: {{ printf "/run/demarkus/worlds/%s" $world.name | quote }}
+              readOnly: true
+            {{- end }}
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "demarkus-knowledge-server.configName" . }}
+            items:
+              - key: config.yaml
+                path: config.yaml
+        - name: tls
+          secret:
+            secretName: {{ include "demarkus-knowledge-server.tlsSecretName" . }}
+            items:
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+        {{- range $index, $world := .Values.worlds }}
+        - name: {{ printf "world-token-%d" $index }}
+          secret:
+            secretName: {{ $world.tokenSecret.name | quote }}
+            items:
+              - key: {{ $world.tokenSecret.key | quote }}
+                path: tokens.toml
+        {{- end }}
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range . }}
+        - maxSkew: {{ .maxSkew }}
+          topologyKey: {{ .topologyKey }}
+          whenUnsatisfiable: {{ .whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "demarkus-knowledge-server.selectorLabels" $ | nindent 14 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/demarkus-knowledge-server/templates/networkpolicy.yaml
+++ b/deploy/helm/demarkus-knowledge-server/templates/networkpolicy.yaml
@@ -44,9 +44,11 @@ spec:
     # Standard NetworkPolicy cannot target GCS FQDNs or rotating addresses.
     # This permits any TCP/443 destination; use an egress proxy or CNI FQDN
     # policy when destination-level restriction is required.
+    {{- if .Values.networkPolicy.allowUnrestrictedHTTPS }}
     - ports:
         - protocol: TCP
           port: 443
+    {{- end }}
     - to:
         - ipBlock:
             cidr: 169.254.169.254/32

--- a/deploy/helm/demarkus-knowledge-server/templates/networkpolicy.yaml
+++ b/deploy/helm/demarkus-knowledge-server/templates/networkpolicy.yaml
@@ -41,7 +41,9 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
-    # GCS uses rotating public addresses, so destination CIDRs cannot be pinned.
+    # Standard NetworkPolicy cannot target GCS FQDNs or rotating addresses.
+    # This permits any TCP/443 destination; use an egress proxy or CNI FQDN
+    # policy when destination-level restriction is required.
     - ports:
         - protocol: TCP
           port: 443

--- a/deploy/helm/demarkus-knowledge-server/templates/networkpolicy.yaml
+++ b/deploy/helm/demarkus-knowledge-server/templates/networkpolicy.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "demarkus-knowledge-server.fullname" . }}
+  labels:
+    {{- include "demarkus-knowledge-server.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "demarkus-knowledge-server.selectorLabels" . | nindent 6 }}
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.broker.namespace | quote }}
+          podSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.broker.podLabels | nindent 14 }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.agent.namespace | quote }}
+          podSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.agent.podLabels | nindent 14 }}
+        {{- range .Values.networkPolicy.externalCIDRs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
+      ports:
+        - protocol: UDP
+          port: {{ .Values.server.udpPort }}
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # GCS uses rotating public addresses, so destination CIDRs cannot be pinned.
+    - ports:
+        - protocol: TCP
+          port: 443
+    - to:
+        - ipBlock:
+            cidr: 169.254.169.254/32
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 8080
+    # GKE Dataplane V2 uses this metadata-server endpoint.
+    - to:
+        - ipBlock:
+            cidr: 169.254.169.252/32
+      ports:
+        - protocol: TCP
+          port: 988
+        - protocol: TCP
+          port: 987
+{{- end }}

--- a/deploy/helm/demarkus-knowledge-server/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/demarkus-knowledge-server/templates/poddisruptionbudget.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "demarkus-knowledge-server.fullname" . }}
+  labels:
+    {{- include "demarkus-knowledge-server.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "demarkus-knowledge-server.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/demarkus-knowledge-server/templates/service.yaml
+++ b/deploy/helm/demarkus-knowledge-server/templates/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "demarkus-knowledge-server.fullname" . }}
+  labels:
+    {{- include "demarkus-knowledge-server.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP | quote }}
+  {{- end }}
+  selector:
+    {{- include "demarkus-knowledge-server.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: mark
+      protocol: UDP
+      port: {{ .Values.server.udpPort }}
+      targetPort: mark

--- a/deploy/helm/demarkus-knowledge-server/templates/serviceaccount.yaml
+++ b/deploy/helm/demarkus-knowledge-server/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "demarkus-knowledge-server.serviceAccountName" . }}
+  labels:
+    {{- include "demarkus-knowledge-server.labels" . | nindent 4 }}
+  {{- $annotations := deepCopy (default dict .Values.serviceAccount.annotations) }}
+  {{- $_ := set $annotations "iam.gke.io/gcp-service-account" .Values.serviceAccount.workloadIdentity.gsa }}
+  annotations:
+    {{- toYaml $annotations | nindent 4 }}
+{{- end }}

--- a/deploy/helm/demarkus-knowledge-server/tests/certificate_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/certificate_test.yaml
@@ -1,0 +1,49 @@
+suite: certificate
+templates:
+  - certificate.yaml
+values:
+  - fixtures/valid-values.yaml
+tests:
+  - it: does not render when an existing TLS Secret is used
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: derives one multi-SAN certificate from all world authorities
+    set:
+      tls.existingSecret: ""
+      tls.certManager.enabled: true
+      tls.certManager.issuerRef.name: internal-ca
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: spec.secretName
+          value: RELEASE-NAME-demarkus-knowledge-server-tls
+      - equal:
+          path: spec.issuerRef
+          value:
+            kind: ClusterIssuer
+            name: internal-ca
+      - equal:
+          path: spec.dnsNames
+          value:
+            - team-a.example.com
+            - team-a.knowledge.svc.cluster.local
+            - team-b.example.com
+
+  - it: propagates issuer kind and annotations
+    set:
+      tls.existingSecret: ""
+      tls.certManager.enabled: true
+      tls.certManager.issuerRef.kind: Issuer
+      tls.certManager.issuerRef.name: internal-ca
+      tls.certManager.annotations:
+        example.com/owner: platform
+    asserts:
+      - equal:
+          path: spec.issuerRef.kind
+          value: Issuer
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform

--- a/deploy/helm/demarkus-knowledge-server/tests/configmap_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/configmap_test.yaml
@@ -1,0 +1,57 @@
+suite: strict configuration
+templates:
+  - configmap.yaml
+values:
+  - fixtures/valid-values.yaml
+tests:
+  - it: renders one strict versioned config document
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-demarkus-knowledge-server-config
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '^version: 1\nlisten:'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'health:\n  address: ":8081"'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'certFile: /run/demarkus/tls/tls.crt\n  keyFile: /run/demarkus/tls/tls.key'
+
+  - it: normalizes authorities and renders fixed isolated token paths
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'tokensFile: "/run/demarkus/worlds/team-a/tokens.toml"'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'tokensFile: "/run/demarkus/worlds/team-b/tokens.toml"'
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: 'tokenSecret'
+
+  - it: applies defaults and preserves per-world overrides
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'name: "team-a"[\s\S]*readOnly: false[\s\S]*maxConcurrentRequests: 32[\s\S]*requestTimeout: "10s"'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'name: "team-b"[\s\S]*readOnly: true[\s\S]*maxConcurrentRequests: 16[\s\S]*requestTimeout: "5s"'
+
+  - it: propagates listener settings
+    set:
+      server.udpPort: 7443
+      server.healthPort: 9090
+      server.maxIncomingStreams: 256
+      server.idleTimeout: 45s
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'address: ":7443"\n  maxIncomingStreams: 256\n  idleTimeout: "45s"'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'health:\n  address: ":9090"'

--- a/deploy/helm/demarkus-knowledge-server/tests/deployment_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/deployment_test.yaml
@@ -1,0 +1,159 @@
+suite: deployment
+templates:
+  - deployment.yaml
+  - configmap.yaml
+values:
+  - fixtures/valid-values.yaml
+tests:
+  - it: deploys two replicas with zero-downtime rolling updates
+    template: deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.replicas
+          value: 2
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
+
+  - it: uses the knowledge image and strict config argument
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/latebit-io/demarkus-knowledge-server:0.25.0
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value: ["-config", "/etc/demarkus/config.yaml"]
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: '^[0-9a-f]{64}$'
+
+  - it: keeps QUIC public and health private at the pod
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: mark
+            protocol: UDP
+            containerPort: 6309
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: health
+            protocol: TCP
+            containerPort: 8081
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /livez
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.port
+          value: health
+
+  - it: mounts existing TLS data read-only
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[1].secret.secretName
+          value: knowledge-tls
+      - equal:
+          path: spec.template.spec.volumes[1].secret.items
+          value:
+            - key: tls.crt
+              path: tls.crt
+            - key: tls.key
+              path: tls.key
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1]
+          value:
+            name: tls
+            mountPath: /run/demarkus/tls
+            readOnly: true
+
+  - it: projects exactly one distinct token volume per world
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[2]
+          value:
+            name: world-token-0
+            secret:
+              secretName: team-a-tokens
+              items:
+                - key: tokens.toml
+                  path: tokens.toml
+      - equal:
+          path: spec.template.spec.volumes[3]
+          value:
+            name: world-token-1
+            secret:
+              secretName: team-b-tokens
+              items:
+                - key: tokens.toml
+                  path: tokens.toml
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[2].mountPath
+          value: /run/demarkus/worlds/team-a
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].mountPath
+          value: /run/demarkus/worlds/team-b
+
+  - it: applies pod and container security contexts
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 65532
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: spreads replicas across nodes and zones
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: kubernetes.io/hostname
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[1].topologyKey
+          value: topology.kubernetes.io/zone
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: uses the Workload Identity service account and graceful termination
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-demarkus-knowledge-server
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 30
+      - notExists:
+          path: spec.template.spec.volumes[5]
+      - notExists:
+          path: spec.volumeClaimTemplates

--- a/deploy/helm/demarkus-knowledge-server/tests/fixtures/valid-values.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/fixtures/valid-values.yaml
@@ -1,0 +1,31 @@
+tls:
+  existingSecret: knowledge-tls
+serviceAccount:
+  workloadIdentity:
+    gsa: knowledge@project.iam.gserviceaccount.com
+worlds:
+  - name: team-a
+    authorities:
+      - team-a.example.com
+      - team-a.knowledge.svc.cluster.local
+    bucket:
+      url: gs://deployment-team-a
+      worldID: 52b471f7-8d38-4c89-b44a-6f4f8b1a4f48
+    tokenSecret:
+      name: team-a-tokens
+      key: tokens.toml
+  - name: team-b
+    authorities:
+      - team-b.example.com
+    bucket:
+      url: gs://deployment-team-b
+      worldID: 42b471f7-8d38-4c89-b44a-6f4f8b1a4f49
+    tokenSecret:
+      name: team-b-tokens
+      key: tokens.toml
+    readOnly: true
+    limits:
+      maxConcurrentRequests: 16
+      requestTimeout: 5s
+      requestsPerSecond: 20
+      burst: 40

--- a/deploy/helm/demarkus-knowledge-server/tests/fixtures/valid-values.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/fixtures/valid-values.yaml
@@ -3,6 +3,8 @@ tls:
 serviceAccount:
   workloadIdentity:
     gsa: knowledge@project.iam.gserviceaccount.com
+networkPolicy:
+  allowUnrestrictedHTTPS: true
 worlds:
   - name: team-a
     authorities:

--- a/deploy/helm/demarkus-knowledge-server/tests/networkpolicy_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/networkpolicy_test.yaml
@@ -79,6 +79,17 @@ tests:
           path: spec.egress[3].ports[1].port
           value: 987
 
+  - it: omits unrestricted HTTPS unless explicitly allowed
+    set:
+      networkPolicy.allowUnrestrictedHTTPS: false
+    asserts:
+      - lengthEqual:
+          path: spec.egress
+          count: 3
+      - equal:
+          path: spec.egress[1].to[0].ipBlock.cidr
+          value: 169.254.169.254/32
+
   - it: admits configured direct-client CIDRs
     set:
       networkPolicy.externalCIDRs: [203.0.113.0/24]

--- a/deploy/helm/demarkus-knowledge-server/tests/networkpolicy_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/networkpolicy_test.yaml
@@ -1,0 +1,95 @@
+suite: network policy
+templates:
+  - networkpolicy.yaml
+values:
+  - fixtures/valid-values.yaml
+tests:
+  - it: isolates ingress and egress by default
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: spec.policyTypes
+          value: [Ingress, Egress]
+      - lengthEqual:
+          path: spec.ingress
+          count: 1
+      - equal:
+          path: spec.ingress[0].ports[0]
+          value:
+            protocol: UDP
+            port: 6309
+
+  - it: admits only labeled broker and agent pods from configured namespaces
+    asserts:
+      - equal:
+          path: spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: demarkus-broker
+      - equal:
+          path: spec.ingress[0].from[0].podSelector.matchLabels["app.kubernetes.io/name"]
+          value: demarkus-broker
+      - equal:
+          path: spec.ingress[0].from[1].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: demarkus-agent
+      - equal:
+          path: spec.ingress[0].from[1].podSelector.matchLabels["app.kubernetes.io/name"]
+          value: demarkus-agent
+
+  - it: allows DNS over UDP and TCP only to kube-system
+    asserts:
+      - equal:
+          path: spec.egress[0].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: kube-system
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            protocol: UDP
+            port: 53
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            protocol: TCP
+            port: 53
+
+  - it: allows GCS HTTPS and both GKE metadata endpoints
+    asserts:
+      - notExists:
+          path: spec.egress[1].to
+      - equal:
+          path: spec.egress[1].ports[0]
+          value:
+            protocol: TCP
+            port: 443
+      - equal:
+          path: spec.egress[2].to[0].ipBlock.cidr
+          value: 169.254.169.254/32
+      - equal:
+          path: spec.egress[2].ports[0].port
+          value: 80
+      - equal:
+          path: spec.egress[2].ports[1].port
+          value: 8080
+      - equal:
+          path: spec.egress[3].to[0].ipBlock.cidr
+          value: 169.254.169.252/32
+      - equal:
+          path: spec.egress[3].ports[0].port
+          value: 988
+      - equal:
+          path: spec.egress[3].ports[1].port
+          value: 987
+
+  - it: admits configured direct-client CIDRs
+    set:
+      networkPolicy.externalCIDRs: [203.0.113.0/24]
+    asserts:
+      - equal:
+          path: spec.ingress[0].from[2].ipBlock.cidr
+          value: 203.0.113.0/24
+
+  - it: can be disabled for a CNI-managed policy
+    set:
+      networkPolicy.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/demarkus-knowledge-server/tests/networkpolicy_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/networkpolicy_test.yaml
@@ -51,7 +51,7 @@ tests:
             protocol: TCP
             port: 53
 
-  - it: allows GCS HTTPS and both GKE metadata endpoints
+  - it: allows unrestricted HTTPS for GCS and both GKE metadata endpoints
     asserts:
       - notExists:
           path: spec.egress[1].to

--- a/deploy/helm/demarkus-knowledge-server/tests/pdb_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/pdb_test.yaml
@@ -1,0 +1,23 @@
+suite: pod disruption budget
+templates:
+  - poddisruptionbudget.yaml
+values:
+  - fixtures/valid-values.yaml
+tests:
+  - it: preserves one replica by default
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: demarkus-knowledge-server
+
+  - it: supports an externally managed PDB
+    set:
+      podDisruptionBudget.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/demarkus-knowledge-server/tests/service_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/service_test.yaml
@@ -1,0 +1,53 @@
+suite: UDP service
+templates:
+  - service.yaml
+values:
+  - fixtures/valid-values.yaml
+tests:
+  - it: exposes exactly one UDP port and no health port
+    asserts:
+      - isKind:
+          of: Service
+      - lengthEqual:
+          path: spec.ports
+          count: 1
+      - equal:
+          path: spec.ports[0]
+          value:
+            name: mark
+            protocol: UDP
+            port: 6309
+            targetPort: mark
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: propagates service settings
+    set:
+      service.type: LoadBalancer
+      service.loadBalancerIP: 203.0.113.10
+      service.annotations:
+        cloud.google.com/l4-rbs: enabled
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.externalTrafficPolicy
+          value: Local
+      - equal:
+          path: spec.loadBalancerIP
+          value: 203.0.113.10
+      - equal:
+          path: metadata.annotations["cloud.google.com/l4-rbs"]
+          value: enabled
+
+  - it: omits load balancer fields for ClusterIP
+    set:
+      service.type: ClusterIP
+      service.loadBalancerIP: ""
+    asserts:
+      - notExists:
+          path: spec.externalTrafficPolicy
+      - notExists:
+          path: spec.loadBalancerIP

--- a/deploy/helm/demarkus-knowledge-server/tests/serviceaccount_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/serviceaccount_test.yaml
@@ -1,0 +1,33 @@
+suite: service account
+templates:
+  - serviceaccount.yaml
+values:
+  - fixtures/valid-values.yaml
+tests:
+  - it: creates a Workload Identity annotated service account
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]
+          value: knowledge@project.iam.gserviceaccount.com
+
+  - it: merges operator annotations with Workload Identity
+    set:
+      serviceAccount.annotations:
+        example.com/owner: platform
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform
+      - equal:
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]
+          value: knowledge@project.iam.gserviceaccount.com
+
+  - it: skips creation when an existing service account is selected
+    set:
+      serviceAccount.create: false
+      serviceAccount.name: existing-ksa
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/demarkus-knowledge-server/tests/validation_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/validation_test.yaml
@@ -1,0 +1,234 @@
+suite: required values and uniqueness
+templates:
+  - configmap.yaml
+values:
+  - fixtures/valid-values.yaml
+tests:
+  - it: rejects fewer than two replicas
+    set:
+      replicaCount: 1
+    asserts:
+      - failedTemplate:
+          errorMessage: replicaCount must be at least 2 for production availability
+
+  - it: rejects colliding public and health ports
+    set:
+      server.healthPort: 6309
+    asserts:
+      - failedTemplate:
+          errorMessage: server.healthPort must differ from server.udpPort
+
+  - it: requires broker ingress selectors when NetworkPolicy is enabled
+    set:
+      networkPolicy.broker.namespace: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: networkPolicy.broker.namespace and podLabels are required when NetworkPolicy is enabled
+
+  - it: preserves direct-client source addresses for CIDR filtering
+    set:
+      service.type: LoadBalancer
+      service.externalTrafficPolicy: Cluster
+      networkPolicy.externalCIDRs: [203.0.113.0/24]
+    asserts:
+      - failedTemplate:
+          errorMessage: service.externalTrafficPolicy must be Local when networkPolicy.externalCIDRs is set
+
+  - it: requires exactly one TLS mode
+    set:
+      tls.existingSecret: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: tls.existingSecret or tls.certManager.enabled is required
+
+  - it: rejects both TLS modes
+    set:
+      tls.certManager.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: tls.existingSecret and tls.certManager.enabled are mutually exclusive; set exactly one
+
+  - it: requires a cert-manager issuer
+    set:
+      tls.existingSecret: ""
+      tls.certManager.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: tls.certManager.issuerRef.name is required when cert-manager is enabled
+
+  - it: requires Workload Identity on a created service account
+    set:
+      serviceAccount.workloadIdentity.gsa: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: serviceAccount.workloadIdentity.gsa is required when serviceAccount.create is true
+
+  - it: requires the name of an existing service account
+    set:
+      serviceAccount.create: false
+      serviceAccount.name: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: serviceAccount.name is required when serviceAccount.create is false
+
+  - it: requires at least one world
+    set:
+      worlds: []
+    asserts:
+      - failedTemplate:
+          errorMessage: worlds must contain at least one world
+
+  - it: rejects duplicate world names
+    set:
+      worlds:
+        - name: team-a
+          authorities: [team-a.example.com]
+          bucket: {url: gs://deployment-team-a, worldID: 52b471f7-8d38-4c89-b44a-6f4f8b1a4f48}
+          tokenSecret: {name: team-a-tokens, key: tokens.toml}
+        - name: team-a
+          authorities: [team-b.example.com]
+          bucket: {url: gs://deployment-team-b, worldID: 42b471f7-8d38-4c89-b44a-6f4f8b1a4f49}
+          tokenSecret: {name: team-b-tokens, key: tokens.toml}
+    asserts:
+      - failedTemplate:
+          errorMessage: 'worlds[1].name "team-a" is duplicated'
+
+  - it: rejects duplicate normalized authorities
+    set:
+      worlds:
+        - name: team-a
+          authorities: [team-a.example.com, TEAM-A.EXAMPLE.COM]
+          bucket: {url: gs://deployment-team-a, worldID: 52b471f7-8d38-4c89-b44a-6f4f8b1a4f48}
+          tokenSecret: {name: team-a-tokens, key: tokens.toml}
+    asserts:
+      - failedTemplate:
+          errorMessage: 'worlds[0].authorities[1] "TEAM-A.EXAMPLE.COM" is duplicated after normalization'
+
+  - it: rejects duplicate buckets
+    set:
+      worlds:
+        - name: team-a
+          authorities: [team-a.example.com]
+          bucket: {url: gs://deployment-team-a, worldID: 52b471f7-8d38-4c89-b44a-6f4f8b1a4f48}
+          tokenSecret: {name: team-a-tokens, key: tokens.toml}
+        - name: team-b
+          authorities: [team-b.example.com]
+          bucket: {url: gs://deployment-team-a, worldID: 42b471f7-8d38-4c89-b44a-6f4f8b1a4f49}
+          tokenSecret: {name: team-b-tokens, key: tokens.toml}
+    asserts:
+      - failedTemplate:
+          errorMessage: 'worlds[1].bucket.url "gs://deployment-team-a" is duplicated'
+
+  - it: rejects duplicate world IDs
+    set:
+      worlds:
+        - name: team-a
+          authorities: [team-a.example.com]
+          bucket: {url: gs://deployment-team-a, worldID: 52b471f7-8d38-4c89-b44a-6f4f8b1a4f48}
+          tokenSecret: {name: team-a-tokens, key: tokens.toml}
+        - name: team-b
+          authorities: [team-b.example.com]
+          bucket: {url: gs://deployment-team-b, worldID: 52b471f7-8d38-4c89-b44a-6f4f8b1a4f48}
+          tokenSecret: {name: team-b-tokens, key: tokens.toml}
+    asserts:
+      - failedTemplate:
+          errorMessage: 'worlds[1].bucket.worldID "52b471f7-8d38-4c89-b44a-6f4f8b1a4f48" is duplicated'
+
+  - it: rejects duplicate token Secrets
+    set:
+      worlds:
+        - name: team-a
+          authorities: [team-a.example.com]
+          bucket: {url: gs://deployment-team-a, worldID: 52b471f7-8d38-4c89-b44a-6f4f8b1a4f48}
+          tokenSecret: {name: team-a-tokens, key: tokens.toml}
+        - name: team-b
+          authorities: [team-b.example.com]
+          bucket: {url: gs://deployment-team-b, worldID: 42b471f7-8d38-4c89-b44a-6f4f8b1a4f49}
+          tokenSecret: {name: team-a-tokens, key: tokens.toml}
+    asserts:
+      - failedTemplate:
+          errorMessage: 'worlds[1].tokenSecret.name "team-a-tokens" is duplicated'
+
+  - it: requires each identity and token value
+    set:
+      worlds:
+        - name: team-a
+          authorities: [team-a.example.com]
+          bucket: {url: gs://deployment-team-a, worldID: 52b471f7-8d38-4c89-b44a-6f4f8b1a4f48}
+          tokenSecret: {name: team-a-tokens, key: ""}
+    asserts:
+      - failedTemplate:
+          errorMessage: worlds[0].tokenSecret.key is required
+
+  - it: rejects world names unsafe for Kubernetes mount paths
+    set:
+      worlds[0].name: Team_A
+    asserts:
+      - failedTemplate:
+          errorMessage: worlds[0].name must be a valid lowercase DNS label
+
+  - it: rejects authority ports
+    set:
+      worlds:
+        - name: team-a
+          authorities: [team-a.example.com:6309]
+          bucket: {url: gs://deployment-team-a, worldID: 52b471f7-8d38-4c89-b44a-6f4f8b1a4f48}
+          tokenSecret: {name: team-a-tokens, key: tokens.toml}
+    asserts:
+      - failedTemplate:
+          errorMessage: 'worlds[0].authorities[0] "team-a.example.com:6309" must be a DNS hostname without a port'
+
+  - it: rejects oversized authority labels
+    set:
+      worlds:
+        - name: team-a
+          authorities: [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.example.com]
+          bucket: {url: gs://deployment-team-a, worldID: 52b471f7-8d38-4c89-b44a-6f4f8b1a4f48}
+          tokenSecret: {name: team-a-tokens, key: tokens.toml}
+    asserts:
+      - failedTemplate:
+          errorMessage: 'worlds[0].authorities[0] "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.example.com" must contain valid DNS labels'
+
+  - it: rejects bucket paths
+    set:
+      worlds:
+        - name: team-a
+          authorities: [team-a.example.com]
+          bucket: {url: gs://deployment-team-a/prefix, worldID: 52b471f7-8d38-4c89-b44a-6f4f8b1a4f48}
+          tokenSecret: {name: team-a-tokens, key: tokens.toml}
+    asserts:
+      - failedTemplate:
+          errorMessage: 'worlds[0].bucket.url "gs://deployment-team-a/prefix" must be an exact lowercase gs://bucket URL'
+
+  - it: accepts valid dotted bucket names over 63 bytes
+    set:
+      worlds:
+        - name: team-a
+          authorities: [team-a.example.com]
+          bucket: {url: gs://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.ccc, worldID: 52b471f7-8d38-4c89-b44a-6f4f8b1a4f48}
+          tokenSecret: {name: team-a-tokens, key: tokens.toml}
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+  - it: rejects noncanonical world IDs
+    set:
+      worlds:
+        - name: team-a
+          authorities: [team-a.example.com]
+          bucket: {url: gs://deployment-team-a, worldID: 52B471F7-8D38-4C89-B44A-6F4F8B1A4F48}
+          tokenSecret: {name: team-a-tokens, key: tokens.toml}
+    asserts:
+      - failedTemplate:
+          errorMessage: 'worlds[0].bucket.worldID "52B471F7-8D38-4C89-B44A-6F4F8B1A4F48" must be a canonical lowercase RFC 4122 UUID'
+
+  - it: rejects UUIDs without the RFC 4122 variant
+    set:
+      worlds:
+        - name: team-a
+          authorities: [team-a.example.com]
+          bucket: {url: gs://deployment-team-a, worldID: 52b471f7-8d38-4c89-744a-6f4f8b1a4f48}
+          tokenSecret: {name: team-a-tokens, key: tokens.toml}
+    asserts:
+      - failedTemplate:
+          errorMessage: 'worlds[0].bucket.worldID "52b471f7-8d38-4c89-744a-6f4f8b1a4f48" must be a canonical lowercase RFC 4122 UUID'

--- a/deploy/helm/demarkus-knowledge-server/tests/validation_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/validation_test.yaml
@@ -211,6 +211,17 @@ tests:
       - isKind:
           of: ConfigMap
 
+  - it: rejects dotted-decimal IPv4 bucket names
+    set:
+      worlds:
+        - name: team-a
+          authorities: [team-a.example.com]
+          bucket: {url: gs://192.168.5.4, worldID: 52b471f7-8d38-4c89-b44a-6f4f8b1a4f48}
+          tokenSecret: {name: team-a-tokens, key: tokens.toml}
+    asserts:
+      - failedTemplate:
+          errorMessage: 'worlds[0].bucket.url "gs://192.168.5.4" must not use an IPv4 address as a bucket name'
+
   - it: rejects noncanonical world IDs
     set:
       worlds:
@@ -220,7 +231,7 @@ tests:
           tokenSecret: {name: team-a-tokens, key: tokens.toml}
     asserts:
       - failedTemplate:
-          errorMessage: 'worlds[0].bucket.worldID "52B471F7-8D38-4C89-B44A-6F4F8B1A4F48" must be a canonical lowercase RFC 4122 UUID'
+          errorMessage: 'worlds[0].bucket.worldID "52B471F7-8D38-4C89-B44A-6F4F8B1A4F48" must be a canonical lowercase UUID with RFC 4122 variant'
 
   - it: rejects UUIDs without the RFC 4122 variant
     set:
@@ -231,4 +242,4 @@ tests:
           tokenSecret: {name: team-a-tokens, key: tokens.toml}
     asserts:
       - failedTemplate:
-          errorMessage: 'worlds[0].bucket.worldID "52b471f7-8d38-4c89-744a-6f4f8b1a4f48" must be a canonical lowercase RFC 4122 UUID'
+          errorMessage: 'worlds[0].bucket.worldID "52b471f7-8d38-4c89-744a-6f4f8b1a4f48" must be a canonical lowercase UUID with RFC 4122 variant'

--- a/deploy/helm/demarkus-knowledge-server/tests/validation_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/validation_test.yaml
@@ -25,6 +25,13 @@ tests:
       - failedTemplate:
           errorMessage: networkPolicy.broker.namespace and podLabels are required when NetworkPolicy is enabled
 
+  - it: requires explicit acceptance of unrestricted HTTPS egress
+    set:
+      networkPolicy.allowUnrestrictedHTTPS: false
+    asserts:
+      - failedTemplate:
+          errorMessage: networkPolicy.allowUnrestrictedHTTPS must be true when built-in NetworkPolicy is enabled; otherwise disable it and provide CNI or proxy egress controls
+
   - it: preserves direct-client source addresses for CIDR filtering
     set:
       service.type: LoadBalancer

--- a/deploy/helm/demarkus-knowledge-server/values.yaml
+++ b/deploy/helm/demarkus-knowledge-server/values.yaml
@@ -76,6 +76,9 @@ podDisruptionBudget:
 
 networkPolicy:
   enabled: true
+  # Standard NetworkPolicy cannot restrict GCS by FQDN. Explicitly accept
+  # unrestricted TCP/443, or disable this policy and supply CNI/proxy controls.
+  allowUnrestrictedHTTPS: false
   broker:
     namespace: demarkus-broker
     podLabels:

--- a/deploy/helm/demarkus-knowledge-server/values.yaml
+++ b/deploy/helm/demarkus-knowledge-server/values.yaml
@@ -1,0 +1,119 @@
+image:
+  repository: ghcr.io/latebit-io/demarkus-knowledge-server
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+replicaCount: 2
+
+server:
+  udpPort: 6309
+  healthPort: 8081
+  maxIncomingStreams: 128
+  idleTimeout: 30s
+
+# Supply at least one world. Buckets, policy documents, and token Secrets
+# must exist before installation; this chart does not provision them.
+worlds: []
+
+worldDefaults:
+  readOnly: false
+  limits:
+    maxConcurrentRequests: 32
+    requestTimeout: 10s
+    requestsPerSecond: 50
+    burst: 100
+
+tls:
+  # Set exactly one mode. Existing Secrets must contain tls.crt and tls.key.
+  existingSecret: ""
+  certManager:
+    enabled: false
+    issuerRef:
+      kind: ClusterIssuer
+      name: ""
+    annotations: {}
+
+service:
+  type: ClusterIP
+  annotations: {}
+  loadBalancerIP: ""
+  externalTrafficPolicy: Local
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  workloadIdentity:
+    # GSA with storage access to every configured world bucket.
+    gsa: ""
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 1536Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi
+
+probes:
+  startup:
+    periodSeconds: 5
+    timeoutSeconds: 2
+    failureThreshold: 24
+  liveness:
+    periodSeconds: 30
+    timeoutSeconds: 2
+    failureThreshold: 3
+  readiness:
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+networkPolicy:
+  enabled: true
+  broker:
+    namespace: demarkus-broker
+    podLabels:
+      app.kubernetes.io/name: demarkus-broker
+  agent:
+    namespace: demarkus-agent
+    podLabels:
+      app.kubernetes.io/name: demarkus-agent
+  # Required for direct clients when service.type is LoadBalancer.
+  externalCIDRs: []
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+
+terminationGracePeriodSeconds: 30
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}
+podLabels: {}
+nameOverride: ""
+fullnameOverride: ""

--- a/server/.goreleaser.yml
+++ b/server/.goreleaser.yml
@@ -60,19 +60,56 @@ builds:
       - "7"
     ldflags:
       - -s -w -X main.version={{ .Version }}
+  - id: demarkus-knowledge-server
+    main: ./cmd/demarkus-knowledge-server
+    binary: demarkus-knowledge-server
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - "7"
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+  - id: demarkus-knowledge-bootstrap
+    main: ./cmd/demarkus-knowledge-bootstrap
+    binary: demarkus-knowledge-bootstrap
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - "7"
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
 
 archives:
   - id: demarkus-server
-    builds:
+    ids:
       - demarkus-server
     name_template: "demarkus-server_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
   # Shipped as its own archive so a file-store deployment never downloads
   # the Postgres flavor.
   - id: demarkus-server-pg
-    builds:
+    ids:
       - demarkus-server-pg
       - demarkus-migrate
     name_template: "demarkus-server-pg_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - id: demarkus-knowledge-server
+    ids:
+      - demarkus-knowledge-server
+      - demarkus-knowledge-bootstrap
+    name_template: "demarkus-knowledge-server_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
   name_template: "demarkus-server_checksums.txt"

--- a/server/Dockerfile.knowledge
+++ b/server/Dockerfile.knowledge
@@ -1,0 +1,10 @@
+# GCS access requires the CA bundle provided by distroless/static.
+# Build context is repo root; binaries are staged by release or Makefile.
+FROM gcr.io/distroless/static-debian12:nonroot
+ARG TARGETARCH
+ARG TARGETVARIANT
+COPY dist/docker/${TARGETARCH}${TARGETVARIANT}/demarkus-knowledge-server /demarkus-knowledge-server
+USER 65532:65532
+EXPOSE 6309/udp
+EXPOSE 8081/tcp
+ENTRYPOINT ["/demarkus-knowledge-server"]

--- a/server/cmd/demarkus-knowledge-bootstrap/bootstrap.go
+++ b/server/cmd/demarkus-knowledge-bootstrap/bootstrap.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/latebit-io/demarkus/protocol/publishpolicy"
+	protocolstore "github.com/latebit-io/demarkus/protocol/store"
+	"github.com/latebit-io/demarkus/server/internal/knowledge/blob"
+	"github.com/latebit-io/demarkus/server/internal/knowledge/bucketstore"
+)
+
+var policyMetadata = map[string]string{
+	"title":      "Knowledge System Policy",
+	"tags":       "category:governance",
+	"importance": "1",
+	"type":       "Reference",
+}
+
+func bootstrap(ctx context.Context, objects blob.Store, worldID string, policy []byte) error {
+	if err := validatePolicy(policy); err != nil {
+		return err
+	}
+	if err := bucketstore.Initialize(ctx, objects, worldID); err != nil {
+		return fmt.Errorf("initialize bucket: %w", err)
+	}
+	store, err := bucketstore.Open(ctx, objects, bucketstore.Options{WorldID: worldID, RequirePolicy: false})
+	if err != nil {
+		return fmt.Errorf("open initialized bucket: %w", err)
+	}
+	if err := seedPolicy(store, policy); err != nil {
+		return err
+	}
+	if _, err := bucketstore.Open(ctx, objects, bucketstore.Options{WorldID: worldID, RequirePolicy: true}); err != nil {
+		return fmt.Errorf("verify required policy: %w", err)
+	}
+	return nil
+}
+
+func validatePolicy(policy []byte) error {
+	if err := protocolstore.ValidateDocumentContent(publishpolicy.DocumentPath, policy); err != nil {
+		return fmt.Errorf("invalid policy document: %w", err)
+	}
+	if err := protocolstore.ValidateWrite(policy, policyMetadata); err != nil {
+		return fmt.Errorf("invalid policy write: %w", err)
+	}
+	parsed := publishpolicy.Parse(string(policy))
+	if err := parsed.Validate(); err != nil {
+		return fmt.Errorf("invalid policy: %w", err)
+	}
+	return nil
+}
+
+func seedPolicy(store *bucketstore.Store, policy []byte) error {
+	document, err := store.Get(publishpolicy.DocumentPath, 0)
+	switch {
+	case err == nil:
+		return verifyPolicy(document, policy)
+	case !errors.Is(err, os.ErrNotExist):
+		return fmt.Errorf("check existing policy: %w", err)
+	}
+
+	document, err = store.WriteVersion(publishpolicy.DocumentPath, 0, policy, policyMetadata)
+	if err == nil {
+		return verifyPolicy(document, policy)
+	}
+	if !errors.Is(err, protocolstore.ErrConflict) {
+		return fmt.Errorf("create policy: %w", err)
+	}
+	document, err = store.Get(publishpolicy.DocumentPath, 0)
+	if err != nil {
+		return fmt.Errorf("read concurrently created policy: %w", err)
+	}
+	return verifyPolicy(document, policy)
+}
+
+func verifyPolicy(document *protocolstore.Document, policy []byte) error {
+	if document == nil {
+		return errors.New("verify policy: store returned no document")
+	}
+	if document.Archived {
+		return errors.New("verify policy: existing policy is archived")
+	}
+	if !bytes.Equal(document.Content, policy) {
+		return errors.New("verify policy: existing policy differs; refusing to overwrite")
+	}
+	for key, expected := range policyMetadata {
+		if document.Metadata[key] != expected {
+			return fmt.Errorf("verify policy: existing metadata %q is %q, want %q; refusing to overwrite", key, document.Metadata[key], expected)
+		}
+	}
+	return nil
+}

--- a/server/cmd/demarkus-knowledge-bootstrap/bootstrap_test.go
+++ b/server/cmd/demarkus-knowledge-bootstrap/bootstrap_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/latebit-io/demarkus/protocol/publishpolicy"
+	"github.com/latebit-io/demarkus/server/internal/knowledge/blob"
+	"github.com/latebit-io/demarkus/server/internal/knowledge/bucketstore"
+)
+
+const testWorldID = "52b471f7-8d38-4c89-b44a-6f4f8b1a4f48"
+
+func TestBootstrapSeedsAndVerifiesPolicy(t *testing.T) {
+	t.Run("creates policy with required metadata", func(t *testing.T) {
+		objects := newMemory(t)
+		policy := []byte("# Policy\n\nstrictness: block\nrequire_tags: category\nrequire_fields: type\n")
+		if err := bootstrap(context.Background(), objects, testWorldID, policy); err != nil {
+			t.Fatalf("bootstrap: %v", err)
+		}
+		store, err := bucketstore.Open(context.Background(), objects, bucketstore.Options{WorldID: testWorldID, RequirePolicy: true})
+		if err != nil {
+			t.Fatalf("open required policy: %v", err)
+		}
+		document, err := store.Get(publishpolicy.DocumentPath, 0)
+		if err != nil {
+			t.Fatalf("get policy: %v", err)
+		}
+		if !bytes.Equal(document.Content, policy) {
+			t.Errorf("policy content = %q", document.Content)
+		}
+		for key, expected := range policyMetadata {
+			if document.Metadata[key] != expected {
+				t.Errorf("metadata[%q] = %q, want %q", key, document.Metadata[key], expected)
+			}
+		}
+	})
+
+	t.Run("is idempotent", func(t *testing.T) {
+		objects := newMemory(t)
+		policy := []byte("strictness: block\n")
+		if err := bootstrap(context.Background(), objects, testWorldID, policy); err != nil {
+			t.Fatalf("first bootstrap: %v", err)
+		}
+		if err := bootstrap(context.Background(), objects, testWorldID, policy); err != nil {
+			t.Fatalf("second bootstrap: %v", err)
+		}
+		store, err := bucketstore.Open(context.Background(), objects, bucketstore.Options{WorldID: testWorldID, RequirePolicy: true})
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		versions, err := store.Versions(publishpolicy.DocumentPath)
+		if err != nil {
+			t.Fatalf("versions: %v", err)
+		}
+		if len(versions) != 1 {
+			t.Errorf("versions = %d, want 1", len(versions))
+		}
+	})
+
+	t.Run("rejects differing policy without overwrite", func(t *testing.T) {
+		objects := newMemory(t)
+		original := []byte("strictness: warn\n")
+		if err := bootstrap(context.Background(), objects, testWorldID, original); err != nil {
+			t.Fatalf("first bootstrap: %v", err)
+		}
+		err := bootstrap(context.Background(), objects, testWorldID, []byte("strictness: block\n"))
+		if err == nil || !strings.Contains(err.Error(), "refusing to overwrite") {
+			t.Fatalf("differing bootstrap error = %v", err)
+		}
+		store, err := bucketstore.Open(context.Background(), objects, bucketstore.Options{WorldID: testWorldID, RequirePolicy: true})
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		document, err := store.Get(publishpolicy.DocumentPath, 0)
+		if err != nil {
+			t.Fatalf("get policy: %v", err)
+		}
+		if !bytes.Equal(document.Content, original) || document.Version != 1 {
+			t.Errorf("policy = version %d %q, want original v1", document.Version, document.Content)
+		}
+	})
+
+	t.Run("rejects invalid policy before initialization", func(t *testing.T) {
+		objects := newMemory(t)
+		err := bootstrap(context.Background(), objects, testWorldID, []byte("strictness: invalid\n"))
+		if err == nil {
+			t.Fatal("bootstrap accepted invalid policy")
+		}
+		listed, listErr := objects.List(context.Background(), "", "")
+		if listErr != nil {
+			t.Fatalf("list: %v", listErr)
+		}
+		if len(listed.Objects) != 0 {
+			t.Errorf("objects created = %d, want 0", len(listed.Objects))
+		}
+	})
+
+	t.Run("honors canceled context", func(t *testing.T) {
+		objects := newMemory(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := bootstrap(ctx, objects, testWorldID, []byte("strictness: block\n")); !errors.Is(err, context.Canceled) {
+			t.Fatalf("bootstrap error = %v, want context canceled", err)
+		}
+	})
+}
+
+func newMemory(t *testing.T) *blob.Memory {
+	t.Helper()
+	objects, err := blob.NewMemory(maxObjectBytes)
+	if err != nil {
+		t.Fatalf("new memory: %v", err)
+	}
+	return objects
+}

--- a/server/cmd/demarkus-knowledge-bootstrap/main.go
+++ b/server/cmd/demarkus-knowledge-bootstrap/main.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/latebit-io/demarkus/protocol"
+	"github.com/latebit-io/demarkus/server/internal/knowledge/blob/gcs"
+	"github.com/latebit-io/demarkus/server/internal/knowledgeconfig"
+)
+
+const (
+	maxObjectBytes = 4 << 20
+	commandTimeout = 2 * time.Minute
+)
+
+var version = "dev"
+
+type config struct {
+	bucketName string
+	worldID    string
+	policy     []byte
+	version    bool
+}
+
+type storageClientFactory func(context.Context) (*storage.Client, error)
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+	if err := run(ctx, os.Args[1:], os.Stdout, func(ctx context.Context) (*storage.Client, error) {
+		return storage.NewClient(ctx)
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, arguments []string, output io.Writer, newClient storageClientFactory) error {
+	config, err := loadConfig(arguments)
+	if err != nil {
+		return err
+	}
+	if config.version {
+		_, err := fmt.Fprintln(output, version)
+		return err
+	}
+
+	client, err := newClient(ctx)
+	if err != nil {
+		return fmt.Errorf("create GCS client with application default credentials: %w", err)
+	}
+	objects, setupErr := gcs.New(client, config.bucketName, maxObjectBytes)
+	if setupErr == nil {
+		setupErr = bootstrap(ctx, objects, config.worldID, config.policy)
+	}
+	closeErr := client.Close()
+	if setupErr != nil || closeErr != nil {
+		return errors.Join(setupErr, wrapCloseError(closeErr))
+	}
+	if _, err := fmt.Fprintf(output, "bootstrapped and verified gs://%s\n", config.bucketName); err != nil {
+		return fmt.Errorf("write result: %w", err)
+	}
+	return nil
+}
+
+func loadConfig(arguments []string) (config, error) {
+	flags := flag.NewFlagSet("demarkus-knowledge-bootstrap", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	bucketURL := flags.String("bucket", "", "target GCS bucket as gs://bucket")
+	worldID := flags.String("world-id", "", "canonical lowercase world UUID")
+	policyFile := flags.String("policy-file", "", "local policy markdown file")
+	showVersion := flags.Bool("version", false, "print version and exit")
+	if err := flags.Parse(arguments); err != nil {
+		return config{}, err
+	}
+	if flags.NArg() != 0 {
+		return config{}, fmt.Errorf("unexpected positional arguments: %v", flags.Args())
+	}
+	if *showVersion {
+		return config{version: true}, nil
+	}
+	bucketName, err := knowledgeconfig.ParseBucketURL(*bucketURL)
+	if err != nil {
+		return config{}, fmt.Errorf("invalid -bucket: %w", err)
+	}
+	if !knowledgeconfig.ValidWorldID(*worldID) {
+		return config{}, fmt.Errorf("invalid -world-id: must be a canonical lowercase RFC 4122 UUID (got %q)", *worldID)
+	}
+	if *policyFile == "" {
+		return config{}, errors.New("-policy-file is required")
+	}
+	policy, err := readPolicy(*policyFile)
+	if err != nil {
+		return config{}, err
+	}
+	if err := validatePolicy(policy); err != nil {
+		return config{}, err
+	}
+	return config{bucketName: bucketName, worldID: *worldID, policy: policy}, nil
+}
+
+func readPolicy(path string) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open -policy-file: %w", err)
+	}
+	info, statErr := file.Stat()
+	if statErr != nil {
+		return nil, errors.Join(fmt.Errorf("stat -policy-file: %w", statErr), wrapFileError("close", file.Close()))
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.Join(errors.New("-policy-file must be a regular file"), wrapFileError("close", file.Close()))
+	}
+	policy, readErr := io.ReadAll(io.LimitReader(file, protocol.MaxBodyLength+1))
+	closeErr := file.Close()
+	if readErr != nil || closeErr != nil {
+		return nil, errors.Join(wrapFileError("read", readErr), wrapFileError("close", closeErr))
+	}
+	if len(policy) > protocol.MaxBodyLength {
+		return nil, fmt.Errorf("-policy-file exceeds %d bytes", protocol.MaxBodyLength)
+	}
+	return policy, nil
+}
+
+func wrapCloseError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("close GCS client: %w", err)
+}
+
+func wrapFileError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s -policy-file: %w", operation, err)
+}

--- a/server/cmd/demarkus-knowledge-bootstrap/main.go
+++ b/server/cmd/demarkus-knowledge-bootstrap/main.go
@@ -37,7 +37,9 @@ func main() {
 	if err := run(ctx, os.Args[1:], os.Stdout, func(ctx context.Context) (*storage.Client, error) {
 		return storage.NewClient(ctx)
 	}); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		if _, writeErr := fmt.Fprintln(os.Stderr, err); writeErr != nil {
+			os.Exit(1)
+		}
 		os.Exit(1)
 	}
 }
@@ -91,7 +93,7 @@ func loadConfig(arguments []string) (config, error) {
 		return config{}, fmt.Errorf("invalid -bucket: %w", err)
 	}
 	if !knowledgeconfig.ValidWorldID(*worldID) {
-		return config{}, fmt.Errorf("invalid -world-id: must be a canonical lowercase RFC 4122 UUID (got %q)", *worldID)
+		return config{}, fmt.Errorf("invalid -world-id: must be a canonical lowercase UUID with RFC 4122 variant (got %q)", *worldID)
 	}
 	if *policyFile == "" {
 		return config{}, errors.New("-policy-file is required")

--- a/server/cmd/demarkus-knowledge-bootstrap/main_test.go
+++ b/server/cmd/demarkus-knowledge-bootstrap/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"cloud.google.com/go/storage"
+)
+
+func TestInvalidArgumentsDoNotCreateGCSClient(t *testing.T) {
+	policyFile := filepath.Join(t.TempDir(), "policy.md")
+	if err := os.WriteFile(policyFile, []byte("strictness: block\n"), 0o600); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+	invalidPolicyFile := filepath.Join(t.TempDir(), "invalid-policy.md")
+	if err := os.WriteFile(invalidPolicyFile, []byte("strictness: invalid\n"), 0o600); err != nil {
+		t.Fatalf("write invalid policy: %v", err)
+	}
+	tests := []struct {
+		name      string
+		arguments []string
+	}{
+		{name: "missing bucket", arguments: []string{"-world-id", testWorldID, "-policy-file", policyFile}},
+		{name: "bucket path", arguments: []string{"-bucket", "gs://valid-bucket/path", "-world-id", testWorldID, "-policy-file", policyFile}},
+		{name: "noncanonical world", arguments: []string{"-bucket", "gs://valid-bucket", "-world-id", "52B471F7-8D38-4C89-B44A-6F4F8B1A4F48", "-policy-file", policyFile}},
+		{name: "missing policy", arguments: []string{"-bucket", "gs://valid-bucket", "-world-id", testWorldID}},
+		{name: "invalid policy", arguments: []string{"-bucket", "gs://valid-bucket", "-world-id", testWorldID, "-policy-file", invalidPolicyFile}},
+		{name: "positional argument", arguments: []string{"-bucket", "gs://valid-bucket", "-world-id", testWorldID, "-policy-file", policyFile, "extra"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			factory := func(context.Context) (*storage.Client, error) {
+				called = true
+				return nil, errors.New("unexpected GCS client creation")
+			}
+			if err := run(context.Background(), test.arguments, io.Discard, factory); err == nil {
+				t.Fatal("run accepted invalid arguments")
+			}
+			if called {
+				t.Fatal("GCS client created for invalid arguments")
+			}
+		})
+	}
+}
+
+func TestVersionDoesNotCreateGCSClient(t *testing.T) {
+	t.Run("prints version", func(t *testing.T) {
+		called := false
+		factory := func(context.Context) (*storage.Client, error) {
+			called = true
+			return nil, errors.New("unexpected GCS client creation")
+		}
+		var output bytes.Buffer
+		if err := run(context.Background(), []string{"-version"}, &output, factory); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if called {
+			t.Fatal("GCS client created for -version")
+		}
+		if output.String() != version+"\n" {
+			t.Errorf("version output = %q, want %q", output.String(), version+"\n")
+		}
+	})
+}

--- a/server/internal/knowledgeconfig/config.go
+++ b/server/internal/knowledgeconfig/config.go
@@ -97,7 +97,7 @@ func ParseBucketURL(value string) (string, error) {
 	return strings.TrimPrefix(value, "gs://"), nil
 }
 
-// ValidWorldID reports whether worldID is a canonical lowercase RFC 4122 UUID.
+// ValidWorldID reports whether worldID is canonical lowercase with an RFC 4122 variant.
 func ValidWorldID(worldID string) bool {
 	return validWorldID(worldID)
 }
@@ -303,7 +303,7 @@ func (config *Config) Validate() error {
 		}
 		bucketURLs[world.Bucket.URL] = worldIndex
 		if !validWorldID(world.Bucket.WorldID) {
-			return fmt.Errorf("%s.bucket.worldID must be a canonical lowercase UUID (got %q)", location, world.Bucket.WorldID)
+			return fmt.Errorf("%s.bucket.worldID must be a canonical lowercase UUID with RFC 4122 variant (got %q)", location, world.Bucket.WorldID)
 		}
 		if previous, exists := worldIDs[world.Bucket.WorldID]; exists {
 			return fmt.Errorf("%s.bucket.worldID %q duplicates worlds[%d].bucket.worldID", location, world.Bucket.WorldID, previous)

--- a/server/internal/knowledgeconfig/config.go
+++ b/server/internal/knowledgeconfig/config.go
@@ -89,6 +89,19 @@ func (config BucketConfig) Name() string {
 	return strings.TrimPrefix(config.URL, "gs://")
 }
 
+// ParseBucketURL validates an exact gs://bucket URL and returns its bucket name.
+func ParseBucketURL(value string) (string, error) {
+	if err := validateBucketURL(value); err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(value, "gs://"), nil
+}
+
+// ValidWorldID reports whether worldID is a canonical lowercase RFC 4122 UUID.
+func ValidWorldID(worldID string) bool {
+	return validWorldID(worldID)
+}
+
 // AuthConfig identifies the world-local capability token file.
 type AuthConfig struct {
 	TokensFile string `yaml:"tokensFile"`

--- a/server/internal/knowledgeconfig/config_test.go
+++ b/server/internal/knowledgeconfig/config_test.go
@@ -208,6 +208,15 @@ func TestBucketURLValidation(t *testing.T) {
 	}
 }
 
+func TestValidWorldIDIsVersionAgnostic(t *testing.T) {
+	if !ValidWorldID("52b471f7-8d38-0c89-b44a-6f4f8b1a4f48") {
+		t.Fatal("ValidWorldID rejected canonical version-agnostic world ID")
+	}
+	if ValidWorldID("52b471f7-8d38-4c89-f44a-6f4f8b1a4f48") {
+		t.Fatal("ValidWorldID accepted non-RFC variant")
+	}
+}
+
 func TestValidateDuplicateWorldIdentities(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deployable knowledge server with multi-architecture container images and Helm chart support.
  * Added a command-line bootstrap tool for initializing and validating knowledge policies.
  * Added configurable TLS, workload identity, networking, security, scaling, and service settings.
  * Added automated validation for world, bucket, policy, and server configuration.
  * Added release packaging and publishing for the knowledge server and Helm chart.

* **Documentation**
  * Added installation, configuration, security, TLS, and operational guidance.

* **Tests**
  * Added comprehensive chart, deployment, networking, certificate, service, and bootstrap coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->