### PR TITLE
feat(client): add federation endpoint routing and prevent graph

### DIFF
--- a/client/cmd/demarkus-agent/main.go
+++ b/client/cmd/demarkus-agent/main.go
@@ -121,7 +121,7 @@ func crawlMain(args []string) {
 	}
 
 	// Create client.
-	opts := fetch.Options{Insecure: *insecure}
+	opts := fetch.Options{Insecure: *insecure, Endpoints: cfg.ClientEndpoints()}
 	client := fetch.NewClient(opts)
 	defer client.Close()
 
@@ -248,7 +248,7 @@ func daemonMain(args []string) {
 	}
 
 	// Create client.
-	opts := fetch.Options{Insecure: *insecure}
+	opts := fetch.Options{Insecure: *insecure, Endpoints: cfg.ClientEndpoints()}
 	client := fetch.NewClient(opts)
 	defer client.Close()
 

--- a/client/fetch/conditional_test.go
+++ b/client/fetch/conditional_test.go
@@ -19,6 +19,10 @@ import (
 // startTestServer runs a minimal in-process QUIC server whose handler maps a
 // parsed request to a response. Returns the host:port to dial.
 func startTestServer(t *testing.T, handle func(protocol.Request) protocol.Response) string {
+	return startTestServerWithSNI(t, nil, handle)
+}
+
+func startTestServerWithSNI(t *testing.T, observed chan<- string, handle func(protocol.Request) protocol.Response) string {
 	t.Helper()
 
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -39,6 +43,12 @@ func startTestServer(t *testing.T, handle func(protocol.Request) protocol.Respon
 	tlsConf := &tls.Config{
 		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key}},
 		NextProtos:   []string{protocol.ALPN},
+	}
+	if observed != nil {
+		tlsConf.GetConfigForClient = func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+			observed <- hello.ServerName
+			return nil, nil
+		}
 	}
 
 	ln, err := quic.ListenAddr("127.0.0.1:0", tlsConf, nil)
@@ -76,6 +86,67 @@ func startTestServer(t *testing.T, handle func(protocol.Request) protocol.Respon
 	}()
 
 	return ln.Addr().String()
