### PR TITLE
feat(client): add atomic sharded hash index publishing and resolution

### DIFF
--- a/client/cmd/demarkus-agent/main.go
+++ b/client/cmd/demarkus-agent/main.go
@@ -80,7 +80,7 @@ func crawlMain(args []string) {
 	publish := fs.Bool("publish", false, "publish indexes to hubs after crawl")
 	perServer := fs.Bool("per-server", false, "publish per-server indexes instead of aggregated")
 	publishGraph := fs.Bool("publish-graph", false, "publish a link-graph export (/graph.md) to hubs after crawl")
-	publishRetention := fs.Int("publish-retention", -1, "cap published artifacts (/graph.md, hash indexes) to their newest N versions; the server prunes older ones on write; 0 keeps every version; -1 uses the config value (default 20)")
+	publishRetention := fs.Int("publish-retention", -1, "cap /graph.md and hash-index manifest histories to their newest N versions; version-pinned shards stay unpruned; 0 keeps every version; -1 uses the config value (default 20)")
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: demarkus-agent crawl [options]\n\n")
 		fmt.Fprintf(os.Stderr, "Runs a single federation crawl.\n\n")
@@ -205,7 +205,7 @@ func daemonMain(args []string) {
 	publish := fs.Bool("publish", false, "publish indexes to hubs after each crawl")
 	perServer := fs.Bool("per-server", false, "publish per-server indexes instead of aggregated")
 	publishGraph := fs.Bool("publish-graph", false, "publish a link-graph export (/graph.md) to hubs after each crawl")
-	publishRetention := fs.Int("publish-retention", -1, "cap published artifacts (/graph.md, hash indexes) to their newest N versions; the server prunes older ones on write; 0 keeps every version; -1 uses the config value (default 20)")
+	publishRetention := fs.Int("publish-retention", -1, "cap /graph.md and hash-index manifest histories to their newest N versions; version-pinned shards stay unpruned; 0 keeps every version; -1 uses the config value (default 20)")
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: demarkus-agent daemon [options]\n\n")
 		fmt.Fprintf(os.Stderr, "Runs federation crawl as a daemon on a schedule.\n\n")

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -100,12 +100,14 @@ func main() {
 // markClient defines the fetch operations used by MCP tool handlers.
 type markClient interface {
 	Fetch(host, path, token string) (fetch.Result, error)
+	FetchContext(ctx context.Context, host, path, token string) (fetch.Result, error)
 	FetchConditional(host, path, token, etag string) (fetch.Result, error)
 	List(host, path, token string) (fetch.Result, error)
 	ListWithOptions(host, path, token string, opts fetch.ListOptions) (fetch.Result, error)
 	Versions(host, path, token string) (fetch.Result, error)
 	Lookup(host, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error)
 	Publish(host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
+	PublishContext(ctx context.Context, host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
 	Append(host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
 	Archive(host, path, token string) (fetch.Result, error)
 }
@@ -1211,14 +1213,15 @@ func (h *handler) markIndex(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 		warnings = append(warnings, fmt.Sprintf("warning: index truncated at %d documents, some content may not be indexed", maxIndexDocuments))
 	}
 
-	body := index.Build(sourceScheme, timeNow(), entries)
+	indexedAt := timeNow()
+	body := index.Build(sourceScheme, indexedAt, entries)
 
 	if dryRun {
 		var b strings.Builder
 		for _, w := range warnings {
 			b.WriteString(w + "\n")
 		}
-		fmt.Fprintf(&b, "Indexed %d documents from %s (dry run, not published)\n\n", len(entries), sourceScheme)
+		fmt.Fprintf(&b, "Indexed %d documents from %s (dry run, logical entry preview only; publication writes a v2 manifest and shards)\n\n", len(entries), sourceScheme)
 		b.WriteString(body)
 		return mcp.NewToolResultText(b.String()), nil
 	}
@@ -1256,14 +1259,14 @@ func (h *handler) markIndex(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 	publishResult, err := index.PublishGeneration(ctx, index.PublishOptions{
 		ManifestPath:            targetPath,
 		Source:                  manifestSource,
-		Indexed:                 timeNow(),
+		Indexed:                 indexedAt,
 		Entries:                 logicalEntries,
 		ExpectedManifestVersion: &expectedVersion,
-	}, func(docPath string) (protocol.Response, error) {
-		result, err := h.client.Fetch(targetHost, docPath, h.resolveToken(targetHost))
+	}, func(ioCtx context.Context, docPath string) (protocol.Response, error) {
+		result, err := h.client.FetchContext(ioCtx, targetHost, docPath, h.resolveToken(targetHost))
 		return result.Response, err
-	}, func(docPath, body string, expected int) (protocol.Response, error) {
-		result, err := h.client.Publish(targetHost, docPath, body, token, expected, agentMeta(ctx))
+	}, func(ioCtx context.Context, docPath, body string, expected int) (protocol.Response, error) {
+		result, err := h.client.PublishContext(ioCtx, targetHost, docPath, body, token, expected, agentMeta(ctx))
 		return result.Response, err
 	})
 	if err != nil {

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -490,7 +490,8 @@ func markIndexTool(host string) mcp.Tool {
 	return mcp.NewTool("mark_index",
 		mcp.WithDescription(
 			"Crawl a Mark Protocol server, collect content hashes from all documents, "+
-				"and publish a hash index document to a target server (typically a hub). "+
+				"and publish a sharded hash index to a target server (typically a hub). "+
+				"Publishing requires read access and publish access to the manifest and its sibling .shards subtree. "+
 				"The tool checks the target's agent manifest before publishing. "+
 				urlHint(host),
 		),
@@ -1070,9 +1071,11 @@ func (h *handler) markResolve(_ context.Context, req mcp.CallToolRequest) (*mcp.
 	if err != nil {
 		return mcp.NewToolResultError("hash is required"), nil
 	}
-	if _, ok := protocol.IsHashPath(hash); !ok {
+	cleanHash, ok := protocol.IsHashPath(hash)
+	if !ok {
 		return mcp.NewToolResultError("invalid hash format: expected sha256-<64 lowercase hex characters>"), nil
 	}
+	hash = cleanHash
 
 	indexURL, err := req.RequireString("index")
 	if err != nil {
@@ -1093,13 +1096,13 @@ func (h *handler) markResolve(_ context.Context, req mcp.CallToolRequest) (*mcp.
 		return mcp.NewToolResultError(fmt.Sprintf("index fetch returned: %s", indexResult.Response.Status)), nil
 	}
 
-	// Parse index and filter for matching hash.
-	entries := index.Parse(indexResult.Response.Body)
-	var matches []index.Entry
-	for _, e := range entries {
-		if e.Hash == hash {
-			matches = append(matches, e)
-		}
+	// V2 manifests fetch only matching prefix shards; legacy indexes stay inline.
+	matches, err := index.EntriesForHash(indexPath, indexResult.Response.Body, hash, func(shardPath string) (protocol.Response, error) {
+		result, err := h.client.Fetch(indexHost, shardPath, h.resolveToken(indexHost))
+		return result.Response, err
+	})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid index: %v", err)), nil
 	}
 	if len(matches) == 0 {
 		return mcp.NewToolResultError(fmt.Sprintf("hash %s not found in index", hash)), nil
@@ -1228,7 +1231,9 @@ func (h *handler) markIndex(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 		return mcp.NewToolResultError("publishing requires a token (-token flag, DEMARKUS_AUTH env var, or stored via 'demarkus token add')"), nil
 	}
 
-	// Merge with existing index if updating.
+	manifestSource := sourceScheme
+	logicalEntries := entries
+	// Merge with an existing legacy index or verified sharded generation.
 	if expectedVersion > 0 {
 		existing, err := h.client.Fetch(targetHost, targetPath, h.resolveToken(targetHost))
 		if err != nil {
@@ -1237,14 +1242,30 @@ func (h *handler) markIndex(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 		if existing.Response.Status != protocol.StatusOK {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to fetch existing index: %s", existing.Response.Status)), nil
 		}
-		existingEntries := index.Parse(existing.Response.Body)
-		merged := index.Merge(existingEntries, sourceScheme, entries)
-		// Use the target as source header since this is now an aggregated index.
-		targetScheme := "mark://" + targetHost
-		body = index.Build(targetScheme, timeNow(), merged)
+		existingEntries, err := index.LoadEntries(targetPath, existing.Response.Body, func(shardPath string) (protocol.Response, error) {
+			result, err := h.client.Fetch(targetHost, shardPath, h.resolveToken(targetHost))
+			return result.Response, err
+		})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to read existing index: %v", err)), nil
+		}
+		logicalEntries = index.Merge(existingEntries, sourceScheme, entries)
+		manifestSource = "mark://" + targetHost
 	}
 
-	result, err := h.client.Publish(targetHost, targetPath, body, token, expectedVersion, agentMeta(ctx))
+	publishResult, err := index.PublishGeneration(ctx, index.PublishOptions{
+		ManifestPath:            targetPath,
+		Source:                  manifestSource,
+		Indexed:                 timeNow(),
+		Entries:                 logicalEntries,
+		ExpectedManifestVersion: &expectedVersion,
+	}, func(docPath string) (protocol.Response, error) {
+		result, err := h.client.Fetch(targetHost, docPath, h.resolveToken(targetHost))
+		return result.Response, err
+	}, func(docPath, body string, expected int) (protocol.Response, error) {
+		result, err := h.client.Publish(targetHost, docPath, body, token, expected, agentMeta(ctx))
+		return result.Response, err
+	})
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("publish failed: %v", err)), nil
 	}
@@ -1254,7 +1275,8 @@ func (h *handler) markIndex(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 		b.WriteString(w + "\n")
 	}
 	fmt.Fprintf(&b, "Indexed %d documents from %s\n", len(entries), sourceScheme)
-	b.WriteString(formatResult(result, "version", "modified"))
+	fmt.Fprintf(&b, "status: ok\nversion: %d\nshards-published: %d\nshards-reused: %d\n",
+		publishResult.ManifestVersion, publishResult.ShardsPublished, publishResult.ShardsReused)
 	return mcp.NewToolResultText(b.String()), nil
 }
 

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -1238,7 +1238,7 @@ func (h *handler) markIndex(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 	logicalEntries := entries
 	// Merge with an existing legacy index or verified sharded generation.
 	if expectedVersion > 0 {
-		existing, err := h.client.Fetch(targetHost, targetPath, h.resolveToken(targetHost))
+		existing, err := h.client.FetchContext(ctx, targetHost, targetPath, h.resolveToken(targetHost))
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to fetch existing index: %v", err)), nil
 		}
@@ -1246,7 +1246,7 @@ func (h *handler) markIndex(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 			return mcp.NewToolResultError(fmt.Sprintf("failed to fetch existing index: %s", existing.Response.Status)), nil
 		}
 		existingEntries, err := index.LoadEntries(targetPath, existing.Response.Body, func(shardPath string) (protocol.Response, error) {
-			result, err := h.client.Fetch(targetHost, shardPath, h.resolveToken(targetHost))
+			result, err := h.client.FetchContext(ctx, targetHost, shardPath, h.resolveToken(targetHost))
 			return result.Response, err
 		})
 		if err != nil {

--- a/client/cmd/demarkus-mcp/main_test.go
+++ b/client/cmd/demarkus-mcp/main_test.go
@@ -575,6 +575,13 @@ func (s *stubClient) Fetch(host, path, token string) (fetch.Result, error) {
 	return fetch.Result{}, nil
 }
 
+func (s *stubClient) FetchContext(ctx context.Context, host, path, token string) (fetch.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return fetch.Result{}, err
+	}
+	return s.Fetch(host, path, token)
+}
+
 func (s *stubClient) FetchConditional(host, path, token, etag string) (fetch.Result, error) {
 	if s.fetchCondFn != nil {
 		return s.fetchCondFn(host, path, token, etag)
@@ -617,6 +624,19 @@ func (s *stubClient) Publish(host, path, body, token string, expectedVersion int
 			}
 			stored := fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: body, Metadata: metadata}}
 			s.mu.Lock()
+			currentVersion := 0
+			current, exists := s.published[host+path]
+			if exists {
+				currentVersion, versionErr = strconv.Atoi(current.Response.Metadata["version"])
+				if versionErr != nil {
+					s.mu.Unlock()
+					return fetch.Result{}, fmt.Errorf("invalid stub version: %w", versionErr)
+				}
+			}
+			if expectedVersion >= 0 && expectedVersion != currentVersion {
+				s.mu.Unlock()
+				return fetch.Result{Response: protocol.Response{Status: protocol.StatusConflict}}, nil
+			}
 			if s.published == nil {
 				s.published = make(map[string]fetch.Result)
 			}
@@ -627,6 +647,13 @@ func (s *stubClient) Publish(host, path, body, token string, expectedVersion int
 		return result, nil
 	}
 	return fetch.Result{}, nil
+}
+
+func (s *stubClient) PublishContext(ctx context.Context, host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return fetch.Result{}, err
+	}
+	return s.Publish(host, path, body, token, expectedVersion, meta)
 }
 func (s *stubClient) Archive(_, _, _ string) (fetch.Result, error) {
 	return fetch.Result{}, nil
@@ -1883,6 +1910,9 @@ func TestHandlerMarkPublish_OnConflictMergeFirstTrySuccess(t *testing.T) {
 	// When the initial publish succeeds, the merge path returns a plain
 	// success — no candidate, no markers, no diff3 invoked.
 	sc := &stubClient{
+		published: map[string]fetch.Result{
+			"example.com:6309/doc.md": {Response: protocol.Response{Status: protocol.StatusOK, Metadata: map[string]string{"version": "5"}}},
+		},
 		publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
 			return fetch.Result{Response: protocol.Response{
 				Status:   protocol.StatusCreated,
@@ -1918,6 +1948,9 @@ func TestHandlerMarkPublish_OnConflictMergeFirstTrySuccess_PreservesAllMetadata(
 	// metadata key the server returned should reach the agent, just like a
 	// plain mark_publish would do via formatResult.
 	sc := &stubClient{
+		published: map[string]fetch.Result{
+			"example.com:6309/doc.md": {Response: protocol.Response{Status: protocol.StatusOK, Metadata: map[string]string{"version": "5"}}},
+		},
 		publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
 			return fetch.Result{Response: protocol.Response{
 				Status: protocol.StatusCreated,

--- a/client/cmd/demarkus-mcp/main_test.go
+++ b/client/cmd/demarkus-mcp/main_test.go
@@ -6,13 +6,16 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"path/filepath"
 
 	"github.com/latebit-io/demarkus/client/fetch"
 	"github.com/latebit-io/demarkus/client/graph"
 	"github.com/latebit-io/demarkus/client/graphstore"
+	"github.com/latebit-io/demarkus/client/index"
 	"github.com/latebit-io/demarkus/client/links"
 	"github.com/latebit-io/demarkus/protocol"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -547,6 +550,8 @@ func TestHandlerMarkAppend_NoToken(t *testing.T) {
 
 // stubClient is a mock markClient for testing handler logic.
 type stubClient struct {
+	mu          sync.Mutex
+	published   map[string]fetch.Result
 	fetchFn     func(host, path, token string) (fetch.Result, error)
 	fetchCondFn func(host, path, token, etag string) (fetch.Result, error)
 	listFn      func(host, path, token string) (fetch.Result, error)
@@ -558,6 +563,12 @@ type stubClient struct {
 }
 
 func (s *stubClient) Fetch(host, path, token string) (fetch.Result, error) {
+	s.mu.Lock()
+	stored, ok := s.published[host+path]
+	s.mu.Unlock()
+	if ok {
+		return stored, nil
+	}
 	if s.fetchFn != nil {
 		return s.fetchFn(host, path, token)
 	}
@@ -594,7 +605,26 @@ func (s *stubClient) ListWithOptions(host, path, token string, opts fetch.ListOp
 }
 func (s *stubClient) Publish(host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error) {
 	if s.publishFn != nil {
-		return s.publishFn(host, path, body, token, expectedVersion, meta)
+		result, err := s.publishFn(host, path, body, token, expectedVersion, meta)
+		if err != nil || (result.Response.Status != protocol.StatusOK && result.Response.Status != protocol.StatusCreated) {
+			return result, err
+		}
+		version, versionErr := strconv.Atoi(result.Response.Metadata["version"])
+		if versionErr == nil && version > 0 {
+			metadata := map[string]string{
+				"version":      strconv.Itoa(version),
+				"content-hash": index.BodyHash(body),
+			}
+			stored := fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: body, Metadata: metadata}}
+			s.mu.Lock()
+			if s.published == nil {
+				s.published = make(map[string]fetch.Result)
+			}
+			s.published[host+path] = stored
+			s.published[host+index.VersionPath(path, version)] = stored
+			s.mu.Unlock()
+		}
+		return result, nil
 	}
 	return fetch.Result{}, nil
 }
@@ -864,6 +894,61 @@ func TestHandlerMarkResolve_Success(t *testing.T) {
 	}
 }
 
+func TestHandlerMarkResolve_SharedManifest(t *testing.T) {
+	hash := "sha256-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	otherHash := "sha256-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	artifacts, err := index.BuildShards("/index.md", index.SlotA, []index.Entry{
+		{Hash: hash, Server: "mark://docs.example.com", Path: "/guide.md"},
+		{Hash: otherHash, Server: "mark://other.example.com", Path: "/other.md"},
+	}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := make([]index.ShardRef, len(artifacts))
+	shards := make(map[string]fetch.Result)
+	for i, artifact := range artifacts {
+		version := i + 1
+		refs[i] = artifact.Ref(version)
+		shards[index.VersionPath(artifact.Path, version)] = fetch.Result{Response: protocol.Response{
+			Status: protocol.StatusOK, Body: artifact.Body,
+			Metadata: map[string]string{"version": strconv.Itoa(version), "content-hash": artifact.ContentHash},
+		}}
+	}
+	manifest, err := index.BuildManifest("/index.md", index.Manifest{
+		Source: "aggregated", Indexed: time.Now(), Complete: true,
+		Documents: 2, ActiveSlot: index.SlotA, Shards: refs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	shardFetches := 0
+	h := &handler{client: &stubClient{fetchFn: func(_, path, _ string) (fetch.Result, error) {
+		if path == "/index.md" {
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: manifest}}, nil
+		}
+		if shard, ok := shards[path]; ok {
+			shardFetches++
+			return shard, nil
+		}
+		if path == "/"+hash {
+			return fetch.Result{Response: protocol.Response{
+				Status: protocol.StatusOK, Body: "# Guide",
+				Metadata: map[string]string{"content-hash": hash, "version": "1"},
+			}}, nil
+		}
+		return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+	}}}
+	result, err := h.markResolve(t.Context(), newCallToolRequest(map[string]any{
+		"hash": hash, "index": "mark://hub.example.com/index.md",
+	}))
+	if err != nil || result.IsError {
+		t.Fatalf("markResolve = (%+v, %v)", result, err)
+	}
+	if shardFetches != 1 {
+		t.Fatalf("shard fetches = %d, want 1", shardFetches)
+	}
+}
+
 func TestHandlerMarkResolve_Fallback(t *testing.T) {
 	hash := "sha256-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
 	indexBody := "| Hash | Server | Path |\n|------|--------|------|\n" +
@@ -944,15 +1029,19 @@ func TestHandlerMarkResolve_InvalidHash(t *testing.T) {
 
 func TestHandlerMarkIndex_Success(t *testing.T) {
 	hash := "sha256-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
-	var publishedBody string
+	var publishedBodies []string
+	var publishedPaths []string
 
 	sc := &stubClient{
-		fetchFn: func(_, path, _ string) (fetch.Result, error) {
+		fetchFn: func(host, path, _ string) (fetch.Result, error) {
 			if path == protocol.WellKnownManifestPath {
 				return fetch.Result{Response: protocol.Response{
 					Status: protocol.StatusOK,
 					Body:   "# Agent Manifest\nThis is a hub.",
 				}}, nil
+			}
+			if host == "hub.com:6309" {
+				return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
 			}
 			return fetch.Result{Response: protocol.Response{
 				Status:   protocol.StatusOK,
@@ -969,8 +1058,12 @@ func TestHandlerMarkIndex_Success(t *testing.T) {
 			}
 			return fetch.Result{Response: protocol.Response{Status: "not-found"}}, nil
 		},
-		publishFn: func(_, _, body, _ string, _ int, _ map[string]string) (fetch.Result, error) {
-			publishedBody = body
+		publishFn: func(_, path, body, _ string, expectedVersion int, _ map[string]string) (fetch.Result, error) {
+			publishedBodies = append(publishedBodies, body)
+			publishedPaths = append(publishedPaths, path)
+			if expectedVersion != 0 {
+				t.Errorf("publish %s expected_version = %d, want 0", path, expectedVersion)
+			}
 			return fetch.Result{Response: protocol.Response{
 				Status:   "created",
 				Metadata: map[string]string{"version": "1"},
@@ -990,11 +1083,15 @@ func TestHandlerMarkIndex_Success(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected tool error: %v", result.Content)
 	}
-	if !strings.Contains(publishedBody, hash) {
+	published := strings.Join(publishedBodies, "\n")
+	if !strings.Contains(published, hash) {
 		t.Error("published index should contain the content hash")
 	}
-	if !strings.Contains(publishedBody, "/doc.md") {
+	if !strings.Contains(published, "/doc.md") {
 		t.Error("published index should contain the document path")
+	}
+	if len(publishedPaths) != 2 || publishedPaths[1] != "/indexes/source.md" {
+		t.Errorf("publish paths = %v, want shard then manifest", publishedPaths)
 	}
 }
 
@@ -1049,9 +1146,12 @@ func TestHandlerMarkIndex_DryRun(t *testing.T) {
 
 func TestHandlerMarkIndex_BlocksWithoutManifest(t *testing.T) {
 	sc := &stubClient{
-		fetchFn: func(_, path, _ string) (fetch.Result, error) {
+		fetchFn: func(host, path, _ string) (fetch.Result, error) {
 			if path == protocol.WellKnownManifestPath {
 				return fetch.Result{Response: protocol.Response{Status: "not-found"}}, nil
+			}
+			if host == "hub.com:6309" {
+				return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
 			}
 			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK}}, nil
 		},
@@ -1074,9 +1174,12 @@ func TestHandlerMarkIndex_BlocksWithoutManifest(t *testing.T) {
 
 func TestHandlerMarkIndex_ForceOverridesManifest(t *testing.T) {
 	sc := &stubClient{
-		fetchFn: func(_, path, _ string) (fetch.Result, error) {
+		fetchFn: func(host, path, _ string) (fetch.Result, error) {
 			if path == protocol.WellKnownManifestPath {
 				return fetch.Result{Response: protocol.Response{Status: "not-found"}}, nil
+			}
+			if host == "hub.com:6309" {
+				return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
 			}
 			return fetch.Result{Response: protocol.Response{
 				Status:   protocol.StatusOK,
@@ -1127,6 +1230,9 @@ func TestHandlerMarkIndex_SourceNoManifestWarns(t *testing.T) {
 				}
 				// Target has manifest.
 				return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: "# Hub"}}, nil
+			}
+			if host == "hub.com:6309" {
+				return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
 			}
 			return fetch.Result{Response: protocol.Response{
 				Status:   protocol.StatusOK,

--- a/client/fetch/fetch.go
+++ b/client/fetch/fetch.go
@@ -140,7 +140,12 @@ func (c *Client) Close() {
 // Fetch retrieves a document from a Mark Protocol server.
 // If token is non-empty, it is sent as the auth metadata for read access to private paths.
 func (c *Client) Fetch(host, path, token string) (Result, error) {
-	return c.cachedRequest(host, path, token, protocol.VerbFetch)
+	return c.FetchContext(context.Background(), host, path, token)
+}
+
+// FetchContext is Fetch with caller cancellation propagated through network I/O.
+func (c *Client) FetchContext(ctx context.Context, host, path, token string) (Result, error) {
+	return c.cachedRequestMetaContext(ctx, host, path, token, protocol.VerbFetch, nil)
 }
 
 // FetchConditional is Fetch with an explicit if-none-match etag, for callers
@@ -257,6 +262,11 @@ func (c *Client) Versions(host, path, token string) (Result, error) {
 //   - 0: create-only (server rejects if document already exists)
 //   - > 0: update-only (server rejects if current version doesn't match)
 func (c *Client) Publish(host, path, body, token string, expectedVersion int, meta map[string]string) (Result, error) {
+	return c.PublishContext(context.Background(), host, path, body, token, expectedVersion, meta)
+}
+
+// PublishContext is Publish with caller cancellation propagated through network I/O.
+func (c *Client) PublishContext(ctx context.Context, host, path, body, token string, expectedVersion int, meta map[string]string) (Result, error) {
 	req := protocol.Request{Verb: protocol.VerbPublish, Path: path, Metadata: make(map[string]string), Body: body}
 	maps.Copy(req.Metadata, meta)
 	if token != "" {
@@ -265,8 +275,8 @@ func (c *Client) Publish(host, path, body, token string, expectedVersion int, me
 	if expectedVersion >= 0 {
 		req.Metadata["expected-version"] = strconv.Itoa(expectedVersion)
 	}
-	return c.doWithRetry(host, func(conn *quic.Conn) (Result, error) {
-		return c.requestOnConn(conn, req)
+	return c.doWithRetryContext(ctx, host, func(conn *quic.Conn) (Result, error) {
+		return c.requestOnConnContext(ctx, conn, req)
 	})
 }
 
@@ -337,18 +347,14 @@ func (c *Client) Archive(host, path, token string) (Result, error) {
 	})
 }
 
-// cachedRequest handles FETCH and LIST with conditional caching.
-func (c *Client) cachedRequest(host, path, token, verb string) (Result, error) {
-	return c.cachedRequestMeta(host, path, token, verb, nil)
+// cachedRequestMeta handles cacheable reads with optional request metadata.
+// Extra metadata bypasses caching because cache keys do not include it.
+func (c *Client) cachedRequestMeta(host, path, token, verb string, extra map[string]string) (Result, error) {
+	return c.cachedRequestMetaContext(context.Background(), host, path, token, verb, extra)
 }
 
-// cachedRequestMeta is cachedRequest with extra request metadata (e.g. LIST
-// options). When extra is non-empty the response cache is bypassed: the cache
-// key is (host, path, verb) and does not encode the extra metadata, so a
-// cached option-free response must not satisfy an option-bearing request, nor
-// the reverse.
-func (c *Client) cachedRequestMeta(host, path, token, verb string, extra map[string]string) (Result, error) {
-	return c.doWithRetry(host, func(conn *quic.Conn) (Result, error) {
+func (c *Client) cachedRequestMetaContext(ctx context.Context, host, path, token, verb string, extra map[string]string) (Result, error) {
+	return c.doWithRetryContext(ctx, host, func(conn *quic.Conn) (Result, error) {
 		req := protocol.Request{Verb: verb, Path: path, Metadata: make(map[string]string)}
 
 		if token != "" {
@@ -374,7 +380,7 @@ func (c *Client) cachedRequestMeta(host, path, token, verb string, extra map[str
 			}
 		}
 
-		result, err := c.requestOnConn(conn, req)
+		result, err := c.requestOnConnContext(ctx, conn, req)
 		if err != nil {
 			return Result{}, err
 		}

--- a/client/index/publish.go
+++ b/client/index/publish.go
@@ -30,18 +30,15 @@ type PublishResult struct {
 }
 
 // FetchDocument fetches one generated index document by absolute path.
-type FetchDocument func(path string) (protocol.Response, error)
+type FetchDocument func(ctx context.Context, path string) (protocol.Response, error)
 
 // PublishDocument publishes one generated document with optimistic concurrency.
-type PublishDocument func(path, body string, expectedVersion int) (protocol.Response, error)
+type PublishDocument func(ctx context.Context, path, body string, expectedVersion int) (protocol.Response, error)
 
 // PublishGeneration stages an inactive shard slot, verifies every shard, then
 // commits the manifest last with CAS. A manifest failure leaves the old slot live.
 func PublishGeneration(ctx context.Context, opts PublishOptions, fetchDocument FetchDocument, publishDocument PublishDocument) (PublishResult, error) { //nolint:gocritic // options are copied so callers cannot mutate an active publication
-	if err := ctx.Err(); err != nil {
-		return PublishResult{}, err
-	}
-	currentVersion, activeSlot, err := fetchCurrentManifest(opts.ManifestPath, fetchDocument)
+	currentVersion, activeSlot, err := fetchCurrentManifest(ctx, opts.ManifestPath, fetchDocument)
 	if err != nil {
 		return PublishResult{}, err
 	}
@@ -56,10 +53,7 @@ func PublishGeneration(ctx context.Context, opts PublishOptions, fetchDocument F
 	refs := make([]ShardRef, 0, len(artifacts))
 	result := PublishResult{}
 	for _, artifact := range artifacts {
-		if err := ctx.Err(); err != nil {
-			return PublishResult{}, err
-		}
-		ref, published, err := stageShard(artifact, fetchDocument, publishDocument)
+		ref, published, err := stageShard(ctx, artifact, fetchDocument, publishDocument)
 		if err != nil {
 			return PublishResult{}, err
 		}
@@ -79,10 +73,7 @@ func PublishGeneration(ctx context.Context, opts PublishOptions, fetchDocument F
 	if err != nil {
 		return PublishResult{}, err
 	}
-	if err := ctx.Err(); err != nil {
-		return PublishResult{}, err
-	}
-	verified, manifestVersion, err := publishAndVerify(opts.ManifestPath, manifestBody, currentVersion, fetchDocument, publishDocument)
+	verified, manifestVersion, err := publishAndVerify(ctx, opts.ManifestPath, manifestBody, currentVersion, fetchDocument, publishDocument)
 	if err != nil {
 		return PublishResult{}, err
 	}
@@ -96,8 +87,8 @@ func PublishGeneration(ctx context.Context, opts PublishOptions, fetchDocument F
 	return result, nil
 }
 
-func fetchCurrentManifest(manifestPath string, fetchDocument FetchDocument) (version int, activeSlot string, err error) {
-	current, err := fetchDocument(manifestPath)
+func fetchCurrentManifest(ctx context.Context, manifestPath string, fetchDocument FetchDocument) (version int, activeSlot string, err error) {
+	current, err := fetchDocument(ctx, manifestPath)
 	if err != nil {
 		return 0, "", fmt.Errorf("fetch manifest %s: %w", manifestPath, err)
 	}
@@ -135,8 +126,8 @@ func fetchCurrentManifest(manifestPath string, fetchDocument FetchDocument) (ver
 	}
 }
 
-func stageShard(artifact ShardArtifact, fetchDocument FetchDocument, publishDocument PublishDocument) (ShardRef, bool, error) { //nolint:gocritic // immutable publication value
-	current, err := fetchDocument(artifact.Path)
+func stageShard(ctx context.Context, artifact ShardArtifact, fetchDocument FetchDocument, publishDocument PublishDocument) (ShardRef, bool, error) { //nolint:gocritic // immutable publication value
+	current, err := fetchDocument(ctx, artifact.Path)
 	if err != nil {
 		return ShardRef{}, false, fmt.Errorf("fetch shard %s: %w", artifact.Path, err)
 	}
@@ -157,7 +148,7 @@ func stageShard(artifact ShardArtifact, fetchDocument FetchDocument, publishDocu
 		return ShardRef{}, false, fmt.Errorf("fetch shard %s returned %s", artifact.Path, current.Status)
 	}
 
-	verified, version, err := publishAndVerify(artifact.Path, artifact.Body, expectedVersion, fetchDocument, publishDocument)
+	verified, version, err := publishAndVerify(ctx, artifact.Path, artifact.Body, expectedVersion, fetchDocument, publishDocument)
 	if err != nil {
 		return ShardRef{}, false, err
 	}
@@ -168,8 +159,8 @@ func stageShard(artifact ShardArtifact, fetchDocument FetchDocument, publishDocu
 	return ref, true, nil
 }
 
-func publishAndVerify(docPath, body string, expectedVersion int, fetchDocument FetchDocument, publishDocument PublishDocument) (protocol.Response, int, error) {
-	published, publishErr := publishDocument(docPath, body, expectedVersion)
+func publishAndVerify(ctx context.Context, docPath, body string, expectedVersion int, fetchDocument FetchDocument, publishDocument PublishDocument) (protocol.Response, int, error) {
+	published, publishErr := publishDocument(ctx, docPath, body, expectedVersion)
 	if publishErr == nil && published.Status != protocol.StatusOK && published.Status != protocol.StatusCreated {
 		publishErr = fmt.Errorf("publish returned %s", published.Status)
 	}
@@ -178,17 +169,17 @@ func publishAndVerify(docPath, body string, expectedVersion int, fetchDocument F
 		version, publishErr = responseVersion(docPath, published)
 	}
 	if publishErr != nil {
-		current, err := fetchDocument(docPath)
+		current, err := fetchDocument(ctx, docPath)
 		if err != nil {
 			return protocol.Response{}, 0, fmt.Errorf("publish %s: %v; reconcile: %w", docPath, publishErr, err)
 		}
 		version, err = verifyPublishedBody(docPath, body, current)
 		if err != nil {
-			return protocol.Response{}, 0, fmt.Errorf("publish %s: %v", docPath, publishErr)
+			return protocol.Response{}, 0, fmt.Errorf("publish %s: %w; reconcile: %w", docPath, publishErr, err)
 		}
 	}
 	versionedPath := VersionPath(docPath, version)
-	verified, err := fetchDocument(versionedPath)
+	verified, err := fetchDocument(ctx, versionedPath)
 	if err != nil {
 		return protocol.Response{}, 0, fmt.Errorf("verify %s: %w", versionedPath, err)
 	}

--- a/client/index/publish.go
+++ b/client/index/publish.go
@@ -1,0 +1,217 @@
+package index
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/latebit-io/demarkus/protocol"
+)
+
+// PublishOptions describes one complete logical index generation.
+type PublishOptions struct {
+	ManifestPath            string
+	Source                  string
+	Indexed                 time.Time
+	Entries                 []Entry
+	ExpectedManifestVersion *int
+	ShardTargetBytes        int
+}
+
+// PublishResult describes the committed generation and staged shard work.
+type PublishResult struct {
+	Manifest        Manifest
+	ManifestBody    string
+	ManifestVersion int
+	ShardsPublished int
+	ShardsReused    int
+}
+
+// FetchDocument fetches one generated index document by absolute path.
+type FetchDocument func(path string) (protocol.Response, error)
+
+// PublishDocument publishes one generated document with optimistic concurrency.
+type PublishDocument func(path, body string, expectedVersion int) (protocol.Response, error)
+
+// PublishGeneration stages an inactive shard slot, verifies every shard, then
+// commits the manifest last with CAS. A manifest failure leaves the old slot live.
+func PublishGeneration(ctx context.Context, opts PublishOptions, fetchDocument FetchDocument, publishDocument PublishDocument) (PublishResult, error) { //nolint:gocritic // options are copied so callers cannot mutate an active publication
+	if err := ctx.Err(); err != nil {
+		return PublishResult{}, err
+	}
+	currentVersion, activeSlot, err := fetchCurrentManifest(opts.ManifestPath, fetchDocument)
+	if err != nil {
+		return PublishResult{}, err
+	}
+	if opts.ExpectedManifestVersion != nil && *opts.ExpectedManifestVersion != currentVersion {
+		return PublishResult{}, fmt.Errorf("manifest version changed: got %d, expected %d", currentVersion, *opts.ExpectedManifestVersion)
+	}
+	slot := InactiveSlot(activeSlot)
+	artifacts, err := BuildShards(opts.ManifestPath, slot, opts.Entries, opts.ShardTargetBytes)
+	if err != nil {
+		return PublishResult{}, err
+	}
+	refs := make([]ShardRef, 0, len(artifacts))
+	result := PublishResult{}
+	for _, artifact := range artifacts {
+		if err := ctx.Err(); err != nil {
+			return PublishResult{}, err
+		}
+		ref, published, err := stageShard(artifact, fetchDocument, publishDocument)
+		if err != nil {
+			return PublishResult{}, err
+		}
+		refs = append(refs, ref)
+		if published {
+			result.ShardsPublished++
+		} else {
+			result.ShardsReused++
+		}
+	}
+
+	manifest := Manifest{
+		Source: opts.Source, Indexed: opts.Indexed.UTC(), Complete: true,
+		Documents: len(opts.Entries), ActiveSlot: slot, Shards: refs,
+	}
+	manifestBody, err := BuildManifest(opts.ManifestPath, manifest)
+	if err != nil {
+		return PublishResult{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return PublishResult{}, err
+	}
+	verified, manifestVersion, err := publishAndVerify(opts.ManifestPath, manifestBody, currentVersion, fetchDocument, publishDocument)
+	if err != nil {
+		return PublishResult{}, err
+	}
+	parsed, err := ParseManifest(opts.ManifestPath, verified.Body)
+	if err != nil {
+		return PublishResult{}, fmt.Errorf("verify manifest %s: %w", opts.ManifestPath, err)
+	}
+	result.Manifest = parsed
+	result.ManifestBody = manifestBody
+	result.ManifestVersion = manifestVersion
+	return result, nil
+}
+
+func fetchCurrentManifest(manifestPath string, fetchDocument FetchDocument) (version int, activeSlot string, err error) {
+	current, err := fetchDocument(manifestPath)
+	if err != nil {
+		return 0, "", fmt.Errorf("fetch manifest %s: %w", manifestPath, err)
+	}
+	switch current.Status {
+	case protocol.StatusNotFound:
+		return 0, "", nil
+	case protocol.StatusOK:
+		version, err := responseVersion(manifestPath, current)
+		if err != nil {
+			return 0, "", err
+		}
+		if current.Metadata["content-hash"] != BodyHash(current.Body) {
+			return 0, "", fmt.Errorf("current manifest %s content hash mismatch", manifestPath)
+		}
+		format, err := documentFormat(current.Body)
+		if err != nil {
+			return 0, "", err
+		}
+		if format == "" {
+			return version, "", nil
+		}
+		if format != ManifestFormat {
+			return 0, "", fmt.Errorf("%w: %q", ErrUnsupportedFormat, format)
+		}
+		manifest, err := ParseManifest(manifestPath, current.Body)
+		if err != nil {
+			return 0, "", err
+		}
+		if !manifest.Complete {
+			return 0, "", errors.New("current hash index manifest is incomplete")
+		}
+		return version, manifest.ActiveSlot, nil
+	default:
+		return 0, "", fmt.Errorf("fetch manifest %s returned %s", manifestPath, current.Status)
+	}
+}
+
+func stageShard(artifact ShardArtifact, fetchDocument FetchDocument, publishDocument PublishDocument) (ShardRef, bool, error) { //nolint:gocritic // immutable publication value
+	current, err := fetchDocument(artifact.Path)
+	if err != nil {
+		return ShardRef{}, false, fmt.Errorf("fetch shard %s: %w", artifact.Path, err)
+	}
+	expectedVersion := 0
+	if current.Status == protocol.StatusOK {
+		expectedVersion, err = responseVersion(artifact.Path, current)
+		if err != nil {
+			return ShardRef{}, false, err
+		}
+		if current.Metadata["content-hash"] == artifact.ContentHash && current.Body == artifact.Body {
+			ref := artifact.Ref(expectedVersion)
+			if _, err := VerifyShard(ref, current); err != nil {
+				return ShardRef{}, false, err
+			}
+			return ref, false, nil
+		}
+	} else if current.Status != protocol.StatusNotFound {
+		return ShardRef{}, false, fmt.Errorf("fetch shard %s returned %s", artifact.Path, current.Status)
+	}
+
+	verified, version, err := publishAndVerify(artifact.Path, artifact.Body, expectedVersion, fetchDocument, publishDocument)
+	if err != nil {
+		return ShardRef{}, false, err
+	}
+	ref := artifact.Ref(version)
+	if _, err := VerifyShard(ref, verified); err != nil {
+		return ShardRef{}, false, err
+	}
+	return ref, true, nil
+}
+
+func publishAndVerify(docPath, body string, expectedVersion int, fetchDocument FetchDocument, publishDocument PublishDocument) (protocol.Response, int, error) {
+	published, publishErr := publishDocument(docPath, body, expectedVersion)
+	if publishErr == nil && published.Status != protocol.StatusOK && published.Status != protocol.StatusCreated {
+		publishErr = fmt.Errorf("publish returned %s", published.Status)
+	}
+	version := 0
+	if publishErr == nil {
+		version, publishErr = responseVersion(docPath, published)
+	}
+	if publishErr != nil {
+		current, err := fetchDocument(docPath)
+		if err != nil {
+			return protocol.Response{}, 0, fmt.Errorf("publish %s: %v; reconcile: %w", docPath, publishErr, err)
+		}
+		version, err = verifyPublishedBody(docPath, body, current)
+		if err != nil {
+			return protocol.Response{}, 0, fmt.Errorf("publish %s: %v", docPath, publishErr)
+		}
+	}
+	versionedPath := VersionPath(docPath, version)
+	verified, err := fetchDocument(versionedPath)
+	if err != nil {
+		return protocol.Response{}, 0, fmt.Errorf("verify %s: %w", versionedPath, err)
+	}
+	if _, err := verifyPublishedBody(docPath, body, verified); err != nil {
+		return protocol.Response{}, 0, err
+	}
+	return verified, version, nil
+}
+
+func verifyPublishedBody(docPath, body string, resp protocol.Response) (int, error) {
+	if resp.Status != protocol.StatusOK {
+		return 0, fmt.Errorf("verify %s returned %s", docPath, resp.Status)
+	}
+	if resp.Body != body || resp.Metadata["content-hash"] != BodyHash(body) {
+		return 0, fmt.Errorf("verify %s content mismatch", docPath)
+	}
+	return responseVersion(docPath, resp)
+}
+
+func responseVersion(docPath string, resp protocol.Response) (int, error) {
+	version, err := strconv.Atoi(resp.Metadata["version"])
+	if err != nil || version < 1 {
+		return 0, fmt.Errorf("document %s has invalid version %q", docPath, resp.Metadata["version"])
+	}
+	return version, nil
+}

--- a/client/index/publish_test.go
+++ b/client/index/publish_test.go
@@ -1,0 +1,265 @@
+package index
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/latebit-io/demarkus/protocol"
+)
+
+type memoryIndexRemote struct {
+	mu           sync.Mutex
+	docs         map[string]protocol.Response
+	history      map[string]map[int]protocol.Response
+	failManifest bool
+	publishes    []string
+}
+
+func newMemoryIndexRemote() *memoryIndexRemote {
+	return &memoryIndexRemote{docs: make(map[string]protocol.Response), history: make(map[string]map[int]protocol.Response)}
+}
+
+func (r *memoryIndexRemote) fetch(docPath string) (protocol.Response, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if base, version, ok := splitTestVersionPath(docPath); ok {
+		if doc, exists := r.history[base][version]; exists {
+			return doc, nil
+		}
+		return protocol.Response{Status: protocol.StatusNotFound}, nil
+	}
+	if doc, ok := r.docs[docPath]; ok {
+		return doc, nil
+	}
+	return protocol.Response{Status: protocol.StatusNotFound}, nil
+}
+
+func (r *memoryIndexRemote) publish(path, body string, expected int) (protocol.Response, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.failManifest && path == "/index.md" {
+		return protocol.Response{}, errors.New("simulated manifest conflict")
+	}
+	current, exists := r.docs[path]
+	currentVersion := 0
+	if exists {
+		currentVersion, _ = strconv.Atoi(current.Metadata["version"])
+	}
+	if expected != currentVersion {
+		return protocol.Response{Status: protocol.StatusConflict}, nil
+	}
+	version := currentVersion + 1
+	status := protocol.StatusOK
+	if !exists {
+		status = protocol.StatusCreated
+	}
+	r.docs[path] = protocol.Response{
+		Status: protocol.StatusOK, Body: body,
+		Metadata: map[string]string{"version": strconv.Itoa(version), "content-hash": BodyHash(body)},
+	}
+	if r.history[path] == nil {
+		r.history[path] = make(map[int]protocol.Response)
+	}
+	r.history[path][version] = r.docs[path]
+	r.publishes = append(r.publishes, path)
+	return protocol.Response{Status: status, Metadata: map[string]string{"version": strconv.Itoa(version)}}, nil
+}
+
+func splitTestVersionPath(docPath string) (base string, version int, ok bool) {
+	cut := strings.LastIndex(docPath, "/v")
+	if cut < 1 {
+		return "", 0, false
+	}
+	version, err := strconv.Atoi(docPath[cut+2:])
+	if err != nil || version < 1 {
+		return "", 0, false
+	}
+	return docPath[:cut], version, true
+}
+
+func TestPublishGenerationCreatesAndVerifiesManifestLast(t *testing.T) {
+	remote := newMemoryIndexRemote()
+	result, err := PublishGeneration(t.Context(), PublishOptions{
+		ManifestPath: "/index.md", Source: "aggregated", Indexed: time.Now(),
+		Entries: []Entry{{Hash: testHashA, Server: "mark://a", Path: "/a.md"}},
+	}, remote.fetch, remote.publish)
+	if err != nil {
+		t.Fatalf("PublishGeneration: %v", err)
+	}
+	if result.Manifest.ActiveSlot != SlotA || result.ManifestVersion != 1 || result.ShardsPublished != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	if got := remote.publishes[len(remote.publishes)-1]; got != "/index.md" {
+		t.Fatalf("last publish = %q", got)
+	}
+	if _, err := EntriesForHash("/index.md", remote.docs["/index.md"].Body, testHashA, remote.fetch); err != nil {
+		t.Fatalf("published generation is unreadable: %v", err)
+	}
+}
+
+func TestPublishGenerationAlternatesSlotsAndReusesShard(t *testing.T) {
+	remote := newMemoryIndexRemote()
+	opts := PublishOptions{
+		ManifestPath: "/index.md", Source: "aggregated", Indexed: time.Now(),
+		Entries: []Entry{{Hash: testHashA, Server: "mark://a", Path: "/a.md"}},
+	}
+	first, err := PublishGeneration(t.Context(), opts, remote.fetch, remote.publish)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts.Indexed = opts.Indexed.Add(time.Minute)
+	second, err := PublishGeneration(t.Context(), opts, remote.fetch, remote.publish)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts.Indexed = opts.Indexed.Add(time.Minute)
+	third, err := PublishGeneration(t.Context(), opts, remote.fetch, remote.publish)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Manifest.ActiveSlot != SlotA || second.Manifest.ActiveSlot != SlotB || third.Manifest.ActiveSlot != SlotA {
+		t.Fatalf("slots = %s, %s, %s", first.Manifest.ActiveSlot, second.Manifest.ActiveSlot, third.Manifest.ActiveSlot)
+	}
+	if third.ShardsReused != 1 || third.ShardsPublished != 0 {
+		t.Fatalf("third result = %+v", third)
+	}
+}
+
+func TestPublishGenerationManifestFailurePreservesPriorGeneration(t *testing.T) {
+	remote := newMemoryIndexRemote()
+	opts := PublishOptions{
+		ManifestPath: "/index.md", Source: "aggregated", Indexed: time.Now(),
+		Entries: []Entry{{Hash: testHashA, Server: "mark://a", Path: "/a.md"}},
+	}
+	if _, err := PublishGeneration(t.Context(), opts, remote.fetch, remote.publish); err != nil {
+		t.Fatal(err)
+	}
+	prior := remote.docs["/index.md"].Body
+	remote.failManifest = true
+	opts.Indexed = opts.Indexed.Add(time.Minute)
+	opts.Entries = []Entry{{Hash: testHashB, Server: "mark://b", Path: "/b.md"}}
+	if _, err := PublishGeneration(t.Context(), opts, remote.fetch, remote.publish); err == nil {
+		t.Fatal("manifest failure returned nil")
+	}
+	if remote.docs["/index.md"].Body != prior {
+		t.Fatal("failed generation replaced prior manifest")
+	}
+	if _, ok := remote.docs["/index.shards/b/ab-000.md"]; !ok {
+		t.Fatal("inactive staged shard missing")
+	}
+}
+
+func TestCommittedManifestPinsImmutableShardVersion(t *testing.T) {
+	remote := newMemoryIndexRemote()
+	result, err := PublishGeneration(t.Context(), PublishOptions{
+		ManifestPath: "/index.md", Source: "aggregated", Indexed: time.Now(),
+		Entries: []Entry{{Hash: testHashA, Server: "mark://a", Path: "/original.md"}},
+	}, remote.fetch, remote.publish)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := BuildShards("/index.md", result.Manifest.ActiveSlot, []Entry{
+		{Hash: testHashA, Server: "mark://a", Path: "/replacement.md"},
+	}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := result.Manifest.Shards[0]
+	if _, err := remote.publish(ref.Path, replacement[0].Body, ref.Version); err != nil {
+		t.Fatal(err)
+	}
+	matches, err := EntriesForHash("/index.md", result.ManifestBody, testHashA, remote.fetch)
+	if err != nil {
+		t.Fatalf("EntriesForHash: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Path != "/original.md" {
+		t.Fatalf("matches = %+v", matches)
+	}
+}
+
+func TestPublishGenerationHonorsManifestCAS(t *testing.T) {
+	remote := newMemoryIndexRemote()
+	legacy := Build("legacy", time.Now(), []Entry{{Hash: testHashA, Server: "mark://a", Path: "/a.md"}})
+	remote.docs["/index.md"] = protocol.Response{
+		Status: protocol.StatusOK, Body: legacy,
+		Metadata: map[string]string{"version": "4", "content-hash": BodyHash(legacy)},
+	}
+	remote.history["/index.md"] = map[int]protocol.Response{4: remote.docs["/index.md"]}
+	expected := 3
+	_, err := PublishGeneration(context.Background(), PublishOptions{
+		ManifestPath: "/index.md", Source: "aggregated", Indexed: time.Now(),
+		Entries:                 []Entry{{Hash: testHashA, Server: "mark://a", Path: "/a.md"}},
+		ExpectedManifestVersion: &expected,
+	}, remote.fetch, remote.publish)
+	if err == nil || len(remote.publishes) != 0 {
+		t.Fatalf("err = %v, publishes = %v", err, remote.publishes)
+	}
+}
+
+func TestPublishGenerationRejectsBadVerification(t *testing.T) {
+	remote := newMemoryIndexRemote()
+	publish := func(path, body string, expected int) (protocol.Response, error) {
+		resp, err := remote.publish(path, body, expected)
+		if path != "/index.md" {
+			doc := remote.docs[path]
+			doc.Metadata["content-hash"] = fmt.Sprintf("sha256-%064d", 0)
+			remote.docs[path] = doc
+		}
+		return resp, err
+	}
+	_, err := PublishGeneration(t.Context(), PublishOptions{
+		ManifestPath: "/index.md", Source: "aggregated", Indexed: time.Now(),
+		Entries: []Entry{{Hash: testHashA, Server: "mark://a", Path: "/a.md"}},
+	}, remote.fetch, publish)
+	if err == nil {
+		t.Fatal("bad shard verification accepted")
+	}
+}
+
+func TestConcurrentPublishersCommitOneCompleteGeneration(t *testing.T) {
+	remote := newMemoryIndexRemote()
+	if _, err := PublishGeneration(t.Context(), PublishOptions{
+		ManifestPath: "/index.md", Source: "aggregated", Indexed: time.Now(),
+		Entries: []Entry{{Hash: testHashA, Server: "mark://a", Path: "/initial.md"}},
+	}, remote.fetch, remote.publish); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := 1
+	var successes atomic.Int32
+	errs := make(chan error, 2)
+	for _, docPath := range []string{"/writer-a.md", "/writer-b.md"} {
+		go func() {
+			_, err := PublishGeneration(t.Context(), PublishOptions{
+				ManifestPath: "/index.md", Source: "aggregated", Indexed: time.Now(),
+				Entries:                 []Entry{{Hash: testHashA, Server: "mark://a", Path: docPath}},
+				ExpectedManifestVersion: &expected,
+			}, remote.fetch, remote.publish)
+			if err == nil {
+				successes.Add(1)
+			}
+			errs <- err
+		}()
+	}
+	for range 2 {
+		<-errs
+	}
+	if successes.Load() != 1 {
+		t.Fatalf("successful publishers = %d, want 1", successes.Load())
+	}
+	manifest := remote.docs["/index.md"]
+	matches, err := EntriesForHash("/index.md", manifest.Body, testHashA, remote.fetch)
+	if err != nil {
+		t.Fatalf("committed generation is unreadable: %v", err)
+	}
+	if len(matches) != 1 || (matches[0].Path != "/writer-a.md" && matches[0].Path != "/writer-b.md") {
+		t.Fatalf("committed matches = %+v", matches)
+	}
+}

--- a/client/index/publish_test.go
+++ b/client/index/publish_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"sync"
@@ -26,7 +27,7 @@ func newMemoryIndexRemote() *memoryIndexRemote {
 	return &memoryIndexRemote{docs: make(map[string]protocol.Response), history: make(map[string]map[int]protocol.Response)}
 }
 
-func (r *memoryIndexRemote) fetch(docPath string) (protocol.Response, error) {
+func (r *memoryIndexRemote) fetch(_ context.Context, docPath string) (protocol.Response, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if base, version, ok := splitTestVersionPath(docPath); ok {
@@ -41,7 +42,11 @@ func (r *memoryIndexRemote) fetch(docPath string) (protocol.Response, error) {
 	return protocol.Response{Status: protocol.StatusNotFound}, nil
 }
 
-func (r *memoryIndexRemote) publish(path, body string, expected int) (protocol.Response, error) {
+func (r *memoryIndexRemote) fetchPath(docPath string) (protocol.Response, error) {
+	return r.fetch(context.Background(), docPath)
+}
+
+func (r *memoryIndexRemote) publish(_ context.Context, path, body string, expected int) (protocol.Response, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.failManifest && path == "/index.md" {
@@ -60,14 +65,17 @@ func (r *memoryIndexRemote) publish(path, body string, expected int) (protocol.R
 	if !exists {
 		status = protocol.StatusCreated
 	}
-	r.docs[path] = protocol.Response{
+	stored := protocol.Response{
 		Status: protocol.StatusOK, Body: body,
 		Metadata: map[string]string{"version": strconv.Itoa(version), "content-hash": BodyHash(body)},
 	}
+	r.docs[path] = stored
 	if r.history[path] == nil {
 		r.history[path] = make(map[int]protocol.Response)
 	}
-	r.history[path][version] = r.docs[path]
+	historical := stored
+	historical.Metadata = maps.Clone(stored.Metadata)
+	r.history[path][version] = historical
 	r.publishes = append(r.publishes, path)
 	return protocol.Response{Status: status, Metadata: map[string]string{"version": strconv.Itoa(version)}}, nil
 }
@@ -99,7 +107,7 @@ func TestPublishGenerationCreatesAndVerifiesManifestLast(t *testing.T) {
 	if got := remote.publishes[len(remote.publishes)-1]; got != "/index.md" {
 		t.Fatalf("last publish = %q", got)
 	}
-	if _, err := EntriesForHash("/index.md", remote.docs["/index.md"].Body, testHashA, remote.fetch); err != nil {
+	if _, err := EntriesForHash("/index.md", remote.docs["/index.md"].Body, testHashA, remote.fetchPath); err != nil {
 		t.Fatalf("published generation is unreadable: %v", err)
 	}
 }
@@ -172,10 +180,10 @@ func TestCommittedManifestPinsImmutableShardVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 	ref := result.Manifest.Shards[0]
-	if _, err := remote.publish(ref.Path, replacement[0].Body, ref.Version); err != nil {
+	if _, err := remote.publish(t.Context(), ref.Path, replacement[0].Body, ref.Version); err != nil {
 		t.Fatal(err)
 	}
-	matches, err := EntriesForHash("/index.md", result.ManifestBody, testHashA, remote.fetch)
+	matches, err := EntriesForHash("/index.md", result.ManifestBody, testHashA, remote.fetchPath)
 	if err != nil {
 		t.Fatalf("EntriesForHash: %v", err)
 	}
@@ -205,12 +213,18 @@ func TestPublishGenerationHonorsManifestCAS(t *testing.T) {
 
 func TestPublishGenerationRejectsBadVerification(t *testing.T) {
 	remote := newMemoryIndexRemote()
-	publish := func(path, body string, expected int) (protocol.Response, error) {
-		resp, err := remote.publish(path, body, expected)
-		if path != "/index.md" {
-			doc := remote.docs[path]
+	publish := func(ctx context.Context, path, body string, expected int) (protocol.Response, error) {
+		resp, err := remote.publish(ctx, path, body, expected)
+		if err == nil && path != "/index.md" {
+			version, versionErr := strconv.Atoi(resp.Metadata["version"])
+			if versionErr != nil {
+				return protocol.Response{}, versionErr
+			}
+			remote.mu.Lock()
+			doc := remote.history[path][version]
 			doc.Metadata["content-hash"] = fmt.Sprintf("sha256-%064d", 0)
-			remote.docs[path] = doc
+			remote.history[path][version] = doc
+			remote.mu.Unlock()
 		}
 		return resp, err
 	}
@@ -255,11 +269,57 @@ func TestConcurrentPublishersCommitOneCompleteGeneration(t *testing.T) {
 		t.Fatalf("successful publishers = %d, want 1", successes.Load())
 	}
 	manifest := remote.docs["/index.md"]
-	matches, err := EntriesForHash("/index.md", manifest.Body, testHashA, remote.fetch)
+	matches, err := EntriesForHash("/index.md", manifest.Body, testHashA, remote.fetchPath)
 	if err != nil {
 		t.Fatalf("committed generation is unreadable: %v", err)
 	}
 	if len(matches) != 1 || (matches[0].Path != "/writer-a.md" && matches[0].Path != "/writer-b.md") {
 		t.Fatalf("committed matches = %+v", matches)
+	}
+}
+
+func TestPublishGenerationCancelsInFlightFetch(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		_, err := PublishGeneration(ctx, PublishOptions{
+			ManifestPath: "/index.md", Source: "aggregated", Indexed: time.Now(),
+		}, func(fetchCtx context.Context, _ string) (protocol.Response, error) {
+			close(started)
+			<-fetchCtx.Done()
+			return protocol.Response{}, fetchCtx.Err()
+		}, func(context.Context, string, string, int) (protocol.Response, error) {
+			return protocol.Response{}, errors.New("publish should not be called")
+		})
+		done <- err
+	}()
+	<-started
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("PublishGeneration error = %v, want context canceled", err)
+	}
+}
+
+func TestPublishGenerationPreservesPublishAndReconcileErrors(t *testing.T) {
+	publishFailure := errors.New("publish transport failed")
+	_, err := PublishGeneration(t.Context(), PublishOptions{
+		ManifestPath: "/index.md", Source: "aggregated", Indexed: time.Now(),
+		Entries: []Entry{{Hash: testHashA, Server: "mark://a", Path: "/a.md"}},
+	}, func(_ context.Context, docPath string) (protocol.Response, error) {
+		if docPath == "/index.md" {
+			return protocol.Response{Status: protocol.StatusNotFound}, nil
+		}
+		if strings.Contains(docPath, ".shards/") {
+			return protocol.Response{Status: protocol.StatusOK, Body: "wrong", Metadata: map[string]string{
+				"version": "1", "content-hash": BodyHash("wrong"),
+			}}, nil
+		}
+		return protocol.Response{Status: protocol.StatusNotFound}, nil
+	}, func(context.Context, string, string, int) (protocol.Response, error) {
+		return protocol.Response{}, publishFailure
+	})
+	if !errors.Is(err, publishFailure) || !strings.Contains(err.Error(), "reconcile:") {
+		t.Fatalf("PublishGeneration error = %v", err)
 	}
 }

--- a/client/index/sharded.go
+++ b/client/index/sharded.go
@@ -287,7 +287,10 @@ func EntriesForHash(manifestPath, body, hash string, fetchShard func(string) (pr
 	if !m.Complete {
 		return nil, errors.New("hash index manifest is incomplete")
 	}
-	prefix, _ := HashPrefix(hash)
+	prefix, err := HashPrefix(hash)
+	if err != nil {
+		return nil, err
+	}
 	var matches []Entry
 	for _, ref := range m.Shards {
 		if ref.Prefix != prefix {

--- a/client/index/sharded.go
+++ b/client/index/sharded.go
@@ -1,0 +1,800 @@
+package index
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"math"
+	"net/url"
+	"path"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/latebit-io/demarkus/protocol"
+)
+
+// ManifestFormat identifies the sharded index manifest and groups its format limits.
+const (
+	ManifestFormat          = "demarkus-hash-index/v2"
+	ShardFormat             = "demarkus-hash-index-shard/v1"
+	DefaultShardTargetBytes = 768 * 1024
+	HashPrefixLength        = 2
+	MaxManifestShards       = 4096
+	MaxIndexEntries         = 1_000_000
+	SlotA                   = "a"
+	SlotB                   = "b"
+)
+
+// ErrUnsupportedFormat reports a generated index format this client cannot read.
+var ErrUnsupportedFormat = errors.New("unsupported hash index format")
+
+// Manifest identifies one complete immutable set of hash-index shards.
+type Manifest struct {
+	Source     string
+	Indexed    time.Time
+	Complete   bool
+	Documents  int
+	ActiveSlot string
+	Shards     []ShardRef
+}
+
+// ShardRef is the integrity and location record for one manifest shard.
+type ShardRef struct {
+	Prefix      string
+	Path        string
+	Version     int
+	ContentHash string
+	Rows        int
+	Bytes       int
+}
+
+// ShardArtifact is a shard body before its published version is known.
+type ShardArtifact struct {
+	Prefix      string
+	Part        int
+	Path        string
+	Body        string
+	ContentHash string
+	Rows        int
+	Bytes       int
+}
+
+// Ref returns the published descriptor for an artifact.
+func (a ShardArtifact) Ref(version int) ShardRef { //nolint:gocritic // immutable descriptor conversion
+	return ShardRef{
+		Prefix:      a.Prefix,
+		Path:        a.Path,
+		Version:     version,
+		ContentHash: a.ContentHash,
+		Rows:        a.Rows,
+		Bytes:       a.Bytes,
+	}
+}
+
+// InactiveSlot returns the slot not named by the current manifest.
+func InactiveSlot(active string) string {
+	if active == SlotA {
+		return SlotB
+	}
+	return SlotA
+}
+
+// VersionPath returns the immutable FETCH path for one document version.
+func VersionPath(docPath string, version int) string {
+	return fmt.Sprintf("%s/v%d", docPath, version)
+}
+
+// BuildManifest renders a deterministic v2 manifest.
+func BuildManifest(manifestPath string, m Manifest) (string, error) { //nolint:gocritic // local copy is sorted without mutating the caller
+	refs := slices.Clone(m.Shards)
+	slices.SortFunc(refs, compareShardRefs)
+	m.Shards = refs
+	if err := validateManifest(manifestPath, m); err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	b.WriteString("# Content Index Manifest\n\n")
+	fmt.Fprintf(&b, "> Format: %s\n", ManifestFormat)
+	fmt.Fprintf(&b, "> Source: %s\n", m.Source)
+	fmt.Fprintf(&b, "> Indexed: %s\n", m.Indexed.UTC().Format(time.RFC3339))
+	fmt.Fprintf(&b, "> Complete: %t\n", m.Complete)
+	fmt.Fprintf(&b, "> Documents: %d\n", m.Documents)
+	fmt.Fprintf(&b, "> Active-Slot: %s\n\n", m.ActiveSlot)
+	b.WriteString("| Prefix | Path | Version | Content Hash | Rows | Bytes |\n")
+	b.WriteString("|--------|------|---------|--------------|------|-------|\n")
+	for _, ref := range refs {
+		fmt.Fprintf(&b, "| %s | %s | %d | %s | %d | %d |\n",
+			ref.Prefix, encodeCell(ref.Path), ref.Version, ref.ContentHash, ref.Rows, ref.Bytes)
+	}
+	if b.Len() > protocol.MaxBodyLength {
+		return "", fmt.Errorf("manifest body exceeds limit: %d > %d", b.Len(), protocol.MaxBodyLength)
+	}
+	return b.String(), nil
+}
+
+// ParseManifest parses and validates a v2 manifest and its shard scope.
+func ParseManifest(manifestPath, body string) (Manifest, error) {
+	if len(body) > protocol.MaxBodyLength {
+		return Manifest{}, fmt.Errorf("manifest body exceeds limit: %d", len(body))
+	}
+	meta, err := generatedMetadata(body, "# Content Index Manifest")
+	if err != nil {
+		return Manifest{}, err
+	}
+	if meta["Format"] != ManifestFormat {
+		return Manifest{}, fmt.Errorf("%w: %q", ErrUnsupportedFormat, meta["Format"])
+	}
+	indexed, err := time.Parse(time.RFC3339, meta["Indexed"])
+	if err != nil {
+		return Manifest{}, fmt.Errorf("invalid Indexed value: %w", err)
+	}
+	complete, err := strconv.ParseBool(meta["Complete"])
+	if err != nil {
+		return Manifest{}, fmt.Errorf("invalid Complete value: %w", err)
+	}
+	documents, err := parseNonNegative("Documents", meta["Documents"])
+	if err != nil {
+		return Manifest{}, err
+	}
+	rows, err := tableRows(body, []string{"Prefix", "Path", "Version", "Content Hash", "Rows", "Bytes"})
+	if err != nil {
+		return Manifest{}, err
+	}
+	refs := make([]ShardRef, 0, len(rows))
+	for i, row := range rows {
+		version, err := parsePositive("Version", row[2])
+		if err != nil {
+			return Manifest{}, fmt.Errorf("shard row %d: %w", i+1, err)
+		}
+		rowCount, err := parsePositive("Rows", row[4])
+		if err != nil {
+			return Manifest{}, fmt.Errorf("shard row %d: %w", i+1, err)
+		}
+		encodedBytes, err := parsePositive("Bytes", row[5])
+		if err != nil {
+			return Manifest{}, fmt.Errorf("shard row %d: %w", i+1, err)
+		}
+		refs = append(refs, ShardRef{
+			Prefix:      row[0],
+			Path:        decodeCell(row[1]),
+			Version:     version,
+			ContentHash: row[3],
+			Rows:        rowCount,
+			Bytes:       encodedBytes,
+		})
+	}
+	m := Manifest{
+		Source:     meta["Source"],
+		Indexed:    indexed,
+		Complete:   complete,
+		Documents:  documents,
+		ActiveSlot: meta["Active-Slot"],
+		Shards:     refs,
+	}
+	if err := validateManifest(manifestPath, m); err != nil {
+		return Manifest{}, err
+	}
+	return m, nil
+}
+
+// BuildShards partitions entries by hash prefix and deterministic overflow
+// parts, keeping every encoded shard at or below targetBytes.
+func BuildShards(manifestPath, slot string, entries []Entry, targetBytes int) ([]ShardArtifact, error) {
+	if err := validateManifestPath(manifestPath); err != nil {
+		return nil, err
+	}
+	if slot != SlotA && slot != SlotB {
+		return nil, fmt.Errorf("invalid shard slot %q", slot)
+	}
+	if targetBytes == 0 {
+		targetBytes = DefaultShardTargetBytes
+	}
+	if targetBytes < 1 || targetBytes > protocol.MaxBodyLength {
+		return nil, fmt.Errorf("invalid shard target %d", targetBytes)
+	}
+	if len(entries) > MaxIndexEntries {
+		return nil, fmt.Errorf("index has %d entries, limit is %d", len(entries), MaxIndexEntries)
+	}
+	sorted := slices.Clone(entries)
+	slices.SortFunc(sorted, compareEntries)
+	var artifacts []ShardArtifact
+	for start := 0; start < len(sorted); {
+		prefix, err := HashPrefix(sorted[start].Hash)
+		if err != nil {
+			return nil, err
+		}
+		end := start
+		for end < len(sorted) {
+			entryPrefix, err := HashPrefix(sorted[end].Hash)
+			if err != nil {
+				return nil, err
+			}
+			if entryPrefix != prefix {
+				break
+			}
+			end++
+		}
+		parts, err := buildPrefixParts(manifestPath, slot, prefix, sorted[start:end], targetBytes)
+		if err != nil {
+			return nil, err
+		}
+		artifacts = append(artifacts, parts...)
+		start = end
+	}
+	return artifacts, nil
+}
+
+// HashPrefix returns the lowercase partition prefix for a content hash.
+func HashPrefix(hash string) (string, error) {
+	clean, ok := protocol.IsHashPath(hash)
+	if !ok {
+		return "", fmt.Errorf("invalid content hash %q", hash)
+	}
+	return clean[len("sha256-") : len("sha256-")+HashPrefixLength], nil
+}
+
+// VerifyShard validates a fetched shard against its manifest descriptor.
+func VerifyShard(ref ShardRef, resp protocol.Response) ([]Entry, error) {
+	if resp.Status != protocol.StatusOK {
+		return nil, fmt.Errorf("shard %s returned %s", ref.Path, resp.Status)
+	}
+	version, err := parsePositive("version", resp.Metadata["version"])
+	if err != nil || version != ref.Version {
+		return nil, fmt.Errorf("shard %s version mismatch: got %q, want %d", ref.Path, resp.Metadata["version"], ref.Version)
+	}
+	if len(resp.Body) != ref.Bytes {
+		return nil, fmt.Errorf("shard %s byte count mismatch: got %d, want %d", ref.Path, len(resp.Body), ref.Bytes)
+	}
+	bodyHash := BodyHash(resp.Body)
+	if bodyHash != ref.ContentHash || resp.Metadata["content-hash"] != ref.ContentHash {
+		return nil, fmt.Errorf("shard %s content hash mismatch", ref.Path)
+	}
+	prefix, part, entries, err := parseShard(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("shard %s: %w", ref.Path, err)
+	}
+	pathPrefix, pathPart, pathErr := parseShardFile(path.Base(ref.Path))
+	if pathErr != nil || prefix != ref.Prefix || prefix != pathPrefix || part != pathPart || len(entries) != ref.Rows {
+		return nil, fmt.Errorf("shard %s identity or row count mismatch", ref.Path)
+	}
+	return entries, nil
+}
+
+// EntriesForHash resolves matching rows from a legacy index or only the v2
+// shards that can contain hash.
+func EntriesForHash(manifestPath, body, hash string, fetchShard func(string) (protocol.Response, error)) ([]Entry, error) {
+	cleanHash, ok := protocol.IsHashPath(hash)
+	if !ok {
+		return nil, fmt.Errorf("invalid content hash %q", hash)
+	}
+	hash = cleanHash
+	format, err := documentFormat(body)
+	if err != nil {
+		return nil, err
+	}
+	if format == "" {
+		return matchingEntries(Parse(body), hash), nil
+	}
+	if format != ManifestFormat {
+		return nil, fmt.Errorf("%w: %q", ErrUnsupportedFormat, format)
+	}
+	m, err := ParseManifest(manifestPath, body)
+	if err != nil {
+		return nil, err
+	}
+	if !m.Complete {
+		return nil, errors.New("hash index manifest is incomplete")
+	}
+	prefix, _ := HashPrefix(hash)
+	var matches []Entry
+	for _, ref := range m.Shards {
+		if ref.Prefix != prefix {
+			continue
+		}
+		resp, err := fetchShard(VersionPath(ref.Path, ref.Version))
+		if err != nil {
+			return nil, fmt.Errorf("fetch shard %s: %w", ref.Path, err)
+		}
+		entries, err := VerifyShard(ref, resp)
+		if err != nil {
+			return nil, err
+		}
+		matches = append(matches, matchingEntries(entries, hash)...)
+	}
+	return matches, nil
+}
+
+// LoadEntries reads and verifies every row from a legacy index or v2 manifest.
+func LoadEntries(manifestPath, body string, fetchShard func(string) (protocol.Response, error)) ([]Entry, error) {
+	format, err := documentFormat(body)
+	if err != nil {
+		return nil, err
+	}
+	if format == "" {
+		return Parse(body), nil
+	}
+	if format != ManifestFormat {
+		return nil, fmt.Errorf("%w: %q", ErrUnsupportedFormat, format)
+	}
+	m, err := ParseManifest(manifestPath, body)
+	if err != nil {
+		return nil, err
+	}
+	if !m.Complete {
+		return nil, errors.New("hash index manifest is incomplete")
+	}
+	var entries []Entry
+	for _, ref := range m.Shards {
+		resp, err := fetchShard(VersionPath(ref.Path, ref.Version))
+		if err != nil {
+			return nil, fmt.Errorf("fetch shard %s: %w", ref.Path, err)
+		}
+		shardEntries, err := VerifyShard(ref, resp)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, shardEntries...)
+	}
+	if len(entries) != m.Documents {
+		return nil, fmt.Errorf("manifest document count mismatch: got %d, want %d", len(entries), m.Documents)
+	}
+	return entries, nil
+}
+
+// BodyHash returns the protocol content hash for a generated body.
+func BodyHash(body string) string {
+	sum := sha256.Sum256([]byte(body))
+	return fmt.Sprintf("sha256-%x", sum)
+}
+
+func buildPrefixParts(manifestPath, slot, prefix string, entries []Entry, target int) ([]ShardArtifact, error) {
+	var artifacts []ShardArtifact
+	for start, part := 0, 0; start < len(entries); part++ {
+		end := start
+		rowBytes := 0
+		for end < len(entries) {
+			row, err := entryRow(entries[end])
+			if err != nil {
+				return nil, err
+			}
+			candidateRows := end - start + 1
+			candidateBytes := len(shardHeader(prefix, part, candidateRows)) + rowBytes + len(row)
+			if candidateBytes > target {
+				if end == start {
+					return nil, fmt.Errorf("one %s shard row exceeds target %d", prefix, target)
+				}
+				break
+			}
+			rowBytes += len(row)
+			end++
+		}
+		body, err := buildShard(prefix, part, entries[start:end])
+		if err != nil {
+			return nil, err
+		}
+		artifact := ShardArtifact{
+			Prefix: prefix,
+			Part:   part,
+			Path:   shardPath(manifestPath, slot, prefix, part),
+			Body:   body,
+			Rows:   end - start,
+			Bytes:  len(body),
+		}
+		artifact.ContentHash = BodyHash(body)
+		artifacts = append(artifacts, artifact)
+		start = end
+	}
+	return artifacts, nil
+}
+
+func buildShard(prefix string, part int, entries []Entry) (string, error) {
+	var b strings.Builder
+	b.WriteString(shardHeader(prefix, part, len(entries)))
+	for _, entry := range entries {
+		row, err := entryRow(entry)
+		if err != nil {
+			return "", err
+		}
+		b.WriteString(row)
+	}
+	return b.String(), nil
+}
+
+func shardHeader(prefix string, part, rows int) string {
+	return fmt.Sprintf("# Content Index Shard\n\n> Format: %s\n> Prefix: %s\n> Part: %d\n> Rows: %d\n\n| Hash | Server | Path |\n|------|--------|------|\n",
+		ShardFormat, prefix, part, rows)
+}
+
+func parseShard(body string) (prefix string, part int, entries []Entry, err error) {
+	if len(body) > protocol.MaxBodyLength {
+		return "", 0, nil, fmt.Errorf("shard body exceeds limit: %d", len(body))
+	}
+	meta, err := generatedMetadata(body, "# Content Index Shard")
+	if err != nil {
+		return "", 0, nil, err
+	}
+	if meta["Format"] != ShardFormat {
+		return "", 0, nil, fmt.Errorf("%w: %q", ErrUnsupportedFormat, meta["Format"])
+	}
+	prefix = meta["Prefix"]
+	if !validPrefix(prefix) {
+		return "", 0, nil, fmt.Errorf("invalid shard prefix %q", prefix)
+	}
+	part, err = parseNonNegative("Part", meta["Part"])
+	if err != nil {
+		return "", 0, nil, err
+	}
+	declaredRows, err := parsePositive("Rows", meta["Rows"])
+	if err != nil {
+		return "", 0, nil, err
+	}
+	if declaredRows > MaxIndexEntries {
+		return "", 0, nil, fmt.Errorf("shard row count %d exceeds limit", declaredRows)
+	}
+	rows, err := tableRows(body, []string{"Hash", "Server", "Path"})
+	if err != nil {
+		return "", 0, nil, err
+	}
+	entries = make([]Entry, 0, len(rows))
+	for _, row := range rows {
+		entry := Entry{Hash: row[0], Server: decodeCell(row[1]), Path: decodeCell(row[2])}
+		if err := validateEntry(entry); err != nil {
+			return "", 0, nil, err
+		}
+		entryPrefix, err := HashPrefix(entry.Hash)
+		if err != nil || entryPrefix != prefix {
+			return "", 0, nil, fmt.Errorf("entry hash %q is outside prefix %s", entry.Hash, prefix)
+		}
+		entries = append(entries, entry)
+	}
+	if len(entries) != declaredRows {
+		return "", 0, nil, fmt.Errorf("declared %d rows, body has %d", declaredRows, len(entries))
+	}
+	return prefix, part, entries, nil
+}
+
+func validateManifest(manifestPath string, m Manifest) error { //nolint:gocyclo,gocritic // one pass over an immutable value enforces cross-field invariants
+	if err := validateManifestPath(manifestPath); err != nil {
+		return err
+	}
+	if strings.TrimSpace(m.Source) == "" || m.Source != strings.TrimSpace(m.Source) || strings.ContainsAny(m.Source, "\r\n\t") {
+		return errors.New("manifest source is required")
+	}
+	if m.Indexed.IsZero() || m.Indexed.Year() < 1 || m.Indexed.Year() > 9999 {
+		return errors.New("manifest indexed time is required")
+	}
+	if m.ActiveSlot != SlotA && m.ActiveSlot != SlotB {
+		return fmt.Errorf("invalid active slot %q", m.ActiveSlot)
+	}
+	if m.Documents < 0 || m.Documents > MaxIndexEntries {
+		return fmt.Errorf("manifest documents %d exceeds limit", m.Documents)
+	}
+	if len(m.Shards) > MaxManifestShards {
+		return fmt.Errorf("manifest has %d shards, limit is %d", len(m.Shards), MaxManifestShards)
+	}
+	rows := 0
+	seenPaths := make(map[string]struct{}, len(m.Shards))
+	parts := make(map[string]map[int]struct{})
+	for _, ref := range m.Shards {
+		if !validPrefix(ref.Prefix) || ref.Version < 1 || ref.Rows < 1 || ref.Bytes < 1 {
+			return fmt.Errorf("invalid shard descriptor for %q", ref.Path)
+		}
+		if clean, ok := protocol.IsHashPath(ref.ContentHash); !ok || clean != ref.ContentHash {
+			return fmt.Errorf("invalid shard content hash %q", ref.ContentHash)
+		}
+		prefix, part, err := parseShardPath(manifestPath, m.ActiveSlot, ref.Path)
+		if err != nil || prefix != ref.Prefix {
+			return fmt.Errorf("invalid shard path %q for prefix %s", ref.Path, ref.Prefix)
+		}
+		if _, duplicate := seenPaths[ref.Path]; duplicate {
+			return fmt.Errorf("duplicate shard path %q", ref.Path)
+		}
+		seenPaths[ref.Path] = struct{}{}
+		if parts[ref.Prefix] == nil {
+			parts[ref.Prefix] = make(map[int]struct{})
+		}
+		parts[ref.Prefix][part] = struct{}{}
+		if ref.Rows > math.MaxInt-rows {
+			return errors.New("manifest shard row count overflows int")
+		}
+		rows += ref.Rows
+	}
+	for prefix, prefixParts := range parts {
+		for part := range len(prefixParts) {
+			if _, ok := prefixParts[part]; !ok {
+				return fmt.Errorf("shard prefix %s is missing part %d", prefix, part)
+			}
+		}
+	}
+	if rows != m.Documents {
+		return fmt.Errorf("manifest documents %d does not match shard rows %d", m.Documents, rows)
+	}
+	return nil
+}
+
+func tableRows(body string, wantHeader []string) ([][]string, error) {
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		cells, ok := splitTableRow(line)
+		if !ok {
+			continue
+		}
+		if !slices.Equal(cells, wantHeader) {
+			return nil, fmt.Errorf("unexpected generated table header %q", line)
+		}
+		if i+1 >= len(lines) || !validTableSeparator(lines[i+1], len(wantHeader)) {
+			return nil, errors.New("table separator is missing")
+		}
+		var rows [][]string
+		tableEnded := false
+		for _, rowLine := range lines[i+2:] {
+			cells, ok := splitDataTableRow(rowLine)
+			if !ok {
+				if strings.TrimSpace(rowLine) == "" {
+					tableEnded = true
+					continue
+				}
+				return nil, errors.New("unexpected content after generated table")
+			}
+			if tableEnded {
+				return nil, errors.New("unexpected content after generated table")
+			}
+			if len(cells) != len(wantHeader) {
+				return nil, fmt.Errorf("table row has %d columns, want %d", len(cells), len(wantHeader))
+			}
+			rows = append(rows, cells)
+		}
+		return rows, nil
+	}
+	return nil, errors.New("required table is missing")
+}
+
+func splitTableRow(line string) ([]string, bool) {
+	line = strings.TrimSpace(line)
+	if len(line) < 2 || line[0] != '|' || line[len(line)-1] != '|' {
+		return nil, false
+	}
+	raw := strings.Split(line[1:len(line)-1], "|")
+	for i := range raw {
+		raw[i] = strings.TrimSpace(raw[i])
+	}
+	return raw, true
+}
+
+func splitDataTableRow(line string) ([]string, bool) {
+	line = strings.TrimSpace(line)
+	if len(line) < 2 || line[0] != '|' || line[len(line)-1] != '|' {
+		return nil, false
+	}
+	raw := strings.Split(line[1:len(line)-1], "|")
+	for i := range raw {
+		if !strings.HasPrefix(raw[i], " ") || !strings.HasSuffix(raw[i], " ") {
+			return nil, false
+		}
+		raw[i] = strings.TrimSuffix(strings.TrimPrefix(raw[i], " "), " ")
+	}
+	return raw, true
+}
+
+func validTableSeparator(line string, columns int) bool {
+	cells, ok := splitTableRow(line)
+	if !ok || len(cells) != columns {
+		return false
+	}
+	for _, cell := range cells {
+		if len(cell) < 3 || strings.Trim(cell, "-") != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func entryRow(entry Entry) (string, error) {
+	if err := validateEntry(entry); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("| %s | %s | %s |\n", entry.Hash, encodeCell(entry.Server), encodeCell(entry.Path)), nil
+}
+
+func shardPath(manifestPath, slot, prefix string, part int) string {
+	return fmt.Sprintf("%s/%s/%s-%03d.md", shardRoot(manifestPath), slot, prefix, part)
+}
+
+func shardRoot(manifestPath string) string {
+	if base, ok := strings.CutSuffix(manifestPath, ".md"); ok {
+		return base + ".shards"
+	}
+	return manifestPath + ".shards"
+}
+
+func parseShardPath(manifestPath, slot, shard string) (prefix string, part int, err error) {
+	root := shardRoot(manifestPath) + "/" + slot
+	if path.Dir(shard) != root {
+		return "", 0, errors.New("shard path is outside active slot")
+	}
+	return parseShardFile(path.Base(shard))
+}
+
+func parseShardFile(name string) (prefix string, part int, err error) {
+	if !strings.HasSuffix(name, ".md") {
+		return "", 0, errors.New("shard filename must end in .md")
+	}
+	prefix, partText, ok := strings.Cut(strings.TrimSuffix(name, ".md"), "-")
+	if !ok || !validPrefix(prefix) {
+		return "", 0, errors.New("invalid shard filename")
+	}
+	part, err = parseNonNegative("shard part", partText)
+	if err != nil || name != fmt.Sprintf("%s-%03d.md", prefix, part) {
+		return "", 0, errors.New("invalid shard part filename")
+	}
+	return prefix, part, nil
+}
+
+func matchingEntries(entries []Entry, hash string) []Entry {
+	var matches []Entry
+	for _, entry := range entries {
+		if entry.Hash == hash {
+			matches = append(matches, entry)
+		}
+	}
+	return matches
+}
+
+func compareEntries(a, b Entry) int {
+	if c := strings.Compare(a.Hash, b.Hash); c != 0 {
+		return c
+	}
+	if c := strings.Compare(a.Server, b.Server); c != 0 {
+		return c
+	}
+	return strings.Compare(a.Path, b.Path)
+}
+
+func compareShardRefs(a, b ShardRef) int {
+	if c := strings.Compare(a.Prefix, b.Prefix); c != 0 {
+		return c
+	}
+	_, aPart, aErr := parseShardFile(path.Base(a.Path))
+	_, bPart, bErr := parseShardFile(path.Base(b.Path))
+	if aErr == nil && bErr == nil {
+		if aPart < bPart {
+			return -1
+		}
+		if aPart > bPart {
+			return 1
+		}
+	}
+	return strings.Compare(a.Path, b.Path)
+}
+
+func validPrefix(prefix string) bool {
+	if len(prefix) != HashPrefixLength {
+		return false
+	}
+	for _, c := range prefix {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func validateManifestPath(manifestPath string) error {
+	if err := protocol.ValidateRequestPath(manifestPath); err != nil || path.Clean(manifestPath) != manifestPath || manifestPath == "/" {
+		return fmt.Errorf("invalid manifest path %q", manifestPath)
+	}
+	generated := shardPath(manifestPath, SlotA, "00", 0)
+	if err := protocol.ValidateRequestPath(generated); err != nil {
+		return fmt.Errorf("manifest path cannot produce valid shard paths: %w", err)
+	}
+	if err := protocol.ValidateRequestPath(VersionPath(generated, math.MaxInt)); err != nil {
+		return fmt.Errorf("manifest path cannot produce versioned shard paths: %w", err)
+	}
+	return nil
+}
+
+func validateEntry(entry Entry) error {
+	cleanHash, ok := protocol.IsHashPath(entry.Hash)
+	if !ok || cleanHash != entry.Hash {
+		return fmt.Errorf("invalid content hash %q", entry.Hash)
+	}
+	server, err := url.Parse(entry.Server)
+	if err != nil || server.Scheme != "mark" || server.Hostname() == "" ||
+		server.User != nil || (server.Path != "" && server.Path != "/") || server.RawQuery != "" || server.Fragment != "" ||
+		strings.ContainsAny(entry.Server, "\r\n\t") {
+		return fmt.Errorf("invalid index server %q", entry.Server)
+	}
+	if port := server.Port(); port != "" {
+		n, portErr := strconv.Atoi(port)
+		if portErr != nil || n < 1 || n > 65535 {
+			return fmt.Errorf("invalid index server %q", entry.Server)
+		}
+	}
+	if err := protocol.ValidateRequestPath(entry.Path); err != nil || entry.Path == "/" ||
+		path.Clean(entry.Path) != entry.Path {
+		return fmt.Errorf("invalid index path %q", entry.Path)
+	}
+	return nil
+}
+
+func documentFormat(body string) (string, error) {
+	heading := firstNonEmptyLine(body)
+	if heading != "# Content Index Manifest" && heading != "# Content Index Shard" {
+		return "", nil
+	}
+	meta, err := generatedMetadata(body, heading)
+	if err != nil {
+		return "", err
+	}
+	return meta["Format"], nil
+}
+
+func generatedMetadata(body, wantHeading string) (map[string]string, error) {
+	lines := strings.Split(body, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != wantHeading {
+		return nil, fmt.Errorf("generated document heading must be %q", wantHeading)
+	}
+	meta := make(map[string]string)
+	for _, rawLine := range lines[1:] {
+		line := strings.TrimSpace(rawLine)
+		if strings.HasPrefix(line, "|") {
+			break
+		}
+		if line == "" {
+			continue
+		}
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "> ") {
+			return nil, fmt.Errorf("unexpected generated document preamble line %q", line)
+		}
+		key, value, ok := strings.Cut(strings.TrimPrefix(line, "> "), ":")
+		if !ok {
+			return nil, fmt.Errorf("invalid metadata line %q", line)
+		}
+		key = strings.TrimSpace(key)
+		if _, duplicate := meta[key]; duplicate {
+			return nil, fmt.Errorf("duplicate metadata field %q", key)
+		}
+		meta[key] = strings.TrimSpace(value)
+	}
+	return meta, nil
+}
+
+func firstNonEmptyLine(body string) string {
+	for line := range strings.SplitSeq(body, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+func parsePositive(name, raw string) (int, error) {
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		return 0, fmt.Errorf("invalid %s value %q", name, raw)
+	}
+	return n, nil
+}
+
+func parseNonNegative(name, raw string) (int, error) {
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid %s value %q", name, raw)
+	}
+	return n, nil
+}
+
+func encodeCell(value string) string {
+	value = strings.ReplaceAll(value, "%", "%25")
+	value = strings.ReplaceAll(value, "|", "%7C")
+	return strings.ReplaceAll(value, " ", "%20")
+}
+
+func decodeCell(value string) string {
+	value = strings.ReplaceAll(value, "%20", " ")
+	value = strings.ReplaceAll(value, "%7C", "|")
+	return strings.ReplaceAll(value, "%25", "%")
+}

--- a/client/index/sharded_test.go
+++ b/client/index/sharded_test.go
@@ -113,6 +113,55 @@ func TestEntriesForHashFetchesOnlyMatchingVerifiedShards(t *testing.T) {
 	}
 }
 
+func TestLoadEntriesReadsFullGenerationAndRejectsShortShard(t *testing.T) {
+	artifacts, err := BuildShards("/index.md", SlotA, []Entry{
+		{Hash: testHashA, Server: "mark://a", Path: "/a.md"},
+		{Hash: testHashB, Server: "mark://b", Path: "/b.md"},
+	}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := make([]ShardRef, len(artifacts))
+	responses := make(map[string]protocol.Response, len(artifacts))
+	for i, artifact := range artifacts {
+		refs[i] = artifact.Ref(i + 1)
+		responses[VersionPath(artifact.Path, i+1)] = protocol.Response{
+			Status: protocol.StatusOK, Body: artifact.Body,
+			Metadata: map[string]string{"version": strconvI(i + 1), "content-hash": artifact.ContentHash},
+		}
+	}
+	buildManifest := func(shardRefs []ShardRef) string {
+		body, buildErr := BuildManifest("/index.md", Manifest{
+			Source: "aggregated", Indexed: time.Now(), Complete: true,
+			Documents: 2, ActiveSlot: SlotA, Shards: shardRefs,
+		})
+		if buildErr != nil {
+			t.Fatal(buildErr)
+		}
+		return body
+	}
+	fetchShard := func(path string) (protocol.Response, error) { return responses[path], nil }
+
+	entries, err := LoadEntries("/index.md", buildManifest(refs), fetchShard)
+	if err != nil {
+		t.Fatalf("LoadEntries: %v", err)
+	}
+	if len(entries) != 2 || entries[0].Path != "/a.md" || entries[1].Path != "/b.md" {
+		t.Fatalf("entries = %+v", entries)
+	}
+
+	shortBody := strings.Replace(artifacts[0].Body, "| "+testHashA+" | mark://a | /a.md |\n", "", 1)
+	refs[0].Bytes = len(shortBody)
+	refs[0].ContentHash = BodyHash(shortBody)
+	responses[VersionPath(refs[0].Path, refs[0].Version)] = protocol.Response{
+		Status: protocol.StatusOK, Body: shortBody,
+		Metadata: map[string]string{"version": strconvI(refs[0].Version), "content-hash": refs[0].ContentHash},
+	}
+	if _, err := LoadEntries("/index.md", buildManifest(refs), fetchShard); err == nil || !strings.Contains(err.Error(), "declared 1 rows, body has 0") {
+		t.Fatalf("short shard error = %v", err)
+	}
+}
+
 func TestVerifyShardRejectsDrift(t *testing.T) {
 	artifacts, err := BuildShards("/index.md", SlotA, []Entry{{Hash: testHashA, Server: "mark://a", Path: "/a.md"}}, 0)
 	if err != nil {

--- a/client/index/sharded_test.go
+++ b/client/index/sharded_test.go
@@ -1,0 +1,286 @@
+package index
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/latebit-io/demarkus/protocol"
+)
+
+const testHashA = "sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+const testHashB = "sha256-abbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+func TestShardedManifestRoundTrip(t *testing.T) {
+	artifacts, err := BuildShards("/index.md", SlotA, []Entry{
+		{Hash: testHashB, Server: "mark://b", Path: "/b.md"},
+		{Hash: testHashA, Server: "mark://a", Path: "/\ta|one.md\u00a0 "},
+	}, 0)
+	if err != nil {
+		t.Fatalf("BuildShards: %v", err)
+	}
+	refs := make([]ShardRef, len(artifacts))
+	for i, artifact := range artifacts {
+		refs[i] = artifact.Ref(i + 3)
+	}
+	m := Manifest{
+		Source: "aggregated", Indexed: time.Date(2026, 8, 25, 10, 0, 0, 0, time.UTC),
+		Complete: true, Documents: 2, ActiveSlot: SlotA, Shards: refs,
+	}
+	body, err := BuildManifest("/index.md", m)
+	if err != nil {
+		t.Fatalf("BuildManifest: %v", err)
+	}
+	got, err := ParseManifest("/index.md", body)
+	if err != nil {
+		t.Fatalf("ParseManifest: %v", err)
+	}
+	if got.Source != m.Source || got.Documents != 2 || got.ActiveSlot != SlotA || len(got.Shards) != 2 {
+		t.Fatalf("manifest = %+v", got)
+	}
+	if !strings.Contains(body, "/index.shards/a/aa-000.md") || !strings.Contains(body, "/index.shards/a/ab-000.md") {
+		t.Fatalf("manifest paths missing:\n%s", body)
+	}
+	_, _, parsedEntries, err := parseShard(artifacts[0].Body)
+	if err != nil {
+		t.Fatalf("parseShard: %v", err)
+	}
+	if parsedEntries[0].Path != "/\ta|one.md\u00a0 " {
+		t.Fatalf("path = %q, want whitespace-preserving round trip", parsedEntries[0].Path)
+	}
+}
+
+func TestBuildShardsDeterministicOverflow(t *testing.T) {
+	entries := make([]Entry, 8)
+	for i := range entries {
+		entries[i] = Entry{Hash: testHashA, Server: "mark://server", Path: fmt.Sprintf("/doc-%02d.md", 7-i)}
+	}
+	one, err := BuildShards("/indexes/all.md", SlotB, entries, 330)
+	if err != nil {
+		t.Fatalf("BuildShards: %v", err)
+	}
+	two, err := BuildShards("/indexes/all.md", SlotB, entries, 330)
+	if err != nil {
+		t.Fatalf("BuildShards repeat: %v", err)
+	}
+	if len(one) < 2 || len(one) != len(two) {
+		t.Fatalf("parts = %d and %d", len(one), len(two))
+	}
+	for i := range one {
+		if one[i].Body != two[i].Body || one[i].Path != two[i].Path || one[i].Bytes > 330 {
+			t.Fatalf("part %d differs or exceeds target: %+v", i, one[i])
+		}
+		if !strings.Contains(one[i].Path, fmt.Sprintf("/b/aa-%03d.md", i)) {
+			t.Errorf("part path = %q", one[i].Path)
+		}
+	}
+}
+
+func TestEntriesForHashFetchesOnlyMatchingVerifiedShards(t *testing.T) {
+	artifacts, err := BuildShards("/index.md", SlotA, []Entry{
+		{Hash: testHashA, Server: "mark://a", Path: "/a.md"},
+		{Hash: testHashB, Server: "mark://b", Path: "/b.md"},
+	}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := make([]ShardRef, len(artifacts))
+	responses := make(map[string]protocol.Response)
+	for i, artifact := range artifacts {
+		refs[i] = artifact.Ref(i + 1)
+		responses[VersionPath(artifact.Path, i+1)] = protocol.Response{Status: protocol.StatusOK, Body: artifact.Body, Metadata: map[string]string{
+			"version": strconvI(i + 1), "content-hash": artifact.ContentHash,
+		}}
+	}
+	manifestBody, err := BuildManifest("/index.md", Manifest{
+		Source: "aggregated", Indexed: time.Now(), Complete: true,
+		Documents: 2, ActiveSlot: SlotA, Shards: refs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fetched []string
+	matches, err := EntriesForHash("/index.md", manifestBody, testHashA, func(path string) (protocol.Response, error) {
+		fetched = append(fetched, path)
+		return responses[path], nil
+	})
+	if err != nil {
+		t.Fatalf("EntriesForHash: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Path != "/a.md" || len(fetched) != 1 || !strings.Contains(fetched[0], "/aa-") {
+		t.Fatalf("matches = %+v, fetched = %v", matches, fetched)
+	}
+}
+
+func TestVerifyShardRejectsDrift(t *testing.T) {
+	artifacts, err := BuildShards("/index.md", SlotA, []Entry{{Hash: testHashA, Server: "mark://a", Path: "/a.md"}}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := artifacts[0]
+	ref := a.Ref(2)
+	tests := []protocol.Response{
+		{Status: protocol.StatusOK, Body: a.Body, Metadata: map[string]string{"version": "3", "content-hash": a.ContentHash}},
+		{Status: protocol.StatusOK, Body: a.Body + "x", Metadata: map[string]string{"version": "2", "content-hash": a.ContentHash}},
+		{Status: protocol.StatusOK, Body: a.Body, Metadata: map[string]string{"version": "2", "content-hash": testHashB}},
+	}
+	for i, resp := range tests {
+		if _, err := VerifyShard(ref, resp); err == nil {
+			t.Errorf("case %d accepted drift", i)
+		}
+	}
+}
+
+func TestVerifyShardRejectsPartPathMismatch(t *testing.T) {
+	artifacts, err := BuildShards("/index.md", SlotA, []Entry{{Hash: testHashA, Server: "mark://a", Path: "/a.md"}}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Replace(artifacts[0].Body, "> Part: 0", "> Part: 1", 1)
+	ref := artifacts[0].Ref(1)
+	ref.ContentHash = BodyHash(body)
+	ref.Bytes = len(body)
+	resp := protocol.Response{Status: protocol.StatusOK, Body: body, Metadata: map[string]string{
+		"version": "1", "content-hash": ref.ContentHash,
+	}}
+	if _, err := VerifyShard(ref, resp); err == nil {
+		t.Fatal("VerifyShard accepted part/path mismatch")
+	}
+}
+
+func TestBuildShardsExactTargetBoundary(t *testing.T) {
+	entry := []Entry{{Hash: testHashA, Server: "mark://a", Path: "/a.md"}}
+	base, err := BuildShards("/index.md", SlotA, entry, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BuildShards("/index.md", SlotA, entry, base[0].Bytes); err != nil {
+		t.Fatalf("exact boundary rejected: %v", err)
+	}
+	if _, err := BuildShards("/index.md", SlotA, entry, base[0].Bytes-1); err == nil {
+		t.Fatal("oversized single row accepted")
+	}
+}
+
+func TestEntriesForHashReadsLegacyIndex(t *testing.T) {
+	body := Build("legacy", time.Now(), []Entry{{Hash: testHashA, Server: "mark://a", Path: "/a.md"}})
+	matches, err := EntriesForHash("/index.md", body, testHashA, func(string) (protocol.Response, error) {
+		t.Fatal("legacy index fetched a shard")
+		return protocol.Response{}, nil
+	})
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("matches = %+v, err = %v", matches, err)
+	}
+}
+
+func TestBuildShardsRejectsUnsafeManifestPath(t *testing.T) {
+	entry := []Entry{{Hash: testHashA, Server: "mark://a", Path: "/a.md"}}
+	for _, manifestPath := range []string{"index.md", "/a/../index.md", "/"} {
+		if _, err := BuildShards(manifestPath, SlotA, entry, 0); err == nil {
+			t.Errorf("BuildShards accepted %q", manifestPath)
+		}
+	}
+}
+
+func TestParseManifestRejectsMissingPart(t *testing.T) {
+	indexed := time.Date(2026, 8, 25, 10, 0, 0, 0, time.UTC)
+	refs := []ShardRef{
+		{Prefix: "aa", Path: "/index.shards/a/aa-000.md", Version: 1, ContentHash: testHashA, Rows: 1, Bytes: 100},
+		{Prefix: "aa", Path: "/index.shards/a/aa-002.md", Version: 1, ContentHash: testHashB, Rows: 1, Bytes: 100},
+	}
+	if _, err := BuildManifest("/index.md", Manifest{
+		Source: "aggregated", Indexed: indexed, Complete: true, Documents: 2, ActiveSlot: SlotA, Shards: refs,
+	}); err == nil {
+		t.Fatal("BuildManifest accepted missing overflow part")
+	}
+}
+
+func TestParseManifestRejectsAmbiguousMetadata(t *testing.T) {
+	body := `# Content Index Manifest
+
+> Format: demarkus-hash-index/v2
+> Format: demarkus-hash-index/v2
+`
+	if _, err := ParseManifest("/index.md", body); err == nil {
+		t.Fatal("ParseManifest accepted duplicate metadata")
+	}
+}
+
+func TestParseManifestRejectsHugeCountsWithoutAllocation(t *testing.T) {
+	body := fmt.Sprintf(`# Content Index Manifest
+
+> Format: %s
+> Source: aggregated
+> Indexed: 2026-08-25T10:00:00Z
+> Complete: true
+> Documents: %d
+> Active-Slot: a
+
+| Prefix | Path | Version | Content Hash | Rows | Bytes |
+|--------|------|---------|--------------|------|-------|
+| aa | /index.shards/a/aa-000.md | 1 | %s | %d | 1 |
+`, ManifestFormat, int(^uint(0)>>1), testHashA, int(^uint(0)>>1))
+	if _, err := ParseManifest("/index.md", body); err == nil {
+		t.Fatal("huge manifest unexpectedly parsed")
+	}
+}
+
+func TestGeneratedParsersRejectPreambleAndBadSeparator(t *testing.T) {
+	body := `# Content Index Manifest
+
+unexpected prose
+> Format: demarkus-hash-index/v2
+`
+	if _, err := ParseManifest("/index.md", body); err == nil {
+		t.Fatal("ParseManifest accepted unexpected preamble")
+	}
+	body = strings.Replace(mustManifestBody(t), "|--------|------|---------|--------------|------|-------|", "|x|x|x|x|x|x|", 1)
+	if _, err := ParseManifest("/index.md", body); err == nil {
+		t.Fatal("ParseManifest accepted invalid separator")
+	}
+}
+
+func TestBuildShardsRejectsInvalidLocations(t *testing.T) {
+	for _, entry := range []Entry{
+		{Hash: testHashA, Server: "mark://user@host", Path: "/a.md"},
+		{Hash: testHashA, Server: "mark://host:70000", Path: "/a.md"},
+		{Hash: testHashA, Server: "mark://host", Path: "/a.md\nnext"},
+	} {
+		if _, err := BuildShards("/index.md", SlotA, []Entry{entry}, 0); err == nil {
+			t.Errorf("BuildShards accepted %+v", entry)
+		}
+	}
+}
+
+func mustManifestBody(t *testing.T) string {
+	t.Helper()
+	body, err := BuildManifest("/index.md", Manifest{
+		Source: "aggregated", Indexed: time.Date(2026, 8, 25, 10, 0, 0, 0, time.UTC),
+		Complete: true, Documents: 0, ActiveSlot: SlotA,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func TestEntriesForHashNormalizesLeadingSlash(t *testing.T) {
+	body := Build("legacy", time.Now(), []Entry{{Hash: testHashA, Server: "mark://a", Path: "/a.md"}})
+	matches, err := EntriesForHash("/index.md", body, "/"+testHashA, bodyFetcherPanic(t))
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("matches = %+v, err = %v", matches, err)
+	}
+}
+
+func bodyFetcherPanic(t *testing.T) func(string) (protocol.Response, error) {
+	t.Helper()
+	return func(string) (protocol.Response, error) {
+		t.Fatal("legacy index fetched a shard")
+		return protocol.Response{}, nil
+	}
+}
+
+func strconvI(value int) string {
+	return fmt.Sprintf("%d", value)
+}

--- a/client/internal/fedcrawl/config.go
+++ b/client/internal/fedcrawl/config.go
@@ -56,11 +56,8 @@ type PolitenessConfig struct {
 
 // PublishConfig controls hub publications (hash indexes and /graph.md).
 type PublishConfig struct {
-	// Retention caps each published artifact's version history to its newest
-	// N versions — the server prunes older versions on write (retention
-	// publish metadata, SPEC §9.9). Everything the agent publishes is
-	// regenerated wholesale on every run, so old versions are pure growth
-	// (one live graph document reached 545 versions before this existed).
+	// Retention caps graph and index-manifest histories. Version-pinned index
+	// shards omit retention so reachable manifest versions stay readable.
 	// 0 keeps every version. (default: 20)
 	Retention int `toml:"retention"`
 }

--- a/client/internal/fedcrawl/crawl.go
+++ b/client/internal/fedcrawl/crawl.go
@@ -472,16 +472,6 @@ func (c *Crawler) Hashes() map[string]index.Entry {
 	return cp
 }
 
-// IndexForServer builds a hash index document for a specific server.
-func (c *Crawler) IndexForServer(host string, indexed time.Time) string {
-	return index.Build("mark://"+host, indexed, c.entriesForServer(host))
-}
-
-// GlobalIndex builds a combined hash index document with entries from all servers.
-func (c *Crawler) GlobalIndex(indexed time.Time) string {
-	return index.Build("aggregated", indexed, c.globalEntries())
-}
-
 func (c *Crawler) entriesForServer(host string) []index.Entry {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -697,7 +687,9 @@ func (c *Crawler) PublishGraphToHubs(ctx context.Context, client PublishClient) 
 // PublishClient wraps the operations needed for publishing.
 type PublishClient interface {
 	Fetch(host, path, token string) (fetch.Result, error)
+	FetchContext(ctx context.Context, host, path, token string) (fetch.Result, error)
 	Publish(host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
+	PublishContext(ctx context.Context, host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
 }
 
 func (c *Crawler) publishShardedIndex(ctx context.Context, client PublishClient, host, manifestPath, source string, entries []index.Entry, indexed time.Time, token string) error {
@@ -706,12 +698,12 @@ func (c *Crawler) publishShardedIndex(ctx context.Context, client PublishClient,
 		Source:       source,
 		Indexed:      indexed,
 		Entries:      entries,
-	}, func(docPath string) (protocol.Response, error) {
-		result, err := client.Fetch(host, docPath, token)
+	}, func(ioCtx context.Context, docPath string) (protocol.Response, error) {
+		result, err := client.FetchContext(ioCtx, host, docPath, token)
 		return result.Response, err
-	}, func(docPath, body string, expectedVersion int) (protocol.Response, error) {
+	}, func(ioCtx context.Context, docPath, body string, expectedVersion int) (protocol.Response, error) {
 		meta := c.generatedArtifactMeta(docPath == manifestPath)
-		result, err := client.Publish(host, docPath, body, token, expectedVersion, meta)
+		result, err := client.PublishContext(ioCtx, host, docPath, body, token, expectedVersion, meta)
 		return result.Response, err
 	})
 	return err

--- a/client/internal/fedcrawl/crawl.go
+++ b/client/internal/fedcrawl/crawl.go
@@ -474,32 +474,34 @@ func (c *Crawler) Hashes() map[string]index.Entry {
 
 // IndexForServer builds a hash index document for a specific server.
 func (c *Crawler) IndexForServer(host string, indexed time.Time) string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	var entries []index.Entry
-	for _, entriesForHash := range c.hashes {
-		for _, e := range entriesForHash {
-			if e.Server == "mark://"+host {
-				entries = append(entries, e)
-			}
-		}
-	}
-
-	// Sort by path for deterministic output.
-	slices.SortFunc(entries, func(a, b index.Entry) int {
-		return strings.Compare(a.Path, b.Path)
-	})
-
-	return index.Build("mark://"+host, indexed, entries)
+	return index.Build("mark://"+host, indexed, c.entriesForServer(host))
 }
 
 // GlobalIndex builds a combined hash index document with entries from all servers.
 func (c *Crawler) GlobalIndex(indexed time.Time) string {
+	return index.Build("aggregated", indexed, c.globalEntries())
+}
+
+func (c *Crawler) entriesForServer(host string) []index.Entry {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	var entries []index.Entry
+	for _, entriesForHash := range c.hashes {
+		for _, entry := range entriesForHash {
+			if entry.Server == "mark://"+host {
+				entries = append(entries, entry)
+			}
+		}
+	}
+	slices.SortFunc(entries, func(a, b index.Entry) int {
+		return strings.Compare(a.Path, b.Path)
+	})
+	return entries
+}
 
-	// Count total entries for preallocation.
+func (c *Crawler) globalEntries() []index.Entry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	total := 0
 	for _, entriesForHash := range c.hashes {
 		total += len(entriesForHash)
@@ -518,8 +520,7 @@ func (c *Crawler) GlobalIndex(indexed time.Time) string {
 		return strings.Compare(a.Path, b.Path)
 	})
 
-	// Use empty source since this is aggregated.
-	return index.Build("aggregated", indexed, entries)
+	return entries
 }
 
 // PublishToHubs publishes indexes to all configured hubs.
@@ -547,10 +548,8 @@ func (c *Crawler) PublishToHubs(ctx context.Context, client PublishClient, perSe
 		if perServer {
 			// Publish an index for each discovered server
 			for serverHost := range c.servers {
-				idxBody := c.IndexForServer(serverHost, now)
 				idxPath := "/index/" + serverHost + ".md"
-
-				if err := c.publishIndex(ctx, client, host, idxPath, idxBody, token); err != nil {
+				if err := c.publishShardedIndex(ctx, client, host, idxPath, "mark://"+serverHost, c.entriesForServer(serverHost), now, token); err != nil {
 					publishErrs = append(publishErrs, fmt.Errorf("publish %s to hub %s: %w", idxPath, hub, err))
 					continue
 				}
@@ -558,10 +557,8 @@ func (c *Crawler) PublishToHubs(ctx context.Context, client PublishClient, perSe
 			}
 		} else {
 			// Publish a single aggregated index
-			idxBody := c.GlobalIndex(now)
 			idxPath := "/index.md"
-
-			if err := c.publishIndex(ctx, client, host, idxPath, idxBody, token); err != nil {
+			if err := c.publishShardedIndex(ctx, client, host, idxPath, "aggregated", c.globalEntries(), now, token); err != nil {
 				publishErrs = append(publishErrs, fmt.Errorf("publish %s to hub %s: %w", idxPath, hub, err))
 				continue
 			}
@@ -699,30 +696,48 @@ func (c *Crawler) PublishGraphToHubs(ctx context.Context, client PublishClient) 
 
 // PublishClient wraps the operations needed for publishing.
 type PublishClient interface {
+	Fetch(host, path, token string) (fetch.Result, error)
 	Publish(host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
 }
 
-// publishIndex publishes a single index document to a hub.
-// Hub indexes are regenerated whole-doc each crawl cycle, so we use
-// expected_version=-1 (no check) for idempotent re-publish. The server's
-// no-op-on-duplicate-content behavior prevents version churn when the
-// computed index is identical to the previous run.
-func (c *Crawler) publishIndex(ctx context.Context, client PublishClient, host, docPath, body, token string) error {
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
+func (c *Crawler) publishShardedIndex(ctx context.Context, client PublishClient, host, manifestPath, source string, entries []index.Entry, indexed time.Time, token string) error {
+	_, err := index.PublishGeneration(ctx, index.PublishOptions{
+		ManifestPath: manifestPath,
+		Source:       source,
+		Indexed:      indexed,
+		Entries:      entries,
+	}, func(docPath string) (protocol.Response, error) {
+		result, err := client.Fetch(host, docPath, token)
+		return result.Response, err
+	}, func(docPath, body string, expectedVersion int) (protocol.Response, error) {
+		meta := c.generatedArtifactMeta(docPath == manifestPath)
+		result, err := client.Publish(host, docPath, body, token, expectedVersion, meta)
+		return result.Response, err
+	})
+	return err
+}
 
+func (c *Crawler) generatedArtifactMeta(retain bool) map[string]string {
 	meta := map[string]string{
 		"agent": "demarkus-agent",
 		"tags":  "category:federation",
 		"type":  "Reference",
 	}
-	// Everything published here (hash indexes, /graph.md) is a generated
-	// artifact regenerated wholesale each run — retention keeps its version
-	// history bounded (the server prunes older versions on write, SPEC §9.9).
-	if c.cfg.Publish.Retention > 0 {
+	if retain && c.cfg.Publish.Retention > 0 {
 		meta["retention"] = strconv.Itoa(c.cfg.Publish.Retention)
 	}
+	return meta
+}
+
+// publishIndex publishes a generated whole document, currently /graph.md.
+// Duplicate bodies create no version, keeping unconditional writes idempotent.
+func (c *Crawler) publishIndex(ctx context.Context, client PublishClient, host, docPath, body, token string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	meta := c.generatedArtifactMeta(true)
+	// Retention bounds generated whole-document history (SPEC §9.9).
 	result, err := client.Publish(host, docPath, body, token, -1, meta)
 	if err != nil {
 		return err

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -3,13 +3,13 @@ package fedcrawl
 import (
 	"context"
 	"errors"
+	"fmt"
 	"maps"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/latebit-io/demarkus/client/fetch"
 	"github.com/latebit-io/demarkus/client/index"
@@ -55,6 +55,20 @@ func newMockClient() *mockClient {
 	}
 }
 
+func TestMockClientRejectsStaleManifestVersion(t *testing.T) {
+	client := newMockClient()
+	if result, err := client.Publish("hub:6309", "/index.md", "first", "", 0, nil); err != nil || result.Response.Status != protocol.StatusCreated {
+		t.Fatalf("initial publish = %+v, %v", result.Response, err)
+	}
+	result, err := client.Publish("hub:6309", "/index.md", "stale", "", 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Response.Status != protocol.StatusConflict || client.pages["hub:6309/index.md"].body != "first" {
+		t.Fatalf("stale publish = %+v, stored = %q", result.Response, client.pages["hub:6309/index.md"].body)
+	}
+}
+
 func (m *mockClient) Publish(host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -74,16 +88,30 @@ func (m *mockClient) Publish(host, path, body, token string, expectedVersion int
 	if status != protocol.StatusOK && status != protocol.StatusCreated {
 		return fetch.Result{Response: protocol.Response{Status: status}}, nil
 	}
-	version := 1
+	currentVersion := 0
 	if current, ok := m.pages[host+path]; ok {
-		version, _ = strconv.Atoi(current.metadata["version"])
-		version++
+		var err error
+		currentVersion, err = strconv.Atoi(current.metadata["version"])
+		if err != nil {
+			return fetch.Result{}, fmt.Errorf("invalid mock version: %w", err)
+		}
 	}
+	if expectedVersion >= 0 && expectedVersion != currentVersion {
+		return fetch.Result{Response: protocol.Response{Status: protocol.StatusConflict}}, nil
+	}
+	version := currentVersion + 1
 	metadata := map[string]string{"version": strconv.Itoa(version), "content-hash": index.BodyHash(body)}
 	stored := mockPage{status: protocol.StatusOK, body: body, metadata: metadata}
 	m.pages[host+path] = stored
 	m.pages[host+index.VersionPath(path, version)] = stored
 	return fetch.Result{Response: protocol.Response{Status: status, Metadata: map[string]string{"version": strconv.Itoa(version)}}}, nil
+}
+
+func (m *mockClient) PublishContext(ctx context.Context, host, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return fetch.Result{}, err
+	}
+	return m.Publish(host, path, body, token, expectedVersion, meta)
 }
 
 func (m *mockClient) addDoc(host, path, body, hash string) {
@@ -138,6 +166,13 @@ func (m *mockClient) Fetch(host, path, _ string) (fetch.Result, error) {
 		Body:     p.body,
 		Metadata: p.metadata,
 	}}, nil
+}
+
+func (m *mockClient) FetchContext(ctx context.Context, host, path, token string) (fetch.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return fetch.Result{}, err
+	}
+	return m.Fetch(host, path, token)
 }
 
 func (m *mockClient) ListWithOptions(host, path, _ string, opts fetch.ListOptions) (fetch.Result, error) {
@@ -629,34 +664,6 @@ func TestCrawlerSubdirectories(t *testing.T) {
 	}
 	if result.HashesCollected != 3 {
 		t.Errorf("HashesCollected = %d, want 3", result.HashesCollected)
-	}
-}
-
-func TestCrawlerIndexForServer(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.Seeds = []string{"mark://example.com"}
-	cfg.Crawl.MaxDocuments = 100
-
-	client := newMockClient()
-	client.addList("example.com:6309", "/", "- [a.md](a.md)\n- [b.md](b.md)\n")
-	client.addDoc("example.com:6309", "/a.md", "# A", "sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-	client.addDoc("example.com:6309", "/b.md", "# B", "sha256-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
-
-	crawler := NewCrawler(cfg, client, nil, nil)
-	_, err := crawler.Run(context.Background())
-	if err != nil {
-		t.Fatalf("Run() error: %v", err)
-	}
-
-	idx := crawler.IndexForServer("example.com:6309", time.Now())
-	if idx == "" {
-		t.Fatal("IndexForServer() returned empty string")
-	}
-	if !contains(idx, "sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
-		t.Error("Index should contain sha256-aaa...")
-	}
-	if !contains(idx, "sha256-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb") {
-		t.Error("Index should contain sha256-bbb...")
 	}
 }
 

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/client/index"
 	"github.com/latebit-io/demarkus/client/links"
 	"github.com/latebit-io/demarkus/protocol"
 )
@@ -70,7 +71,19 @@ func (m *mockClient) Publish(host, path, body, token string, expectedVersion int
 	if s, ok := m.publishStatuses[host+path]; ok {
 		status = s
 	}
-	return fetch.Result{Response: protocol.Response{Status: status}}, nil
+	if status != protocol.StatusOK && status != protocol.StatusCreated {
+		return fetch.Result{Response: protocol.Response{Status: status}}, nil
+	}
+	version := 1
+	if current, ok := m.pages[host+path]; ok {
+		version, _ = strconv.Atoi(current.metadata["version"])
+		version++
+	}
+	metadata := map[string]string{"version": strconv.Itoa(version), "content-hash": index.BodyHash(body)}
+	stored := mockPage{status: protocol.StatusOK, body: body, metadata: metadata}
+	m.pages[host+path] = stored
+	m.pages[host+index.VersionPath(path, version)] = stored
+	return fetch.Result{Response: protocol.Response{Status: status, Metadata: map[string]string{"version": strconv.Itoa(version)}}}, nil
 }
 
 func (m *mockClient) addDoc(host, path, body, hash string) {
@@ -808,11 +821,11 @@ func TestPublishToHubs(t *testing.T) {
 		if count != 1 {
 			t.Errorf("count = %d, want 1", count)
 		}
-		if len(client.publishes) != 1 {
-			t.Fatalf("expected 1 publish, got %d", len(client.publishes))
+		if len(client.publishes) != 2 {
+			t.Fatalf("expected shard + manifest publishes, got %d", len(client.publishes))
 		}
-		if client.publishes[0].Path != "/index.md" {
-			t.Errorf("publish path = %q, want /index.md", client.publishes[0].Path)
+		if client.publishes[1].Path != "/index.md" {
+			t.Errorf("last publish path = %q, want /index.md", client.publishes[1].Path)
 		}
 	})
 
@@ -838,12 +851,12 @@ func TestPublishToHubs(t *testing.T) {
 		if count != 2 {
 			t.Errorf("count = %d, want 2", count)
 		}
-		if len(client.publishes) != 2 {
-			t.Fatalf("expected 2 publishes, got %d", len(client.publishes))
+		if len(client.publishes) != 4 {
+			t.Fatalf("expected two shards + two manifests, got %d", len(client.publishes))
 		}
 		for i, call := range client.publishes {
-			if call.ExpectedVersion != -1 {
-				t.Errorf("publishes[%d].ExpectedVersion = %d, want -1 (no-check)", i, call.ExpectedVersion)
+			if call.ExpectedVersion != 0 {
+				t.Errorf("publishes[%d].ExpectedVersion = %d, want 0", i, call.ExpectedVersion)
 			}
 		}
 	})
@@ -1000,8 +1013,12 @@ func TestPublishRetentionMeta(t *testing.T) {
 			t.Fatal("expected publishes")
 		}
 		for _, call := range client.publishes {
-			if call.Meta["retention"] != "20" {
+			isShard := strings.Contains(call.Path, ".shards/")
+			if !isShard && call.Meta["retention"] != "20" {
 				t.Errorf("publish %s%s meta.retention = %q, want %q", call.Host, call.Path, call.Meta["retention"], "20")
+			}
+			if isShard && call.Meta["retention"] != "" {
+				t.Errorf("version-pinned shard %s%s must not prune history", call.Host, call.Path)
 			}
 			if call.Meta["agent"] != "demarkus-agent" {
 				t.Errorf("publish %s%s lost agent meta: %v", call.Host, call.Path, call.Meta)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1313,7 +1313,7 @@ Hubs are the entry points into the information graph:
 - `CrawlAndPersist` — shared crawl path used by CLI (`demarkus graph`), TUI (`d` key), and MCP (`mark_graph`); merges new nodes/edges into the existing store
 - `mark_backlinks` MCP tool — queries the stored graph for reverse links
 - TUI loads the stored graph instantly on `d`, then runs a live crawl in the background to discover new links
-- Hub pattern with `mark_index` — federated content indexing and hash-based resolution across servers
+- Hub pattern with `mark_index` — federated content indexing through version-pinned prefix shards; inactive-slot staging and manifest-last CAS keep each published generation atomic
 - Graph as content — `Store.Export()` renders the graph as publishable markdown with `mark://` links (six-column Edges table: `From | To | Rel | Label | Anchor | Count`); `ParseExport()` parses it back, accepting the legacy two-column shape too; CLI `demarkus graph export` and MCP `mark_graph_export` tool
 - Edge semantics — edges carry provenance (link label, source section anchor, occurrence count) and typed relations ingested from `rel-<predicate>` publisher metadata (ADR 0004)
 - Agent discovery — `mark_graph_publish` MCP tool exports and publishes the graph in one step; other agents crawl the published document to inherit the topology without recrawling original servers

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -973,7 +973,7 @@ Publishers require read access and publish access to both the manifest path and 
 - Multiple agents can maintain independent indexes on the same or different hubs.
 - No single point of failure: if a hub is unavailable, agents can query servers directly by hash.
 - Version-pinned shards are immutable inputs to a manifest generation. Publishers MUST NOT apply retention that can prune a shard version while a reachable manifest references it.
-- Manifest retention does not imply shard retention. Shards remain unpruned until a reference-aware collector can prove no retained manifest version names them.
+- Manifest retention does not imply shard retention. Shards remain unpruned until a reference-aware collector can prove no retained manifest version names them. A fixed shard window is unsafe because failed or concurrent staging can advance shard versions without advancing manifest history.
 
 ## 13. Future Extensions
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -933,9 +933,9 @@ Servers do not crawl or discover content from other servers. Agents fill this ro
 
 1. An agent fetches documents from one or more servers, collecting `content-hash` values from each response.
 2. The agent builds a mapping of content hashes to server locations.
-3. The agent publishes this mapping as a document to a hub server (e.g., a markdown table or structured list).
+3. The agent publishes this mapping as a sharded index generation to a hub server.
 
-**Example index document published to a hub:**
+Legacy indexes store all entries in one markdown table:
 
 ```markdown
 # Content Index
@@ -946,6 +946,16 @@ Servers do not crawl or discover content from other servers. Agents fill this ro
 | sha256-d4e5f6... | mark://notes.example.com | /readme.md |
 | sha256-d4e5f6... | mark://mirror.example.com | /copy.md |
 ```
+
+Current indexes use a `demarkus-hash-index/v2` manifest at the requested index path. The manifest records the source, index time, completeness, document count, active slot, and each shard's hash prefix, path, immutable version, content hash, row count, and byte count. Shards use `demarkus-hash-index-shard/v1` and retain the `Hash | Server | Path` table shape.
+
+Entries are partitioned by the first two lowercase hexadecimal characters after `sha256-`. A prefix may have multiple deterministic overflow parts. For a manifest at `/index.md`, shard paths have the form `/index.shards/{a|b}/<prefix>-<part>.md`. Other manifest paths use the same `.shards` suffix rule.
+
+Publishers stage a complete generation in the inactive `a` or `b` slot. They publish and verify every shard first, then compare-and-swap the manifest last. A failed manifest publish leaves the previous generation active. Readers fetch each shard through its immutable version path, such as `/index.shards/a/a1-000.md/v4`, and verify response version, byte count, content hash, shard identity, and row count against the manifest. Implementations MUST reject incomplete manifests, out-of-scope shard paths, missing overflow parts, and aggregate count mismatches.
+
+Hash resolution fetches only shards matching the requested hash prefix. Full-index updates fetch and verify every referenced shard before merging. Readers SHOULD continue accepting legacy single-document indexes so deployed indexes migrate on their next successful publication.
+
+Publishers require read access and publish access to both the manifest path and its `.shards` subtree; read access may be public. Deployments MUST upgrade all index readers and writers before enabling v2 publication at an existing legacy path; a legacy reader interprets a v2 manifest as an empty index and a legacy writer can overwrite it.
 
 **Resolution flow when content is missing:**
 
@@ -962,6 +972,8 @@ Servers do not crawl or discover content from other servers. Agents fill this ro
 - Hubs are just servers: the index is a regular published document, not a special protocol feature.
 - Multiple agents can maintain independent indexes on the same or different hubs.
 - No single point of failure: if a hub is unavailable, agents can query servers directly by hash.
+- Version-pinned shards are immutable inputs to a manifest generation. Publishers MUST NOT apply retention that can prune a shard version while a reachable manifest references it.
+- Manifest retention does not imply shard retention. Shards remain unpruned until a reference-aware collector can prove no retained manifest version names them.
 
 ## 13. Future Extensions
 

--- a/docs/site/tools/agent.md
+++ b/docs/site/tools/agent.md
@@ -201,7 +201,7 @@ When `-publish` is set, the crawler publishes hash indexes to configured hubs.
 
 ### Aggregated Index
 
-By default, publishes one logical index at `/index.md` containing entries from all servers:
+By default, the crawler publishes one logical index at `/index.md` containing entries from all servers:
 
 ```bash
 demarkus-agent crawl -config fedcrawl.toml -publish -insecure
@@ -219,7 +219,7 @@ Indexes are published to `/index/<host>.md` on each hub.
 
 Each logical index path is a small manifest. Entries are stored in hash-prefix shards under a sibling `.shards/a/` or `.shards/b/` directory. The agent stages and verifies the inactive slot before publishing the manifest, so readers see either the old complete generation or the new complete generation. Existing single-document indexes are converted automatically on their next publication.
 
-The agent needs read access and publish access to the manifest and its `.shards` subtree; read access may be public. Upgrade index readers and writers together before enabling this publisher against an existing legacy index. Configured retention applies to graph documents and index manifests; version-pinned shard history remains unpruned so retained manifests cannot acquire dangling references.
+The agent needs read access and publish access to the manifest and its `.shards` subtree; read access may be public. Upgrade index readers and writers together before enabling this publisher against an existing legacy index. Configured retention applies to graph documents and index manifests. Version-pinned shard history remains unpruned so retained manifests cannot acquire dangling references. Operators should monitor `.shards` growth until reference-aware garbage collection is available; a fixed shard window is unsafe because failed or concurrent staging can advance shard versions without advancing the manifest.
 
 ### Content-Addressed Discovery
 

--- a/docs/site/tools/agent.md
+++ b/docs/site/tools/agent.md
@@ -201,7 +201,7 @@ When `-publish` is set, the crawler publishes hash indexes to configured hubs.
 
 ### Aggregated Index
 
-By default, publishes a single `/index.md` containing entries from all servers:
+By default, publishes one logical index at `/index.md` containing entries from all servers:
 
 ```bash
 demarkus-agent crawl -config fedcrawl.toml -publish -insecure
@@ -217,9 +217,13 @@ demarkus-agent crawl -config fedcrawl.toml -publish -per-server -insecure
 
 Indexes are published to `/index/<host>.md` on each hub.
 
+Each logical index path is a small manifest. Entries are stored in hash-prefix shards under a sibling `.shards/a/` or `.shards/b/` directory. The agent stages and verifies the inactive slot before publishing the manifest, so readers see either the old complete generation or the new complete generation. Existing single-document indexes are converted automatically on their next publication.
+
+The agent needs read access and publish access to the manifest and its `.shards` subtree; read access may be public. Upgrade index readers and writers together before enabling this publisher against an existing legacy index. Configured retention applies to graph documents and index manifests; version-pinned shard history remains unpruned so retained manifests cannot acquire dangling references.
+
 ### Content-Addressed Discovery
 
-Published indexes enable content-addressed fetching. A hub can resolve a content hash to servers hosting that content:
+Published indexes enable content-addressed fetching. Resolution reads only the shard matching the requested hash prefix:
 
 ```bash
 # Resolve content by hash (requires hub with index)

--- a/docs/site/tools/agent.md
+++ b/docs/site/tools/agent.md
@@ -223,7 +223,7 @@ The agent needs read access and publish access to the manifest and its `.shards`
 
 ### Content-Addressed Discovery
 
-Published indexes enable content-addressed fetching. Resolution reads only the shard matching the requested hash prefix:
+Published indexes enable content-addressed fetching. Resolution reads all shards matching the requested hash prefix, including every deterministic overflow part:
 
 ```bash
 # Resolve content by hash (requires hub with index)

--- a/tools/demarkus-broker/MCP-API.md
+++ b/tools/demarkus-broker/MCP-API.md
@@ -255,6 +255,14 @@ Crawl a source world, collect content hashes, and publish a hash
 index to a target world (typically a hub). Verifies the target has a
 hub manifest unless `force: true`.
 
+The target path stores a `demarkus-hash-index/v2` manifest. The broker
+stages version-pinned hash-prefix shards under the target's `.shards`
+directory and compare-and-swaps the manifest last. Updates verify and
+merge legacy or sharded target indexes before publication.
+The manifest and its sibling `.shards` subtree must be publicly readable;
+the target token requires publish access to both. Upgrade all readers and
+writers before publishing v2 at an existing legacy path.
+
 | Param | Type | Required | Notes |
 | --- | --- | --- | --- |
 | `source` | string | yes | Source world URL to crawl. |

--- a/tools/demarkus-broker/internal/broker/mcp_tools_federation.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_federation.go
@@ -58,9 +58,11 @@ func (g *mcpGateway) handleMarkResolve(_ context.Context, req mcp.CallToolReques
 	if err != nil {
 		return mcp.NewToolResultError("hash is required"), nil
 	}
-	if _, ok := protocol.IsHashPath(hash); !ok {
+	cleanHash, ok := protocol.IsHashPath(hash)
+	if !ok {
 		return mcp.NewToolResultError("invalid hash format: expected sha256-<64 lowercase hex characters>"), nil
 	}
+	hash = cleanHash
 	indexURL, err := req.RequireString("index")
 	if err != nil {
 		return mcp.NewToolResultError("index is required"), nil
@@ -79,13 +81,13 @@ func (g *mcpGateway) handleMarkResolve(_ context.Context, req mcp.CallToolReques
 		return mcp.NewToolResultError(fmt.Sprintf("index fetch returned: %s", indexResult.Response.Status)), nil
 	}
 
-	// 2. Parse and filter for matching hash entries.
-	entries := index.Parse(indexResult.Response.Body)
-	matches := make([]index.Entry, 0, len(entries))
-	for _, e := range entries {
-		if e.Hash == hash {
-			matches = append(matches, e)
-		}
+	// 2. V2 manifests fetch only matching prefix shards; legacy indexes stay inline.
+	matches, err := index.EntriesForHash(indexPath, indexResult.Response.Body, hash, func(shardPath string) (protocol.Response, error) {
+		result, err := g.dispatcher.Fetch(indexWorld, shardPath, "")
+		return result.Response, err
+	})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid index: %v", err)), nil
 	}
 	if len(matches) == 0 {
 		return mcp.NewToolResultError(fmt.Sprintf("hash %s not found in index", hash)), nil

--- a/tools/demarkus-broker/internal/broker/mcp_tools_federation_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_federation_test.go
@@ -3,13 +3,16 @@ package broker
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/client/index"
 	"github.com/latebit-io/demarkus/protocol"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -160,6 +163,60 @@ func TestHandleMarkResolveHappyPath(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Errorf("response missing %q\nfull:\n%s", want, text)
 		}
+	}
+}
+
+func TestHandleMarkResolveShardedManifest(t *testing.T) {
+	artifacts, err := index.BuildShards("/hub/index.md", index.SlotA, []index.Entry{
+		{Hash: testHashA, Server: "mark://team-a", Path: "/foo.md"},
+		{Hash: testHashB, Server: "mark://team-b", Path: "/bar.md"},
+	}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := make([]index.ShardRef, len(artifacts))
+	shards := make(map[string]fetch.Result)
+	for i, artifact := range artifacts {
+		version := i + 1
+		refs[i] = artifact.Ref(version)
+		shards[index.VersionPath(artifact.Path, version)] = fetch.Result{Response: protocol.Response{
+			Status: protocol.StatusOK, Body: artifact.Body,
+			Metadata: map[string]string{"version": fmt.Sprint(version), "content-hash": artifact.ContentHash},
+		}}
+	}
+	manifest, err := index.BuildManifest("/hub/index.md", index.Manifest{
+		Source: "aggregated", Indexed: time.Now(), Complete: true,
+		Documents: 2, ActiveSlot: index.SlotA, Shards: refs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var shardFetches atomic.Int32
+	d := &fakeDispatcher{fetchFn: func(_, path, _ string) (fetch.Result, error) {
+		if path == "/hub/index.md" {
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: manifest}}, nil
+		}
+		if shard, ok := shards[path]; ok {
+			shardFetches.Add(1)
+			return shard, nil
+		}
+		if path == "/"+testHashA {
+			return fetch.Result{Response: protocol.Response{
+				Status: protocol.StatusOK, Body: "# resolved content\n",
+				Metadata: map[string]string{"content-hash": testHashA, "version": "1"},
+			}}, nil
+		}
+		return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+	}}
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), d)
+	res, err := g.handleMarkResolve(withAliceClaims(t.Context()), callToolReq("mark_resolve", map[string]any{
+		"hash": testHashA, "index": "mark://team-a/hub/index.md",
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("handleMarkResolve = (%+v, %v)", res, err)
+	}
+	if shardFetches.Load() != 1 {
+		t.Fatalf("shard fetches = %d, want 1", shardFetches.Load())
 	}
 }
 

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
@@ -355,7 +355,7 @@ var errIndexTruncated = errors.New("document limit reached, index is truncated")
 // demarkus-mcp's mark_index behavior, including the manifest
 // safeguards: target world must have an agent manifest or
 // force=true must be passed to override.
-func (g *mcpGateway) handleMarkIndex(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go
+func (g *mcpGateway) handleMarkIndex(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic,gocyclo // MCP signature; validation and publication stay one flow
 	sourceURL, err := req.RequireString("source")
 	if err != nil {
 		return mcp.NewToolResultError("source is required"), nil
@@ -426,7 +426,8 @@ func (g *mcpGateway) handleMarkIndex(ctx context.Context, req mcp.CallToolReques
 		warnings = append(warnings, fmt.Sprintf("warning: crawl skipped %d entries, index is incomplete", len(iw.incomplete)))
 	}
 
-	body := index.Build(sourceScheme, time.Now(), entries)
+	indexedAt := time.Now()
+	body := index.Build(sourceScheme, indexedAt, entries)
 
 	if dryRun {
 		var b strings.Builder
@@ -441,7 +442,9 @@ func (g *mcpGateway) handleMarkIndex(ctx context.Context, req mcp.CallToolReques
 		return mcp.NewToolResultError("crawl incomplete; refusing to publish an authoritative index"), nil
 	}
 
-	// Merge with existing index if updating an existing target.
+	manifestSource := sourceScheme
+	logicalEntries := entries
+	// Merge with an existing legacy index or verified sharded generation.
 	if expectedVersion > 0 {
 		existing, fetchErr := g.dispatcher.Fetch(targetWorld, targetPath, "")
 		if fetchErr != nil {
@@ -450,15 +453,50 @@ func (g *mcpGateway) handleMarkIndex(ctx context.Context, req mcp.CallToolReques
 		if existing.Response.Status != protocol.StatusOK {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to fetch existing index: %s", existing.Response.Status)), nil
 		}
-		existingEntries := index.Parse(existing.Response.Body)
-		merged := index.Merge(existingEntries, sourceScheme, entries)
-		targetScheme := "mark://" + targetWorld
-		body = index.Build(targetScheme, time.Now(), merged)
+		existingEntries, loadErr := index.LoadEntries(targetPath, existing.Response.Body, func(shardPath string) (protocol.Response, error) {
+			shard, err := g.dispatcher.Fetch(targetWorld, shardPath, "")
+			return shard.Response, err
+		})
+		if loadErr != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to read existing index: %v", loadErr)), nil
+		}
+		logicalEntries = index.Merge(existingEntries, sourceScheme, entries)
+		manifestSource = "mark://" + targetWorld
 	}
 
 	meta := agentMetaFromClaims(claims)
 	result, err := g.dispatchWithWriteAuth(ctx, targetWorld, func(token string) (fetch.Result, error) {
-		return g.dispatcher.Publish(targetWorld, targetPath, body, token, expectedVersion, meta)
+		unauthorized := false
+		published, publishErr := index.PublishGeneration(ctx, index.PublishOptions{
+			ManifestPath:            targetPath,
+			Source:                  manifestSource,
+			Indexed:                 indexedAt,
+			Entries:                 logicalEntries,
+			ExpectedManifestVersion: &expectedVersion,
+		}, func(docPath string) (protocol.Response, error) {
+			fetched, fetchErr := g.dispatcher.Fetch(targetWorld, docPath, "")
+			return fetched.Response, fetchErr
+		}, func(docPath, docBody string, expected int) (protocol.Response, error) {
+			publishedDoc, publishDocErr := g.dispatcher.Publish(targetWorld, docPath, docBody, token, expected, meta)
+			if publishDocErr == nil && publishedDoc.Response.Status == protocol.StatusUnauthorized {
+				unauthorized = true
+			}
+			return publishedDoc.Response, publishDocErr
+		})
+		if publishErr != nil {
+			if unauthorized {
+				return fetch.Result{Response: protocol.Response{Status: protocol.StatusUnauthorized}}, nil
+			}
+			return fetch.Result{}, publishErr
+		}
+		return fetch.Result{Response: protocol.Response{
+			Status: protocol.StatusOK,
+			Metadata: map[string]string{
+				"version":          strconv.Itoa(published.ManifestVersion),
+				"shards-published": strconv.Itoa(published.ShardsPublished),
+				"shards-reused":    strconv.Itoa(published.ShardsReused),
+			},
+		}}, nil
 	})
 	if err != nil {
 		return g.toolErrorFor("index (publish)", targetWorld, err), nil
@@ -469,7 +507,7 @@ func (g *mcpGateway) handleMarkIndex(ctx context.Context, req mcp.CallToolReques
 		out.WriteString(w + "\n")
 	}
 	fmt.Fprintf(&out, "Indexed %d documents from %s\n", len(entries), sourceScheme)
-	out.WriteString(formatToolResult(result, "version", "modified"))
+	out.WriteString(formatToolResult(result, "version", "shards-published", "shards-reused"))
 	return mcp.NewToolResultText(out.String()), nil
 }
 

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
@@ -348,6 +348,7 @@ const maxIndexDocuments = 1000
 // errIndexTruncated is sentinel-returned by walkDir to short-
 // circuit the recursion when maxIndexDocuments is reached.
 var errIndexTruncated = errors.New("document limit reached, index is truncated")
+var errIndexPublishUnauthorized = errors.New("index publish unauthorized")
 
 // handleMarkIndex crawls a source world, collects content
 // hashes, and either returns the index document (dry_run) or
@@ -434,7 +435,7 @@ func (g *mcpGateway) handleMarkIndex(ctx context.Context, req mcp.CallToolReques
 		for _, w := range warnings {
 			b.WriteString(w + "\n")
 		}
-		fmt.Fprintf(&b, "Indexed %d documents from %s (dry run, not published)\n\n", len(entries), sourceScheme)
+		fmt.Fprintf(&b, "Indexed %d documents from %s (dry run, logical entry preview only; publication writes a v2 manifest and shards)\n\n", len(entries), sourceScheme)
 		b.WriteString(body)
 		return mcp.NewToolResultText(b.String()), nil
 	}
@@ -466,25 +467,24 @@ func (g *mcpGateway) handleMarkIndex(ctx context.Context, req mcp.CallToolReques
 
 	meta := agentMetaFromClaims(claims)
 	result, err := g.dispatchWithWriteAuth(ctx, targetWorld, func(token string) (fetch.Result, error) {
-		unauthorized := false
 		published, publishErr := index.PublishGeneration(ctx, index.PublishOptions{
 			ManifestPath:            targetPath,
 			Source:                  manifestSource,
 			Indexed:                 indexedAt,
 			Entries:                 logicalEntries,
 			ExpectedManifestVersion: &expectedVersion,
-		}, func(docPath string) (protocol.Response, error) {
-			fetched, fetchErr := g.dispatcher.Fetch(targetWorld, docPath, "")
+		}, func(ioCtx context.Context, docPath string) (protocol.Response, error) {
+			fetched, fetchErr := g.dispatcher.FetchContext(ioCtx, targetWorld, docPath, "")
 			return fetched.Response, fetchErr
-		}, func(docPath, docBody string, expected int) (protocol.Response, error) {
-			publishedDoc, publishDocErr := g.dispatcher.Publish(targetWorld, docPath, docBody, token, expected, meta)
+		}, func(ioCtx context.Context, docPath, docBody string, expected int) (protocol.Response, error) {
+			publishedDoc, publishDocErr := g.dispatcher.PublishContext(ioCtx, targetWorld, docPath, docBody, token, expected, meta)
 			if publishDocErr == nil && publishedDoc.Response.Status == protocol.StatusUnauthorized {
-				unauthorized = true
+				return publishedDoc.Response, errIndexPublishUnauthorized
 			}
 			return publishedDoc.Response, publishDocErr
 		})
 		if publishErr != nil {
-			if unauthorized {
+			if errors.Is(publishErr, errIndexPublishUnauthorized) {
 				return fetch.Result{Response: protocol.Response{Status: protocol.StatusUnauthorized}}, nil
 			}
 			return fetch.Result{}, publishErr

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
@@ -447,7 +447,7 @@ func (g *mcpGateway) handleMarkIndex(ctx context.Context, req mcp.CallToolReques
 	logicalEntries := entries
 	// Merge with an existing legacy index or verified sharded generation.
 	if expectedVersion > 0 {
-		existing, fetchErr := g.dispatcher.Fetch(targetWorld, targetPath, "")
+		existing, fetchErr := g.dispatcher.FetchContext(ctx, targetWorld, targetPath, "")
 		if fetchErr != nil {
 			return g.toolErrorFor("index (fetch existing)", targetWorld, fetchErr), nil
 		}
@@ -455,7 +455,7 @@ func (g *mcpGateway) handleMarkIndex(ctx context.Context, req mcp.CallToolReques
 			return mcp.NewToolResultError(fmt.Sprintf("failed to fetch existing index: %s", existing.Response.Status)), nil
 		}
 		existingEntries, loadErr := index.LoadEntries(targetPath, existing.Response.Body, func(shardPath string) (protocol.Response, error) {
-			shard, err := g.dispatcher.Fetch(targetWorld, shardPath, "")
+			shard, err := g.dispatcher.FetchContext(ctx, targetWorld, shardPath, "")
 			return shard.Response, err
 		})
 		if loadErr != nil {

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph_test.go
@@ -287,7 +287,7 @@ func TestHandleMarkIndexBoundsOnDirectoryCycle(t *testing.T) {
 		TokensSecret: "hub-tokens",
 		Allow:        AllowConfig{Domains: []string{"example.com"}},
 		DefaultToken: TokenScope{
-			Paths: []string{"/*"},
+			Paths: []string{"/**"},
 		},
 	})
 	var listCalls atomic.Int32
@@ -462,16 +462,19 @@ const indexManifestBody = "# Agent Manifest\n\nThis world accepts index publicat
 
 func TestHandleMarkIndexHappyPath(t *testing.T) {
 	cfg := mcpTestConfig()
+	cfg.Server.MCP.FirstMintMaxAttempts = 3
+	cfg.Server.MCP.FirstMintInitialBackoff = time.Nanosecond
 	cfg.Worlds = append(cfg.Worlds, WorldConfig{
 		Name:         "hub",
 		Namespace:    "hub",
 		TokensSecret: "hub-tokens",
 		Allow:        AllowConfig{Domains: []string{"example.com"}},
 		DefaultToken: TokenScope{
-			Paths: []string{"/*"},
+			Paths: []string{"/**"},
 		},
 	})
 	var publishCalled atomic.Bool
+	var publishAttempts atomic.Int32
 	d := &fakeDispatcher{
 		fetchFn: func(_, path, token string) (fetch.Result, error) {
 			if token != "" {
@@ -524,6 +527,9 @@ func TestHandleMarkIndexHappyPath(t *testing.T) {
 			if token == "" {
 				t.Error("index publish dispatched without a publish token")
 			}
+			if publishAttempts.Add(1) == 1 {
+				return fetch.Result{Response: protocol.Response{Status: protocol.StatusUnauthorized}}, nil
+			}
 			return fetch.Result{Response: protocol.Response{
 				Status:   protocol.StatusOK,
 				Metadata: map[string]string{"version": "1", "modified": "2026-05-22T11:00:00Z"},
@@ -544,6 +550,20 @@ func TestHandleMarkIndexHappyPath(t *testing.T) {
 	if !publishCalled.Load() {
 		t.Error("publish was not called; expected the index doc to be written to target")
 	}
+	d.mu.Lock()
+	publishCalls := append([]writeCall(nil), d.publishCalls...)
+	d.mu.Unlock()
+	if len(publishCalls) != 4 {
+		t.Fatalf("publish calls = %d, want rejected shard + two shards + manifest", len(publishCalls))
+	}
+	if publishCalls[3].path != "/index.md" {
+		t.Fatalf("last publish path = %q, want manifest /index.md", publishCalls[3].path)
+	}
+	for i, call := range publishCalls {
+		if call.expectedVersion != 0 {
+			t.Errorf("publish call %d expected_version = %d, want 0", i, call.expectedVersion)
+		}
+	}
 	text := toolResultText(t, res)
 	if !strings.Contains(text, "Indexed 2 documents") {
 		t.Errorf("expected indexed-count line, got:\n%s", text)
@@ -558,7 +578,7 @@ func TestHandleMarkIndexBlocksWhenTargetHasNoManifest(t *testing.T) {
 		TokensSecret: "hub-tokens",
 		Allow:        AllowConfig{Domains: []string{"example.com"}},
 		DefaultToken: TokenScope{
-			Paths: []string{"/*"},
+			Paths: []string{"/**"},
 		},
 	})
 	d := &fakeDispatcher{
@@ -595,7 +615,7 @@ func TestHandleMarkIndexForceOverridesManifestBlock(t *testing.T) {
 		TokensSecret: "hub-tokens",
 		Allow:        AllowConfig{Domains: []string{"example.com"}},
 		DefaultToken: TokenScope{
-			Paths: []string{"/*"},
+			Paths: []string{"/**"},
 		},
 	})
 	var publishCalled atomic.Bool
@@ -646,7 +666,7 @@ func TestHandleMarkIndexDryRunReturnsBodyWithoutPublishing(t *testing.T) {
 		TokensSecret: "hub-tokens",
 		Allow:        AllowConfig{Domains: []string{"example.com"}},
 		DefaultToken: TokenScope{
-			Paths: []string{"/*"},
+			Paths: []string{"/**"},
 		},
 	})
 	var publishCalled atomic.Bool

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph_test.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/latebit-io/demarkus/client/fetch"
 	"github.com/latebit-io/demarkus/client/graph"
+	"github.com/latebit-io/demarkus/client/index"
 	"github.com/latebit-io/demarkus/protocol"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -459,6 +461,30 @@ func TestHandleMarkGraphPublishForwardsThroughWriteAuth(t *testing.T) {
 // indexManifestBody builds a minimal agent manifest the dispatcher
 // can return when the test wants to satisfy the manifest check.
 const indexManifestBody = "# Agent Manifest\n\nThis world accepts index publications.\n"
+
+func TestIndexUnauthorizedReconcileDoesNotMaskLaterManifestFailure(t *testing.T) {
+	var shard protocol.Response
+	_, err := index.PublishGeneration(t.Context(), index.PublishOptions{
+		ManifestPath: "/index.md", Source: "mark://team-a", Indexed: time.Now(),
+		Entries: []index.Entry{{Hash: "sha256-" + strings.Repeat("a", 64), Server: "mark://team-a", Path: "/a.md"}},
+	}, func(_ context.Context, path string) (protocol.Response, error) {
+		if strings.Contains(path, ".shards/") && shard.Status != "" {
+			return shard, nil
+		}
+		return protocol.Response{Status: protocol.StatusNotFound}, nil
+	}, func(_ context.Context, path, body string, _ int) (protocol.Response, error) {
+		if strings.Contains(path, ".shards/") {
+			shard = protocol.Response{Status: protocol.StatusOK, Body: body, Metadata: map[string]string{
+				"version": "1", "content-hash": index.BodyHash(body),
+			}}
+			return protocol.Response{Status: protocol.StatusUnauthorized}, errIndexPublishUnauthorized
+		}
+		return protocol.Response{Status: protocol.StatusConflict}, nil
+	})
+	if err == nil || errors.Is(err, errIndexPublishUnauthorized) {
+		t.Fatalf("manifest failure = %v, want non-auth error", err)
+	}
+}
 
 func TestHandleMarkIndexHappyPath(t *testing.T) {
 	cfg := mcpTestConfig()

--- a/tools/demarkus-broker/internal/broker/mcp_tools_list.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_list.go
@@ -337,7 +337,8 @@ func markIndexTool() mcp.Tool {
 	return mcp.NewTool("mark_index",
 		mcp.WithDescription(
 			"Crawl a Mark Protocol server, collect content hashes from all documents, "+
-				"and publish a hash index document to a target server (typically a hub). "+
+				"and publish a sharded hash index to a target server (typically a hub). "+
+				"The target manifest and .shards subtree must be publicly readable; the world token needs publish access to both. "+
 				"The tool checks the target's agent manifest before publishing. "+
 				mcpURLHint,
 		),

--- a/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
@@ -101,6 +101,13 @@ func (f *fakeDispatcher) Fetch(worldName, path, token string) (fetch.Result, err
 	return fn(worldName, path, token)
 }
 
+func (f *fakeDispatcher) FetchContext(ctx context.Context, worldName, path, token string) (fetch.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return fetch.Result{}, err
+	}
+	return f.Fetch(worldName, path, token)
+}
+
 func (f *fakeDispatcher) FetchConditional(worldName, path, token, etag string) (fetch.Result, error) {
 	f.mu.Lock()
 	f.fetchCondCalls = append(f.fetchCondCalls, condCall{worldName, path, token, etag})
@@ -204,6 +211,19 @@ func (f *fakeDispatcher) Publish(worldName, path, body, token string, expectedVe
 		}
 		stored := fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: body, Metadata: metadata}}
 		f.mu.Lock()
+		currentVersion := 0
+		current, exists := f.published[worldName+path]
+		if exists {
+			currentVersion, versionErr = strconv.Atoi(current.Response.Metadata["version"])
+			if versionErr != nil {
+				f.mu.Unlock()
+				return fetch.Result{}, fmt.Errorf("invalid fake version: %w", versionErr)
+			}
+		}
+		if expectedVersion >= 0 && expectedVersion != currentVersion {
+			f.mu.Unlock()
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusConflict}}, nil
+		}
 		if f.published == nil {
 			f.published = make(map[string]fetch.Result)
 		}
@@ -212,6 +232,13 @@ func (f *fakeDispatcher) Publish(worldName, path, body, token string, expectedVe
 		f.mu.Unlock()
 	}
 	return result, nil
+}
+
+func (f *fakeDispatcher) PublishContext(ctx context.Context, worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return fetch.Result{}, err
+	}
+	return f.Publish(worldName, path, body, token, expectedVersion, meta)
 }
 
 func (f *fakeDispatcher) Append(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error) {

--- a/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/client/index"
 	"github.com/latebit-io/demarkus/client/links"
 	"github.com/latebit-io/demarkus/protocol"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -36,6 +37,7 @@ type fakeDispatcher struct {
 	publishFn   func(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
 	appendFn    func(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
 	archiveFn   func(worldName, path, token string) (fetch.Result, error)
+	published   map[string]fetch.Result
 
 	fetchCalls     []dispatchCall
 	fetchCondCalls []condCall
@@ -87,8 +89,12 @@ type writeCall struct {
 func (f *fakeDispatcher) Fetch(worldName, path, token string) (fetch.Result, error) {
 	f.mu.Lock()
 	f.fetchCalls = append(f.fetchCalls, dispatchCall{worldName, path, token})
+	stored, ok := f.published[worldName+path]
 	fn := f.fetchFn
 	f.mu.Unlock()
+	if ok {
+		return stored, nil
+	}
 	if fn == nil {
 		return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK}}, nil
 	}
@@ -177,13 +183,35 @@ func (f *fakeDispatcher) Publish(worldName, path, body, token string, expectedVe
 	f.publishCalls = append(f.publishCalls, writeCall{worldName, path, body, token, expectedVersion, cloneMeta(meta)})
 	fn := f.publishFn
 	f.mu.Unlock()
+	var result fetch.Result
+	var err error
 	if fn == nil {
-		return fetch.Result{Response: protocol.Response{
+		result = fetch.Result{Response: protocol.Response{
 			Status:   protocol.StatusOK,
 			Metadata: map[string]string{"version": "1"},
-		}}, nil
+		}}
+	} else {
+		result, err = fn(worldName, path, body, token, expectedVersion, meta)
 	}
-	return fn(worldName, path, body, token, expectedVersion, meta)
+	if err != nil || (result.Response.Status != protocol.StatusOK && result.Response.Status != protocol.StatusCreated) {
+		return result, err
+	}
+	version, versionErr := strconv.Atoi(result.Response.Metadata["version"])
+	if versionErr == nil && version > 0 {
+		metadata := map[string]string{
+			"version":      strconv.Itoa(version),
+			"content-hash": index.BodyHash(body),
+		}
+		stored := fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: body, Metadata: metadata}}
+		f.mu.Lock()
+		if f.published == nil {
+			f.published = make(map[string]fetch.Result)
+		}
+		f.published[worldName+path] = stored
+		f.published[worldName+index.VersionPath(path, version)] = stored
+		f.mu.Unlock()
+	}
+	return result, nil
 }
 
 func (f *fakeDispatcher) Append(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error) {

--- a/tools/demarkus-broker/internal/broker/mcp_tools_write_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_write_test.go
@@ -22,6 +22,9 @@ import (
 func TestHandleMarkPublishHappyPath(t *testing.T) {
 	cfg := mcpTestConfig()
 	d := &fakeDispatcher{
+		published: map[string]fetch.Result{
+			"team-a/foo.md": {Response: protocol.Response{Status: protocol.StatusOK, Metadata: map[string]string{"version": "3"}}},
+		},
 		publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
 			return fetch.Result{Response: protocol.Response{
 				Status: protocol.StatusOK,
@@ -193,6 +196,9 @@ func TestHandleMarkPublishNegativeExpectedVersion(t *testing.T) {
 func TestHandleMarkPublishMergeCleanOutcomeOK(t *testing.T) {
 	cfg := mcpTestConfig()
 	d := &fakeDispatcher{
+		published: map[string]fetch.Result{
+			"team-a/foo.md": {Response: protocol.Response{Status: protocol.StatusOK, Metadata: map[string]string{"version": "4"}}},
+		},
 		publishFn: func(_, _, _, _ string, _ int, _ map[string]string) (fetch.Result, error) {
 			return fetch.Result{Response: protocol.Response{
 				Status: protocol.StatusOK,

--- a/tools/demarkus-broker/internal/broker/world_pool.go
+++ b/tools/demarkus-broker/internal/broker/world_pool.go
@@ -23,12 +23,14 @@ import (
 // tools land in Slices 4–5.
 type worldDispatcher interface {
 	Fetch(worldName, path, token string) (fetch.Result, error)
+	FetchContext(ctx context.Context, worldName, path, token string) (fetch.Result, error)
 	FetchConditional(worldName, path, token, etag string) (fetch.Result, error)
 	List(worldName, path, token string, opts fetch.ListOptions) (fetch.Result, error)
 	Versions(worldName, path, token string) (fetch.Result, error)
 	Lookup(worldName, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error)
 	LookupContext(ctx context.Context, worldName, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error)
 	Publish(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
+	PublishContext(ctx context.Context, worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
 	Append(worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error)
 	Archive(worldName, path, token string) (fetch.Result, error)
 }
@@ -112,6 +114,14 @@ func (p *worldPool) Fetch(worldName, path, token string) (fetch.Result, error) {
 	return c.Fetch(host, path, token)
 }
 
+func (p *worldPool) FetchContext(ctx context.Context, worldName, path, token string) (fetch.Result, error) {
+	c, host, err := p.clientFor(worldName)
+	if err != nil {
+		return fetch.Result{}, err
+	}
+	return c.FetchContext(ctx, host, path, token)
+}
+
 // FetchConditional dispatches a FETCH with an explicit if-none-match etag
 // (the graph seeder tracks /graph.md freshness itself).
 func (p *worldPool) FetchConditional(worldName, path, token, etag string) (fetch.Result, error) {
@@ -174,6 +184,14 @@ func (p *worldPool) Publish(worldName, path, body, token string, expectedVersion
 		return fetch.Result{}, err
 	}
 	return c.Publish(host, path, body, token, expectedVersion, meta)
+}
+
+func (p *worldPool) PublishContext(ctx context.Context, worldName, path, body, token string, expectedVersion int, meta map[string]string) (fetch.Result, error) {
+	c, host, err := p.clientFor(worldName)
+	if err != nil {
+		return fetch.Result{}, err
+	}
+	return c.PublishContext(ctx, host, path, body, token, expectedVersion, meta)
 }
 
 // Append dispatches an APPEND against worldName. The world


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sharded hash-index publication with version-pinned shards and atomic manifest updates.
  * Added targeted hash resolution for sharded indexes while preserving legacy compatibility.
  * Added shard reuse, verification, optimistic concurrency, and publication status reporting.
  * Added context-aware fetch and publish operations.

* **Bug Fixes**
  * Improved hash normalization and validation during content resolution.
  * Retention now preserves shards referenced by active index manifests.

* **Documentation**
  * Updated index formats, permissions, publication behavior, migration guidance, and retention rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->