### PR TITLE
fix(client): add federation metadata and suppress CLI QUIC warning

### DIFF
--- a/client/cmd/demarkus/main.go
+++ b/client/cmd/demarkus/main.go
@@ -27,7 +27,12 @@ import (
 	"github.com/latebit-io/demarkus/protocol/store"
 )
 
+const quicBufferWarningEnv = "QUIC_GO_DISABLE_RECEIVE_BUFFER_WARNING"
+
 func main() {
+	if err := suppressQUICBufferWarning(); err != nil {
+		log.Fatal(err)
+	}
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
 		case "edit":
@@ -57,6 +62,18 @@ func main() {
 		}
 	}
 	requestMain()
+}
+
+// Short-lived CLI processes cannot tune host sysctls and would emit quic-go's
+// advisory on every command. An explicit environment setting still wins.
+func suppressQUICBufferWarning() error {
+	if _, explicit := os.LookupEnv(quicBufferWarningEnv); explicit {
+		return nil
+	}
+	if err := os.Setenv(quicBufferWarningEnv, "true"); err != nil {
+		return fmt.Errorf("set %s: %w", quicBufferWarningEnv, err)
+	}
+	return nil
 }
 
 func requestMain() {

--- a/client/cmd/demarkus/main_test.go
+++ b/client/cmd/demarkus/main_test.go
@@ -60,6 +60,43 @@ func TestValidateVerb(t *testing.T) {
 	}
 }
 
+func TestSuppressQUICBufferWarning(t *testing.T) {
+	t.Run("defaults to suppressed", func(t *testing.T) {
+		old, existed := os.LookupEnv(quicBufferWarningEnv)
+		if err := os.Unsetenv(quicBufferWarningEnv); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			var err error
+			if existed {
+				err = os.Setenv(quicBufferWarningEnv, old)
+			} else {
+				err = os.Unsetenv(quicBufferWarningEnv)
+			}
+			if err != nil {
+				t.Errorf("restore environment: %v", err)
+			}
+		})
+
+		if err := suppressQUICBufferWarning(); err != nil {
+			t.Fatal(err)
+		}
+		if got := os.Getenv(quicBufferWarningEnv); got != "true" {
+			t.Errorf("%s = %q, want true", quicBufferWarningEnv, got)
+		}
+	})
+
+	t.Run("preserves explicit setting", func(t *testing.T) {
+		t.Setenv(quicBufferWarningEnv, "false")
+		if err := suppressQUICBufferWarning(); err != nil {
+			t.Fatal(err)
+		}
+		if got := os.Getenv(quicBufferWarningEnv); got != "false" {
+			t.Errorf("%s = %q, want false", quicBufferWarningEnv, got)
+		}
+	})
+}
+
 func TestEditorCommand(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/client/internal/fedcrawl/crawl.go
+++ b/client/internal/fedcrawl/crawl.go
@@ -660,7 +660,11 @@ func (c *Crawler) publishIndex(ctx context.Context, client PublishClient, host, 
 		return ctx.Err()
 	}
 
-	meta := map[string]string{"agent": "demarkus-agent"}
+	meta := map[string]string{
+		"agent": "demarkus-agent",
+		"tags":  "category:federation",
+		"type":  "Reference",
+	}
 	// Everything published here (hash indexes, /graph.md) is a generated
 	// artifact regenerated wholesale each run — retention keeps its version
 	// history bounded (the server prunes older versions on write, SPEC §9.9).

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -438,6 +438,12 @@ func TestPublishIndex(t *testing.T) {
 			if call.Token != "tok" {
 				t.Errorf("Token = %q, want tok", call.Token)
 			}
+			if call.Meta["tags"] != "category:federation" {
+				t.Errorf("meta.tags = %q, want category:federation", call.Meta["tags"])
+			}
+			if call.Meta["type"] != "Reference" {
+				t.Errorf("meta.type = %q, want Reference", call.Meta["type"])
+			}
 		})
 	}
 }
@@ -706,6 +712,9 @@ func TestPublishRetentionMeta(t *testing.T) {
 			}
 			if call.Meta["agent"] != "demarkus-agent" {
 				t.Errorf("publish %s%s lost agent meta: %v", call.Host, call.Path, call.Meta)
+			}
+			if call.Meta["tags"] != "category:federation" || call.Meta["type"] != "Reference" {
+				t.Errorf("publish %s%s lacks policy metadata: %v", call.Host, call.Path, call.Meta)
 			}
 		}
 	})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Suppressed unnecessary QUIC receive-buffer warnings during CLI startup.
  - Preserved any existing configuration for warning behavior.
  - Added federation metadata to published index documents, improving classification and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->