+}
+
+func TestEndpointOverridesKeepLogicalConnectionsSeparate(t *testing.T) {
+	observed := make(chan string, 2)
+	dialAddress := startTestServerWithSNI(t, observed, func(protocol.Request) protocol.Response {
+		return protocol.Response{Status: protocol.StatusOK, Body: "# OK\n"}
+	})
+
+	c := NewClient(Options{Insecure: true, Endpoints: map[string]Endpoint{
+		"world-a:6309": {DialAddress: dialAddress, ServerName: "world-a.internal"},
+		"world-b:6309": {DialAddress: dialAddress, ServerName: "world-b.internal"},
+	}})
+	defer c.Close()
+
+	for _, authority := range []string{"world-a:6309", "world-b:6309"} {
+		result, err := c.Fetch(authority, "/index.md", "")
+		if err != nil {
+			t.Fatalf("Fetch(%s): %v", authority, err)
+		}
+		if result.Response.Status != protocol.StatusOK {
+			t.Fatalf("Fetch(%s) status = %q", authority, result.Response.Status)
+		}
+	}
+
+	got := map[string]bool{<-observed: true, <-observed: true}
+	for _, want := range []string{"world-a.internal", "world-b.internal"} {
+		if !got[want] {
+			t.Errorf("observed SNI = %v, missing %q", got, want)
+		}
+	}
+}
+
+func TestParseMarkURLNormalizesAuthority(t *testing.T) {
+	tests := []struct {
+		raw      string
+		wantHost string
+		wantPath string
+	}{
+		{"mark://WORLD/Index.md", "world:6309", "/Index.md"},
+		{"mark://world:7000", "world:7000", "/"},
+		{"mark://[2001:db8::1]/index.md", "[2001:db8::1]:6309", "/index.md"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			host, path, err := ParseMarkURL(tt.raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if host != tt.wantHost || path != tt.wantPath {
+				t.Errorf("ParseMarkURL(%q) = (%q, %q), want (%q, %q)", tt.raw, host, path, tt.wantHost, tt.wantPath)
+			}
+		})
+	}
+
+	for _, raw := range []string{"mark://", "mark://world:0", "mark://world:65536"} {
+		t.Run("invalid "+raw, func(t *testing.T) {
+			if _, _, err := ParseMarkURL(raw); err == nil {
+				t.Fatalf("ParseMarkURL(%q) unexpectedly succeeded", raw)
+			}
+		})
+	}
 }
 
 func TestFetchConditional(t *testing.T) {

--- a/client/fetch/fetch.go
+++ b/client/fetch/fetch.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"maps"
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -28,10 +29,19 @@ func ParseMarkURL(raw string) (host, path string, err error) {
 	if u.Scheme != "mark" {
 		return "", "", fmt.Errorf("unsupported scheme: %s (expected mark://)", u.Scheme)
 	}
-	host = u.Host
-	if u.Port() == "" {
-		host = fmt.Sprintf("%s:%d", u.Hostname(), protocol.DefaultPort)
+	hostname := strings.ToLower(u.Hostname())
+	if hostname == "" {
+		return "", "", fmt.Errorf("invalid URL: authority host is required")
 	}
+	port := u.Port()
+	if port == "" {
+		port = strconv.Itoa(protocol.DefaultPort)
+	}
+	portNumber, err := strconv.Atoi(port)
+	if err != nil || portNumber < 1 || portNumber > 65535 {
+		return "", "", fmt.Errorf("invalid URL: port %q must be between 1 and 65535", port)
+	}
+	host = net.JoinHostPort(hostname, port)
 	path = u.Path
 	if path == "" {
 		path = "/"
@@ -45,12 +55,23 @@ type Result struct {
 	FromCache bool
 }
 
+// Endpoint separates a logical Mark authority from its network route.
+// DialAddress opens the socket; ServerName drives TLS SNI and verification.
+type Endpoint struct {
+	DialAddress string
+	ServerName  string
+}
+
 // Options configures client behavior.
 type Options struct {
 	Cache          *cache.Cache
 	Insecure       bool
 	DialTimeout    time.Duration
 	RequestTimeout time.Duration
+	// Endpoints optionally overrides transport routing by normalized logical
+	// authority (host:port). URLs, caches, tokens, and connection pooling remain
+	// keyed by that authority.
+	Endpoints map[string]Endpoint
 	// KeepAlivePeriod controls QUIC keep-alive PING cadence on pooled
 	// connections. Long-lived consumers (TUI, MCP servers, federation
 	// crawlers) keep one connection per host across many requests; if
@@ -89,6 +110,7 @@ type Client struct {
 // NewClient creates a new client with the given options.
 func NewClient(opts Options) *Client {
 	opts.applyDefaults()
+	opts.Endpoints = maps.Clone(opts.Endpoints)
 	qc := &quic.Config{}
 	// Negative KeepAlivePeriod disables; positive applies.
 	if opts.KeepAlivePeriod > 0 {
@@ -380,15 +402,25 @@ func (c *Client) getConn(host string) (*quic.Conn, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.opts.DialTimeout)
 	defer cancel()
 
-	// Clone TLS config and set ServerName for certificate validation.
-	tlsConf := c.tlsConf.Clone()
-	if hostname, _, ok := strings.Cut(host, ":"); ok {
-		tlsConf.ServerName = hostname
-	} else {
-		tlsConf.ServerName = host
+	endpoint := Endpoint{DialAddress: host}
+	if configured, ok := c.opts.Endpoints[host]; ok {
+		endpoint = configured
+		if endpoint.DialAddress == "" {
+			endpoint.DialAddress = host
+		}
 	}
-	conn, err := quic.DialAddr(ctx, host, tlsConf, c.quicConf)
+
+	// Clone TLS config and set ServerName for routing and certificate validation.
+	tlsConf := c.tlsConf.Clone()
+	tlsConf.ServerName = endpoint.ServerName
+	if tlsConf.ServerName == "" {
+		tlsConf.ServerName = authorityHostname(host)
+	}
+	conn, err := quic.DialAddr(ctx, endpoint.DialAddress, tlsConf, c.quicConf)
 	if err != nil {
+		if endpoint.DialAddress != host {
+			return nil, fmt.Errorf("dial %s via %s: %w", host, endpoint.DialAddress, err)
+		}
 		return nil, fmt.Errorf("dial %s: %w", host, err)
 	}
 
@@ -404,6 +436,13 @@ func (c *Client) getConn(host string) (*quic.Conn, error) {
 	c.mu.Unlock()
 
 	return conn, nil
+}
+
+func authorityHostname(authority string) string {
+	if host, _, err := net.SplitHostPort(authority); err == nil {
+		return host
+	}
+	return authority
 }
 
 func (c *Client) removeConn(host string) {

--- a/client/internal/fedcrawl/config.go
+++ b/client/internal/fedcrawl/config.go
@@ -4,22 +4,35 @@ package fedcrawl
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/latebit-io/demarkus/client/fetch"
 )
 
 // Config holds the crawler configuration loaded from a TOML file.
 type Config struct {
 	Seeds []string `toml:"seeds"` // Initial servers to crawl (mark://host:port)
 	Hubs  []string `toml:"hubs"`  // Servers to publish indexes to
+	// Endpoints maps logical Mark authorities to transport routes. This lets
+	// broker-style world names remain graph/token identity while agents dial
+	// cluster-internal addresses with the SNI required by a shared listener.
+	Endpoints map[string]EndpointConfig `toml:"endpoints"`
 
 	Crawl      CrawlConfig      `toml:"crawl"`
 	Schedule   ScheduleConfig   `toml:"schedule"`
 	Politeness PolitenessConfig `toml:"politeness"`
 	Publish    PublishConfig    `toml:"publish"`
+}
+
+// EndpointConfig is the TOML representation of an explicit transport endpoint.
+type EndpointConfig struct {
+	DialAddress string `toml:"dial_address"`
+	ServerName  string `toml:"server_name"`
 }
 
 // CrawlConfig controls the scope and depth of crawling.
@@ -125,6 +138,9 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("hub %d %q must be a mark:// URL", i, hub)
 		}
 	}
+	if err := c.normalizeEndpoints(); err != nil {
+		return err
+	}
 	if c.Crawl.MaxDepth < 0 {
 		return fmt.Errorf("crawl.max_depth must be non-negative")
 	}
@@ -150,4 +166,97 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("publish.retention must be non-negative (0 keeps every version)")
 	}
 	return nil
+}
+
+// ClientEndpoints converts validated crawler endpoints to fetch transport
+// endpoints. Validate must run first so keys and dial addresses are canonical.
+func (c *Config) ClientEndpoints() map[string]fetch.Endpoint {
+	if len(c.Endpoints) == 0 {
+		return nil
+	}
+	endpoints := make(map[string]fetch.Endpoint, len(c.Endpoints))
+	for authority, endpoint := range c.Endpoints {
+		endpoints[authority] = fetch.Endpoint{
+			DialAddress: endpoint.DialAddress,
+			ServerName:  endpoint.ServerName,
+		}
+	}
+	return endpoints
+}
+
+func (c *Config) normalizeEndpoints() error {
+	if len(c.Endpoints) == 0 {
+		return nil
+	}
+	normalized := make(map[string]EndpointConfig, len(c.Endpoints))
+	for rawAuthority, endpoint := range c.Endpoints {
+		authority, err := normalizeAuthority(rawAuthority)
+		if err != nil {
+			return fmt.Errorf("endpoint authority %q: %w", rawAuthority, err)
+		}
+		if _, duplicate := normalized[authority]; duplicate {
+			return fmt.Errorf("endpoint authority %q duplicates normalized authority %q", rawAuthority, authority)
+		}
+		dialAddress, err := normalizeAuthority(endpoint.DialAddress)
+		if err != nil {
+			return fmt.Errorf("endpoint %q dial_address: %w", rawAuthority, err)
+		}
+		serverName := endpoint.ServerName
+		if serverName == "" {
+			serverName = authorityHostname(authority)
+		}
+		serverName, err = normalizeServerName(serverName)
+		if err != nil {
+			return fmt.Errorf("endpoint %q server_name: %w", rawAuthority, err)
+		}
+		normalized[authority] = EndpointConfig{DialAddress: dialAddress, ServerName: serverName}
+	}
+	c.Endpoints = normalized
+	return nil
+}
+
+func normalizeAuthority(raw string) (string, error) {
+	if raw == "" || raw != strings.TrimSpace(raw) {
+		return "", fmt.Errorf("must be a non-empty authority without surrounding whitespace")
+	}
+	if strings.Contains(raw, "://") {
+		return "", fmt.Errorf("must omit the URL scheme")
+	}
+	u, err := url.Parse("mark://" + raw)
+	if err != nil || u.Host == "" || u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("must contain only host and optional port")
+	}
+	host, _, err := fetch.ParseMarkURL(u.String())
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(host), nil
+}
+
+func authorityHostname(authority string) string {
+	if host, _, err := net.SplitHostPort(authority); err == nil {
+		return strings.Trim(host, "[]")
+	}
+	return strings.Trim(authority, "[]")
+}
+
+func normalizeServerName(raw string) (string, error) {
+	name := strings.ToLower(strings.TrimSpace(raw))
+	if name == "" || name != raw {
+		return "", fmt.Errorf("must be a non-empty lowercase DNS name without surrounding whitespace")
+	}
+	if strings.HasSuffix(name, ".") || net.ParseIP(name) != nil {
+		return "", fmt.Errorf("must be a DNS name without a trailing dot")
+	}
+	for label := range strings.SplitSeq(name, ".") {
+		if label == "" || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return "", fmt.Errorf("invalid DNS name %q", raw)
+		}
+		for _, r := range label {
+			if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-' {
+				return "", fmt.Errorf("invalid DNS name %q", raw)
+			}
+		}
+	}
+	return name, nil
 }

--- a/client/internal/fedcrawl/config.go
+++ b/client/internal/fedcrawl/config.go
@@ -128,16 +128,16 @@ func (c *Config) Validate() error {
 	if len(c.Seeds) == 0 {
 		return fmt.Errorf("at least one seed server is required")
 	}
-	for i, seed := range c.Seeds {
-		if !strings.HasPrefix(seed, "mark://") {
-			return fmt.Errorf("seed %d %q must be a mark:// URL", i, seed)
-		}
+	seeds, err := normalizeServerURLs("seed", c.Seeds)
+	if err != nil {
+		return err
 	}
-	for i, hub := range c.Hubs {
-		if !strings.HasPrefix(hub, "mark://") {
-			return fmt.Errorf("hub %d %q must be a mark:// URL", i, hub)
-		}
+	hubs, err := normalizeServerURLs("hub", c.Hubs)
+	if err != nil {
+		return err
 	}
+	c.Seeds = seeds
+	c.Hubs = hubs
 	if err := c.normalizeEndpoints(); err != nil {
 		return err
 	}
@@ -166,6 +166,25 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("publish.retention must be non-negative (0 keeps every version)")
 	}
 	return nil
+}
+
+func normalizeServerURLs(kind string, values []string) ([]string, error) {
+	normalized := make([]string, len(values))
+	for i, raw := range values {
+		u, err := url.Parse(raw)
+		if err != nil || u.Scheme != "mark" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+			return nil, fmt.Errorf("%s %d %q must be a mark:// server URL", kind, i, raw)
+		}
+		host, path, err := fetch.ParseMarkURL(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%s %d %q: %w", kind, i, raw, err)
+		}
+		if path != "/" {
+			return nil, fmt.Errorf("%s %d %q must not contain a document path", kind, i, raw)
+		}
+		normalized[i] = "mark://" + host
+	}
+	return normalized, nil
 }
 
 // ClientEndpoints converts validated crawler endpoints to fetch transport

--- a/client/internal/fedcrawl/config_test.go
+++ b/client/internal/fedcrawl/config_test.go
@@ -186,6 +186,30 @@ func TestValidate(t *testing.T) {
 		}
 	})
 
