### PR TITLE
feat(tools): add universe-wide catalog lookup

### DIFF
--- a/client/fetch/fetch.go
+++ b/client/fetch/fetch.go
@@ -346,7 +346,6 @@ func (c *Client) requestOnConnContext(ctx context.Context, conn *quic.Conn, req 
 	if err != nil {
 		return Result{}, fmt.Errorf("open stream: %w", err)
 	}
-	defer func() { _ = stream.Close() }()
 	stopCancel := context.AfterFunc(ctx, func() {
 		stream.CancelRead(0)
 		stream.CancelWrite(0)
@@ -354,15 +353,24 @@ func (c *Client) requestOnConnContext(ctx context.Context, conn *quic.Conn, req 
 	defer stopCancel()
 
 	if _, err := req.WriteTo(stream); err != nil {
+		stream.CancelWrite(0)
+		stream.CancelRead(0)
 		if ctx.Err() != nil {
 			return Result{}, ctx.Err()
 		}
 		return Result{}, fmt.Errorf("send request: %w", err)
 	}
-	_ = stream.Close()
+	if err := stream.Close(); err != nil {
+		stream.CancelRead(0)
+		if ctx.Err() != nil {
+			return Result{}, ctx.Err()
+		}
+		return Result{}, fmt.Errorf("close request stream: %w", err)
+	}
 
 	resp, err := protocol.ParseResponse(stream)
 	if err != nil {
+		stream.CancelRead(0)
 		if ctx.Err() != nil {
 			return Result{}, ctx.Err()
 		}

--- a/client/fetch/fetch.go
+++ b/client/fetch/fetch.go
@@ -242,6 +242,12 @@ type LookupOptions struct {
 // scope, returning an importance-ranked markdown table. query is required.
 // If token is non-empty it is sent so read-auth-gated documents are included.
 func (c *Client) Lookup(host, scope, query, token string, opts LookupOptions) (Result, error) {
+	return c.LookupContext(context.Background(), host, scope, query, token, opts)
+}
+
+// LookupContext is Lookup with caller cancellation propagated through dialing,
+// retries, and stream I/O.
+func (c *Client) LookupContext(ctx context.Context, host, scope, query, token string, opts LookupOptions) (Result, error) {
 	if query == "" {
 		return Result{}, fmt.Errorf("LOOKUP requires a non-empty query")
 	}
@@ -255,8 +261,8 @@ func (c *Client) Lookup(host, scope, query, token string, opts LookupOptions) (R
 	if token != "" {
 		req.Metadata["auth"] = token
 	}
-	return c.doWithRetry(host, func(conn *quic.Conn) (Result, error) {
-		return c.requestOnConn(conn, req)
+	return c.doWithRetryContext(ctx, host, func(conn *quic.Conn) (Result, error) {
+		return c.requestOnConnContext(ctx, conn, req)
 	})
 }
 
@@ -329,7 +335,11 @@ func (c *Client) cachedRequestMeta(host, path, token, verb string, extra map[str
 
 // requestOnConn opens a stream, sends a request, and reads the response.
 func (c *Client) requestOnConn(conn *quic.Conn, req protocol.Request) (Result, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), c.opts.RequestTimeout)
+	return c.requestOnConnContext(context.Background(), conn, req)
+}
+
+func (c *Client) requestOnConnContext(ctx context.Context, conn *quic.Conn, req protocol.Request) (Result, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.opts.RequestTimeout)
 	defer cancel()
 
 	stream, err := conn.OpenStreamSync(ctx)
@@ -337,14 +347,25 @@ func (c *Client) requestOnConn(conn *quic.Conn, req protocol.Request) (Result, e
 		return Result{}, fmt.Errorf("open stream: %w", err)
 	}
 	defer func() { _ = stream.Close() }()
+	stopCancel := context.AfterFunc(ctx, func() {
+		stream.CancelRead(0)
+		stream.CancelWrite(0)
+	})
+	defer stopCancel()
 
 	if _, err := req.WriteTo(stream); err != nil {
+		if ctx.Err() != nil {
+			return Result{}, ctx.Err()
+		}
 		return Result{}, fmt.Errorf("send request: %w", err)
 	}
 	_ = stream.Close()
 
 	resp, err := protocol.ParseResponse(stream)
 	if err != nil {
+		if ctx.Err() != nil {
+			return Result{}, ctx.Err()
+		}
 		return Result{}, fmt.Errorf("read response: %w", err)
 	}
 
@@ -353,15 +374,24 @@ func (c *Client) requestOnConn(conn *quic.Conn, req protocol.Request) (Result, e
 
 // doWithRetry retries transient failures up to 5 times with a fixed 100ms delay.
 func (c *Client) doWithRetry(host string, fn func(conn *quic.Conn) (Result, error)) (Result, error) {
+	return c.doWithRetryContext(context.Background(), host, fn)
+}
+
+func (c *Client) doWithRetryContext(ctx context.Context, host string, fn func(conn *quic.Conn) (Result, error)) (Result, error) {
 	const maxRetries = 5
 	const retryDelay = 100 * time.Millisecond
 
 	var lastErr error
 	for attempt := range maxRetries {
-		conn, err := c.getConn(host)
+		if err := ctx.Err(); err != nil {
+			return Result{}, err
+		}
+		conn, err := c.getConnContext(ctx, host)
 		if err != nil {
 			if attempt < maxRetries-1 && isTransientError(err) {
-				time.Sleep(retryDelay)
+				if err := waitForRetry(ctx, retryDelay); err != nil {
+					return Result{}, err
+				}
 				c.removeConn(host)
 				continue
 			}
@@ -372,10 +402,15 @@ func (c *Client) doWithRetry(host string, fn func(conn *quic.Conn) (Result, erro
 		if err == nil {
 			return result, nil
 		}
+		if ctx.Err() != nil {
+			return Result{}, ctx.Err()
+		}
 
 		lastErr = err
 		if attempt < maxRetries-1 && isTransientError(err) {
-			time.Sleep(retryDelay)
+			if err := waitForRetry(ctx, retryDelay); err != nil {
+				return Result{}, err
+			}
 			c.removeConn(host)
 			continue
 		}
@@ -386,7 +421,16 @@ func (c *Client) doWithRetry(host string, fn func(conn *quic.Conn) (Result, erro
 	return Result{}, lastErr
 }
 
-func (c *Client) getConn(host string) (*quic.Conn, error) {
+func waitForRetry(ctx context.Context, delay time.Duration) error {
+	select {
+	case <-time.After(delay):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *Client) getConnContext(ctx context.Context, host string) (*quic.Conn, error) {
 	c.mu.Lock()
 	conn, ok := c.conns[host]
 	c.mu.Unlock()
@@ -399,7 +443,7 @@ func (c *Client) getConn(host string) (*quic.Conn, error) {
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), c.opts.DialTimeout)
+	ctx, cancel := context.WithTimeout(ctx, c.opts.DialTimeout)
 	defer cancel()
 
 	endpoint := Endpoint{DialAddress: host}

--- a/client/fetch/lookup_context_test.go
+++ b/client/fetch/lookup_context_test.go
@@ -1,0 +1,41 @@
+package fetch
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/latebit-io/demarkus/protocol"
+)
+
+func TestLookupContextCancelsBlockedResponse(t *testing.T) {
+	received := make(chan struct{})
+	release := make(chan struct{})
+	host := startTestServer(t, func(protocol.Request) protocol.Response {
+		close(received)
+		<-release
+		return protocol.Response{Status: protocol.StatusOK}
+	})
+	c := NewClient(Options{Insecure: true, RequestTimeout: 10 * time.Second})
+	defer c.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := c.LookupContext(ctx, host, "/", "auth", "", LookupOptions{})
+		done <- err
+	}()
+	<-received
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("LookupContext error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("LookupContext did not stop after cancellation")
+	}
+	close(release)
+}

--- a/tools/demarkus-broker/MCP-API.md
+++ b/tools/demarkus-broker/MCP-API.md
@@ -1,8 +1,9 @@
 # Broker MCP API
 
-Operator + developer reference for the 14-tool MCP surface exposed by
-the demarkus-broker's `/mcp` endpoint. Mirrors the local
-`client/cmd/demarkus-mcp` stdio server byte-for-byte: a document
+Operator + developer reference for the 17-tool MCP surface exposed by
+the demarkus-broker's `/mcp` endpoint. Fifteen tools mirror the local
+`client/cmd/demarkus-mcp` stdio server; `mark_worlds` and
+`mark_lookup_all` are broker-only system operations. A document
 fetched via the broker and the same document fetched direct-QUIC
 produce identical body bytes, version, modified timestamp, etag, and
 content-hash. The broker is a wire-shape adapter
@@ -45,7 +46,7 @@ the broker's `/me/install`, `AllowConfig`, and audit logs already use
 The broker does **not** mint per-user tokens. World access is gated as
 follows:
 
-- **Reads** (`mark_fetch`, `mark_list`, `mark_versions`, and the
+- **Reads** (`mark_fetch`, `mark_list`, `mark_versions`, catalog lookups, and the
   federation reads) dispatch with an empty bearer. The world's
   `tokens.toml` grants no `read` operation to any token, so reads are
   open to any SSO-authenticated identity.
@@ -66,7 +67,7 @@ write re-reads the broker Secret rather than re-minting.
 
 ## URL form
 
-Every tool that addresses a world uses the URL shape:
+Every tool that addresses one world uses the URL shape:
 
 ```text
 mark://{worldName}/{path}
@@ -88,7 +89,7 @@ for caller-supplied URLs.
 
 ## Tools
 
-All 14 tools below have semantic parity with the local
+Fifteen tools below have semantic parity with the local
 `client/cmd/demarkus-mcp` stdio server. The proxy-fidelity gate is a
 broker-side unit test that asserts the broker's `formatToolResult`
 matches the local server's `formatResult` byte-for-byte across
@@ -96,11 +97,27 @@ representative `fetch.Result` cases.
 
 ### Read
 
+#### `mark_worlds`
+
+List every world the authenticated identity may read, including each
+world's logical name, public URL, internal topology address, and
+whether the identity may also write it. This is broker-only and takes
+no parameters.
+
 #### `mark_fetch`
 
 Fetch a document. Returns `status` (`ok` | `not-found` | `archived` |
 `unauthorized`), `version`, `modified`, `etag`, `content-hash`, and
 the markdown `body`. Identical wire shape to direct-QUIC `FETCH`.
+
+| Param | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `url` | string | yes | `mark://{worldName}/{path}` |
+
+#### `mark_explore`
+
+Orient around one document in one call: outline head, outbound links,
+recorded backlinks, and sibling documents, each capped at 10 entries.
 
 | Param | Type | Required | Notes |
 | --- | --- | --- | --- |
@@ -139,6 +156,23 @@ row count). Dispatched unauthenticated like the other reads.
 | `query` | string | yes | Subject; matched against tags and titles (min 2 chars). |
 | `filter` | string | no | Comma-separated `key=value`; built-ins `tag=`, `modified-after=`, `modified-before=`. |
 | `limit` | number | no | Max results (server default 10, cap 1000). |
+
+#### `mark_lookup_all`
+
+Look up a subject across every readable world. The broker performs
+bounded concurrent LOOKUP calls, qualifies each path as
+`mark://{worldName}/{path}`, and applies one global result limit.
+Results are ordered by per-world rank, then importance, world, and
+path. Successful matches remain available when some worlds fail;
+those failures are listed in a `status: partial` response. If every
+world fails, the tool returns an error.
+
+| Param | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `query` | string | yes | Subject; matched against tags and titles (min 2 chars), or `*`. |
+| `scope` | string | no | Server-relative scope applied to every world (default `/`). |
+| `filter` | string | no | Comma-separated `key=value` predicates applied in every world. |
+| `limit` | number | no | Global max results (default 10, cap 1000). |
 
 ### Write
 
@@ -299,7 +333,9 @@ step. `mark_graph_export` + `mark_publish` combined.
 The broker returns errors via the MCP tool-error envelope (`isError:
 true` in the `CallToolResult`) for genuine tool failures: malformed
 URL, unknown world, transport failure to the world, exhausted
-first-mint retry budget. World-side `conflict`, `archived`, and
+first-mint retry budget, or failure of every world in `mark_lookup_all`.
+Partial `mark_lookup_all` failures return `status: partial` with the
+successful matches and an explicit failure table. World-side `conflict`, `archived`, and
 `not-permitted` responses are forwarded **verbatim** with `isError:
 false` — they are first-class outcomes the agent acts on (re-fetch
 and retry; ask the operator for more scope), not gateway errors.

--- a/tools/demarkus-broker/MCP-API.md
+++ b/tools/demarkus-broker/MCP-API.md
@@ -78,7 +78,10 @@ mark://{worldName}/{path}
 resolves the name to a cluster-internal address using
 `worlds[].internalAddress` if set, otherwise the standard Service-DNS
 convention `<name>.<namespace>.svc.cluster.local:6309`. The agent
-never sees the internal address — it knows worlds only by name.
+addresses tools only by logical world name; internal addresses are not
+accepted as tool authorities. The broker-only `mark_worlds` discovery
+response deliberately exposes each internal topology address to authenticated
+identities so graph consumers can join host-keyed edges to logical worlds.
 
 Path traversal, query strings, and fragments are rejected by the
 gateway parser (strict shape, clear errors). The crawler used by

--- a/tools/demarkus-broker/internal/broker/mcp_gateway.go
+++ b/tools/demarkus-broker/internal/broker/mcp_gateway.go
@@ -14,14 +14,8 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 )
 
-// mcpGateway is the broker's MCP-over-HTTPS gateway. It owns the mcp-go
-// MCPServer and its Streamable HTTP transport, sharing auth +
-// rate-limit machinery with the parent broker Server.
-//
-// All 16 tools have real handlers. Reads dispatch with an empty bearer
-// (the world's tokens.toml grants no read op, so the org SSO gate at
-// the broker is the only access control); writes provision a per-world
-// token through worldWriteTokens and dispatch through worldDispatcher.
+// mcpGateway serves 17 MCP-over-HTTPS tools. Reads use broker SSO;
+// writes also provision per-world tokens through worldWriteTokens.
 type mcpGateway struct {
 	srv        *Server
 	mcpServer  *mcpserver.MCPServer
@@ -51,22 +45,8 @@ type mcpGateway struct {
 	graphSeedChecked map[string]time.Time
 }
 
-// newMCPGateway constructs a gateway, registers the 16 tool
-// definitions (real handlers for Slice 2's read verbs, placeholders
-// for the rest), and wraps the mcp-go MCPServer in a Streamable HTTP
-// transport. The transport is an http.Handler — the caller mounts
-// it on whichever path/middleware chain it wants (Routes mounts it
-// at /mcp behind the gateway auth chain).
-//
-// version is plumbed through to the MCPServer constructor so the
-// initialize response surfaces the broker's build version to MCP
-// clients. mcp-go advertises tool/resource/prompt capabilities
-// automatically on registration; resources and prompts joined the
-// surface in the resources+prompts follow-up (mcp_resources.go /
-// mcp_prompts.go), superseding the gateway plan's original Out-of-Scope.
-//
-// dispatcher is the worldDispatcher backing the tool handlers.
-// Production wires *worldPool; tests inject a fake.
+// newMCPGateway registers the 17 tools and wraps them in Streamable HTTP.
+// Production supplies *worldPool; tests inject a dispatcher fake.
 func newMCPGateway(s *Server, version string, dispatcher worldDispatcher) *mcpGateway {
 	// Session-end eviction for the fetch dedup state. The store is
 	// constructed before the MCPServer because the hook closes over it.
@@ -105,11 +85,8 @@ func newMCPGateway(s *Server, version string, dispatcher worldDispatcher) *mcpGa
 	return g
 }
 
-// registerTools wires the 16 tool definitions onto the MCP server.
-// Tools absent from the toolHandlers map fall through to
-// notImplementedHandler. The per-tool handler map lives in
-// toolHandlers so adding new implementations is a one-line edit and
-// the placeholder fallback is impossible to forget.
+// registerTools wires all definitions to their handlers. Missing handlers use
+// notImplementedHandler so an incomplete registration fails visibly.
 func (g *mcpGateway) registerTools() {
 	handlers := g.toolHandlers()
 	tools := mcpTools()
@@ -122,20 +99,15 @@ func (g *mcpGateway) registerTools() {
 	}
 }
 
-// toolHandlers returns the per-tool handler map. Tools absent
-// from the map use notImplementedHandler. Method (rather than a
-// package-level var) so the handlers carry the gateway receiver
-// without indirection through a global.
-//
-// All 16 tools are real handlers — every entry below points at a
-// concrete implementation, and notImplementedHandler should never
-// run in production.
+// toolHandlers maps all 17 tools to concrete implementations. Keeping this a
+// method binds handlers to the gateway without global indirection.
 func (g *mcpGateway) toolHandlers() map[string]mcpserver.ToolHandlerFunc {
 	return map[string]mcpserver.ToolHandlerFunc{
 		"mark_fetch":         g.handleMarkFetch,
 		"mark_explore":       g.handleMarkExplore,
 		"mark_list":          g.handleMarkList,
 		"mark_lookup":        g.handleMarkLookup,
+		"mark_lookup_all":    g.handleMarkLookupAll,
 		"mark_versions":      g.handleMarkVersions,
 		"mark_publish":       g.handleMarkPublish,
 		"mark_append":        g.handleMarkAppend,

--- a/tools/demarkus-broker/internal/broker/mcp_tools_list.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_list.go
@@ -28,6 +28,7 @@ var mcpToolNames = []string{
 	"mark_list",
 	"mark_versions",
 	"mark_lookup",
+	"mark_lookup_all",
 	"mark_publish",
 	"mark_append",
 	"mark_archive",
@@ -41,14 +42,8 @@ var mcpToolNames = []string{
 	"mark_worlds",
 }
 
-// mcpTools returns the 16 tool definitions exposed by the broker MCP
-// gateway. The first 15 mirror client/cmd/demarkus-mcp's tool surface
-// for parity (so the agent sees the same vocabulary regardless of
-// transport); only the URL-format description differs because the
-// broker addresses worlds by name rather than host:port. mark_worlds
-// is deliberately broker-only: enumerating worlds is a knowledge-system
-// concept — the local single-world MCP's universe IS its one world, so
-// there is nothing to enumerate there.
+// mcpTools returns 15 direct-MCP parity tools plus broker-only mark_worlds and
+// mark_lookup_all, which operate on the knowledge system rather than one world.
 func mcpTools() []mcp.Tool {
 	return []mcp.Tool{
 		markFetchTool(),
@@ -56,6 +51,7 @@ func mcpTools() []mcp.Tool {
 		markListTool(),
 		markVersionsTool(),
 		markLookupTool(),
+		markLookupAllTool(),
 		markPublishTool(),
 		markAppendTool(),
 		markArchiveTool(),
@@ -177,6 +173,32 @@ func markLookupTool() mcp.Tool {
 		),
 		mcp.WithNumber("limit",
 			mcp.Description("maximum number of results (server default 10, hard cap 1000)"),
+		),
+	)
+}
+
+func markLookupAllTool() mcp.Tool {
+	return mcp.NewTool("mark_lookup_all",
+		mcp.WithDescription(
+			"Look up documents by subject across every world your identity may read. "+
+				"Returns one globally limited markdown table whose paths are qualified as "+
+				"mark://{worldName}/{path}. Results retain each world's relevance rank and "+
+				"use importance and world identity for deterministic ordering. Partial world "+
+				"failures are reported alongside successful matches. This is a broker-wide "+
+				"catalog lookup, not full-text search.",
+		),
+		mcp.WithString("query",
+			mcp.Required(),
+			mcp.Description("subject to look up; matched against document tags and titles (minimum 2 characters), or '*' to match every catalogued document"),
+		),
+		mcp.WithString("scope",
+			mcp.Description("server-relative scope applied to every world, e.g. / or /docs/ (default /)"),
+		),
+		mcp.WithString("filter",
+			mcp.Description("comma-separated key=value predicates applied in every world; built-ins: tag=, modified-after=, modified-before="),
+		),
+		mcp.WithNumber("limit",
+			mcp.Description("global maximum number of results across all worlds (default 10, hard cap 1000)"),
 		),
 	)
 }

--- a/tools/demarkus-broker/internal/broker/mcp_tools_list_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_list_test.go
@@ -5,16 +5,16 @@ import (
 	"testing"
 )
 
-func TestMCPToolsExactly16(t *testing.T) {
+func TestMCPToolsExactly17(t *testing.T) {
 	tools := mcpTools()
 	if len(tools) != len(mcpToolNames) {
 		t.Fatalf("mcpTools() returned %d tools, mcpToolNames lists %d — names + builders out of sync", len(tools), len(mcpToolNames))
 	}
 	// 15 tools mirror client/cmd/demarkus-mcp for cross-transport parity;
-	// mark_worlds is the one deliberate broker-only addition (enumerating
-	// worlds is a knowledge-system concept with no single-world analogue).
-	if len(tools) != 16 {
-		t.Fatalf("expected 16 tools (demarkus-mcp parity surface + mark_worlds), got %d", len(tools))
+	// mark_worlds and mark_lookup_all are deliberate broker-only additions:
+	// both operate on the knowledge system rather than one world.
+	if len(tools) != 17 {
+		t.Fatalf("expected 17 tools (demarkus-mcp parity surface + 2 broker tools), got %d", len(tools))
 	}
 	for i, tool := range tools {
 		if tool.Name != mcpToolNames[i] {
@@ -52,6 +52,11 @@ func TestMCPToolsExposeRequiredArguments(t *testing.T) {
 			tool:         "mark_fetch",
 			wantRequired: []string{"url"},
 			wantOptional: []string{"force"},
+		},
+		{
+			tool:         "mark_lookup_all",
+			wantRequired: []string{"query"},
+			wantOptional: []string{"scope", "filter", "limit"},
 		},
 		{
 			tool:         "mark_explore",

--- a/tools/demarkus-broker/internal/broker/mcp_tools_lookup_all.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_lookup_all.go
@@ -1,0 +1,335 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/protocol"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+const (
+	defaultLookupAllLimit = 10
+	maxLookupAllResults   = 1000
+	lookupAllWorkers      = 8
+)
+
+type lookupAllMatch struct {
+	world      string
+	path       string
+	importance float64
+	title      string
+	tags       string
+	rank       int
+}
+
+type lookupAllFailure struct {
+	world string
+	err   error
+}
+
+type lookupAllWorldResult struct {
+	world   string
+	matches []lookupAllMatch
+	err     error
+}
+
+// handleMarkLookupAll fans LOOKUP out across readable worlds. A rank-first
+// merge preserves each server's relevance ordering without inventing a
+// cross-world score the protocol does not expose.
+func (g *mcpGateway) handleMarkLookupAll(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go
+	if _, ok := claimsFromCtx(ctx); !ok {
+		return mcp.NewToolResultError("internal: missing identity on tool-call context"), nil
+	}
+	query, err := req.RequireString("query")
+	if err != nil {
+		return mcp.NewToolResultError("query is required"), nil
+	}
+	scope := req.GetString("scope", "/")
+	if err := protocol.ValidateRequestPath(scope); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid scope: %v", err)), nil
+	}
+	limit := req.GetInt("limit", defaultLookupAllLimit)
+	if limit < 1 {
+		return mcp.NewToolResultError("limit must be at least 1"), nil
+	}
+	if limit > maxLookupAllResults {
+		limit = maxLookupAllResults
+	}
+
+	worlds := readableWorlds(g.srv.cfg)
+	results := g.lookupAllWorlds(ctx, worlds, scope, query, fetch.LookupOptions{
+		Filter: req.GetString("filter", ""),
+		Limit:  limit,
+	})
+	matches, failures := collectLookupAllResults(results)
+	if len(failures) == len(worlds) && len(worlds) > 0 {
+		return mcp.NewToolResultError("lookup failed in all worlds: " + formatLookupAllFailureList(failures)), nil
+	}
+
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].rank != matches[j].rank {
+			return matches[i].rank < matches[j].rank
+		}
+		if matches[i].importance != matches[j].importance {
+			return matches[i].importance > matches[j].importance
+		}
+		if matches[i].world != matches[j].world {
+			return matches[i].world < matches[j].world
+		}
+		return matches[i].path < matches[j].path
+	})
+	if len(matches) > limit {
+		matches = matches[:limit]
+	}
+	return mcp.NewToolResultText(formatLookupAllResult(query, len(worlds), matches, failures)), nil
+}
+
+func (g *mcpGateway) lookupAllWorlds(ctx context.Context, worlds []*WorldConfig, scope, query string, opts fetch.LookupOptions) []lookupAllWorldResult {
+	jobs := make(chan *WorldConfig)
+	results := make(chan lookupAllWorldResult, len(worlds))
+	workers := min(lookupAllWorkers, len(worlds))
+
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Go(func() {
+			for world := range jobs {
+				select {
+				case <-ctx.Done():
+					results <- lookupAllWorldResult{world: world.Name, err: ctx.Err()}
+					continue
+				default:
+				}
+				result, err := g.dispatcher.Lookup(world.Name, scope, query, "", opts)
+				if err == nil && result.Response.Status != protocol.StatusOK {
+					err = fmt.Errorf("status %s%s", result.Response.Status, lookupFailureDetail(result.Response.Body))
+				}
+				var matches []lookupAllMatch
+				if err == nil {
+					matches, err = parseLookupAllMatches(world.Name, result)
+				}
+				results <- lookupAllWorldResult{world: world.Name, matches: matches, err: err}
+			}
+		})
+	}
+	go func() {
+		for _, world := range worlds {
+			jobs <- world
+		}
+		close(jobs)
+		wg.Wait()
+		close(results)
+	}()
+
+	out := make([]lookupAllWorldResult, 0, len(worlds))
+	for len(out) < len(worlds) {
+		select {
+		case result := <-results:
+			out = append(out, result)
+		case <-ctx.Done():
+			seen := make(map[string]bool, len(out))
+			for _, result := range out {
+				seen[result.world] = true
+			}
+			for _, world := range worlds {
+				if !seen[world.Name] {
+					out = append(out, lookupAllWorldResult{world: world.Name, err: ctx.Err()})
+				}
+			}
+			return out
+		}
+	}
+	return out
+}
+
+func collectLookupAllResults(results []lookupAllWorldResult) ([]lookupAllMatch, []lookupAllFailure) {
+	var matches []lookupAllMatch
+	var failures []lookupAllFailure
+	for _, result := range results {
+		if result.err != nil {
+			failures = append(failures, lookupAllFailure{world: result.world, err: result.err})
+			continue
+		}
+		matches = append(matches, result.matches...)
+	}
+	sort.Slice(failures, func(i, j int) bool { return failures[i].world < failures[j].world })
+	return matches, failures
+}
+
+func parseLookupAllMatches(world string, result fetch.Result) ([]lookupAllMatch, error) {
+	lines := strings.Split(strings.ReplaceAll(result.Response.Body, "\r\n", "\n"), "\n")
+	header := -1
+	for i, line := range lines {
+		cells, ok := splitLookupTableRow(line)
+		if ok && len(cells) == 4 && strings.EqualFold(cells[0], "Path") && strings.EqualFold(cells[1], "Importance") && strings.EqualFold(cells[2], "Title") && strings.EqualFold(cells[3], "Tags") {
+			header = i
+			break
+		}
+	}
+	if header < 0 {
+		return nil, fmt.Errorf("malformed LOOKUP response: result table missing")
+	}
+
+	matches := make([]lookupAllMatch, 0)
+	for _, line := range lines[header+1:] {
+		if strings.TrimSpace(line) == "" {
+			if len(matches) > 0 {
+				break
+			}
+			continue
+		}
+		cells, ok := splitLookupTableRow(line)
+		if !ok {
+			break
+		}
+		if isLookupTableSeparator(cells) {
+			continue
+		}
+		if len(cells) != 4 {
+			return nil, fmt.Errorf("malformed LOOKUP response: row has %d columns", len(cells))
+		}
+		importance, err := strconv.ParseFloat(unescapeLookupCell(cells[1]), 64)
+		if err != nil || math.IsNaN(importance) || math.IsInf(importance, 0) || importance < 0 || importance > 1 {
+			return nil, fmt.Errorf("malformed LOOKUP response: invalid importance %q", cells[1])
+		}
+		matchPath := unescapeLookupCell(cells[0])
+		if !strings.HasPrefix(matchPath, "/") {
+			return nil, fmt.Errorf("malformed LOOKUP response: invalid path %q", matchPath)
+		}
+		matches = append(matches, lookupAllMatch{
+			world:      world,
+			path:       matchPath,
+			importance: importance,
+			title:      unescapeLookupCell(cells[2]),
+			tags:       unescapeLookupCell(cells[3]),
+			rank:       len(matches),
+		})
+	}
+
+	want, err := strconv.Atoi(result.Response.Metadata["matches"])
+	if err != nil || want != len(matches) {
+		return nil, fmt.Errorf("malformed LOOKUP response: matches metadata does not match table")
+	}
+	return matches, nil
+}
+
+func splitLookupTableRow(line string) ([]string, bool) {
+	line = strings.TrimSpace(line)
+	if len(line) < 2 || line[0] != '|' || line[len(line)-1] != '|' {
+		return nil, false
+	}
+	var cells []string
+	start := 1
+	for i := 1; i < len(line)-1; i++ {
+		if line[i] != '|' || lookupCharEscaped(line, i) {
+			continue
+		}
+		cells = append(cells, strings.TrimSpace(line[start:i]))
+		start = i + 1
+	}
+	cells = append(cells, strings.TrimSpace(line[start:len(line)-1]))
+	return cells, true
+}
+
+func lookupCharEscaped(s string, at int) bool {
+	backslashes := 0
+	for i := at - 1; i >= 0 && s[i] == '\\'; i-- {
+		backslashes++
+	}
+	return backslashes%2 == 1
+}
+
+func isLookupTableSeparator(cells []string) bool {
+	if len(cells) != 4 {
+		return false
+	}
+	for _, cell := range cells {
+		trimmed := strings.Trim(strings.TrimSpace(cell), ":")
+		if len(trimmed) < 3 || strings.Trim(trimmed, "-") != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func unescapeLookupCell(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) && strings.ContainsRune(`\\[]()*_`+"`~#|", rune(s[i+1])) {
+			i++
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+var lookupCellEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`[`, `\[`, `]`, `\]`,
+	`(`, `\(`, `)`, `\)`,
+	`*`, `\*`, `_`, `\_`,
+	"`", "\\`", `~`, `\~`,
+	`#`, `\#`, `|`, `\|`,
+)
+
+func escapeLookupCell(s string) string {
+	return lookupCellEscaper.Replace(strings.ReplaceAll(strings.ReplaceAll(s, "\r", " "), "\n", " "))
+}
+
+func formatLookupAllResult(query string, worldCount int, matches []lookupAllMatch, failures []lookupAllFailure) string {
+	var b strings.Builder
+	status := "ok"
+	if len(failures) > 0 {
+		status = "partial"
+	}
+	fmt.Fprintf(&b, "status: %s\nworlds: %d\nsucceeded: %d\nfailed: %d\nmatches: %d\n", status, worldCount, worldCount-len(failures), len(failures), len(matches))
+	fmt.Fprintf(&b, "\n# Lookup matches for \"%s\" across readable worlds\n\n", escapeLookupCell(query))
+	b.WriteString("| Path | Importance | Title | Tags |\n|------|------------|-------|------|\n")
+	for _, match := range matches {
+		fmt.Fprintf(&b, "| %s | %.2f | %s | %s |\n",
+			escapeLookupCell(qualifiedLookupURL(match.world, match.path)), match.importance,
+			escapeLookupCell(match.title), escapeLookupCell(match.tags))
+	}
+	if len(failures) > 0 {
+		b.WriteString("\n## World failures\n\n| World | Error |\n|-------|-------|\n")
+		for _, failure := range failures {
+			fmt.Fprintf(&b, "| %s | %s |\n", escapeLookupCell(failure.world), escapeLookupCell(failure.err.Error()))
+		}
+	}
+	return b.String()
+}
+
+func qualifiedLookupURL(world, path string) string {
+	return (&url.URL{Scheme: "mark", Host: world, Path: path}).String()
+}
+
+func formatLookupAllFailureList(failures []lookupAllFailure) string {
+	parts := make([]string, 0, len(failures))
+	for _, failure := range failures {
+		parts = append(parts, failure.world+": "+failure.err.Error())
+	}
+	return strings.Join(parts, "; ")
+}
+
+func lookupFailureDetail(body string) string {
+	detail := strings.Join(strings.Fields(body), " ")
+	if detail == "" {
+		return ""
+	}
+	const maxRunes = 256
+	runes := []rune(detail)
+	if len(runes) > maxRunes {
+		detail = string(runes[:maxRunes]) + "..."
+	}
+	return ": " + detail
+}
+
+var _ mcpserver.ToolHandlerFunc = (*mcpGateway)(nil).handleMarkLookupAll

--- a/tools/demarkus-broker/internal/broker/mcp_tools_lookup_all.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_lookup_all.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"net/url"
@@ -108,7 +109,7 @@ func (g *mcpGateway) lookupAllWorlds(ctx context.Context, worlds []*WorldConfig,
 					continue
 				default:
 				}
-				result, err := g.dispatcher.Lookup(world.Name, scope, query, "", opts)
+				result, err := g.dispatcher.LookupContext(ctx, world.Name, scope, query, "", opts)
 				if err == nil && result.Response.Status != protocol.StatusOK {
 					err = fmt.Errorf("status %s%s", result.Response.Status, lookupFailureDetail(result.Response.Body))
 				}
@@ -122,7 +123,20 @@ func (g *mcpGateway) lookupAllWorlds(ctx context.Context, worlds []*WorldConfig,
 	}
 	go func() {
 		for _, world := range worlds {
-			jobs <- world
+			if ctx.Err() != nil {
+				close(jobs)
+				wg.Wait()
+				close(results)
+				return
+			}
+			select {
+			case jobs <- world:
+			case <-ctx.Done():
+				close(jobs)
+				wg.Wait()
+				close(results)
+				return
+			}
 		}
 		close(jobs)
 		wg.Wait()
@@ -132,19 +146,29 @@ func (g *mcpGateway) lookupAllWorlds(ctx context.Context, worlds []*WorldConfig,
 	out := make([]lookupAllWorldResult, 0, len(worlds))
 	for len(out) < len(worlds) {
 		select {
-		case result := <-results:
+		case result, ok := <-results:
+			if !ok {
+				return completeCanceledLookupResults(out, worlds, ctx.Err())
+			}
 			out = append(out, result)
 		case <-ctx.Done():
-			seen := make(map[string]bool, len(out))
-			for _, result := range out {
-				seen[result.world] = true
-			}
-			for _, world := range worlds {
-				if !seen[world.Name] {
-					out = append(out, lookupAllWorldResult{world: world.Name, err: ctx.Err()})
-				}
-			}
-			return out
+			return completeCanceledLookupResults(out, worlds, ctx.Err())
+		}
+	}
+	return out
+}
+
+func completeCanceledLookupResults(out []lookupAllWorldResult, worlds []*WorldConfig, err error) []lookupAllWorldResult {
+	if err == nil {
+		err = errors.New("lookup workers stopped before all worlds returned")
+	}
+	seen := make(map[string]bool, len(out))
+	for _, result := range out {
+		seen[result.world] = true
+	}
+	for _, world := range worlds {
+		if !seen[world.Name] {
+			out = append(out, lookupAllWorldResult{world: world.Name, err: err})
 		}
 	}
 	return out

--- a/tools/demarkus-broker/internal/broker/mcp_tools_lookup_all_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_lookup_all_test.go
@@ -1,0 +1,297 @@
+package broker
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/protocol"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestHandleMarkLookupAllMergesReadableWorlds(t *testing.T) {
+	cfg := mcpTestConfig()
+	cfg.Worlds = append(cfg.Worlds,
+		WorldConfig{Name: "team-b", Namespace: "team-b"},
+		WorldConfig{Name: "offline", Namespace: "offline"},
+	)
+	d := &fakeDispatcher{
+		lookupFn: func(world, _, _, _ string, _ fetch.LookupOptions) (fetch.Result, error) {
+			switch world {
+			case "team-a":
+				return lookupResult(
+					"| /auth\\|guide.md | 0.40 | Auth \\[Guide\\] | auth, guide |",
+					"| /architecture.md | 0.99 | Architecture | design |",
+				), nil
+			case "team-b":
+				return lookupResult(
+					"| /identity.md | 0.90 | Identity | auth |",
+					"| /sessions.md | 0.20 | Sessions | auth |",
+				), nil
+			default:
+				return fetch.Result{}, errors.New("dial timeout")
+			}
+		},
+	}
+	g := newGatewayWithDispatcher(t, cfg, d)
+
+	res, err := g.handleMarkLookupAll(withAliceClaims(context.Background()), callToolReq("mark_lookup_all", map[string]any{
+		"query":  "auth",
+		"scope":  "/docs/",
+		"filter": "tag=auth",
+		"limit":  float64(3),
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkLookupAll: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("isError = true: %+v", res.Content)
+	}
+	text := toolResultText(t, res)
+	for _, want := range []string{
+		"status: partial",
+		"worlds: 3",
+		"succeeded: 2",
+		"failed: 1",
+		"matches: 3",
+		"mark://team-a/auth%7Cguide.md",
+		`Auth \[Guide\]`,
+		"| offline | dial timeout |",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("response missing %q\nfull:\n%s", want, text)
+		}
+	}
+
+	// Rank is comparable across worlds; importance only breaks ties within
+	// the same rank. A second-ranked 0.99 result must follow both top hits.
+	positions := []int{
+		strings.Index(text, "mark://team-b/identity.md"),
+		strings.Index(text, "mark://team-a/auth%7Cguide.md"),
+		strings.Index(text, "mark://team-a/architecture.md"),
+	}
+	if positions[0] < 0 || positions[1] <= positions[0] || positions[2] <= positions[1] {
+		t.Errorf("unexpected merged order: %v\n%s", positions, text)
+	}
+	if strings.Contains(text, "mark://team-b/sessions.md") {
+		t.Errorf("global limit did not truncate fourth result:\n%s", text)
+	}
+
+	if len(d.lookupCalls) != 3 {
+		t.Fatalf("lookup dispatch count = %d, want 3", len(d.lookupCalls))
+	}
+	for _, call := range d.lookupCalls {
+		if call.scope != "/docs/" || call.query != "auth" || call.token != "" {
+			t.Errorf("dispatch = %+v", call)
+		}
+		if call.opts.Filter != "tag=auth" || call.opts.Limit != 3 {
+			t.Errorf("dispatch opts = %+v, want filter=tag=auth limit=3", call.opts)
+		}
+	}
+}
+
+func TestHandleMarkLookupAllReportsTotalFailure(t *testing.T) {
+	cfg := mcpTestConfig()
+	cfg.Worlds = append(cfg.Worlds, WorldConfig{Name: "team-b", Namespace: "team-b"})
+	d := &fakeDispatcher{
+		lookupFn: func(world, _, _, _ string, _ fetch.LookupOptions) (fetch.Result, error) {
+			return fetch.Result{}, errors.New("unreachable " + world)
+		},
+	}
+	g := newGatewayWithDispatcher(t, cfg, d)
+
+	res, err := g.handleMarkLookupAll(withAliceClaims(context.Background()), callToolReq("mark_lookup_all", map[string]any{
+		"query": "auth",
+	}))
+	if err != nil {
+		t.Fatalf("handleMarkLookupAll: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected tool error when every world fails")
+	}
+	text := toolResultText(t, res)
+	if !strings.Contains(text, "team-a: unreachable team-a; team-b: unreachable team-b") {
+		t.Errorf("failures are missing or nondeterministic:\n%s", text)
+	}
+}
+
+func TestHandleMarkLookupAllRejectsInvalidArguments(t *testing.T) {
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), &fakeDispatcher{})
+	tests := []struct {
+		name string
+		ctx  context.Context
+		args map[string]any
+	}{
+		{name: "missing identity", ctx: context.Background(), args: map[string]any{"query": "auth"}},
+		{name: "missing query", ctx: withAliceClaims(context.Background()), args: map[string]any{}},
+		{name: "relative scope", ctx: withAliceClaims(context.Background()), args: map[string]any{"query": "auth", "scope": "docs/"}},
+		{name: "control in scope", ctx: withAliceClaims(context.Background()), args: map[string]any{"query": "auth", "scope": "/docs/\nlimit: 1000"}},
+		{name: "zero limit", ctx: withAliceClaims(context.Background()), args: map[string]any{"query": "auth", "limit": float64(0)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := g.handleMarkLookupAll(tt.ctx, callToolReq("mark_lookup_all", tt.args))
+			if err != nil {
+				t.Fatalf("handleMarkLookupAll: %v", err)
+			}
+			if !res.IsError {
+				t.Fatal("expected tool error")
+			}
+		})
+	}
+}
+
+func TestHandleMarkLookupAllReturnsOnCancellation(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	d := &fakeDispatcher{
+		lookupFn: func(_, _, _, _ string, _ fetch.LookupOptions) (fetch.Result, error) {
+			close(started)
+			<-release
+			return lookupResult(), nil
+		},
+	}
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), d)
+	ctx, cancel := context.WithCancel(withAliceClaims(context.Background()))
+	type outcome struct {
+		result *mcp.CallToolResult
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		result, err := g.handleMarkLookupAll(ctx, callToolReq("mark_lookup_all", map[string]any{"query": "auth"}))
+		done <- outcome{result: result, err: err}
+	}()
+	<-started
+	cancel()
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("handleMarkLookupAll: %v", got.err)
+		}
+		if !got.result.IsError {
+			t.Fatal("expected canceled all-world lookup to return a tool error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("lookup waited for blocked world after cancellation")
+	}
+	close(release)
+}
+
+func TestHandleMarkLookupAllBoundsFanout(t *testing.T) {
+	cfg := mcpTestConfig()
+	for i := 1; i < lookupAllWorkers+4; i++ {
+		cfg.Worlds = append(cfg.Worlds, WorldConfig{Name: "team-" + strconv.Itoa(i), Namespace: "team"})
+	}
+	started := make(chan struct{}, len(cfg.Worlds))
+	release := make(chan struct{})
+	d := &fakeDispatcher{
+		lookupFn: func(_, _, _, _ string, _ fetch.LookupOptions) (fetch.Result, error) {
+			started <- struct{}{}
+			<-release
+			return lookupResult(), nil
+		},
+	}
+	g := newGatewayWithDispatcher(t, cfg, d)
+	type outcome struct {
+		result *mcp.CallToolResult
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		result, err := g.handleMarkLookupAll(withAliceClaims(context.Background()), callToolReq("mark_lookup_all", map[string]any{"query": "auth"}))
+		done <- outcome{result: result, err: err}
+	}()
+
+	for range lookupAllWorkers {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("lookup workers did not start")
+		}
+	}
+	select {
+	case <-started:
+		t.Fatalf("more than %d lookups ran concurrently", lookupAllWorkers)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("handleMarkLookupAll: %v", got.err)
+		}
+		if got.result.IsError {
+			t.Fatalf("isError = true: %+v", got.result.Content)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("lookup did not finish after workers were released")
+	}
+}
+
+func TestHandleMarkLookupAllAppliesGlobalLimitBounds(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		args  map[string]any
+		limit int
+	}{
+		{name: "default", args: map[string]any{"query": "auth"}, limit: defaultLookupAllLimit},
+		{name: "cap", args: map[string]any{"query": "auth", "limit": float64(2000)}, limit: maxLookupAllResults},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var got int
+			d := &fakeDispatcher{
+				lookupFn: func(_, _, _, _ string, opts fetch.LookupOptions) (fetch.Result, error) {
+					got = opts.Limit
+					return lookupResult(), nil
+				},
+			}
+			g := newGatewayWithDispatcher(t, mcpTestConfig(), d)
+			result, err := g.handleMarkLookupAll(withAliceClaims(context.Background()), callToolReq("mark_lookup_all", tt.args))
+			if err != nil || result.IsError {
+				t.Fatalf("handleMarkLookupAll: result=%+v err=%v", result, err)
+			}
+			if got != tt.limit {
+				t.Errorf("world limit = %d, want %d", got, tt.limit)
+			}
+		})
+	}
+}
+
+func TestParseLookupAllMatchesRejectsMetadataDrift(t *testing.T) {
+	result := lookupResult("| /auth.md | 0.90 | Auth | auth |")
+	result.Response.Metadata["matches"] = "2"
+	if _, err := parseLookupAllMatches("team-a", result); err == nil {
+		t.Fatal("expected malformed response error")
+	}
+}
+
+func TestParseLookupAllMatchesRejectsOutOfRangeImportance(t *testing.T) {
+	result := lookupResult("| /auth.md | 1.10 | Auth | auth |")
+	if _, err := parseLookupAllMatches("team-a", result); err == nil {
+		t.Fatal("expected malformed response error")
+	}
+}
+
+func TestQualifiedLookupURLEncodesReservedPathBytes(t *testing.T) {
+	got := qualifiedLookupURL("team-a", "/docs/a #?%.md")
+	if want := "mark://team-a/docs/a%20%23%3F%25.md"; got != want {
+		t.Errorf("qualifiedLookupURL = %q, want %q", got, want)
+	}
+}
+
+func lookupResult(rows ...string) fetch.Result {
+	body := "\n# Lookup matches\n\n| Path | Importance | Title | Tags |\n|------|------------|-------|------|\n"
+	if len(rows) > 0 {
+		body += strings.Join(rows, "\n") + "\n"
+	}
+	return fetch.Result{Response: protocol.Response{
+		Status:   protocol.StatusOK,
+		Metadata: map[string]string{"matches": strconv.Itoa(len(rows))},
+		Body:     body,
+	}}
+}

--- a/tools/demarkus-broker/internal/broker/mcp_tools_lookup_all_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_lookup_all_test.go
@@ -149,10 +149,14 @@ func TestHandleMarkLookupAllReturnsOnCancellation(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
 	d := &fakeDispatcher{
-		lookupFn: func(_, _, _, _ string, _ fetch.LookupOptions) (fetch.Result, error) {
+		lookupCtxFn: func(ctx context.Context, _, _, _, _ string, _ fetch.LookupOptions) (fetch.Result, error) {
 			close(started)
-			<-release
-			return lookupResult(), nil
+			select {
+			case <-release:
+				return lookupResult(), nil
+			case <-ctx.Done():
+				return fetch.Result{}, ctx.Err()
+			}
 		},
 	}
 	g := newGatewayWithDispatcher(t, mcpTestConfig(), d)

--- a/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
@@ -29,6 +29,7 @@ type fakeDispatcher struct {
 	listFn      func(worldName, path, token string) (fetch.Result, error)
 	versionsFn  func(worldName, path, token string) (fetch.Result, error)
 	lookupFn    func(worldName, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error)
+	lookupCtxFn func(ctx context.Context, worldName, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error)
 	publishFn   func(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
 	appendFn    func(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
 	archiveFn   func(worldName, path, token string) (fetch.Result, error)
@@ -126,10 +127,22 @@ func (f *fakeDispatcher) Versions(worldName, path, token string) (fetch.Result, 
 }
 
 func (f *fakeDispatcher) Lookup(worldName, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error) {
+	return f.lookup(context.Background(), worldName, scope, query, token, opts, false)
+}
+
+func (f *fakeDispatcher) LookupContext(ctx context.Context, worldName, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error) {
+	return f.lookup(ctx, worldName, scope, query, token, opts, true)
+}
+
+func (f *fakeDispatcher) lookup(ctx context.Context, worldName, scope, query, token string, opts fetch.LookupOptions, contextAware bool) (fetch.Result, error) {
 	f.mu.Lock()
 	f.lookupCalls = append(f.lookupCalls, lookupCall{worldName, scope, query, token, opts})
 	fn := f.lookupFn
+	ctxFn := f.lookupCtxFn
 	f.mu.Unlock()
+	if contextAware && ctxFn != nil {
+		return ctxFn(ctx, worldName, scope, query, token, opts)
+	}
 	if fn == nil {
 		return fetch.Result{Response: protocol.Response{
 			Status:   protocol.StatusOK,

--- a/tools/demarkus-broker/internal/broker/world_pool.go
+++ b/tools/demarkus-broker/internal/broker/world_pool.go
@@ -1,6 +1,7 @@
 package broker
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -26,6 +27,7 @@ type worldDispatcher interface {
 	List(worldName, path, token string, opts fetch.ListOptions) (fetch.Result, error)
 	Versions(worldName, path, token string) (fetch.Result, error)
 	Lookup(worldName, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error)
+	LookupContext(ctx context.Context, worldName, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error)
 	Publish(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
 	Append(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
 	Archive(worldName, path, token string) (fetch.Result, error)
@@ -151,6 +153,14 @@ func (p *worldPool) Lookup(worldName, scope, query, token string, opts fetch.Loo
 		return fetch.Result{}, err
 	}
 	return c.Lookup(host, scope, query, token, opts)
+}
+
+func (p *worldPool) LookupContext(ctx context.Context, worldName, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error) {
+	c, host, err := p.clientFor(worldName)
+	if err != nil {
+		return fetch.Result{}, err
+	}
+	return c.LookupContext(ctx, host, scope, query, token, opts)
 }
 
 // Publish dispatches a PUBLISH against worldName. Byte-for-byte


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added cross-world search across all readable worlds.
  - Results are combined, ranked, and limited to the requested number.
  - Responses include world-qualified links and details about worlds that could not be searched.
  - Added validation for search queries, scopes, limits, and result metadata.
  - Search operations now support cancellation and stop promptly when canceled.

- **Documentation**
  - Updated MCP API documentation for the expanded 17-tool surface, access behavior, cross-world search, limits, concurrency, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->