+	t.Run("normalizes seed and hub authorities", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Seeds = []string{"mark://WORLD"}
+		cfg.Hubs = []string{"mark://ROOT/"}
+		if err := cfg.Validate(); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Seeds[0] != "mark://world:6309" || cfg.Hubs[0] != "mark://root:6309" {
+			t.Errorf("normalized servers = seeds %v hubs %v", cfg.Seeds, cfg.Hubs)
+		}
+	})
+
+	t.Run("rejects malformed server URLs", func(t *testing.T) {
+		for _, raw := range []string{"mark://world/docs", "mark://world?x=1", "mark://world#fragment", "mark://world:0"} {
+			t.Run(raw, func(t *testing.T) {
+				cfg := DefaultConfig()
+				cfg.Seeds = []string{raw}
+				if err := cfg.Validate(); err == nil {
+					t.Fatal("expected malformed seed error")
+				}
+			})
+		}
+	})
+
 	t.Run("invalid hub scheme", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.Seeds = []string{"mark://example.com"}

--- a/client/internal/fedcrawl/config_test.go
+++ b/client/internal/fedcrawl/config_test.go
@@ -59,6 +59,10 @@ func TestLoadValid(t *testing.T) {
 seeds = ["mark://hub.example.com", "mark://peer.example.com"]
 hubs = ["mark://hub.example.com"]
 
+[endpoints."hub.example.com"]
+dial_address = "hub.internal:7000"
+server_name = "hub.internal"
+
 [crawl]
 max_depth = 3
 max_servers = 100
@@ -86,6 +90,9 @@ per_server_concurrency = 3
 	}
 	if len(cfg.Hubs) != 1 {
 		t.Errorf("len(Hubs) = %d, want 1", len(cfg.Hubs))
+	}
+	if endpoint := cfg.Endpoints["hub.example.com"]; endpoint.DialAddress != "hub.internal:7000" || endpoint.ServerName != "hub.internal" {
+		t.Errorf("Endpoints[hub.example.com] = %+v", endpoint)
 	}
 	if cfg.Crawl.MaxDepth != 3 {
 		t.Errorf("MaxDepth = %d, want 3", cfg.Crawl.MaxDepth)
@@ -212,6 +219,66 @@ func TestValidate(t *testing.T) {
 		cfg.Politeness.RequestDelay = -1
 		if err := cfg.Validate(); err == nil {
 			t.Error("expected error for negative request delay")
+		}
+	})
+
+	t.Run("normalizes endpoints", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Seeds = []string{"mark://world"}
+		cfg.Endpoints = map[string]EndpointConfig{
+			"WORLD": {DialAddress: "shared.internal", ServerName: "shared.internal"},
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("Validate() error: %v", err)
+		}
+		endpoint, ok := cfg.Endpoints["world:6309"]
+		if !ok {
+			t.Fatalf("normalized endpoint missing: %v", cfg.Endpoints)
+		}
+		if endpoint.DialAddress != "shared.internal:6309" || endpoint.ServerName != "shared.internal" {
+			t.Errorf("normalized endpoint = %+v", endpoint)
+		}
+		clientEndpoint := cfg.ClientEndpoints()["world:6309"]
+		if clientEndpoint.DialAddress != endpoint.DialAddress || clientEndpoint.ServerName != endpoint.ServerName {
+			t.Errorf("client endpoint = %+v, config endpoint = %+v", clientEndpoint, endpoint)
+		}
+	})
+
+	t.Run("rejects invalid endpoints", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			authority string
+			endpoint  EndpointConfig
+		}{
+			{"scheme in authority", "mark://world", EndpointConfig{DialAddress: "shared.internal"}},
+			{"path in authority", "world/path", EndpointConfig{DialAddress: "shared.internal"}},
+			{"scheme in dial address", "world", EndpointConfig{DialAddress: "mark://shared.internal"}},
+			{"empty dial address", "world", EndpointConfig{}},
+			{"zero dial port", "world", EndpointConfig{DialAddress: "shared.internal:0"}},
+			{"out of range dial port", "world", EndpointConfig{DialAddress: "shared.internal:65536"}},
+			{"port in server name", "world", EndpointConfig{DialAddress: "shared.internal", ServerName: "shared.internal:6309"}},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				cfg := DefaultConfig()
+				cfg.Seeds = []string{"mark://world"}
+				cfg.Endpoints = map[string]EndpointConfig{tt.authority: tt.endpoint}
+				if err := cfg.Validate(); err == nil {
+					t.Fatal("expected endpoint validation error")
+				}
+			})
+		}
+	})
+
+	t.Run("rejects normalized endpoint duplicates", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Seeds = []string{"mark://world"}
+		cfg.Endpoints = map[string]EndpointConfig{
+			"world":      {DialAddress: "shared.internal"},
+			"world:6309": {DialAddress: "shared.internal"},
+		}
+		if err := cfg.Validate(); err == nil {
+			t.Fatal("expected duplicate endpoint error")
 		}
 	})
 }

--- a/client/internal/fedcrawl/crawl.go
+++ b/client/internal/fedcrawl/crawl.go
@@ -337,12 +337,13 @@ func (s *serverWalk) walkDir(ctx context.Context, dirPath string, depth int) err
 			c.mu.Unlock()
 		}
 
-		// Record this document's outbound links into the graph (the durable
-		// topology map the hub publishes for the reading room's floor).
-		c.recordEdges(s.host, fullPath, doc.Response.Body, doc.Response.Metadata)
-
-		// Discover cross-server links.
-		c.discoverServers(doc.Response.Body, s.host, s.run.queue, s.run.wg)
+		// /graph.md is a generated projection of other documents' edges. Hash it
+		// like any document, but do not turn its table links into synthetic
+		// graph.md→node edges or use them to amplify the discovery frontier.
+		if fullPath != "/graph.md" {
+			c.recordEdges(s.host, fullPath, doc.Response.Body, doc.Response.Metadata)
+			c.discoverServers(doc.Response.Body, s.host, s.run.queue, s.run.wg)
+		}
 
 		s.count++
 	}
@@ -378,6 +379,11 @@ func (c *Crawler) discoverServers(body, currentHost string, queue chan<- string,
 		if host == currentHost {
 			continue
 		}
+		// A hub is an aggregation destination, not crawl input, unless the
+		// operator also listed it as a seed. Its edge remains in the graph.
+		if c.isPublishOnlyHub(host) {
+			continue
+		}
 
 		// Check if we should queue this host.
 		// Only hold mutex while checking/updating shared state.
@@ -398,6 +404,22 @@ func (c *Crawler) discoverServers(body, currentHost string, queue chan<- string,
 			queue <- host
 		}
 	}
+}
+
+func (c *Crawler) isPublishOnlyHub(host string) bool {
+	for _, seed := range c.cfg.Seeds {
+		seedHost, _, err := fetch.ParseMarkURL(seed + "/")
+		if err == nil && seedHost == host {
+			return false
+		}
+	}
+	for _, hub := range c.cfg.Hubs {
+		hubHost, _, err := fetch.ParseMarkURL(hub + "/")
+		if err == nil && hubHost == host {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveToken returns the auth token for a host.

--- a/client/internal/fedcrawl/crawl.go
+++ b/client/internal/fedcrawl/crawl.go
@@ -70,9 +70,10 @@ type CrawlResult struct {
 // Run executes the federation crawl starting from configured seeds.
 // It discovers servers, collects content hashes, and returns results.
 func (c *Crawler) Run(ctx context.Context) (*CrawlResult, error) {
-	// Validate workers to prevent deadlock.
-	if c.cfg.Crawl.Workers <= 0 {
-		return nil, fmt.Errorf("crawl.workers must be > 0")
+	// Run is the package boundary, so enforce normalization even when callers
+	// construct a Crawler directly instead of using the agent command.
+	if err := c.cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid crawler config: %w", err)
 	}
 
 	// Reset crawl state for each invocation.

--- a/client/internal/fedcrawl/crawl.go
+++ b/client/internal/fedcrawl/crawl.go
@@ -407,19 +407,8 @@ func (c *Crawler) discoverServers(body, currentHost string, queue chan<- string,
 }
 
 func (c *Crawler) isPublishOnlyHub(host string) bool {
-	for _, seed := range c.cfg.Seeds {
-		seedHost, _, err := fetch.ParseMarkURL(seed + "/")
-		if err == nil && seedHost == host {
-			return false
-		}
-	}
-	for _, hub := range c.cfg.Hubs {
-		hubHost, _, err := fetch.ParseMarkURL(hub + "/")
-		if err == nil && hubHost == host {
-			return true
-		}
-	}
-	return false
+	authority := "mark://" + host
+	return slices.Contains(c.cfg.Hubs, authority) && !slices.Contains(c.cfg.Seeds, authority)
 }
 
 // resolveToken returns the auth token for a host.

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -3,6 +3,7 @@ package fedcrawl
 import (
 	"context"
 	"maps"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -181,6 +182,77 @@ func TestCrawlerMultiServer(t *testing.T) {
 	}
 	if result.DocumentsCrawled != 2 {
 		t.Errorf("DocumentsCrawled = %d, want 2", result.DocumentsCrawled)
+	}
+}
+
+func TestCrawlerDoesNotDiscoverPublishOnlyHub(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Seeds = []string{"mark://content"}
+	cfg.Hubs = []string{"mark://root"}
+
+	client := newMockClient()
+	client.addList("content:6309", "/", "- [index.md](index.md)\n")
+	client.addDoc("content:6309", "/index.md", "See [root](mark://root/index.md).", "sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	// A queued hub would be observable as another discovered server.
+	client.addList("root:6309", "/", "- [index.md](index.md)\n")
+	client.addDoc("root:6309", "/index.md", "# Root", "sha256-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+	crawler := NewCrawler(cfg, client, nil, nil)
+	result, err := crawler.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if result.ServersDiscovered != 1 || result.DocumentsCrawled != 1 {
+		t.Fatalf("result = %+v, want one crawled content server", result)
+	}
+	if graph := crawler.GraphExport(); !strings.Contains(graph, "mark://root/index.md") {
+		t.Errorf("graph lost publish-only hub edge:\n%s", graph)
+	}
+}
+
+func TestCrawlerCrawlsHubWhenExplicitlySeeded(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Seeds = []string{"mark://content", "mark://root"}
+	cfg.Hubs = []string{"mark://root"}
+
+	client := newMockClient()
+	client.addList("content:6309", "/", "- [index.md](index.md)\n")
+	client.addDoc("content:6309", "/index.md", "# Content", "sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	client.addList("root:6309", "/", "- [index.md](index.md)\n")
+	client.addDoc("root:6309", "/index.md", "# Root", "sha256-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+	crawler := NewCrawler(cfg, client, nil, nil)
+	result, err := crawler.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if result.ServersDiscovered != 2 || result.DocumentsCrawled != 2 {
+		t.Fatalf("result = %+v, want both explicit seeds crawled", result)
+	}
+}
+
+func TestCrawlerHashesGraphExportWithoutRecrawlingIt(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Seeds = []string{"mark://content"}
+
+	client := newMockClient()
+	client.addList("content:6309", "/", "- [index.md](index.md)\n- [graph.md](graph.md)\n")
+	client.addDoc("content:6309", "/index.md", "# Content", "sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	client.addDoc("content:6309", "/graph.md", "# Document Graph\n\n[projected](mark://projected/index.md)", "sha256-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	client.addList("projected:6309", "/", "- [index.md](index.md)\n")
+	client.addDoc("projected:6309", "/index.md", "# Projected", "sha256-cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+
+	crawler := NewCrawler(cfg, client, nil, nil)
+	result, err := crawler.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if result.ServersDiscovered != 1 || result.DocumentsCrawled != 2 || result.HashesCollected != 2 {
+		t.Fatalf("result = %+v, want graph hashed without projected server crawl", result)
+	}
+	graph := crawler.GraphExport()
+	if strings.Contains(graph, "/graph.md") || strings.Contains(graph, "mark://projected") {
+		t.Errorf("generated graph export leaked into accumulated graph:\n%s", graph)
 	}
 }
 

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -189,6 +189,9 @@ func TestCrawlerDoesNotDiscoverPublishOnlyHub(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Seeds = []string{"mark://content"}
 	cfg.Hubs = []string{"mark://root"}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
 
 	client := newMockClient()
 	client.addList("content:6309", "/", "- [index.md](index.md)\n")
@@ -214,6 +217,9 @@ func TestCrawlerCrawlsHubWhenExplicitlySeeded(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Seeds = []string{"mark://content", "mark://root"}
 	cfg.Hubs = []string{"mark://root"}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
 
 	client := newMockClient()
 	client.addList("content:6309", "/", "- [index.md](index.md)\n")

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -189,9 +189,6 @@ func TestCrawlerDoesNotDiscoverPublishOnlyHub(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Seeds = []string{"mark://content"}
 	cfg.Hubs = []string{"mark://root"}
-	if err := cfg.Validate(); err != nil {
-		t.Fatal(err)
-	}
 
 	client := newMockClient()
 	client.addList("content:6309", "/", "- [index.md](index.md)\n")
@@ -217,9 +214,6 @@ func TestCrawlerCrawlsHubWhenExplicitlySeeded(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Seeds = []string{"mark://content", "mark://root"}
 	cfg.Hubs = []string{"mark://root"}
-	if err := cfg.Validate(); err != nil {
-		t.Fatal(err)
-	}
 
 	client := newMockClient()
 	client.addList("content:6309", "/", "- [index.md](index.md)\n")
@@ -234,6 +228,20 @@ func TestCrawlerCrawlsHubWhenExplicitlySeeded(t *testing.T) {
 	}
 	if result.ServersDiscovered != 2 || result.DocumentsCrawled != 2 {
 		t.Fatalf("result = %+v, want both explicit seeds crawled", result)
+	}
+}
+
+func TestCrawlerRunRejectsInvalidConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Seeds = []string{"mark://content/document.md"}
+
+	crawler := NewCrawler(cfg, newMockClient(), nil, nil)
+	result, err := crawler.Run(context.Background())
+	if err == nil {
+		t.Fatal("Run() unexpectedly accepted invalid config")
+	}
+	if result != nil {
+		t.Errorf("Run() result = %+v, want nil on invalid config", result)
 	}
 }
 

--- a/deploy/helm/demarkus-agent/README.md
+++ b/deploy/helm/demarkus-agent/README.md
@@ -25,6 +25,7 @@ For private seeds (read-auth enabled), add a token entry for that host as well.
 | `replicaCount` | int | `1` | Keep at 1 — multiple replicas re-do the same crawl |
 | `config.seeds` | list | `[]` | `mark://` URLs to crawl. **Required.** |
 | `config.hubs` | list | `[]` | `mark://` URLs to publish indexes to. Empty = crawl-only mode |
+| `config.endpoints` | map | `{}` | Logical authority to explicit `dialAddress` and optional `serverName` transport route |
 | `config.crawl.maxDepth` | int | `2` | Max link hops per server |
 | `config.crawl.maxServers` | int | `50` | Max servers to discover per run |
 | `config.crawl.maxDocuments` | int | `1000` | Max documents per crawl run |
@@ -46,6 +47,28 @@ For private seeds (read-auth enabled), add a token entry for that host as well.
 | `podSecurityContext` | object | non-root user 65532 | Pod-level security |
 | `securityContext` | object | read-only root FS, drop all caps | Container-level security |
 
+### Explicit endpoints
+
+Use endpoint overrides when document links use stable logical authorities but
+the agent must dial a private address or send different SNI:
+
+```yaml
+config:
+  seeds: [mark://team-a]
+  hubs: [mark://root]
+  endpoints:
+    team-a:
+      dialAddress: team-a-knowledge.namespace.svc.cluster.local:6309
+      serverName: team-a-knowledge.namespace.svc.cluster.local
+    root:
+      dialAddress: root-knowledge.namespace.svc.cluster.local:6309
+      serverName: root-knowledge.namespace.svc.cluster.local
+```
+
+Graph URLs, hash indexes, state, and token lookup remain keyed by `team-a:6309`
+and `root:6309`. Only socket destination and TLS server name are overridden.
+Token files must therefore use logical authority keys.
+
 ## How auth is wired
 
 The agent uses the protocol-client tokens convention. On startup it calls `tokens.LoadDefault()` which reads `~/.mark/tokens.toml`. The chart mounts the tokens Secret at `/home/demarkus/.mark/tokens.toml` and sets `HOME=/home/demarkus`, so the existing code path Just Works.
@@ -59,6 +82,15 @@ For a single hub with a single token, you can also set the `DEMARKUS_AUTH` env v
 | `hubs: []` | Nothing. Crawl-only. State is updated. |
 | `hubs: [X]`, `perServer: false` | Single aggregated `/index.md` to each hub |
 | `hubs: [X]`, `perServer: true` | One `/index/<server>.md` per discovered seed, to each hub |
+
+Configured hubs are not followed from document links unless they also appear in
+`config.seeds`. This prevents an aggregation hub from recursively crawling and
+indexing its own generated graph and hash indexes.
+
+The canonical `/graph.md` export is fetched and included in hash indexes, but
+its generated table links are not recorded as authored edges or followed for
+server discovery. This prevents graph exports from recursively amplifying one
+another.
 
 Re-publishing is idempotent: the agent uses `expected_version=-1` (no check), and the server's no-op-on-duplicate-content prevents version churn when the computed index is unchanged.
 

--- a/deploy/helm/demarkus-agent/templates/configmap.yaml
+++ b/deploy/helm/demarkus-agent/templates/configmap.yaml
@@ -26,6 +26,14 @@ data:
     hubs = []
     {{- end }}
 
+    {{- range $authority, $endpoint := .Values.config.endpoints }}
+    [endpoints.{{ $authority | quote }}]
+    dial_address = {{ $endpoint.dialAddress | quote }}
+    {{- if $endpoint.serverName }}
+    server_name = {{ $endpoint.serverName | quote }}
+    {{- end }}
+
+    {{- end }}
     [crawl]
     max_depth = {{ .Values.config.crawl.maxDepth }}
     max_servers = {{ .Values.config.crawl.maxServers }}

--- a/deploy/helm/demarkus-agent/tests/configmap_test.yaml
+++ b/deploy/helm/demarkus-agent/tests/configmap_test.yaml
@@ -37,6 +37,25 @@ tests:
           path: data["agent.toml"]
           pattern: 'request_delay = "100ms"'
 
+  - it: renders logical authority endpoint overrides
+    set:
+      config.seeds:
+        - mark://team-a
+      config.endpoints.team-a.dialAddress: shared.internal:6309
+      config.endpoints.team-a.serverName: team-a.internal
+      config.endpoints.team-b.dialAddress: shared.internal:6309
+      config.endpoints.team-b.serverName: team-b.internal
+    asserts:
+      - matchRegex:
+          path: data["agent.toml"]
+          pattern: '\[endpoints\."team-a"\]'
+      - matchRegex:
+          path: data["agent.toml"]
+          pattern: 'dial_address = "shared.internal:6309"'
+      - matchRegex:
+          path: data["agent.toml"]
+          pattern: 'server_name = "team-b.internal"'
+
   - it: emits empty arrays when no seeds/hubs configured
     set:
       config.seeds: []
@@ -48,3 +67,6 @@ tests:
       - matchRegex:
           path: data["agent.toml"]
           pattern: 'hubs = \[\]'
+      - notMatchRegex:
+          path: data["agent.toml"]
+          pattern: '\[endpoints\.'

--- a/deploy/helm/demarkus-agent/tests/configmap_test.yaml
+++ b/deploy/helm/demarkus-agent/tests/configmap_test.yaml
@@ -41,9 +41,9 @@ tests:
     set:
       config.seeds:
         - mark://team-a
-      config.endpoints.team-a.dialAddress: shared.internal:6309
+      config.endpoints.team-a.dialAddress: shared-a.internal:6309
       config.endpoints.team-a.serverName: team-a.internal
-      config.endpoints.team-b.dialAddress: shared.internal:6309
+      config.endpoints.team-b.dialAddress: shared-b.internal:6309
       config.endpoints.team-b.serverName: team-b.internal
     asserts:
       - matchRegex:
@@ -51,10 +51,10 @@ tests:
           pattern: '\[endpoints\."team-a"\]'
       - matchRegex:
           path: data["agent.toml"]
-          pattern: 'dial_address = "shared.internal:6309"'
+          pattern: '(?s)\[endpoints\."team-a"\]\ndial_address = "shared-a.internal:6309"\nserver_name = "team-a.internal"'
       - matchRegex:
           path: data["agent.toml"]
-          pattern: 'server_name = "team-b.internal"'
+          pattern: '(?s)\[endpoints\."team-b"\]\ndial_address = "shared-b.internal:6309"\nserver_name = "team-b.internal"'
 
   - it: emits empty arrays when no seeds/hubs configured
     set:

--- a/deploy/helm/demarkus-agent/values.yaml
+++ b/deploy/helm/demarkus-agent/values.yaml
@@ -33,6 +33,14 @@ config:
   hubs: []
   #  - mark://hub.example.com:6309
 
+  # Optional logical-authority transport overrides. Keys match authorities in
+  # seeds, hubs, or discovered mark:// links. Identity and token lookup keep
+  # using the key; only socket dialing and TLS SNI use these endpoint fields.
+  endpoints: {}
+  #  team-a:
+  #    dialAddress: shared.internal:6309
+  #    serverName: team-a.internal
+
   crawl:
     maxDepth: 2
     maxServers: 50

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1310,6 +1310,7 @@ Hubs are the entry points into the information graph:
 - Graph as content — `Store.Export()` renders the graph as publishable markdown with `mark://` links (six-column Edges table: `From | To | Rel | Label | Anchor | Count`); `ParseExport()` parses it back, accepting the legacy two-column shape too; CLI `demarkus graph export` and MCP `mark_graph_export` tool
 - Edge semantics — edges carry provenance (link label, source section anchor, occurrence count) and typed relations ingested from `rel-<predicate>` publisher metadata (ADR 0004)
 - Agent discovery — `mark_graph_publish` MCP tool exports and publishes the graph in one step; other agents crawl the published document to inherit the topology without recrawling original servers
+- Federation crawler exception — `demarkus-agent` already LISTs every document on each discovered server, so it hash-indexes canonical `/graph.md` but does not reinterpret that generated projection as authored edges or discovery links; graph consumers import exports through `ParseExport()` instead
 
 ## Security Considerations
 

--- a/docs/adr/0005-node-identity-default-port.md
+++ b/docs/adr/0005-node-identity-default-port.md
@@ -146,10 +146,10 @@ Amended 2026-08-17 after building this on `feat/node-identity-default-port`.
   Canonicalizing both sides fixed it, but `CanonicalURL` normalizes an empty
   path to `/`, which broke the bare-authority prefix match until the trailing
   slash was trimmed. The cross-module contract test caught both.
-- **Fedcrawl was deliberately left alone.** Its crawl state and hash-index
-  entries key on dial addresses by design, and its graph is normalized at the
-  `graphstore.Merge` boundary anyway. Forcing identity there would break
-  `state.GetURL` and the index contract for no gain.
+- **Fedcrawl initially remained dial-keyed.** Explicit transport endpoints later
+  gave it the ADR 0007 separation: crawl state, hash-index entries, and graph
+  nodes use logical authorities, while socket addresses and TLS server names
+  may differ. Default-port normalization still applies at the authority edge.
 
 ## Alternatives rejected
 

--- a/docs/adr/0007-sni-virtual-world-routing.md
+++ b/docs/adr/0007-sni-virtual-world-routing.md
@@ -88,6 +88,10 @@ authority. Brokers and agents may configure the three values separately where
 DNS aliases are unavailable. A broker world name remains a local routing label
 and is not substituted for the Mark authority.
 
+The federation agent implements this model through optional endpoint overrides.
+Its configured authority remains the crawl, graph, index, state, and token key;
+the override supplies `DialAddress` and `ServerName` to the shared QUIC client.
+
 ## Consequences
 
 - Existing Mark wire requests and all seven verbs remain unchanged.

--- a/docs/site/reference/index.md
+++ b/docs/site/reference/index.md
@@ -36,6 +36,10 @@ The federation crawler (`demarkus-agent`) uses a TOML configuration file:
 seeds = ["mark://server1:6309", "mark://server2:6309"]
 hubs = ["mark://hub.example:6309"]
 
+[endpoints."server1:6309"]
+dial_address = "server1.internal:6309"
+server_name = "server1.internal"
+
 [crawl]
 max_servers = 50      # Maximum servers to discover
 max_documents = 1000  # Maximum documents per crawl run
@@ -54,6 +58,8 @@ interval = "6h"  # Time between crawl runs (daemon mode)
 |-------|---------|-------------|
 | `seeds` | *(required)* | Initial servers to crawl |
 | `hubs` | *(empty)* | Servers to publish hash indexes to |
+| `endpoints.<authority>.dial_address` | *(authority)* | Socket destination override |
+| `endpoints.<authority>.server_name` | *(authority host)* | TLS SNI and certificate name override |
 | `crawl.max_servers` | `50` | Maximum servers to discover per run |
 | `crawl.max_documents` | `1000` | Maximum documents to fetch per run |
 | `crawl.workers` | `5` | Concurrent fetch goroutines |

--- a/docs/site/reference/index.md
+++ b/docs/site/reference/index.md
@@ -58,7 +58,7 @@ interval = "6h"  # Time between crawl runs (daemon mode)
 |-------|---------|-------------|
 | `seeds` | *(required)* | Initial servers to crawl |
 | `hubs` | *(empty)* | Servers to publish hash indexes to |
-| `endpoints.<authority>.dial_address` | *(authority)* | Socket destination override |
+| `endpoints.<authority>.dial_address` | *(required per endpoint)* | Socket destination override |
 | `endpoints.<authority>.server_name` | *(authority host)* | TLS SNI and certificate name override |
 | `crawl.max_servers` | `50` | Maximum servers to discover per run |
 | `crawl.max_documents` | `1000` | Maximum documents to fetch per run |

--- a/docs/site/tools/agent.md
+++ b/docs/site/tools/agent.md
@@ -44,6 +44,10 @@ Create `fedcrawl.toml`:
 seeds = ["mark://localhost:6309"]
 hubs = ["mark://hub.example:6309"]
 
+[endpoints."hub.example:6309"]
+dial_address = "hub.internal:6309"
+server_name = "hub.internal"
+
 [crawl]
 max_servers = 50
 max_documents = 1000
@@ -126,6 +130,26 @@ hubs = ["mark://hub.example:6309"]
 
 - `seeds` — Initial servers to crawl (required unless `-seeds` flag provided)
 - `hubs` — Servers to publish hash indexes to
+
+Hubs are publish-only unless also listed in `seeds`. Links to a publish-only hub
+remain graph edges but do not enqueue the hub's generated artifacts for crawling.
+The crawler hashes `/graph.md`, but does not ingest its generated table links as
+authored edges or discovery targets; graph exports are projections, not sources.
+
+### Explicit Transport Endpoints
+
+An endpoint override separates stable Mark identity from deployment routing:
+
+```toml
+[endpoints."team-a"]
+dial_address = "shared.internal:6309"
+server_name = "team-a.internal"
+```
+
+The table key remains the authority used by links, graph nodes, indexes, state,
+and token lookup. `dial_address` only opens the socket. `server_name` selects the
+virtual server through TLS SNI and certificate verification; when omitted it
+defaults to the logical authority hostname.
 
 ### `[crawl]` Section
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable per-authority endpoint routing with custom dial addresses and TLS server names.
  - Added Helm support while preserving logical authorities for identity, graph, state, hash, and token operations.

- **Bug Fixes**
  - Improved authority normalization and port validation.
  - Prevented publish-only hubs and generated graph links from triggering unintended crawling.
  - Ensured graph exports are hashed without becoming discovery data.

- **Documentation**
  - Updated configuration guides, examples, and architecture documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->