### PR TITLE
feat(tools): Add atomic sharded graph snapshots with resilient seeding

### DIFF
--- a/client/cmd/demarkus-mcp/explore.go
+++ b/client/cmd/demarkus-mcp/explore.go
@@ -37,7 +37,7 @@ func markExploreTool(host string) mcp.Tool {
 	)
 }
 
-func (h *handler) markExplore(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go
+func (h *handler) markExplore(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go
 	rawURL, err := req.RequireString("url")
 	if err != nil {
 		return mcp.NewToolResultError("url is required"), nil
@@ -87,7 +87,7 @@ func (h *handler) markExplore(_ context.Context, req mcp.CallToolRequest) (*mcp.
 		mdoutline.CappedList(&b, out, exploreSectionCap, "links")
 	}
 
-	h.seedGraph(host)
+	h.seedGraph(ctx, host)
 	h.writeBacklinksSection(&b, links.NodeURL(host, path))
 	h.writeSiblingsSection(&b, host, path, token)
 

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -226,6 +226,7 @@ func (h *handler) seedGraph(ctx context.Context, host string) { //nolint:gocyclo
 		return
 	}
 	if result.Response.Status != protocol.StatusNotFound {
+		log.Printf("warning: graph snapshot mark://%s%s returned %s", host, graphstore.SnapshotManifestPath, result.Response.Status)
 		return
 	}
 
@@ -244,6 +245,7 @@ func (h *handler) seedGraph(ctx context.Context, host string) { //nolint:gocyclo
 		return
 	}
 	if result.Response.Status != protocol.StatusOK {
+		log.Printf("warning: legacy graph seed mark://%s%s returned %s", host, legacyPath, result.Response.Status)
 		return
 	}
 	nodes, edges, parseErr := graphstore.ParseExportStrict(result.Response.Body)

--- a/client/cmd/demarkus-mcp/main.go
+++ b/client/cmd/demarkus-mcp/main.go
@@ -102,6 +102,7 @@ type markClient interface {
 	Fetch(host, path, token string) (fetch.Result, error)
 	FetchContext(ctx context.Context, host, path, token string) (fetch.Result, error)
 	FetchConditional(host, path, token, etag string) (fetch.Result, error)
+	FetchConditionalContext(ctx context.Context, host, path, token, etag string) (fetch.Result, error)
 	List(host, path, token string) (fetch.Result, error)
 	ListWithOptions(host, path, token string, opts fetch.ListOptions) (fetch.Result, error)
 	Versions(host, path, token string) (fetch.Result, error)
@@ -127,10 +128,10 @@ type handler struct {
 	seenMu sync.Mutex
 	seen   map[string]fetchdedup.Doc
 
-	// seedMu guards seedChecked: host → last /graph.md seed check, the
-	// per-process throttle for seedGraph. Process-scoped like seen.
-	seedMu      sync.Mutex
-	seedChecked map[string]time.Time
+	// seedMu guards per-host refresh single-flight and successful-check throttle.
+	seedMu         sync.Mutex
+	seedChecked    map[string]time.Time
+	seedRefreshing map[string]chan struct{}
 }
 
 // seenLookup returns the recorded identity for key, if any.
@@ -151,22 +152,25 @@ func (h *handler) seenRecord(key string, d fetchdedup.Doc) {
 	h.seen[key] = d
 }
 
-// seedCheckInterval caps /graph.md seed checks at one per host per interval;
+// seedCheckInterval caps published graph checks at one per host per interval;
 // the first graph-tool call in a session always checks.
 const seedCheckInterval = 5 * time.Minute
 
-// seedGraph refreshes the local graph store from the published /graph.md of
-// the world at host (canonical host:port, as returned by resolveURL) so
-// backlink queries answer before any local crawl. Local crawls win (see
-// graphstore.SeedFromExport). Never fatal: every failure degrades silently
-// to the unseeded store, warn-logging real errors.
-func (h *handler) seedGraph(host string) {
-	if h.graphStore == nil || h.client == nil || host == "" {
+// seedGraph refreshes from the published graph so cold backlink queries work.
+// Local crawls stay authoritative; failures warn and leave current state intact.
+func (h *handler) seedGraph(ctx context.Context, host string) { //nolint:gocyclo // snapshot-first fallback has explicit terminal states
+	if h.graphStore == nil || h.client == nil || host == "" || ctx.Err() != nil {
 		return
 	}
-	const path = "/graph.md"
-
 	h.seedMu.Lock()
+	if done := h.seedRefreshing[host]; done != nil {
+		h.seedMu.Unlock()
+		select {
+		case <-done:
+		case <-ctx.Done():
+		}
+		return
+	}
 	if last, ok := h.seedChecked[host]; ok && time.Since(last) < seedCheckInterval {
 		h.seedMu.Unlock()
 		return
@@ -174,31 +178,87 @@ func (h *handler) seedGraph(host string) {
 	if h.seedChecked == nil {
 		h.seedChecked = make(map[string]time.Time)
 	}
-	h.seedChecked[host] = time.Now()
+	if h.seedRefreshing == nil {
+		h.seedRefreshing = make(map[string]chan struct{})
+	}
+	done := make(chan struct{})
+	h.seedRefreshing[host] = done
 	h.seedMu.Unlock()
+	success := false
+	defer func() {
+		h.seedMu.Lock()
+		if success {
+			h.seedChecked[host] = time.Now()
+		}
+		close(done)
+		delete(h.seedRefreshing, host)
+		h.seedMu.Unlock()
+	}()
 
-	result, err := h.client.FetchConditional(host, path, h.resolveToken(host), h.graphStore.SeedEtag(host))
+	token := h.resolveToken(host)
+	etag := h.graphStore.SeedEtag(host)
+	result, err := h.client.FetchConditionalContext(ctx, host, graphstore.SnapshotManifestPath, token, etag)
 	if err != nil {
-		log.Printf("warning: graph seed fetch mark://%s%s: %v", host, path, err)
+		log.Printf("warning: graph snapshot fetch mark://%s%s: %v", host, graphstore.SnapshotManifestPath, err)
 		return
 	}
-	// not-modified means the stored seed is current; any other non-ok status
-	// (a world without /graph.md is normal) means nothing to seed.
+	if result.Response.Status == protocol.StatusNotModified {
+		success = true
+		return
+	}
+	if result.Response.Status == protocol.StatusOK {
+		nodes, edges, loadErr := graphstore.LoadSnapshot(graphstore.SnapshotManifestPath, result.Response, func(shardPath string) (protocol.Response, error) {
+			shard, fetchErr := h.client.FetchContext(ctx, host, shardPath, token)
+			return shard.Response, fetchErr
+		})
+		if loadErr != nil {
+			log.Printf("warning: graph snapshot load mark://%s%s: %v", host, graphstore.SnapshotManifestPath, loadErr)
+			return
+		}
+		h.graphStore.ReplaceSeed(host, nodes, edges)
+		if snapshotEtag := result.Response.Metadata["etag"]; snapshotEtag != "" {
+			h.graphStore.SetSeedEtag(host, snapshotEtag)
+		}
+		if err := h.graphStore.Save(); err != nil {
+			log.Printf("warning: graph seed save: %v", err)
+		}
+		success = true
+		return
+	}
+	if result.Response.Status != protocol.StatusNotFound {
+		return
+	}
+
+	const legacyPath = "/graph.md"
+	result, err = h.client.FetchConditionalContext(ctx, host, legacyPath, token, etag)
+	if err != nil {
+		log.Printf("warning: graph seed fetch mark://%s%s: %v", host, legacyPath, err)
+		return
+	}
+	if result.Response.Status == protocol.StatusNotFound {
+		success = true
+		return
+	}
+	if result.Response.Status == protocol.StatusNotModified {
+		success = true
+		return
+	}
 	if result.Response.Status != protocol.StatusOK {
 		return
 	}
-
-	nodes, edges := graphstore.ParseExport(result.Response.Body)
-	if len(nodes) == 0 && len(edges) == 0 {
+	nodes, edges, parseErr := graphstore.ParseExportStrict(result.Response.Body)
+	if parseErr != nil {
+		log.Printf("warning: legacy graph seed parse mark://%s%s: %v", host, legacyPath, parseErr)
 		return
 	}
-	h.graphStore.SeedFromExport(nodes, edges)
+	h.graphStore.ReplaceSeed(host, nodes, edges)
 	if etag := result.Response.Metadata["etag"]; etag != "" {
 		h.graphStore.SetSeedEtag(host, etag)
 	}
 	if err := h.graphStore.Save(); err != nil {
 		log.Printf("warning: graph seed save: %v", err)
 	}
+	success = true
 }
 
 // resolveToken returns the auth token for a host using the shared cascade:
@@ -1360,7 +1420,7 @@ func (h *handler) markGraph(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 	}
 
 	// Seed before crawling so depth-limited crawls still benefit from hub context.
-	h.seedGraph(host)
+	h.seedGraph(ctx, host)
 
 	g, err := h.graphStore.CrawlAndPersist(ctx, startURL, func(host, path string) (graph.FetchResult, error) {
 		r, fetchErr := h.client.Fetch(host, path, h.resolveToken(host))
@@ -1434,7 +1494,7 @@ func markBacklinksTool(host string) mcp.Tool {
 	)
 }
 
-func (h *handler) markBacklinks(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go
+func (h *handler) markBacklinks(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go
 	rawURL, err := req.RequireString("url")
 	if err != nil {
 		return mcp.NewToolResultError("url is required"), nil
@@ -1452,7 +1512,7 @@ func (h *handler) markBacklinks(_ context.Context, req mcp.CallToolRequest) (*mc
 		return mcp.NewToolResultError("graph store not available"), nil
 	}
 
-	h.seedGraph(host)
+	h.seedGraph(ctx, host)
 
 	backlinks := h.graphStore.BacklinksEnriched(fullURL)
 	if len(backlinks) == 0 {

--- a/client/cmd/demarkus-mcp/main_test.go
+++ b/client/cmd/demarkus-mcp/main_test.go
@@ -554,6 +554,7 @@ type stubClient struct {
 	published   map[string]fetch.Result
 	fetchFn     func(host, path, token string) (fetch.Result, error)
 	fetchCondFn func(host, path, token, etag string) (fetch.Result, error)
+	snapshotFn  func(host, path, token, etag string) (fetch.Result, error)
 	listFn      func(host, path, token string) (fetch.Result, error)
 	listOptsFn  func(host, path, token string, opts fetch.ListOptions) (fetch.Result, error)
 	versionsFn  func(host, path, token string) (fetch.Result, error)
@@ -583,11 +584,24 @@ func (s *stubClient) FetchContext(ctx context.Context, host, path, token string)
 }
 
 func (s *stubClient) FetchConditional(host, path, token, etag string) (fetch.Result, error) {
+	if path == graphstore.SnapshotManifestPath {
+		if s.snapshotFn != nil {
+			return s.snapshotFn(host, path, token, etag)
+		}
+		return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+	}
 	if s.fetchCondFn != nil {
 		return s.fetchCondFn(host, path, token, etag)
 	}
 	// Seed fetches against a stub with no graph.md behave like a missing doc.
 	return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+}
+
+func (s *stubClient) FetchConditionalContext(ctx context.Context, host, path, token, etag string) (fetch.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return fetch.Result{}, err
+	}
+	return s.FetchConditional(host, path, token, etag)
 }
 func (s *stubClient) List(host, path, token string) (fetch.Result, error) {
 	if s.listFn != nil {

--- a/client/cmd/demarkus-mcp/seed_test.go
+++ b/client/cmd/demarkus-mcp/seed_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,6 +26,39 @@ func hubGraphBody() string {
 	g.AddEdgeInfo(graph.Edge{From: "mark://host:6309/a.md", To: "mark://host:6309/b.md", Label: "B", Count: 1})
 	src.Merge(g, nil)
 	return src.Export()
+}
+
+func hubSnapshot(t *testing.T) (protocol.Response, map[string]protocol.Response) { //nolint:gocritic // fixture returns manifest and shard set
+	t.Helper()
+	exported := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
+	nodes := []graphstore.StoredNode{
+		{URL: "mark://host:6309/a.md", Title: "Page A", Status: "ok", LinkCount: 1},
+		{URL: "mark://host:6309/b.md", Title: "Page B", Status: "ok"},
+	}
+	edges := []graphstore.StoredEdge{{From: "mark://host:6309/a.md", To: "mark://host:6309/b.md", Label: "B", Count: 1}}
+	artifacts, err := graphstore.BuildSnapshotShards(graphstore.SnapshotManifestPath, graphstore.SnapshotSlotA, nodes, edges, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := make([]graphstore.SnapshotShardRef, len(artifacts))
+	shards := make(map[string]protocol.Response, len(artifacts))
+	for i, artifact := range artifacts {
+		refs[i] = artifact.Ref(i + 1)
+		shards[graphstore.SnapshotVersionPath(artifact.Path, i+1)] = protocol.Response{
+			Status: protocol.StatusOK, Body: artifact.Body,
+			Metadata: map[string]string{"version": strconv.Itoa(i + 1), "content-hash": artifact.ContentHash},
+		}
+	}
+	manifest, err := graphstore.BuildSnapshotManifest(graphstore.SnapshotManifestPath, graphstore.SnapshotManifest{
+		Exported: exported, Complete: true, Nodes: len(nodes), Edges: len(edges),
+		ActiveSlot: graphstore.SnapshotSlotA, Shards: refs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return protocol.Response{Status: protocol.StatusOK, Body: manifest, Metadata: map[string]string{
+		"etag": "snapshot-etag-1", "content-hash": graphstore.SnapshotBodyHash(manifest),
+	}}, shards
 }
 
 func emptyGraphStore(t *testing.T) *graphstore.Store {
@@ -74,6 +109,81 @@ func TestSeedGraph_ColdStoreAnswersBacklinks(t *testing.T) {
 	}
 	if got := h.graphStore.SeedEtag("host:6309"); got != "hub-etag-1" {
 		t.Errorf("SeedEtag = %q, want hub-etag-1", got)
+	}
+}
+
+func TestSeedGraph_EmptyLegacyGenerationClearsSeed(t *testing.T) {
+	store := emptyGraphStore(t)
+	store.ReplaceSeed("host:6309",
+		[]graphstore.StoredNode{{URL: "mark://host/source.md", Status: "ok"}},
+		[]graphstore.StoredEdge{{From: "mark://host/source.md", To: "mark://host/old.md", Count: 1}},
+	)
+	sc := &stubClient{fetchCondFn: func(_, _, _, _ string) (fetch.Result, error) {
+		return fetch.Result{Response: protocol.Response{
+			Status: protocol.StatusOK,
+			Body:   graphstore.BuildExport(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), nil, nil),
+		}}, nil
+	}}
+	h := &handler{client: sc, graphStore: store}
+	h.seedGraph(t.Context(), "host:6309")
+	if got := store.Backlinks("mark://host/old.md"); len(got) != 0 {
+		t.Fatalf("stale backlink survived empty legacy generation: %v", got)
+	}
+	if node := store.GetNode("mark://host/source.md"); node != nil {
+		t.Fatalf("stale node survived empty legacy generation: %+v", node)
+	}
+}
+
+func TestSeedGraph_PrefersAtomicSnapshot(t *testing.T) {
+	manifest, shards := hubSnapshot(t)
+	sc := &stubClient{
+		snapshotFn: func(_, path, _, _ string) (fetch.Result, error) {
+			if path != graphstore.SnapshotManifestPath {
+				t.Fatalf("snapshot path = %q", path)
+			}
+			return fetch.Result{Response: manifest}, nil
+		},
+		fetchCondFn: func(_, _, _, _ string) (fetch.Result, error) {
+			t.Fatal("legacy graph should not be fetched when snapshot exists")
+			return fetch.Result{}, nil
+		},
+		fetchFn: func(_, path, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: shards[path]}, nil
+		},
+	}
+	h := &handler{client: sc, defaultHost: "mark://host:6309", graphStore: emptyGraphStore(t)}
+	res, err := h.markBacklinks(context.Background(), newCallToolRequest(map[string]any{"url": "/b.md"}))
+	if err != nil || res.IsError {
+		t.Fatalf("markBacklinks err=%v result=%+v", err, res)
+	}
+	if text := resultText(t, res); !strings.Contains(text, "Page A") {
+		t.Fatalf("snapshot backlink missing: %s", text)
+	}
+	if got := h.graphStore.SeedEtag("host:6309"); got != "snapshot-etag-1" {
+		t.Fatalf("seed etag = %q", got)
+	}
+}
+
+func TestSeedGraph_SnapshotShardFetchHonorsCancellation(t *testing.T) {
+	manifest, shards := hubSnapshot(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	sc := &stubClient{
+		snapshotFn: func(_, _, _, _ string) (fetch.Result, error) {
+			cancel()
+			return fetch.Result{Response: manifest}, nil
+		},
+		fetchFn: func(_, path, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: shards[path]}, nil
+		},
+	}
+	h := &handler{client: sc, graphStore: emptyGraphStore(t)}
+	h.seedGraph(ctx, "host:6309")
+	if got := h.graphStore.NodeCount(); got != 0 {
+		t.Fatalf("NodeCount = %d after canceled shard fetch", got)
+	}
+	h.seedGraph(t.Context(), "host:6309")
+	if got := h.graphStore.NodeCount(); got != 2 {
+		t.Fatalf("NodeCount = %d after retry, want 2", got)
 	}
 }
 
@@ -210,6 +320,42 @@ func TestSeedGraph_ThrottledWithinWindow(t *testing.T) {
 	if calls != 1 {
 		t.Errorf("seed fetches = %d, want 1 (throttled)", calls)
 	}
+}
+
+func TestSeedGraph_RefreshIsSingleFlight(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	sc := &stubClient{fetchCondFn: func(_, _, _, _ string) (fetch.Result, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+	}}
+	h := &handler{client: sc, graphStore: emptyGraphStore(t)}
+	done := make(chan struct{})
+	go func() {
+		h.seedGraph(t.Context(), "host:6309")
+		close(done)
+	}()
+	<-started
+	follower := make(chan struct{})
+	go func() {
+		h.seedGraph(t.Context(), "host:6309")
+		close(follower)
+	}()
+	select {
+	case <-follower:
+		t.Fatal("follower returned before active refresh completed")
+	case <-time.After(20 * time.Millisecond):
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("concurrent seed fetches = %d, want 1", got)
+	}
+	close(release)
+	<-done
+	<-follower
 }
 
 func TestSeedGraph_EtagRoundTrip(t *testing.T) {

--- a/client/fetch/fetch.go
+++ b/client/fetch/fetch.go
@@ -154,10 +154,15 @@ func (c *Client) FetchContext(ctx context.Context, host, path, token string) (Re
 // never fires). A not-modified status returns with an empty body. An empty
 // etag degrades to a plain Fetch.
 func (c *Client) FetchConditional(host, path, token, etag string) (Result, error) {
+	return c.FetchConditionalContext(context.Background(), host, path, token, etag)
+}
+
+// FetchConditionalContext is FetchConditional with caller cancellation.
+func (c *Client) FetchConditionalContext(ctx context.Context, host, path, token, etag string) (Result, error) {
 	if etag == "" {
-		return c.Fetch(host, path, token)
+		return c.FetchContext(ctx, host, path, token)
 	}
-	return c.cachedRequestMeta(host, path, token, protocol.VerbFetch, map[string]string{"if-none-match": etag})
+	return c.cachedRequestMetaContext(ctx, host, path, token, protocol.VerbFetch, map[string]string{"if-none-match": etag})
 }
 
 // ListOptions carries optional parameters for a LIST request.

--- a/client/graphstore/export.go
+++ b/client/graphstore/export.go
@@ -1,12 +1,16 @@
 package graphstore
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/latebit-io/demarkus/client/links"
+	"github.com/latebit-io/demarkus/protocol"
 )
 
 // nodeRowRe matches a node table row: | [label](url) | title | status | N |
@@ -26,6 +30,12 @@ var legacyEdgeRowRe = regexp.MustCompile(`^\|\s*(\S+)\s*\|\s*(\S+)\s*\|$`)
 // The output contains mark:// links so crawling the document naturally
 // discovers the topology. Thread-safe.
 func (s *Store) Export() string {
+	nodes, edges := s.Snapshot()
+	return BuildExport(time.Now(), nodes, edges)
+}
+
+// Snapshot returns deterministic copies of the graph's nodes and edges.
+func (s *Store) Snapshot() ([]StoredNode, []StoredEdge) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -50,10 +60,26 @@ func (s *Store) Export() string {
 		}
 		return edges[i].Rel < edges[j].Rel
 	})
+	return nodes, edges
+}
 
+// BuildExport renders a deterministic graph export for one timestamp.
+func BuildExport(exported time.Time, nodes []StoredNode, edges []StoredEdge) string {
+	nodes = append([]StoredNode(nil), nodes...)
+	edges = append([]StoredEdge(nil), edges...)
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].URL < nodes[j].URL })
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].From != edges[j].From {
+			return edges[i].From < edges[j].From
+		}
+		if edges[i].To != edges[j].To {
+			return edges[i].To < edges[j].To
+		}
+		return edges[i].Rel < edges[j].Rel
+	})
 	var b strings.Builder
 	b.WriteString("# Document Graph\n\n")
-	b.WriteString(fmt.Sprintf("> Exported: %s\n", time.Now().UTC().Format(time.RFC3339)))
+	b.WriteString(fmt.Sprintf("> Exported: %s\n", exported.UTC().Format(time.RFC3339)))
 	b.WriteString(fmt.Sprintf("> Nodes: %d\n", len(nodes)))
 	b.WriteString(fmt.Sprintf("> Edges: %d\n", len(edges)))
 
@@ -173,4 +199,186 @@ func ParseExport(body string) ([]StoredNode, []StoredEdge) {
 	}
 
 	return nodes, edges
+}
+
+// ParseExportStrict validates a generated legacy export before parsing it.
+func ParseExportStrict(body string) ([]StoredNode, []StoredEdge, error) {
+	if len(body) > protocol.MaxBodyLength {
+		return nil, nil, fmt.Errorf("graph export exceeds body limit: %d", len(body))
+	}
+	if firstNonemptyExportLine(body) != "# Document Graph" {
+		return nil, nil, errors.New("graph export title is invalid")
+	}
+	meta := make(map[string]string)
+	for line := range strings.SplitSeq(body, "\n") {
+		if !strings.HasPrefix(line, "> ") {
+			continue
+		}
+		key, value, ok := strings.Cut(strings.TrimPrefix(line, "> "), ": ")
+		if !ok || value == "" {
+			return nil, nil, fmt.Errorf("invalid graph export metadata %q", line)
+		}
+		if key != "Exported" && key != "Nodes" && key != "Edges" {
+			return nil, nil, fmt.Errorf("unknown graph export metadata %q", key)
+		}
+		if _, duplicate := meta[key]; duplicate {
+			return nil, nil, fmt.Errorf("duplicate graph export metadata %q", key)
+		}
+		meta[key] = value
+	}
+	exported, err := time.Parse(time.RFC3339, meta["Exported"])
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid graph export time: %w", err)
+	}
+	if exported.Year() < 1 || exported.Year() > 9999 {
+		return nil, nil, errors.New("invalid graph export year")
+	}
+	declaredNodes, err := strconv.Atoi(meta["Nodes"])
+	if err != nil || declaredNodes < 0 {
+		return nil, nil, errors.New("invalid graph export node count")
+	}
+	declaredEdges, err := strconv.Atoi(meta["Edges"])
+	if err != nil || declaredEdges < 0 {
+		return nil, nil, errors.New("invalid graph export edge count")
+	}
+	if err := validateExportTables(body, declaredEdges > 0); err != nil {
+		return nil, nil, err
+	}
+	nodes, edges := ParseExport(body)
+	if len(nodes) != declaredNodes || len(edges) != declaredEdges {
+		return nil, nil, fmt.Errorf("graph export count mismatch: got %d nodes/%d edges, want %d/%d",
+			len(nodes), len(edges), declaredNodes, declaredEdges)
+	}
+	if err := normalizeStrictExport(nodes, edges); err != nil {
+		return nil, nil, err
+	}
+	return nodes, edges, nil
+}
+
+func normalizeStrictExport(nodes []StoredNode, edges []StoredEdge) error {
+	seenNodes := make(map[string]struct{}, len(nodes))
+	for i := range nodes {
+		if err := validateSnapshotURL(nodes[i].URL); err != nil {
+			return err
+		}
+		nodes[i].URL = links.CanonicalURL(nodes[i].URL)
+		if _, duplicate := seenNodes[nodes[i].URL]; duplicate {
+			return fmt.Errorf("duplicate graph node %q", nodes[i].URL)
+		}
+		seenNodes[nodes[i].URL] = struct{}{}
+	}
+	seenEdges := make(map[edgeKey]struct{}, len(edges))
+	for i := range edges {
+		if err := validateSnapshotURL(edges[i].From); err != nil {
+			return err
+		}
+		if err := validateSnapshotURL(edges[i].To); err != nil {
+			return err
+		}
+		edges[i].From = links.CanonicalURL(edges[i].From)
+		edges[i].To = links.CanonicalURL(edges[i].To)
+		key := edges[i].key()
+		if _, duplicate := seenEdges[key]; duplicate {
+			return fmt.Errorf("duplicate graph edge %q -> %q", edges[i].From, edges[i].To)
+		}
+		seenEdges[key] = struct{}{}
+	}
+	return nil
+}
+
+func validateExportTables(body string, requireEdges bool) error { //nolint:gocyclo // strict state-machine validation stays linear
+	section := ""
+	rowIndex := 0
+	edgeColumns := 6
+	foundNodes, foundEdges := false, false
+	for line := range strings.SplitSeq(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch trimmed {
+		case "## Nodes":
+			if foundNodes {
+				return errors.New("duplicate graph nodes table")
+			}
+			section, rowIndex, foundNodes = "nodes", 0, true
+			continue
+		case "## Edges":
+			if foundEdges {
+				return errors.New("duplicate graph edges table")
+			}
+			if section == "nodes" && rowIndex < 2 {
+				return errors.New("graph nodes table is incomplete")
+			}
+			section, rowIndex, foundEdges = "edges", 0, true
+			continue
+		}
+		if section == "" || !strings.HasPrefix(trimmed, "|") {
+			continue
+		}
+		rowIndex++
+		if rowIndex == 1 {
+			want := "| URL | Title | Status | Links |"
+			if section == "edges" {
+				want = "| From | To | Rel | Label | Anchor | Count |"
+				if trimmed == "| From | To |" {
+					want, edgeColumns = trimmed, 2
+				}
+			}
+			if trimmed != want {
+				return fmt.Errorf("invalid graph %s header", section)
+			}
+			continue
+		}
+		if rowIndex == 2 {
+			cells := strings.Split(strings.Trim(trimmed, "|"), "|")
+			wantColumns := 4
+			if section == "edges" {
+				wantColumns = edgeColumns
+			}
+			if len(cells) != wantColumns {
+				return fmt.Errorf("invalid graph %s separator", section)
+			}
+			for _, cell := range cells {
+				cell = strings.TrimSpace(cell)
+				if len(cell) < 3 || strings.Trim(cell, "-") != "" {
+					return fmt.Errorf("invalid graph %s separator", section)
+				}
+			}
+			continue
+		}
+		if section == "nodes" && nodeRowRe.FindStringSubmatch(trimmed) == nil {
+			return fmt.Errorf("invalid graph node row %q", trimmed)
+		}
+		if section == "nodes" {
+			match := nodeRowRe.FindStringSubmatch(trimmed)
+			if _, err := strconv.Atoi(match[4]); err != nil {
+				return fmt.Errorf("invalid graph node link count %q", match[4])
+			}
+		}
+		if section == "edges" && ((edgeColumns == 6 && edgeRowRe.FindStringSubmatch(trimmed) == nil) ||
+			(edgeColumns == 2 && legacyEdgeRowRe.FindStringSubmatch(trimmed) == nil)) {
+			return fmt.Errorf("invalid graph edge row %q", trimmed)
+		}
+		if section == "edges" && edgeColumns == 6 {
+			match := edgeRowRe.FindStringSubmatch(trimmed)
+			count, err := strconv.Atoi(match[6])
+			if err != nil || count < 1 {
+				return fmt.Errorf("invalid graph edge count %q", match[6])
+			}
+		}
+	}
+	if section != "" && rowIndex < 2 {
+		return fmt.Errorf("graph %s table is incomplete", section)
+	}
+	if !foundNodes || (requireEdges && !foundEdges) {
+		return errors.New("graph export table is missing")
+	}
+	return nil
+}
+
+func firstNonemptyExportLine(body string) string {
+	for line := range strings.SplitSeq(body, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			return line
+		}
+	}
+	return ""
 }

--- a/client/graphstore/export.go
+++ b/client/graphstore/export.go
@@ -67,8 +67,12 @@ func BuildExport(exported time.Time, nodes []StoredNode, edges []StoredEdge) str
 	b.WriteString("| URL | Title | Status | Links |\n")
 	b.WriteString("|-----|-------|--------|-------|\n")
 	for _, n := range nodes {
+		status := strings.ReplaceAll(strings.Join(strings.Fields(n.Status), "-"), "|", "-")
+		if status == "" {
+			status = "external"
+		}
 		b.WriteString(fmt.Sprintf("| [%s](%s) | %s | %s | %d |\n",
-			n.URL, n.URL, escapeCell(n.Title), n.Status, n.LinkCount))
+			n.URL, n.URL, escapeCell(n.Title), status, n.LinkCount))
 	}
 
 	if len(edges) > 0 {

--- a/client/graphstore/export.go
+++ b/client/graphstore/export.go
@@ -39,27 +39,15 @@ func (s *Store) Snapshot() ([]StoredNode, []StoredEdge) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	// Sort nodes by URL for stable output.
 	nodes := make([]StoredNode, 0, len(s.nodes))
 	for _, n := range s.nodes {
 		nodes = append(nodes, *n)
 	}
-	sort.Slice(nodes, func(i, j int) bool {
-		return nodes[i].URL < nodes[j].URL
-	})
+	sort.Slice(nodes, func(i, j int) bool { return lessStoredNode(&nodes[i], &nodes[j]) })
 
-	// Sort edges by From, then To.
 	edges := make([]StoredEdge, len(s.edges))
 	copy(edges, s.edges)
-	sort.Slice(edges, func(i, j int) bool {
-		if edges[i].From != edges[j].From {
-			return edges[i].From < edges[j].From
-		}
-		if edges[i].To != edges[j].To {
-			return edges[i].To < edges[j].To
-		}
-		return edges[i].Rel < edges[j].Rel
-	})
+	sort.Slice(edges, func(i, j int) bool { return lessStoredEdge(&edges[i], &edges[j]) })
 	return nodes, edges
 }
 
@@ -67,16 +55,8 @@ func (s *Store) Snapshot() ([]StoredNode, []StoredEdge) {
 func BuildExport(exported time.Time, nodes []StoredNode, edges []StoredEdge) string {
 	nodes = append([]StoredNode(nil), nodes...)
 	edges = append([]StoredEdge(nil), edges...)
-	sort.Slice(nodes, func(i, j int) bool { return nodes[i].URL < nodes[j].URL })
-	sort.Slice(edges, func(i, j int) bool {
-		if edges[i].From != edges[j].From {
-			return edges[i].From < edges[j].From
-		}
-		if edges[i].To != edges[j].To {
-			return edges[i].To < edges[j].To
-		}
-		return edges[i].Rel < edges[j].Rel
-	})
+	sort.Slice(nodes, func(i, j int) bool { return lessStoredNode(&nodes[i], &nodes[j]) })
+	sort.Slice(edges, func(i, j int) bool { return lessStoredEdge(&edges[i], &edges[j]) })
 	var b strings.Builder
 	b.WriteString("# Document Graph\n\n")
 	b.WriteString(fmt.Sprintf("> Exported: %s\n", exported.UTC().Format(time.RFC3339)))
@@ -103,6 +83,20 @@ func BuildExport(exported time.Time, nodes []StoredNode, edges []StoredEdge) str
 	}
 
 	return b.String()
+}
+
+func lessStoredNode(a, b *StoredNode) bool {
+	return a.URL < b.URL
+}
+
+func lessStoredEdge(a, b *StoredEdge) bool {
+	if a.From != b.From {
+		return a.From < b.From
+	}
+	if a.To != b.To {
+		return a.To < b.To
+	}
+	return a.Rel < b.Rel
 }
 
 // escapeCell escapes characters that would break markdown table formatting.
@@ -344,25 +338,29 @@ func validateExportTables(body string, requireEdges bool) error { //nolint:gocyc
 			}
 			continue
 		}
-		if section == "nodes" && nodeRowRe.FindStringSubmatch(trimmed) == nil {
-			return fmt.Errorf("invalid graph node row %q", trimmed)
-		}
 		if section == "nodes" {
 			match := nodeRowRe.FindStringSubmatch(trimmed)
+			if match == nil {
+				return fmt.Errorf("invalid graph node row %q", trimmed)
+			}
 			if _, err := strconv.Atoi(match[4]); err != nil {
 				return fmt.Errorf("invalid graph node link count %q", match[4])
 			}
+			continue
 		}
-		if section == "edges" && ((edgeColumns == 6 && edgeRowRe.FindStringSubmatch(trimmed) == nil) ||
-			(edgeColumns == 2 && legacyEdgeRowRe.FindStringSubmatch(trimmed) == nil)) {
+		if edgeColumns == 2 {
+			if legacyEdgeRowRe.FindStringSubmatch(trimmed) == nil {
+				return fmt.Errorf("invalid graph edge row %q", trimmed)
+			}
+			continue
+		}
+		match := edgeRowRe.FindStringSubmatch(trimmed)
+		if match == nil {
 			return fmt.Errorf("invalid graph edge row %q", trimmed)
 		}
-		if section == "edges" && edgeColumns == 6 {
-			match := edgeRowRe.FindStringSubmatch(trimmed)
-			count, err := strconv.Atoi(match[6])
-			if err != nil || count < 1 {
-				return fmt.Errorf("invalid graph edge count %q", match[6])
-			}
+		count, err := strconv.Atoi(match[6])
+		if err != nil || count < 1 {
+			return fmt.Errorf("invalid graph edge count %q", match[6])
 		}
 	}
 	if section != "" && rowIndex < 2 {

--- a/client/graphstore/export_test.go
+++ b/client/graphstore/export_test.go
@@ -100,6 +100,9 @@ func TestParseExport(t *testing.T) {
 `
 
 	nodes, edges := ParseExport(md)
+	if _, _, err := ParseExportStrict(md); err != nil {
+		t.Fatalf("ParseExportStrict legacy export: %v", err)
+	}
 
 	if len(nodes) != 2 {
 		t.Fatalf("len(nodes) = %d, want 2", len(nodes))
@@ -125,6 +128,58 @@ func TestParseExport(t *testing.T) {
 	}
 	if edges[0].Count != 1 {
 		t.Errorf("legacy edge Count = %d, want 1", edges[0].Count)
+	}
+}
+
+func TestParseExportStrictAcceptsEmptyGeneration(t *testing.T) {
+	body := BuildExport(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), nil, nil)
+	nodes, edges, err := ParseExportStrict(body)
+	if err != nil {
+		t.Fatalf("ParseExportStrict: %v", err)
+	}
+	if len(nodes) != 0 || len(edges) != 0 {
+		t.Fatalf("got %d nodes/%d edges, want empty", len(nodes), len(edges))
+	}
+}
+
+func TestParseExportStrictRejectsCountMismatch(t *testing.T) {
+	body := BuildExport(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), nil, nil)
+	body = strings.Replace(body, "> Nodes: 0", "> Nodes: 1", 1)
+	if _, _, err := ParseExportStrict(body); err == nil {
+		t.Fatal("ParseExportStrict accepted count mismatch")
+	}
+}
+
+func TestParseExportStrictRejectsMalformedRow(t *testing.T) {
+	body := BuildExport(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), []StoredNode{{URL: "mark://a/a.md", Status: "ok"}}, nil)
+	body = strings.Replace(body, "| [mark://a/a.md](mark://a/a.md) |  | ok | 0 |", "| malformed |", 1)
+	if _, _, err := ParseExportStrict(body); err == nil {
+		t.Fatal("ParseExportStrict accepted malformed row")
+	}
+}
+
+func TestParseExportStrictRejectsIncompleteEmptyTable(t *testing.T) {
+	body := "# Document Graph\n\n> Exported: 2026-01-01T00:00:00Z\n> Nodes: 0\n> Edges: 0\n\n## Nodes\n"
+	if _, _, err := ParseExportStrict(body); err == nil {
+		t.Fatal("ParseExportStrict accepted incomplete empty table")
+	}
+}
+
+func TestParseExportStrictRejectsCanonicalDuplicates(t *testing.T) {
+	body := BuildExport(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), []StoredNode{
+		{URL: "mark://host/a.md", Status: "ok"},
+		{URL: "mark://host:6309/a.md", Status: "ok"},
+	}, nil)
+	if _, _, err := ParseExportStrict(body); err == nil || !strings.Contains(err.Error(), "duplicate graph node") {
+		t.Fatalf("canonical duplicate error = %v", err)
+	}
+}
+
+func TestParseExportStrictRejectsOverflowedRowCount(t *testing.T) {
+	body := BuildExport(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), []StoredNode{{URL: "mark://a/a.md", Status: "ok"}}, nil)
+	body = strings.Replace(body, "| 0 |", "| 999999999999999999999999999999 |", 1)
+	if _, _, err := ParseExportStrict(body); err == nil || !strings.Contains(err.Error(), "link count") {
+		t.Fatalf("overflow error = %v", err)
 	}
 }
 

--- a/client/graphstore/export_test.go
+++ b/client/graphstore/export_test.go
@@ -78,6 +78,17 @@ func TestExportEmpty(t *testing.T) {
 	}
 }
 
+func TestBuildExportNormalizesEmptyStatus(t *testing.T) {
+	body := BuildExport(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), []StoredNode{{URL: "mark://a/a.md"}}, nil)
+	nodes, _, err := ParseExportStrict(body)
+	if err != nil {
+		t.Fatalf("ParseExportStrict: %v", err)
+	}
+	if len(nodes) != 1 || nodes[0].Status != "external" {
+		t.Fatalf("nodes = %+v", nodes)
+	}
+}
+
 func TestParseExport(t *testing.T) {
 	md := `# Document Graph
 

--- a/client/graphstore/snapshot.go
+++ b/client/graphstore/snapshot.go
@@ -356,43 +356,75 @@ func buildSnapshotEdgeShards(manifestPath, slot string, edges []StoredEdge, targ
 }
 
 func largestSnapshotNodeShard(manifestPath, slot string, nodes []StoredNode, start, part, target int) (int, SnapshotArtifact, error) {
-	bestEnd := 0
-	var best SnapshotArtifact
-	for low, high := start+1, len(nodes); low <= high; {
+	bestEnd := start + 1
+	best, err := buildSnapshotArtifact(manifestPath, slot, snapshotShardKindNodes, part, nodes[start:bestEnd], nil)
+	if err != nil {
+		return 0, SnapshotArtifact{}, err
+	}
+	if best.Bytes > target {
+		return 0, SnapshotArtifact{}, fmt.Errorf("one graph node exceeds shard target %d", target)
+	}
+	high := bestEnd
+	for bestEnd < len(nodes) {
+		probeEnd := min(start+2*(bestEnd-start), len(nodes))
+		artifact, buildErr := buildSnapshotArtifact(manifestPath, slot, snapshotShardKindNodes, part, nodes[start:probeEnd], nil)
+		if buildErr != nil {
+			return 0, SnapshotArtifact{}, buildErr
+		}
+		if artifact.Bytes > target {
+			high = probeEnd - 1
+			break
+		}
+		bestEnd, best = probeEnd, artifact
+	}
+	for low := bestEnd + 1; low <= high; {
 		mid := low + (high-low)/2
-		artifact, err := buildSnapshotArtifact(manifestPath, slot, snapshotShardKindNodes, part, nodes[start:mid], nil)
-		if err != nil {
-			return 0, SnapshotArtifact{}, err
+		artifact, buildErr := buildSnapshotArtifact(manifestPath, slot, snapshotShardKindNodes, part, nodes[start:mid], nil)
+		if buildErr != nil {
+			return 0, SnapshotArtifact{}, buildErr
 		}
 		if artifact.Bytes <= target {
 			bestEnd, best, low = mid, artifact, mid+1
 		} else {
 			high = mid - 1
 		}
-	}
-	if bestEnd == 0 {
-		return 0, SnapshotArtifact{}, fmt.Errorf("one graph node exceeds shard target %d", target)
 	}
 	return bestEnd, best, nil
 }
 
 func largestSnapshotEdgeShard(manifestPath, slot string, edges []StoredEdge, start, part, target int) (int, SnapshotArtifact, error) {
-	bestEnd := 0
-	var best SnapshotArtifact
-	for low, high := start+1, len(edges); low <= high; {
+	bestEnd := start + 1
+	best, err := buildSnapshotArtifact(manifestPath, slot, snapshotShardKindEdges, part, nil, edges[start:bestEnd])
+	if err != nil {
+		return 0, SnapshotArtifact{}, err
+	}
+	if best.Bytes > target {
+		return 0, SnapshotArtifact{}, fmt.Errorf("one graph edge exceeds shard target %d", target)
+	}
+	high := bestEnd
+	for bestEnd < len(edges) {
+		probeEnd := min(start+2*(bestEnd-start), len(edges))
+		artifact, buildErr := buildSnapshotArtifact(manifestPath, slot, snapshotShardKindEdges, part, nil, edges[start:probeEnd])
+		if buildErr != nil {
+			return 0, SnapshotArtifact{}, buildErr
+		}
+		if artifact.Bytes > target {
+			high = probeEnd - 1
+			break
+		}
+		bestEnd, best = probeEnd, artifact
+	}
+	for low := bestEnd + 1; low <= high; {
 		mid := low + (high-low)/2
-		artifact, err := buildSnapshotArtifact(manifestPath, slot, snapshotShardKindEdges, part, nil, edges[start:mid])
-		if err != nil {
-			return 0, SnapshotArtifact{}, err
+		artifact, buildErr := buildSnapshotArtifact(manifestPath, slot, snapshotShardKindEdges, part, nil, edges[start:mid])
+		if buildErr != nil {
+			return 0, SnapshotArtifact{}, buildErr
 		}
 		if artifact.Bytes <= target {
 			bestEnd, best, low = mid, artifact, mid+1
 		} else {
 			high = mid - 1
 		}
-	}
-	if bestEnd == 0 {
-		return 0, SnapshotArtifact{}, fmt.Errorf("one graph edge exceeds shard target %d", target)
 	}
 	return bestEnd, best, nil
 }
@@ -436,7 +468,10 @@ func verifySnapshotShard(ref SnapshotShardRef, response protocol.Response) ([]St
 		return nil, nil, fmt.Errorf("graph shard %s returned %s", ref.Path, response.Status)
 	}
 	version, err := snapshotPositive("version", response.Metadata["version"])
-	if err != nil || version != ref.Version {
+	if err != nil {
+		return nil, nil, fmt.Errorf("graph shard %s: %w", ref.Path, err)
+	}
+	if version != ref.Version {
 		return nil, nil, fmt.Errorf("graph shard %s version mismatch", ref.Path)
 	}
 	if len(response.Body) != ref.Bytes || SnapshotBodyHash(response.Body) != ref.ContentHash || response.Metadata["content-hash"] != ref.ContentHash {
@@ -582,11 +617,16 @@ func snapshotVersionSuffix(docPath string) bool {
 }
 
 func snapshotShardPath(manifestPath, slot, kind string, part int) string {
+	return fmt.Sprintf("%s/%s/%s-%03d.md", SnapshotShardRoot(manifestPath), slot, kind, part)
+}
+
+// SnapshotShardRoot returns the generated shard directory for a manifest.
+func SnapshotShardRoot(manifestPath string) string {
 	root := strings.TrimSuffix(manifestPath, ".md") + ".shards"
 	if path.Base(manifestPath) == "manifest.md" {
 		root = path.Join(path.Dir(manifestPath), "shards")
 	}
-	return fmt.Sprintf("%s/%s/%s-%03d.md", root, slot, kind, part)
+	return root
 }
 
 func parseSnapshotDocument(body, title string) (metadata map[string]string, table string, err error) {

--- a/client/graphstore/snapshot.go
+++ b/client/graphstore/snapshot.go
@@ -1,0 +1,798 @@
+package graphstore
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/url"
+	"path"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/latebit-io/demarkus/client/links"
+	"github.com/latebit-io/demarkus/protocol"
+)
+
+const (
+	// SnapshotManifestPath is the additive entry point for atomic graph snapshots.
+	SnapshotManifestPath = "/graph/manifest.md"
+	// SnapshotManifestFormat identifies the manifest wire format.
+	SnapshotManifestFormat = "demarkus-graph-snapshot/v1"
+	// SnapshotShardFormat identifies the shard wire format.
+	SnapshotShardFormat = "demarkus-graph-snapshot-shard/v1"
+	// DefaultSnapshotShardBytes is the target shard body size.
+	DefaultSnapshotShardBytes = 768 * 1024
+	// MaxSnapshotShards bounds manifest fan-out.
+	MaxSnapshotShards = 4096
+	// MaxSnapshotNodes bounds one complete generation.
+	MaxSnapshotNodes = 1_000_000
+	// MaxSnapshotEdges bounds one complete generation.
+	MaxSnapshotEdges = 1_000_000
+	// SnapshotSlotA is the first alternating publication slot.
+	SnapshotSlotA = "a"
+	// SnapshotSlotB is the second alternating publication slot.
+	SnapshotSlotB          = "b"
+	snapshotShardKindNodes = "nodes"
+	snapshotShardKindEdges = "edges"
+	snapshotJSONFence      = "\n```json\n"
+	snapshotJSONFenceEnd   = "\n```\n"
+)
+
+// SnapshotManifest identifies one complete immutable graph generation.
+type SnapshotManifest struct {
+	Exported   time.Time
+	Complete   bool
+	Nodes      int
+	Edges      int
+	ActiveSlot string
+	Shards     []SnapshotShardRef
+}
+
+// SnapshotShardRef describes one immutable graph shard.
+type SnapshotShardRef struct {
+	Kind        string
+	Part        int
+	Path        string
+	Version     int
+	ContentHash string
+	Nodes       int
+	Edges       int
+	Bytes       int
+}
+
+// SnapshotArtifact is a graph shard before its published version is known.
+type SnapshotArtifact struct {
+	Kind        string
+	Part        int
+	Path        string
+	Body        string
+	ContentHash string
+	Nodes       int
+	Edges       int
+	Bytes       int
+}
+
+// Ref returns the immutable descriptor for a published artifact.
+func (a SnapshotArtifact) Ref(version int) SnapshotShardRef { //nolint:gocritic // immutable descriptor conversion
+	return SnapshotShardRef{
+		Kind: a.Kind, Part: a.Part, Path: a.Path, Version: version,
+		ContentHash: a.ContentHash, Nodes: a.Nodes, Edges: a.Edges, Bytes: a.Bytes,
+	}
+}
+
+// InactiveSnapshotSlot returns the slot not named by the current manifest.
+func InactiveSnapshotSlot(active string) string {
+	if active == SnapshotSlotA {
+		return SnapshotSlotB
+	}
+	return SnapshotSlotA
+}
+
+// SnapshotVersionPath returns an immutable FETCH path.
+func SnapshotVersionPath(docPath string, version int) string {
+	return fmt.Sprintf("%s/v%d", docPath, version)
+}
+
+// SnapshotBodyHash returns the protocol content hash for body.
+func SnapshotBodyHash(body string) string {
+	sum := sha256.Sum256([]byte(body))
+	return fmt.Sprintf("sha256-%x", sum)
+}
+
+// BuildSnapshotManifest renders a deterministic snapshot manifest.
+func BuildSnapshotManifest(manifestPath string, manifest SnapshotManifest) (string, error) { //nolint:gocritic // local copy is sorted without mutating the caller
+	manifest.Shards = slices.Clone(manifest.Shards)
+	slices.SortFunc(manifest.Shards, compareSnapshotRefs)
+	if err := validateSnapshotManifest(manifestPath, manifest); err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	b.WriteString("# Graph Snapshot Manifest\n\n")
+	fmt.Fprintf(&b, "> Format: %s\n", SnapshotManifestFormat)
+	fmt.Fprintf(&b, "> Exported: %s\n", manifest.Exported.UTC().Format(time.RFC3339))
+	fmt.Fprintf(&b, "> Complete: %t\n", manifest.Complete)
+	fmt.Fprintf(&b, "> Nodes: %d\n", manifest.Nodes)
+	fmt.Fprintf(&b, "> Edges: %d\n", manifest.Edges)
+	fmt.Fprintf(&b, "> Active-Slot: %s\n\n", manifest.ActiveSlot)
+	b.WriteString("| Kind | Part | Path | Version | Content Hash | Nodes | Edges | Bytes |\n")
+	b.WriteString("|------|------|------|---------|--------------|-------|-------|-------|\n")
+	for _, ref := range manifest.Shards {
+		fmt.Fprintf(&b, "| %s | %d | %s | %d | %s | %d | %d | %d |\n",
+			ref.Kind, ref.Part, ref.Path, ref.Version, ref.ContentHash, ref.Nodes, ref.Edges, ref.Bytes)
+	}
+	if b.Len() > protocol.MaxBodyLength {
+		return "", fmt.Errorf("snapshot manifest exceeds body limit: %d", b.Len())
+	}
+	return b.String(), nil
+}
+
+// ParseSnapshotManifest strictly parses a snapshot manifest.
+func ParseSnapshotManifest(manifestPath, body string) (SnapshotManifest, error) {
+	if len(body) > protocol.MaxBodyLength {
+		return SnapshotManifest{}, fmt.Errorf("snapshot manifest exceeds body limit: %d", len(body))
+	}
+	meta, table, err := parseSnapshotDocument(body, "# Graph Snapshot Manifest")
+	if err != nil {
+		return SnapshotManifest{}, err
+	}
+	if err := validateSnapshotMetadataKeys(meta, "Format", "Exported", "Complete", "Nodes", "Edges", "Active-Slot"); err != nil {
+		return SnapshotManifest{}, err
+	}
+	if meta["Format"] != SnapshotManifestFormat {
+		return SnapshotManifest{}, fmt.Errorf("unsupported graph snapshot format %q", meta["Format"])
+	}
+	exported, err := time.Parse(time.RFC3339, meta["Exported"])
+	if err != nil {
+		return SnapshotManifest{}, fmt.Errorf("invalid Exported value: %w", err)
+	}
+	if exported.Year() < 1 || exported.Year() > 9999 {
+		return SnapshotManifest{}, errors.New("invalid Exported year")
+	}
+	complete, err := strconv.ParseBool(meta["Complete"])
+	if err != nil {
+		return SnapshotManifest{}, fmt.Errorf("invalid Complete value: %w", err)
+	}
+	nodeCount, err := snapshotNonNegative("Nodes", meta["Nodes"])
+	if err != nil {
+		return SnapshotManifest{}, err
+	}
+	edgeCount, err := snapshotNonNegative("Edges", meta["Edges"])
+	if err != nil {
+		return SnapshotManifest{}, err
+	}
+	rows, err := parseSnapshotTable(table, []string{"Kind", "Part", "Path", "Version", "Content Hash", "Nodes", "Edges", "Bytes"})
+	if err != nil {
+		return SnapshotManifest{}, err
+	}
+	refs := make([]SnapshotShardRef, 0, len(rows))
+	for rowIndex, row := range rows {
+		part, partErr := snapshotNonNegative("Part", row[1])
+		version, versionErr := snapshotPositive("Version", row[3])
+		nodes, nodesErr := snapshotNonNegative("Nodes", row[5])
+		edges, edgesErr := snapshotNonNegative("Edges", row[6])
+		bytes, bytesErr := snapshotPositive("Bytes", row[7])
+		if err := errors.Join(partErr, versionErr, nodesErr, edgesErr, bytesErr); err != nil {
+			return SnapshotManifest{}, fmt.Errorf("shard row %d: %w", rowIndex+1, err)
+		}
+		refs = append(refs, SnapshotShardRef{
+			Kind: row[0], Part: part, Path: row[2], Version: version,
+			ContentHash: row[4], Nodes: nodes, Edges: edges, Bytes: bytes,
+		})
+	}
+	manifest := SnapshotManifest{
+		Exported: exported, Complete: complete, Nodes: nodeCount, Edges: edgeCount,
+		ActiveSlot: meta["Active-Slot"], Shards: refs,
+	}
+	if err := validateSnapshotManifest(manifestPath, manifest); err != nil {
+		return SnapshotManifest{}, err
+	}
+	return manifest, nil
+}
+
+// BuildSnapshotShards partitions a graph into bounded node and edge shards.
+func BuildSnapshotShards(manifestPath, slot string, nodes []StoredNode, edges []StoredEdge, targetBytes int) ([]SnapshotArtifact, error) {
+	if err := validateSnapshotManifestPath(manifestPath); err != nil {
+		return nil, err
+	}
+	if slot != SnapshotSlotA && slot != SnapshotSlotB {
+		return nil, fmt.Errorf("invalid snapshot slot %q", slot)
+	}
+	if targetBytes == 0 {
+		targetBytes = DefaultSnapshotShardBytes
+	}
+	if targetBytes < 1 || targetBytes > protocol.MaxBodyLength {
+		return nil, fmt.Errorf("invalid snapshot shard target %d", targetBytes)
+	}
+	if len(nodes) > MaxSnapshotNodes || len(edges) > MaxSnapshotEdges {
+		return nil, fmt.Errorf("graph exceeds snapshot limits: %d nodes, %d edges", len(nodes), len(edges))
+	}
+	nodes = append([]StoredNode(nil), nodes...)
+	edges = append([]StoredEdge(nil), edges...)
+	seenNodes := make(map[string]struct{}, len(nodes))
+	for i := range nodes {
+		if err := validateSnapshotURL(nodes[i].URL); err != nil {
+			return nil, err
+		}
+		nodes[i].URL = links.CanonicalURL(nodes[i].URL)
+		if _, duplicate := seenNodes[nodes[i].URL]; duplicate {
+			return nil, fmt.Errorf("duplicate graph node %q", nodes[i].URL)
+		}
+		seenNodes[nodes[i].URL] = struct{}{}
+	}
+	seenEdges := make(map[edgeKey]struct{}, len(edges))
+	for i := range edges {
+		if err := validateSnapshotURL(edges[i].From); err != nil {
+			return nil, err
+		}
+		if err := validateSnapshotURL(edges[i].To); err != nil {
+			return nil, err
+		}
+		edges[i].From = links.CanonicalURL(edges[i].From)
+		edges[i].To = links.CanonicalURL(edges[i].To)
+		if _, duplicate := seenEdges[edges[i].key()]; duplicate {
+			return nil, fmt.Errorf("duplicate graph edge %q -> %q", edges[i].From, edges[i].To)
+		}
+		seenEdges[edges[i].key()] = struct{}{}
+	}
+	slices.SortFunc(nodes, func(a, b StoredNode) int { return strings.Compare(a.URL, b.URL) })
+	slices.SortFunc(edges, compareSnapshotEdges)
+	artifacts, err := buildSnapshotNodeShards(manifestPath, slot, nodes, targetBytes)
+	if err != nil {
+		return nil, err
+	}
+	edgeArtifacts, err := buildSnapshotEdgeShards(manifestPath, slot, edges, targetBytes)
+	if err != nil {
+		return nil, err
+	}
+	artifacts = append(artifacts, edgeArtifacts...)
+	if len(artifacts) > MaxSnapshotShards {
+		return nil, fmt.Errorf("snapshot has %d shards, limit is %d", len(artifacts), MaxSnapshotShards)
+	}
+	return artifacts, nil
+}
+
+// LoadSnapshot verifies and combines every shard in one complete generation.
+func LoadSnapshot(manifestPath string, response protocol.Response, fetchShard func(string) (protocol.Response, error)) ([]StoredNode, []StoredEdge, error) {
+	if response.Status != protocol.StatusOK {
+		return nil, nil, fmt.Errorf("snapshot manifest returned %s", response.Status)
+	}
+	if response.Metadata["content-hash"] != SnapshotBodyHash(response.Body) {
+		return nil, nil, errors.New("snapshot manifest content hash mismatch")
+	}
+	manifest, err := ParseSnapshotManifest(manifestPath, response.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !manifest.Complete {
+		return nil, nil, errors.New("graph snapshot is incomplete")
+	}
+	var nodes []StoredNode
+	var edges []StoredEdge
+	seenNodes := make(map[string]struct{}, manifest.Nodes)
+	seenEdges := make(map[edgeKey]struct{}, manifest.Edges)
+	for _, ref := range manifest.Shards {
+		shard, err := fetchShard(SnapshotVersionPath(ref.Path, ref.Version))
+		if err != nil {
+			return nil, nil, fmt.Errorf("fetch graph shard %s: %w", ref.Path, err)
+		}
+		shardNodes, shardEdges, err := verifySnapshotShard(ref, shard)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, node := range shardNodes {
+			if _, duplicate := seenNodes[node.URL]; duplicate {
+				return nil, nil, fmt.Errorf("duplicate graph snapshot node %q", node.URL)
+			}
+			seenNodes[node.URL] = struct{}{}
+			nodes = append(nodes, node)
+		}
+		for _, edge := range shardEdges {
+			if _, duplicate := seenEdges[edge.key()]; duplicate {
+				return nil, nil, fmt.Errorf("duplicate graph snapshot edge %q -> %q", edge.From, edge.To)
+			}
+			seenEdges[edge.key()] = struct{}{}
+			edges = append(edges, edge)
+		}
+	}
+	if len(nodes) != manifest.Nodes || len(edges) != manifest.Edges {
+		return nil, nil, fmt.Errorf("snapshot count mismatch: got %d nodes/%d edges, want %d/%d",
+			len(nodes), len(edges), manifest.Nodes, manifest.Edges)
+	}
+	return nodes, edges, nil
+}
+
+type snapshotNode struct {
+	URL       string `json:"url"`
+	Title     string `json:"title,omitempty"`
+	Status    string `json:"status,omitempty"`
+	LinkCount int    `json:"links"`
+}
+
+type snapshotEdge struct {
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Rel    string `json:"rel,omitempty"`
+	Label  string `json:"label,omitempty"`
+	Anchor string `json:"anchor,omitempty"`
+	Count  int    `json:"count"`
+}
+
+type snapshotPayload struct {
+	Nodes []snapshotNode `json:"nodes,omitempty"`
+	Edges []snapshotEdge `json:"edges,omitempty"`
+}
+
+func buildSnapshotNodeShards(manifestPath, slot string, nodes []StoredNode, target int) ([]SnapshotArtifact, error) {
+	var artifacts []SnapshotArtifact
+	for start := 0; start < len(nodes); {
+		part := len(artifacts)
+		end, artifact, err := largestSnapshotNodeShard(manifestPath, slot, nodes, start, part, target)
+		if err != nil {
+			return nil, err
+		}
+		artifacts = append(artifacts, artifact)
+		start = end
+	}
+	return artifacts, nil
+}
+
+func buildSnapshotEdgeShards(manifestPath, slot string, edges []StoredEdge, target int) ([]SnapshotArtifact, error) {
+	var artifacts []SnapshotArtifact
+	for start := 0; start < len(edges); {
+		part := len(artifacts)
+		end, artifact, err := largestSnapshotEdgeShard(manifestPath, slot, edges, start, part, target)
+		if err != nil {
+			return nil, err
+		}
+		artifacts = append(artifacts, artifact)
+		start = end
+	}
+	return artifacts, nil
+}
+
+func largestSnapshotNodeShard(manifestPath, slot string, nodes []StoredNode, start, part, target int) (int, SnapshotArtifact, error) {
+	bestEnd := 0
+	var best SnapshotArtifact
+	for low, high := start+1, len(nodes); low <= high; {
+		mid := low + (high-low)/2
+		artifact, err := buildSnapshotArtifact(manifestPath, slot, snapshotShardKindNodes, part, nodes[start:mid], nil)
+		if err != nil {
+			return 0, SnapshotArtifact{}, err
+		}
+		if artifact.Bytes <= target {
+			bestEnd, best, low = mid, artifact, mid+1
+		} else {
+			high = mid - 1
+		}
+	}
+	if bestEnd == 0 {
+		return 0, SnapshotArtifact{}, fmt.Errorf("one graph node exceeds shard target %d", target)
+	}
+	return bestEnd, best, nil
+}
+
+func largestSnapshotEdgeShard(manifestPath, slot string, edges []StoredEdge, start, part, target int) (int, SnapshotArtifact, error) {
+	bestEnd := 0
+	var best SnapshotArtifact
+	for low, high := start+1, len(edges); low <= high; {
+		mid := low + (high-low)/2
+		artifact, err := buildSnapshotArtifact(manifestPath, slot, snapshotShardKindEdges, part, nil, edges[start:mid])
+		if err != nil {
+			return 0, SnapshotArtifact{}, err
+		}
+		if artifact.Bytes <= target {
+			bestEnd, best, low = mid, artifact, mid+1
+		} else {
+			high = mid - 1
+		}
+	}
+	if bestEnd == 0 {
+		return 0, SnapshotArtifact{}, fmt.Errorf("one graph edge exceeds shard target %d", target)
+	}
+	return bestEnd, best, nil
+}
+
+func buildSnapshotArtifact(manifestPath, slot, kind string, part int, nodes []StoredNode, edges []StoredEdge) (SnapshotArtifact, error) {
+	payload := snapshotPayload{Nodes: make([]snapshotNode, len(nodes)), Edges: make([]snapshotEdge, len(edges))}
+	for i, node := range nodes {
+		if err := validateSnapshotURL(node.URL); err != nil {
+			return SnapshotArtifact{}, fmt.Errorf("node %d: %w", i+1, err)
+		}
+		payload.Nodes[i] = snapshotNode{URL: node.URL, Title: node.Title, Status: node.Status, LinkCount: node.LinkCount}
+	}
+	for i, edge := range edges {
+		if err := validateSnapshotURL(edge.From); err != nil {
+			return SnapshotArtifact{}, fmt.Errorf("edge %d from: %w", i+1, err)
+		}
+		if err := validateSnapshotURL(edge.To); err != nil {
+			return SnapshotArtifact{}, fmt.Errorf("edge %d to: %w", i+1, err)
+		}
+		payload.Edges[i] = snapshotEdge{
+			From: edge.From, To: edge.To, Rel: edge.Rel, Label: edge.Label,
+			Anchor: edge.Anchor, Count: max(edge.Count, 1),
+		}
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return SnapshotArtifact{}, err
+	}
+	body := fmt.Sprintf("# Graph Snapshot Shard\n\n> Format: %s\n> Kind: %s\n> Part: %d\n> Nodes: %d\n> Edges: %d\n%s%s%s",
+		SnapshotShardFormat, kind, part, len(nodes), len(edges), snapshotJSONFence, encoded, snapshotJSONFenceEnd)
+	artifact := SnapshotArtifact{
+		Kind: kind, Part: part, Path: snapshotShardPath(manifestPath, slot, kind, part),
+		Body: body, Nodes: len(nodes), Edges: len(edges), Bytes: len(body),
+	}
+	artifact.ContentHash = SnapshotBodyHash(body)
+	return artifact, nil
+}
+
+func verifySnapshotShard(ref SnapshotShardRef, response protocol.Response) ([]StoredNode, []StoredEdge, error) { //nolint:gocyclo,gocritic // verification keeps descriptor checks together
+	if response.Status != protocol.StatusOK {
+		return nil, nil, fmt.Errorf("graph shard %s returned %s", ref.Path, response.Status)
+	}
+	version, err := snapshotPositive("version", response.Metadata["version"])
+	if err != nil || version != ref.Version {
+		return nil, nil, fmt.Errorf("graph shard %s version mismatch", ref.Path)
+	}
+	if len(response.Body) != ref.Bytes || SnapshotBodyHash(response.Body) != ref.ContentHash || response.Metadata["content-hash"] != ref.ContentHash {
+		return nil, nil, fmt.Errorf("graph shard %s content mismatch", ref.Path)
+	}
+	meta, payloadText, err := parseSnapshotDocument(response.Body, "# Graph Snapshot Shard")
+	if err != nil {
+		return nil, nil, fmt.Errorf("graph shard %s: %w", ref.Path, err)
+	}
+	if err := validateSnapshotMetadataKeys(meta, "Format", "Kind", "Part", "Nodes", "Edges"); err != nil {
+		return nil, nil, fmt.Errorf("graph shard %s: %w", ref.Path, err)
+	}
+	if meta["Format"] != SnapshotShardFormat || meta["Kind"] != ref.Kind || meta["Part"] != strconv.Itoa(ref.Part) {
+		return nil, nil, fmt.Errorf("graph shard %s identity mismatch", ref.Path)
+	}
+	var payload snapshotPayload
+	if err := validateSnapshotJSON(payloadText); err != nil {
+		return nil, nil, fmt.Errorf("graph shard %s payload: %w", ref.Path, err)
+	}
+	decoder := json.NewDecoder(strings.NewReader(payloadText))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&payload); err != nil {
+		return nil, nil, fmt.Errorf("graph shard %s payload: %w", ref.Path, err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, nil, fmt.Errorf("graph shard %s has trailing JSON", ref.Path)
+	}
+	declaredNodes, nodesErr := snapshotNonNegative("Nodes", meta["Nodes"])
+	declaredEdges, edgesErr := snapshotNonNegative("Edges", meta["Edges"])
+	if err := errors.Join(nodesErr, edgesErr); err != nil || declaredNodes != ref.Nodes || declaredEdges != ref.Edges {
+		return nil, nil, fmt.Errorf("graph shard %s declared count mismatch", ref.Path)
+	}
+	if len(payload.Nodes) != ref.Nodes || len(payload.Edges) != ref.Edges {
+		return nil, nil, fmt.Errorf("graph shard %s count mismatch", ref.Path)
+	}
+	nodes := make([]StoredNode, len(payload.Nodes))
+	for i, node := range payload.Nodes {
+		if err := validateSnapshotURL(node.URL); err != nil {
+			return nil, nil, err
+		}
+		node.URL = links.CanonicalURL(node.URL)
+		if node.LinkCount < 0 {
+			return nil, nil, errors.New("graph shard link count must be non-negative")
+		}
+		nodes[i] = StoredNode{URL: node.URL, Title: node.Title, Status: node.Status, LinkCount: node.LinkCount}
+	}
+	edges := make([]StoredEdge, len(payload.Edges))
+	for i, edge := range payload.Edges {
+		if err := validateSnapshotURL(edge.From); err != nil {
+			return nil, nil, err
+		}
+		if err := validateSnapshotURL(edge.To); err != nil {
+			return nil, nil, err
+		}
+		edge.From = links.CanonicalURL(edge.From)
+		edge.To = links.CanonicalURL(edge.To)
+		if edge.Count < 1 {
+			return nil, nil, errors.New("graph shard edge count must be positive")
+		}
+		edges[i] = StoredEdge(edge)
+	}
+	return nodes, edges, nil
+}
+
+func validateSnapshotManifest(manifestPath string, manifest SnapshotManifest) error { //nolint:gocyclo,gocritic // one pass enforces descriptor invariants
+	if err := validateSnapshotManifestPath(manifestPath); err != nil {
+		return err
+	}
+	if manifest.Exported.IsZero() || manifest.Exported.Year() < 1 || manifest.Exported.Year() > 9999 || !manifest.Complete {
+		return errors.New("complete snapshot metadata is required")
+	}
+	if manifest.ActiveSlot != SnapshotSlotA && manifest.ActiveSlot != SnapshotSlotB {
+		return fmt.Errorf("invalid snapshot slot %q", manifest.ActiveSlot)
+	}
+	if manifest.Nodes < 0 || manifest.Nodes > MaxSnapshotNodes || manifest.Edges < 0 || manifest.Edges > MaxSnapshotEdges {
+		return errors.New("snapshot counts exceed limits")
+	}
+	if len(manifest.Shards) > MaxSnapshotShards {
+		return fmt.Errorf("snapshot has %d shards, limit is %d", len(manifest.Shards), MaxSnapshotShards)
+	}
+	counts := map[string]int{snapshotShardKindNodes: 0, snapshotShardKindEdges: 0}
+	parts := map[string]map[int]struct{}{snapshotShardKindNodes: {}, snapshotShardKindEdges: {}}
+	seen := make(map[string]struct{}, len(manifest.Shards))
+	for _, ref := range manifest.Shards {
+		if (ref.Kind != snapshotShardKindNodes && ref.Kind != snapshotShardKindEdges) || ref.Part < 0 || ref.Version < 1 || ref.Bytes < 1 || ref.Bytes > protocol.MaxBodyLength ||
+			ref.Nodes > MaxSnapshotNodes || ref.Edges > MaxSnapshotEdges {
+			return fmt.Errorf("invalid graph shard descriptor %q", ref.Path)
+		}
+		if ref.Kind == snapshotShardKindNodes && (ref.Nodes < 1 || ref.Edges != 0) {
+			return fmt.Errorf("invalid node shard counts for %q", ref.Path)
+		}
+		if ref.Kind == snapshotShardKindEdges && (ref.Edges < 1 || ref.Nodes != 0) {
+			return fmt.Errorf("invalid edge shard counts for %q", ref.Path)
+		}
+		if clean, ok := protocol.IsHashPath(ref.ContentHash); !ok || clean != ref.ContentHash {
+			return fmt.Errorf("invalid graph shard hash %q", ref.ContentHash)
+		}
+		if ref.Path != snapshotShardPath(manifestPath, manifest.ActiveSlot, ref.Kind, ref.Part) {
+			return fmt.Errorf("invalid graph shard path %q", ref.Path)
+		}
+		if _, duplicate := seen[ref.Path]; duplicate {
+			return fmt.Errorf("duplicate graph shard path %q", ref.Path)
+		}
+		seen[ref.Path] = struct{}{}
+		parts[ref.Kind][ref.Part] = struct{}{}
+		counts[snapshotShardKindNodes] += ref.Nodes
+		counts[snapshotShardKindEdges] += ref.Edges
+	}
+	for kind, kindParts := range parts {
+		for part := range len(kindParts) {
+			if _, ok := kindParts[part]; !ok {
+				return fmt.Errorf("graph %s shards are missing part %d", kind, part)
+			}
+		}
+	}
+	if counts[snapshotShardKindNodes] != manifest.Nodes || counts[snapshotShardKindEdges] != manifest.Edges {
+		return errors.New("snapshot manifest counts do not match shard rows")
+	}
+	return nil
+}
+
+func validateSnapshotManifestPath(manifestPath string) error {
+	if err := protocol.ValidateRequestPath(manifestPath); err != nil || path.Clean(manifestPath) != manifestPath || manifestPath == "/" || !strings.HasSuffix(manifestPath, ".md") || strings.Contains(manifestPath, "|") {
+		return fmt.Errorf("invalid snapshot manifest path %q", manifestPath)
+	}
+	if _, ok := protocol.IsHashPath(manifestPath); ok || snapshotVersionSuffix(manifestPath) {
+		return fmt.Errorf("snapshot manifest path conflicts with immutable fetch syntax %q", manifestPath)
+	}
+	generated := snapshotShardPath(manifestPath, SnapshotSlotA, snapshotShardKindNodes, MaxSnapshotShards-1)
+	if err := protocol.ValidateRequestPath(SnapshotVersionPath(generated, math.MaxInt)); err != nil {
+		return fmt.Errorf("snapshot path cannot produce valid shards: %w", err)
+	}
+	return nil
+}
+
+func snapshotVersionSuffix(docPath string) bool {
+	base := path.Base(docPath)
+	if len(base) < 2 || base[0] != 'v' {
+		return false
+	}
+	version, err := strconv.Atoi(base[1:])
+	return err == nil && version > 0
+}
+
+func snapshotShardPath(manifestPath, slot, kind string, part int) string {
+	root := strings.TrimSuffix(manifestPath, ".md") + ".shards"
+	if path.Base(manifestPath) == "manifest.md" {
+		root = path.Join(path.Dir(manifestPath), "shards")
+	}
+	return fmt.Sprintf("%s/%s/%s-%03d.md", root, slot, kind, part)
+}
+
+func parseSnapshotDocument(body, title string) (metadata map[string]string, table string, err error) {
+	if !strings.HasPrefix(body, title+"\n") {
+		return nil, "", fmt.Errorf("expected title %q", title)
+	}
+	if strings.Contains(body, snapshotJSONFence) {
+		head, rest, ok := strings.Cut(body, snapshotJSONFence)
+		if !ok {
+			return nil, "", errors.New("snapshot JSON fence is missing")
+		}
+		payload, suffix, ok := strings.Cut(rest, snapshotJSONFenceEnd)
+		if !ok || suffix != "" {
+			return nil, "", errors.New("snapshot JSON fence is malformed")
+		}
+		meta, err := parseSnapshotMetadata(head)
+		return meta, payload, err
+	}
+	tableAt := strings.Index(body, "\n|")
+	if tableAt < 0 {
+		return nil, "", errors.New("snapshot table is missing")
+	}
+	meta, err := parseSnapshotMetadata(body[:tableAt])
+	if err != nil {
+		return nil, "", err
+	}
+	return meta, body[tableAt+1:], nil
+}
+
+func parseSnapshotMetadata(body string) (map[string]string, error) {
+	meta := make(map[string]string)
+	for lineNumber, line := range strings.Split(body, "\n") {
+		if lineNumber == 0 && strings.HasPrefix(line, "# ") {
+			continue
+		}
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "> ") {
+			return nil, fmt.Errorf("unexpected snapshot content %q", line)
+		}
+		key, value, ok := strings.Cut(strings.TrimPrefix(line, "> "), ": ")
+		if !ok || key == "" || value == "" {
+			return nil, fmt.Errorf("invalid snapshot metadata %q", line)
+		}
+		if _, duplicate := meta[key]; duplicate {
+			return nil, fmt.Errorf("duplicate snapshot metadata %q", key)
+		}
+		meta[key] = value
+	}
+	return meta, nil
+}
+
+func validateSnapshotJSON(payload string) error {
+	decoder := json.NewDecoder(strings.NewReader(payload))
+	if err := consumeSnapshotJSONValue(decoder); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		return errors.New("trailing JSON content")
+	}
+	return nil
+}
+
+func validateSnapshotMetadataKeys(meta map[string]string, allowed ...string) error {
+	want := make(map[string]struct{}, len(allowed))
+	for _, key := range allowed {
+		want[key] = struct{}{}
+	}
+	for key := range meta {
+		if _, ok := want[key]; !ok {
+			return fmt.Errorf("unexpected snapshot metadata %q", key)
+		}
+	}
+	for key := range want {
+		if _, ok := meta[key]; !ok {
+			return fmt.Errorf("missing snapshot metadata %q", key)
+		}
+	}
+	return nil
+}
+
+func consumeSnapshotJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delim, composite := token.(json.Delim)
+	if !composite {
+		return nil
+	}
+	switch delim {
+	case '{':
+		seen := make(map[string]struct{})
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return errors.New("JSON object key is not a string")
+			}
+			if _, duplicate := seen[key]; duplicate {
+				return fmt.Errorf("duplicate JSON key %q", key)
+			}
+			seen[key] = struct{}{}
+			if err := consumeSnapshotJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+	case '[':
+		for decoder.More() {
+			if err := consumeSnapshotJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+	default:
+		return errors.New("invalid JSON delimiter")
+	}
+	_, err = decoder.Token()
+	return err
+}
+
+func parseSnapshotTable(table string, header []string) ([][]string, error) {
+	lines := strings.Split(strings.TrimSpace(table), "\n")
+	if len(lines) < 2 {
+		return nil, errors.New("snapshot table is incomplete")
+	}
+	parseRow := func(line string) ([]string, bool) {
+		line = strings.TrimSpace(line)
+		if len(line) < 2 || line[0] != '|' || line[len(line)-1] != '|' {
+			return nil, false
+		}
+		cells := strings.Split(line[1:len(line)-1], "|")
+		for i := range cells {
+			cells[i] = strings.TrimSpace(cells[i])
+		}
+		return cells, true
+	}
+	gotHeader, ok := parseRow(lines[0])
+	if !ok || !slices.Equal(gotHeader, header) {
+		return nil, errors.New("snapshot table header is invalid")
+	}
+	separator, ok := parseRow(lines[1])
+	if !ok || len(separator) != len(header) {
+		return nil, errors.New("snapshot table separator is invalid")
+	}
+	for _, cell := range separator {
+		if len(cell) < 3 || strings.Trim(cell, "-") != "" {
+			return nil, errors.New("snapshot table separator is invalid")
+		}
+	}
+	rows := make([][]string, 0, len(lines)-2)
+	for _, line := range lines[2:] {
+		row, ok := parseRow(line)
+		if !ok || len(row) != len(header) {
+			return nil, errors.New("snapshot table row is invalid")
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func snapshotPositive(name, raw string) (int, error) {
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < 1 {
+		return 0, fmt.Errorf("invalid %s value %q", name, raw)
+	}
+	return value, nil
+}
+
+func snapshotNonNegative(name, raw string) (int, error) {
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < 0 {
+		return 0, fmt.Errorf("invalid %s value %q", name, raw)
+	}
+	return value, nil
+}
+
+func validateSnapshotURL(raw string) error {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || strings.ContainsAny(raw, "\r\n\t") {
+		return fmt.Errorf("invalid graph URL %q", raw)
+	}
+	if parsed.Scheme == "mark" {
+		if parsed.Hostname() == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+			return fmt.Errorf("invalid graph URL %q", raw)
+		}
+	}
+	return nil
+}
+
+func compareSnapshotRefs(a, b SnapshotShardRef) int { //nolint:gocritic // slices.SortFunc signature
+	if order := strings.Compare(a.Kind, b.Kind); order != 0 {
+		return order
+	}
+	return a.Part - b.Part
+}
+
+func compareSnapshotEdges(a, b StoredEdge) int { //nolint:gocritic // slices.SortFunc signature
+	if order := strings.Compare(a.From, b.From); order != 0 {
+		return order
+	}
+	if order := strings.Compare(a.To, b.To); order != 0 {
+		return order
+	}
+	return strings.Compare(a.Rel, b.Rel)
+}

--- a/client/graphstore/snapshot_publish.go
+++ b/client/graphstore/snapshot_publish.go
@@ -1,0 +1,189 @@
+package graphstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/latebit-io/demarkus/protocol"
+)
+
+// SnapshotPublishOptions describes one complete graph generation.
+type SnapshotPublishOptions struct {
+	ManifestPath            string
+	Exported                time.Time
+	Nodes                   []StoredNode
+	Edges                   []StoredEdge
+	ExpectedManifestVersion *int
+	ShardTargetBytes        int
+}
+
+// SnapshotPublishResult describes the committed generation.
+type SnapshotPublishResult struct {
+	Manifest        SnapshotManifest
+	ManifestVersion int
+	ShardsPublished int
+	ShardsReused    int
+}
+
+// SnapshotFetch fetches one generated graph document.
+type SnapshotFetch func(ctx context.Context, path string) (protocol.Response, error)
+
+// SnapshotPublish publishes one generated graph document with CAS.
+type SnapshotPublish func(ctx context.Context, path, body string, expectedVersion int) (protocol.Response, error)
+
+// PublishSnapshot stages verified shards and commits the manifest last.
+func PublishSnapshot(ctx context.Context, opts SnapshotPublishOptions, fetchDocument SnapshotFetch, publishDocument SnapshotPublish) (SnapshotPublishResult, error) { //nolint:gocritic // immutable options isolate active publication
+	currentVersion, activeSlot, err := fetchCurrentSnapshot(ctx, opts.ManifestPath, fetchDocument)
+	if err != nil {
+		return SnapshotPublishResult{}, err
+	}
+	if opts.ExpectedManifestVersion != nil && *opts.ExpectedManifestVersion != currentVersion {
+		return SnapshotPublishResult{}, fmt.Errorf("snapshot manifest version changed: got %d, expected %d", currentVersion, *opts.ExpectedManifestVersion)
+	}
+	slot := InactiveSnapshotSlot(activeSlot)
+	artifacts, err := BuildSnapshotShards(opts.ManifestPath, slot, opts.Nodes, opts.Edges, opts.ShardTargetBytes)
+	if err != nil {
+		return SnapshotPublishResult{}, err
+	}
+	refs := make([]SnapshotShardRef, 0, len(artifacts))
+	result := SnapshotPublishResult{}
+	for _, artifact := range artifacts {
+		ref, published, err := stageSnapshotShard(ctx, artifact, fetchDocument, publishDocument)
+		if err != nil {
+			return SnapshotPublishResult{}, err
+		}
+		refs = append(refs, ref)
+		if published {
+			result.ShardsPublished++
+		} else {
+			result.ShardsReused++
+		}
+	}
+	manifest := SnapshotManifest{
+		Exported: opts.Exported.UTC(), Complete: true, Nodes: len(opts.Nodes), Edges: len(opts.Edges),
+		ActiveSlot: slot, Shards: refs,
+	}
+	body, err := BuildSnapshotManifest(opts.ManifestPath, manifest)
+	if err != nil {
+		return SnapshotPublishResult{}, err
+	}
+	verified, version, err := publishAndVerifySnapshot(ctx, opts.ManifestPath, body, currentVersion, fetchDocument, publishDocument)
+	if err != nil {
+		return SnapshotPublishResult{}, err
+	}
+	parsed, err := ParseSnapshotManifest(opts.ManifestPath, verified.Body)
+	if err != nil {
+		return SnapshotPublishResult{}, fmt.Errorf("verify snapshot manifest: %w", err)
+	}
+	result.Manifest = parsed
+	result.ManifestVersion = version
+	return result, nil
+}
+
+func fetchCurrentSnapshot(ctx context.Context, manifestPath string, fetchDocument SnapshotFetch) (version int, activeSlot string, err error) {
+	current, err := fetchDocument(ctx, manifestPath)
+	if err != nil {
+		return 0, "", fmt.Errorf("fetch snapshot manifest: %w", err)
+	}
+	switch current.Status {
+	case protocol.StatusNotFound:
+		return 0, "", nil
+	case protocol.StatusOK:
+		version, err := snapshotResponseVersion(manifestPath, current)
+		if err != nil {
+			return 0, "", err
+		}
+		if current.Metadata["content-hash"] != SnapshotBodyHash(current.Body) {
+			return 0, "", errors.New("current snapshot manifest content hash mismatch")
+		}
+		manifest, err := ParseSnapshotManifest(manifestPath, current.Body)
+		if err != nil {
+			return 0, "", err
+		}
+		return version, manifest.ActiveSlot, nil
+	default:
+		return 0, "", fmt.Errorf("fetch snapshot manifest returned %s", current.Status)
+	}
+}
+
+func stageSnapshotShard(ctx context.Context, artifact SnapshotArtifact, fetchDocument SnapshotFetch, publishDocument SnapshotPublish) (SnapshotShardRef, bool, error) { //nolint:gocritic // immutable artifact value
+	current, err := fetchDocument(ctx, artifact.Path)
+	if err != nil {
+		return SnapshotShardRef{}, false, fmt.Errorf("fetch graph shard %s: %w", artifact.Path, err)
+	}
+	expectedVersion := 0
+	if current.Status == protocol.StatusOK {
+		expectedVersion, err = snapshotResponseVersion(artifact.Path, current)
+		if err != nil {
+			return SnapshotShardRef{}, false, err
+		}
+		if current.Body == artifact.Body && current.Metadata["content-hash"] == artifact.ContentHash {
+			ref := artifact.Ref(expectedVersion)
+			if _, _, err := verifySnapshotShard(ref, current); err != nil {
+				return SnapshotShardRef{}, false, err
+			}
+			return ref, false, nil
+		}
+	} else if current.Status != protocol.StatusNotFound {
+		return SnapshotShardRef{}, false, fmt.Errorf("fetch graph shard %s returned %s", artifact.Path, current.Status)
+	}
+	verified, version, err := publishAndVerifySnapshot(ctx, artifact.Path, artifact.Body, expectedVersion, fetchDocument, publishDocument)
+	if err != nil {
+		return SnapshotShardRef{}, false, err
+	}
+	ref := artifact.Ref(version)
+	if _, _, err := verifySnapshotShard(ref, verified); err != nil {
+		return SnapshotShardRef{}, false, err
+	}
+	return ref, true, nil
+}
+
+func publishAndVerifySnapshot(ctx context.Context, docPath, body string, expectedVersion int, fetchDocument SnapshotFetch, publishDocument SnapshotPublish) (protocol.Response, int, error) {
+	published, publishErr := publishDocument(ctx, docPath, body, expectedVersion)
+	if publishErr == nil && published.Status != protocol.StatusOK && published.Status != protocol.StatusCreated {
+		publishErr = fmt.Errorf("publish returned %s", published.Status)
+	}
+	version := 0
+	if publishErr == nil {
+		version, publishErr = snapshotResponseVersion(docPath, published)
+	}
+	if publishErr != nil {
+		current, err := fetchDocument(ctx, docPath)
+		if err != nil {
+			return protocol.Response{}, 0, fmt.Errorf("publish %s: %v; reconcile: %w", docPath, publishErr, err)
+		}
+		version, err = verifySnapshotBody(docPath, body, current)
+		if err != nil {
+			return protocol.Response{}, 0, fmt.Errorf("publish %s: %w; reconcile: %w", docPath, publishErr, err)
+		}
+	}
+	verified, err := fetchDocument(ctx, SnapshotVersionPath(docPath, version))
+	if err != nil {
+		return protocol.Response{}, 0, fmt.Errorf("verify graph snapshot %s: %w", docPath, err)
+	}
+	if _, err := verifySnapshotBody(docPath, body, verified); err != nil {
+		return protocol.Response{}, 0, err
+	}
+	return verified, version, nil
+}
+
+func verifySnapshotBody(docPath, body string, response protocol.Response) (int, error) {
+	if response.Status != protocol.StatusOK {
+		return 0, fmt.Errorf("verify graph snapshot %s returned %s", docPath, response.Status)
+	}
+	if response.Body != body || response.Metadata["content-hash"] != SnapshotBodyHash(body) {
+		return 0, fmt.Errorf("verify graph snapshot %s content mismatch", docPath)
+	}
+	return snapshotResponseVersion(docPath, response)
+}
+
+func snapshotResponseVersion(docPath string, response protocol.Response) (int, error) {
+	version, err := strconv.Atoi(response.Metadata["version"])
+	if err != nil || version < 1 {
+		return 0, fmt.Errorf("graph snapshot document %s has invalid version %q", docPath, response.Metadata["version"])
+	}
+	return version, nil
+}

--- a/client/graphstore/snapshot_test.go
+++ b/client/graphstore/snapshot_test.go
@@ -70,6 +70,12 @@ func TestGraphSnapshotRoundTripAndIntegrity(t *testing.T) {
 	}
 
 	corruptPath := SnapshotVersionPath(refs[0].Path, refs[0].Version)
+	missingVersion := responses[corruptPath]
+	missingVersion.Metadata = maps.Clone(missingVersion.Metadata)
+	delete(missingVersion.Metadata, "version")
+	if _, _, err := verifySnapshotShard(refs[0], missingVersion); err == nil || !strings.Contains(err.Error(), "invalid version") {
+		t.Fatalf("missing version error = %v", err)
+	}
 	corrupt := responses[corruptPath]
 	corrupt.Body += "x"
 	responses[corruptPath] = corrupt
@@ -103,6 +109,9 @@ func TestGraphSnapshotRejectsAliasesAndMalformedGeneratedContent(t *testing.T) {
 }
 
 func TestGraphSnapshotRejectsUnrepresentableManifestValues(t *testing.T) {
+	if got := SnapshotShardRoot(SnapshotManifestPath); got != "/graph/shards" {
+		t.Fatalf("SnapshotShardRoot = %q", got)
+	}
 	if _, err := BuildSnapshotManifest("/graph/man|ifest.md", SnapshotManifest{
 		Exported: time.Now(), Complete: true, ActiveSlot: SnapshotSlotA,
 	}); err == nil {

--- a/client/graphstore/snapshot_test.go
+++ b/client/graphstore/snapshot_test.go
@@ -1,0 +1,378 @@
+package graphstore
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/latebit-io/demarkus/protocol"
+)
+
+func TestGraphSnapshotRoundTripAndIntegrity(t *testing.T) {
+	exported := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
+	nodes := []StoredNode{
+		{URL: "mark://b/b.md", Title: "B", Status: "ok", LinkCount: 1},
+		{URL: "mark://a/a.md", Title: "A", Status: "ok", LinkCount: 1},
+	}
+	edges := []StoredEdge{
+		{From: "mark://b/b.md", To: "mark://a/a.md", Count: 1},
+		{From: "mark://a/a.md", To: "mark://b/b.md", Rel: "related", Label: "B", Count: 2},
+	}
+	one, err := BuildSnapshotShards(SnapshotManifestPath, SnapshotSlotA, nodes[:1], nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oneEdge, err := BuildSnapshotShards(SnapshotManifestPath, SnapshotSlotA, nil, edges[1:], 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := max(one[0].Bytes, oneEdge[0].Bytes)
+	artifacts, err := BuildSnapshotShards(SnapshotManifestPath, SnapshotSlotA, nodes, edges, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(artifacts) < 2 {
+		t.Fatalf("shards = %d, want separate node and edge shards", len(artifacts))
+	}
+	refs := make([]SnapshotShardRef, len(artifacts))
+	responses := make(map[string]protocol.Response, len(artifacts))
+	for i, artifact := range artifacts {
+		refs[i] = artifact.Ref(i + 1)
+		responses[SnapshotVersionPath(artifact.Path, i+1)] = protocol.Response{
+			Status: protocol.StatusOK, Body: artifact.Body,
+			Metadata: map[string]string{"version": strconv.Itoa(i + 1), "content-hash": artifact.ContentHash},
+		}
+	}
+	manifestBody, err := BuildSnapshotManifest(SnapshotManifestPath, SnapshotManifest{
+		Exported: exported, Complete: true, Nodes: len(nodes), Edges: len(edges),
+		ActiveSlot: SnapshotSlotA, Shards: refs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestResponse := protocol.Response{Status: protocol.StatusOK, Body: manifestBody, Metadata: map[string]string{
+		"content-hash": SnapshotBodyHash(manifestBody),
+	}}
+	loadedNodes, loadedEdges, err := LoadSnapshot(SnapshotManifestPath, manifestResponse, func(path string) (protocol.Response, error) {
+		return responses[path], nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loadedNodes) != 2 || loadedNodes[0].URL != "mark://a/a.md" || len(loadedEdges) != 2 || loadedEdges[0].From != "mark://a/a.md" {
+		t.Fatalf("loaded nodes=%+v edges=%+v", loadedNodes, loadedEdges)
+	}
+
+	corruptPath := SnapshotVersionPath(refs[0].Path, refs[0].Version)
+	corrupt := responses[corruptPath]
+	corrupt.Body += "x"
+	responses[corruptPath] = corrupt
+	if _, _, err := LoadSnapshot(SnapshotManifestPath, manifestResponse, func(path string) (protocol.Response, error) {
+		return responses[path], nil
+	}); err == nil || !strings.Contains(err.Error(), "content mismatch") {
+		t.Fatalf("corrupt snapshot error = %v", err)
+	}
+}
+
+func TestGraphSnapshotRejectsAliasesAndMalformedGeneratedContent(t *testing.T) {
+	if _, err := BuildSnapshotShards(SnapshotManifestPath, SnapshotSlotA, []StoredNode{
+		{URL: "mark://host/a.md"},
+		{URL: "mark://host:6309/a.md"},
+	}, nil, 0); err == nil || !strings.Contains(err.Error(), "duplicate graph node") {
+		t.Fatalf("alias error = %v", err)
+	}
+	manifest, err := BuildSnapshotManifest(SnapshotManifestPath, SnapshotManifest{
+		Exported: time.Now(), Complete: true, ActiveSlot: SnapshotSlotA,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest = strings.Replace(manifest, "\n\n| Kind", "\nunexpected\n\n| Kind", 1)
+	if _, err := ParseSnapshotManifest(SnapshotManifestPath, manifest); err == nil || !strings.Contains(err.Error(), "unexpected snapshot content") {
+		t.Fatalf("preamble error = %v", err)
+	}
+	if err := validateSnapshotJSON(`{"nodes":[],"nodes":[]}`); err == nil || !strings.Contains(err.Error(), "duplicate JSON key") {
+		t.Fatalf("duplicate JSON error = %v", err)
+	}
+}
+
+func TestGraphSnapshotRejectsUnrepresentableManifestValues(t *testing.T) {
+	if _, err := BuildSnapshotManifest("/graph/man|ifest.md", SnapshotManifest{
+		Exported: time.Now(), Complete: true, ActiveSlot: SnapshotSlotA,
+	}); err == nil {
+		t.Fatal("manifest path containing table delimiter accepted")
+	}
+	for _, manifestPath := range []string{"/graph/v2", "/graph/manifest", "/sha256-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"} {
+		if _, err := BuildSnapshotManifest(manifestPath, SnapshotManifest{
+			Exported: time.Now(), Complete: true, ActiveSlot: SnapshotSlotA,
+		}); err == nil {
+			t.Fatalf("special fetch path %q accepted", manifestPath)
+		}
+	}
+	if _, err := BuildSnapshotManifest(SnapshotManifestPath, SnapshotManifest{
+		Exported: time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC), Complete: true, ActiveSlot: SnapshotSlotA,
+	}); err == nil {
+		t.Fatal("year zero accepted")
+	}
+	artifacts, err := BuildSnapshotShards(SnapshotManifestPath, SnapshotSlotA,
+		[]StoredNode{{URL: "mark://a/a.md", Status: "ok"}}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := artifacts[0].Ref(1)
+	ref.Bytes = protocol.MaxBodyLength + 1
+	if _, err := BuildSnapshotManifest(SnapshotManifestPath, SnapshotManifest{
+		Exported: time.Now(), Complete: true, Nodes: 1, ActiveSlot: SnapshotSlotA, Shards: []SnapshotShardRef{ref},
+	}); err == nil {
+		t.Fatal("oversized shard descriptor accepted")
+	}
+}
+
+type snapshotRemote struct {
+	mu        sync.Mutex
+	docs      map[string]protocol.Response
+	history   map[string]map[int]protocol.Response
+	publishes []string
+	failRoot  bool
+}
+
+func newSnapshotRemote() *snapshotRemote {
+	return &snapshotRemote{docs: make(map[string]protocol.Response), history: make(map[string]map[int]protocol.Response)}
+}
+
+func (r *snapshotRemote) fetch(_ context.Context, docPath string) (protocol.Response, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if base, version, ok := splitSnapshotVersionPath(docPath); ok {
+		if response, exists := r.history[base][version]; exists {
+			return response, nil
+		}
+		return protocol.Response{Status: protocol.StatusNotFound}, nil
+	}
+	if response, exists := r.docs[docPath]; exists {
+		return response, nil
+	}
+	return protocol.Response{Status: protocol.StatusNotFound}, nil
+}
+
+func (r *snapshotRemote) publish(_ context.Context, docPath, body string, expectedVersion int) (protocol.Response, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.failRoot && docPath == SnapshotManifestPath {
+		return protocol.Response{Status: protocol.StatusConflict}, nil
+	}
+	currentVersion := 0
+	if current, exists := r.docs[docPath]; exists {
+		var err error
+		currentVersion, err = strconv.Atoi(current.Metadata["version"])
+		if err != nil {
+			return protocol.Response{}, err
+		}
+	}
+	if expectedVersion != currentVersion {
+		return protocol.Response{Status: protocol.StatusConflict}, nil
+	}
+	version := currentVersion + 1
+	stored := protocol.Response{Status: protocol.StatusOK, Body: body, Metadata: map[string]string{
+		"version": strconv.Itoa(version), "content-hash": SnapshotBodyHash(body),
+	}}
+	r.docs[docPath] = stored
+	if r.history[docPath] == nil {
+		r.history[docPath] = make(map[int]protocol.Response)
+	}
+	historical := stored
+	historical.Metadata = maps.Clone(stored.Metadata)
+	r.history[docPath][version] = historical
+	r.publishes = append(r.publishes, docPath)
+	status := protocol.StatusOK
+	if currentVersion == 0 {
+		status = protocol.StatusCreated
+	}
+	return protocol.Response{Status: status, Metadata: map[string]string{"version": strconv.Itoa(version)}}, nil
+}
+
+func TestPublishGraphSnapshotCommitsManifestLast(t *testing.T) {
+	remote := newSnapshotRemote()
+	result, err := PublishSnapshot(t.Context(), SnapshotPublishOptions{
+		ManifestPath: SnapshotManifestPath, Exported: time.Now(),
+		Nodes: []StoredNode{{URL: "mark://a/a.md", Status: "ok"}},
+		Edges: []StoredEdge{{From: "mark://a/a.md", To: "mark://b/b.md", Count: 1}},
+	}, remote.fetch, remote.publish)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ManifestVersion != 1 || result.Manifest.ActiveSlot != SnapshotSlotA || result.ShardsPublished != 2 {
+		t.Fatalf("result = %+v", result)
+	}
+	if got := remote.publishes[len(remote.publishes)-1]; got != SnapshotManifestPath {
+		t.Fatalf("last publish = %q", got)
+	}
+	manifestResponse := remote.docs[SnapshotManifestPath]
+	if _, _, err := LoadSnapshot(SnapshotManifestPath, manifestResponse, func(path string) (protocol.Response, error) {
+		return remote.fetch(t.Context(), path)
+	}); err != nil {
+		t.Fatalf("committed snapshot unreadable: %v", err)
+	}
+}
+
+func TestPublishGraphSnapshotFailurePreservesPreviousGeneration(t *testing.T) {
+	remote := newSnapshotRemote()
+	opts := SnapshotPublishOptions{
+		ManifestPath: SnapshotManifestPath, Exported: time.Now(),
+		Nodes: []StoredNode{{URL: "mark://a/a.md", Title: "A", Status: "ok"}},
+	}
+	if _, err := PublishSnapshot(t.Context(), opts, remote.fetch, remote.publish); err != nil {
+		t.Fatal(err)
+	}
+	previous := remote.docs[SnapshotManifestPath].Body
+	remote.failRoot = true
+	opts.Exported = opts.Exported.Add(time.Minute)
+	opts.Nodes[0].Title = "Changed"
+	if _, err := PublishSnapshot(t.Context(), opts, remote.fetch, remote.publish); err == nil {
+		t.Fatal("manifest failure returned nil")
+	}
+	if remote.docs[SnapshotManifestPath].Body != previous {
+		t.Fatal("failed publication replaced committed manifest")
+	}
+	if _, ok := remote.docs["/graph/shards/b/nodes-000.md"]; !ok {
+		t.Fatal("inactive staged shard missing")
+	}
+}
+
+func TestPublishGraphSnapshotAlternatesAndReusesSlots(t *testing.T) {
+	remote := newSnapshotRemote()
+	opts := SnapshotPublishOptions{
+		ManifestPath: SnapshotManifestPath, Exported: time.Now(),
+		Nodes: []StoredNode{{URL: "mark://a/a.md", Status: "ok"}},
+	}
+	first, err := PublishSnapshot(t.Context(), opts, remote.fetch, remote.publish)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts.Exported = opts.Exported.Add(time.Minute)
+	second, err := PublishSnapshot(t.Context(), opts, remote.fetch, remote.publish)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts.Exported = opts.Exported.Add(time.Minute)
+	third, err := PublishSnapshot(t.Context(), opts, remote.fetch, remote.publish)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Manifest.ActiveSlot != SnapshotSlotA || second.Manifest.ActiveSlot != SnapshotSlotB || third.Manifest.ActiveSlot != SnapshotSlotA {
+		t.Fatalf("slots = %s, %s, %s", first.Manifest.ActiveSlot, second.Manifest.ActiveSlot, third.Manifest.ActiveSlot)
+	}
+	if third.ShardsReused != 1 || third.ShardsPublished != 0 {
+		t.Fatalf("third publication = %+v", third)
+	}
+}
+
+func TestGraphSnapshotPinsImmutableShardVersion(t *testing.T) {
+	remote := newSnapshotRemote()
+	result, err := PublishSnapshot(t.Context(), SnapshotPublishOptions{
+		ManifestPath: SnapshotManifestPath, Exported: time.Now(),
+		Nodes: []StoredNode{{URL: "mark://a/a.md", Title: "Original", Status: "ok"}},
+	}, remote.fetch, remote.publish)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := result.Manifest.Shards[0]
+	replacement, err := BuildSnapshotShards(SnapshotManifestPath, result.Manifest.ActiveSlot, []StoredNode{{URL: "mark://a/a.md", Title: "Replacement", Status: "ok"}}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := remote.publish(t.Context(), ref.Path, replacement[0].Body, ref.Version); err != nil {
+		t.Fatal(err)
+	}
+	manifest := remote.docs[SnapshotManifestPath]
+	nodes, _, err := LoadSnapshot(SnapshotManifestPath, manifest, func(path string) (protocol.Response, error) {
+		return remote.fetch(t.Context(), path)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 || nodes[0].Title != "Original" {
+		t.Fatalf("loaded nodes = %+v", nodes)
+	}
+}
+
+func TestGraphSnapshotManifestCASAndCancellation(t *testing.T) {
+	remote := newSnapshotRemote()
+	if _, err := PublishSnapshot(t.Context(), SnapshotPublishOptions{
+		ManifestPath: SnapshotManifestPath, Exported: time.Now(),
+	}, remote.fetch, remote.publish); err != nil {
+		t.Fatal(err)
+	}
+	publishes := len(remote.publishes)
+	stale := 0
+	if _, err := PublishSnapshot(t.Context(), SnapshotPublishOptions{
+		ManifestPath: SnapshotManifestPath, Exported: time.Now(), ExpectedManifestVersion: &stale,
+	}, remote.fetch, remote.publish); err == nil || len(remote.publishes) != publishes {
+		t.Fatalf("stale CAS err=%v publishes=%v", err, remote.publishes)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		_, err := PublishSnapshot(ctx, SnapshotPublishOptions{ManifestPath: SnapshotManifestPath, Exported: time.Now()},
+			func(fetchCtx context.Context, _ string) (protocol.Response, error) {
+				close(started)
+				<-fetchCtx.Done()
+				return protocol.Response{}, fetchCtx.Err()
+			}, remote.publish)
+		done <- err
+	}()
+	<-started
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancellation error = %v", err)
+	}
+}
+
+func TestConcurrentGraphSnapshotPublishersCommitOneGeneration(t *testing.T) {
+	remote := newSnapshotRemote()
+	if _, err := PublishSnapshot(t.Context(), SnapshotPublishOptions{
+		ManifestPath: SnapshotManifestPath, Exported: time.Now(),
+	}, remote.fetch, remote.publish); err != nil {
+		t.Fatal(err)
+	}
+	expected := 1
+	var successes atomic.Int32
+	done := make(chan struct{}, 2)
+	for _, title := range []string{"A", "B"} {
+		go func() {
+			_, err := PublishSnapshot(t.Context(), SnapshotPublishOptions{
+				ManifestPath: SnapshotManifestPath, Exported: time.Now(), ExpectedManifestVersion: &expected,
+				Nodes: []StoredNode{{URL: "mark://a/a.md", Title: title, Status: "ok"}},
+			}, remote.fetch, remote.publish)
+			if err == nil {
+				successes.Add(1)
+			}
+			done <- struct{}{}
+		}()
+	}
+	<-done
+	<-done
+	if successes.Load() != 1 {
+		t.Fatalf("successful publishers = %d, want 1", successes.Load())
+	}
+}
+
+func splitSnapshotVersionPath(docPath string) (base string, version int, ok bool) {
+	cut := strings.LastIndex(docPath, "/v")
+	if cut < 1 {
+		return "", 0, false
+	}
+	version, err := strconv.Atoi(docPath[cut+2:])
+	if err != nil || version < 1 {
+		return "", 0, false
+	}
+	return docPath[:cut], version, true
+}

--- a/client/graphstore/store.go
+++ b/client/graphstore/store.go
@@ -197,9 +197,6 @@ func Load(path string) (*Store, error) {
 // In-memory stores from New are a no-op.
 func (s *Store) Save() error {
 	if s.path == "" {
-		// In-memory store; nothing to persist. CrawlAndPersist
-		// still calls us unconditionally, so this no-op is the
-		// load-bearing part of the New() contract.
 		return nil
 	}
 	s.saveMu.Lock()

--- a/client/graphstore/store.go
+++ b/client/graphstore/store.go
@@ -13,6 +13,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -26,9 +27,8 @@ import (
 )
 
 // schemaVersion is the on-disk format version. Increment on breaking changes.
-// v2 keys nodes by canonical identity, the authority without the default
-// port (ADR 0005); v1 files are migrated on load.
-const schemaVersion = 2
+// v2 canonicalizes node identities. v3 persists complete seed graphs by owner.
+const schemaVersion = 3
 
 // minSchemaVersion is the oldest on-disk format still readable.
 const minSchemaVersion = 1
@@ -65,20 +65,27 @@ func (e *StoredEdge) key() edgeKey {
 // document is the on-disk JSON envelope. SeedEtags is additive (omitted when
 // empty) so pre-seed graph.json files round-trip unchanged; schema stays v1.
 type document struct {
-	Version   int               `json:"version"`
-	Nodes     []StoredNode      `json:"nodes"`
-	Edges     []StoredEdge      `json:"edges"`
-	SeedEtags map[string]string `json:"seed_etags,omitempty"`
+	Version    int                      `json:"version"`
+	Nodes      []StoredNode             `json:"nodes"`
+	Edges      []StoredEdge             `json:"edges"`
+	SeedEtags  map[string]string        `json:"seed_etags,omitempty"`
+	SeedGraphs map[string]seedGraphData `json:"seed_graphs,omitempty"`
+}
+
+type seedGraphData struct {
+	Nodes []StoredNode `json:"nodes"`
+	Edges []StoredEdge `json:"edges"`
 }
 
 // Store is the persistent graph state.
 type Store struct {
-	path      string
-	mu        sync.RWMutex
-	nodes     map[string]*StoredNode
-	edges     []StoredEdge
-	edgeIdx   map[edgeKey]int
-	seedEtags map[string]string // host -> last seen /graph.md etag
+	path       string
+	mu         sync.RWMutex
+	nodes      map[string]*StoredNode
+	edges      []StoredEdge
+	edgeIdx    map[edgeKey]int
+	seedEtags  map[string]string        // host -> last seen published graph etag
+	seedGraphs map[string]seedGraphData // owner -> latest complete non-authoritative graph
 }
 
 // DefaultPath returns the default graph store location (~/.mark/graph.json).
@@ -98,9 +105,10 @@ func DefaultPath() string {
 // wants the disk-backing.
 func New() *Store {
 	return &Store{
-		nodes:     make(map[string]*StoredNode),
-		edgeIdx:   make(map[edgeKey]int),
-		seedEtags: make(map[string]string),
+		nodes:      make(map[string]*StoredNode),
+		edgeIdx:    make(map[edgeKey]int),
+		seedEtags:  make(map[string]string),
+		seedGraphs: make(map[string]seedGraphData),
 	}
 }
 
@@ -113,10 +121,11 @@ func Load(path string) (*Store, error) {
 	}
 
 	s := &Store{
-		path:      path,
-		nodes:     make(map[string]*StoredNode),
-		edgeIdx:   make(map[edgeKey]int),
-		seedEtags: make(map[string]string),
+		path:       path,
+		nodes:      make(map[string]*StoredNode),
+		edgeIdx:    make(map[edgeKey]int),
+		seedEtags:  make(map[string]string),
+		seedGraphs: make(map[string]seedGraphData),
 	}
 
 	data, err := os.ReadFile(path)
@@ -157,6 +166,23 @@ func Load(path string) (*Store, error) {
 		}
 	}
 	maps.Copy(s.seedEtags, doc.SeedEtags)
+	for owner, seeded := range doc.SeedGraphs {
+		for i := range seeded.Nodes {
+			seeded.Nodes[i].URL = links.CanonicalURL(seeded.Nodes[i].URL)
+			seeded.Nodes[i].CrawledAt = time.Time{}
+			seeded.Nodes[i].Etag = ""
+		}
+		for i := range seeded.Edges {
+			seeded.Edges[i].From = links.CanonicalURL(seeded.Edges[i].From)
+			seeded.Edges[i].To = links.CanonicalURL(seeded.Edges[i].To)
+			seeded.Edges[i].Count = max(seeded.Edges[i].Count, 1)
+		}
+		s.seedGraphs[owner] = seeded
+	}
+	if doc.Version < 3 && len(s.seedEtags) > 0 {
+		// Pre-snapshot stores lack owner provenance; force one full refresh.
+		clear(s.seedEtags)
+	}
 
 	return s, nil
 }
@@ -190,6 +216,9 @@ func (s *Store) Save() error {
 	}
 	if len(s.seedEtags) > 0 {
 		doc.SeedEtags = s.seedEtags
+	}
+	if len(s.seedGraphs) > 0 {
+		doc.SeedGraphs = s.seedGraphs
 	}
 
 	data, err := json.MarshalIndent(doc, "", "  ")
@@ -227,14 +256,14 @@ func (s *Store) Merge(g *graph.Graph, etags map[string]string) int {
 	refreshed := make(map[string]bool)
 
 	for _, n := range g.AllNodes() {
-		n.URL = links.CanonicalURL(n.URL)
+		nodeURL := links.CanonicalURL(n.URL)
 		if !observedStatus(n.Status) {
 			// Failed fetch: we learned nothing about this node. Keep the
 			// stored copy untouched (its CrawledAt keeps it authoritative
 			// against seeds); only record nodes we have never seen.
-			if s.nodes[n.URL] == nil {
-				s.nodes[n.URL] = &StoredNode{
-					URL:       n.URL,
+			if s.nodes[nodeURL] == nil {
+				s.nodes[nodeURL] = &StoredNode{
+					URL:       nodeURL,
 					Title:     n.Title,
 					Status:    n.Status,
 					LinkCount: n.LinkCount,
@@ -245,18 +274,18 @@ func (s *Store) Merge(g *graph.Graph, etags map[string]string) int {
 			continue
 		}
 		sn := &StoredNode{
-			URL:       n.URL,
+			URL:       nodeURL,
 			Title:     n.Title,
 			Status:    n.Status,
 			LinkCount: n.LinkCount,
 			CrawledAt: now,
 		}
 		if etags != nil {
-			sn.Etag = etags[n.URL]
+			sn.Etag = etags[nodeURL]
 		}
-		s.nodes[n.URL] = sn
+		s.nodes[nodeURL] = sn
 		count++
-		refreshed[n.URL] = true
+		refreshed[nodeURL] = true
 	}
 
 	s.dropEdgesFromLocked(refreshed)
@@ -329,54 +358,99 @@ func (s *Store) authoritativeLocked(url string) bool {
 // replaced, so stale rows from an earlier seed do not linger. Returns the
 // number of nodes seeded.
 func (s *Store) SeedFromExport(nodes []StoredNode, edges []StoredEdge) int {
+	return s.ReplaceSeed("", nodes, edges)
+}
+
+// ReplaceSeed atomically replaces one owner's complete seeded graph.
+// Locally crawled sources remain authoritative.
+func (s *Store) ReplaceSeed(owner string, nodes []StoredNode, edges []StoredEdge) int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	seeded := seedGraphData{
+		Nodes: append([]StoredNode(nil), nodes...),
+		Edges: append([]StoredEdge(nil), edges...),
+	}
+	for i := range seeded.Nodes {
+		seeded.Nodes[i].URL = links.CanonicalURL(seeded.Nodes[i].URL)
+		seeded.Nodes[i].CrawledAt = time.Time{}
+		seeded.Nodes[i].Etag = ""
+	}
+	for i := range seeded.Edges {
+		seeded.Edges[i].From = links.CanonicalURL(seeded.Edges[i].From)
+		seeded.Edges[i].To = links.CanonicalURL(seeded.Edges[i].To)
+		seeded.Edges[i].Count = max(seeded.Edges[i].Count, 1)
+	}
+	if previous, ok := s.seedGraphs[owner]; ok {
+		latestSources := make(map[string]bool, len(seeded.Edges))
+		for _, edge := range seeded.Edges {
+			latestSources[edge.From] = true
+		}
+		unobserved := make(map[string]bool)
+		for _, node := range seeded.Nodes {
+			if !observedStatus(node.Status) && !latestSources[node.URL] {
+				unobserved[node.URL] = true
+			}
+		}
+		for _, edge := range previous.Edges {
+			if unobserved[edge.From] {
+				seeded.Edges = append(seeded.Edges, edge)
+			}
+		}
+	}
 	added := 0
-	for _, n := range nodes {
-		// Another producer's export may predate ADR 0005 or address its worlds
-		// differently; normalize before it reaches a stored key.
-		n.URL = links.CanonicalURL(n.URL)
-		if s.authoritativeLocked(n.URL) {
-			continue
-		}
-		sn := n
-		sn.CrawledAt = time.Time{}
-		sn.Etag = "" // the hub export carries no per-node etags
-		s.nodes[sn.URL] = &sn
-		added++
-	}
-
-	// Sources whose outgoing edge set this seed replaces: every source the
-	// aggregate actually observed (real status) plus every seed-edge From,
-	// excluding locally authoritative ones. Node-based inclusion matters
-	// when a source's outgoing set went to zero: no edge rows remain, yet
-	// its stale seeded edges must still drop (Merge's refreshed criterion,
-	// applied to the seed's view).
-	seeded := make(map[string]bool)
-	for _, n := range nodes {
-		if observedStatus(n.Status) && !s.authoritativeLocked(n.URL) {
-			seeded[n.URL] = true
+	for _, node := range seeded.Nodes {
+		if !s.authoritativeLocked(node.URL) {
+			added++
 		}
 	}
-	for i := range edges {
-		edges[i].From = links.CanonicalURL(edges[i].From)
-		edges[i].To = links.CanonicalURL(edges[i].To)
-		if !s.authoritativeLocked(edges[i].From) {
-			seeded[edges[i].From] = true
-		}
-	}
-	s.dropEdgesFromLocked(seeded)
-
-	for _, e := range edges {
-		if !seeded[e.From] {
-			continue
-		}
-		e.Count = max(e.Count, 1)
-		s.upsertEdgeLocked(&e)
-	}
-
+	s.seedGraphs[owner] = seeded
+	s.rebuildSeedsLocked()
 	return added
+}
+
+func (s *Store) rebuildSeedsLocked() {
+	localNodes := make(map[string]*StoredNode)
+	for nodeURL, node := range s.nodes {
+		if !node.CrawledAt.IsZero() {
+			nodeCopy := *node
+			localNodes[nodeURL] = &nodeCopy
+		}
+	}
+	var localEdges []StoredEdge
+	for _, edge := range s.edges {
+		if s.authoritativeLocked(edge.From) {
+			localEdges = append(localEdges, edge)
+		}
+	}
+	s.nodes = localNodes
+	s.edges = nil
+	s.edgeIdx = make(map[edgeKey]int)
+	for i := range localEdges {
+		s.upsertEdgeLocked(&localEdges[i])
+	}
+
+	owners := slices.Sorted(maps.Keys(s.seedGraphs))
+	for _, owner := range owners {
+		seeded := s.seedGraphs[owner]
+		for i := range seeded.Nodes {
+			node := seeded.Nodes[i]
+			if local := localNodes[node.URL]; local != nil && observedStatus(local.Status) {
+				continue
+			}
+			nodeCopy := node
+			s.nodes[node.URL] = &nodeCopy
+		}
+	}
+	for _, owner := range owners {
+		for i := range s.seedGraphs[owner].Edges {
+			edge := s.seedGraphs[owner].Edges[i]
+			if s.authoritativeLocked(edge.From) {
+				continue
+			}
+			s.upsertEdgeLocked(&edge)
+		}
+	}
 }
 
 // SeedEtag returns the last recorded /graph.md etag for host ("" if none).

--- a/client/graphstore/store.go
+++ b/client/graphstore/store.go
@@ -41,6 +41,7 @@ type StoredNode struct {
 	LinkCount int       `json:"link_count"`
 	Etag      string    `json:"etag,omitempty"`
 	CrawledAt time.Time `json:"crawled_at"`
+	Seeded    bool      `json:"seeded,omitempty"`
 }
 
 // StoredEdge is a directed link between two document URLs.
@@ -81,6 +82,7 @@ type seedGraphData struct {
 type Store struct {
 	path       string
 	mu         sync.RWMutex
+	saveMu     sync.Mutex
 	nodes      map[string]*StoredNode
 	edges      []StoredEdge
 	edgeIdx    map[edgeKey]int
@@ -150,6 +152,9 @@ func Load(path string) (*Store, error) {
 	for i := range doc.Nodes {
 		n := doc.Nodes[i]
 		n.URL = links.CanonicalURL(n.URL)
+		if n.CrawledAt.IsZero() {
+			n.Seeded = true
+		}
 		if prev := s.nodes[n.URL]; prev != nil && prev.CrawledAt.After(n.CrawledAt) {
 			continue
 		}
@@ -171,6 +176,7 @@ func Load(path string) (*Store, error) {
 			seeded.Nodes[i].URL = links.CanonicalURL(seeded.Nodes[i].URL)
 			seeded.Nodes[i].CrawledAt = time.Time{}
 			seeded.Nodes[i].Etag = ""
+			seeded.Nodes[i].Seeded = true
 		}
 		for i := range seeded.Edges {
 			seeded.Edges[i].From = links.CanonicalURL(seeded.Edges[i].From)
@@ -187,13 +193,8 @@ func Load(path string) (*Store, error) {
 	return s, nil
 }
 
-// Save writes the graph store to disk atomically (write tmp, rename).
-// When s.path is empty (in-memory store from New()) this is a
-// no-op so callers can treat persistence as transparent and rely
-// on the New()-constructed store for ephemeral use cases.
-// NOTE: holds RLock across marshal + disk I/O. Fine while Save is only called
-// from CrawlAndPersist (infrequent, user-triggered). If concurrent or periodic
-// saves are added, snapshot state under lock and write outside it.
+// Save atomically persists one store snapshot through a serialized temp path.
+// In-memory stores from New are a no-op.
 func (s *Store) Save() error {
 	if s.path == "" {
 		// In-memory store; nothing to persist. CrawlAndPersist
@@ -201,6 +202,8 @@ func (s *Store) Save() error {
 		// load-bearing part of the New() contract.
 		return nil
 	}
+	s.saveMu.Lock()
+	defer s.saveMu.Unlock()
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -338,25 +341,18 @@ func observedStatus(status string) bool {
 	return status != "" && status != "external" && status != "error"
 }
 
-// authoritativeLocked reports whether the stored node for url reflects a real
-// local crawl: a genuinely fetched status and a non-zero CrawledAt. Seeded
-// nodes carry zero CrawledAt, the durable "not locally observed" marker.
-// Caller must hold s.mu.
+// authoritativeLocked reports whether url has a successfully fetched local row.
+// Seeded distinguishes seed overlays that retain a local encounter timestamp.
 func (s *Store) authoritativeLocked(url string) bool {
 	n := s.nodes[url]
 	if n == nil {
 		return false
 	}
-	return observedStatus(n.Status) && !n.CrawledAt.IsZero()
+	return !n.Seeded && observedStatus(n.Status) && !n.CrawledAt.IsZero()
 }
 
-// SeedFromExport merges a published /graph.md aggregate (as parsed by
-// ParseExport) into the store. Local wins: nodes and edges of a locally
-// authoritative source are never touched. Seeded nodes get zero CrawledAt so
-// a later local crawl flips them authoritative through Merge. For every
-// non-authoritative source in the seed, the stored outgoing edge set is
-// replaced, so stale rows from an earlier seed do not linger. Returns the
-// number of nodes seeded.
+// SeedFromExport replaces the default owner's graph while fetched local rows win.
+// A later successful local crawl supersedes seed provenance. Returns nodes seeded.
 func (s *Store) SeedFromExport(nodes []StoredNode, edges []StoredEdge) int {
 	return s.ReplaceSeed("", nodes, edges)
 }
@@ -375,6 +371,7 @@ func (s *Store) ReplaceSeed(owner string, nodes []StoredNode, edges []StoredEdge
 		seeded.Nodes[i].URL = links.CanonicalURL(seeded.Nodes[i].URL)
 		seeded.Nodes[i].CrawledAt = time.Time{}
 		seeded.Nodes[i].Etag = ""
+		seeded.Nodes[i].Seeded = true
 	}
 	for i := range seeded.Edges {
 		seeded.Edges[i].From = links.CanonicalURL(seeded.Edges[i].From)
@@ -435,8 +432,11 @@ func (s *Store) rebuildSeedsLocked() {
 		seeded := s.seedGraphs[owner]
 		for i := range seeded.Nodes {
 			node := seeded.Nodes[i]
-			if local := localNodes[node.URL]; local != nil && observedStatus(local.Status) {
-				continue
+			if local := localNodes[node.URL]; local != nil {
+				if !local.Seeded && observedStatus(local.Status) {
+					continue
+				}
+				node.CrawledAt = local.CrawledAt
 			}
 			nodeCopy := node
 			s.nodes[node.URL] = &nodeCopy

--- a/client/graphstore/store_test.go
+++ b/client/graphstore/store_test.go
@@ -838,8 +838,12 @@ func TestSeedFromExportOverwritesNonAuthoritative(t *testing.T) {
 	if n.Status != "ok" || n.Title != "A" {
 		t.Errorf("node = %+v, want seeded ok/A", n)
 	}
-	if !n.CrawledAt.IsZero() {
-		t.Error("seeded copy must carry zero CrawledAt")
+	if n.CrawledAt.IsZero() || !n.Seeded {
+		t.Fatalf("seeded copy lost local marker: %+v", n)
+	}
+	s.SeedFromExport(nil, nil)
+	if n := s.GetNode("mark://a/a.md"); n == nil || n.CrawledAt.IsZero() {
+		t.Fatalf("omitted seed erased locally observed node: %+v", n)
 	}
 }
 
@@ -856,6 +860,9 @@ func TestSeedThenCrawlFlipsAuthoritative(t *testing.T) {
 	g.AddNode(&graph.Node{URL: "mark://a/a.md", Title: "A", Status: "ok", LinkCount: 1})
 	g.AddEdgeInfo(graph.Edge{From: "mark://a/a.md", To: "mark://a/b.md"})
 	s.Merge(g, nil)
+	if node := s.GetNode("mark://a/a.md"); node == nil || node.Seeded {
+		t.Fatalf("local crawl retained seed provenance: %+v", node)
+	}
 
 	if bl := s.Backlinks("mark://a/hub-only.md"); len(bl) != 0 {
 		t.Errorf("stale seeded edge survived local crawl: %v", bl)
@@ -868,6 +875,39 @@ func TestSeedThenCrawlFlipsAuthoritative(t *testing.T) {
 	s.SeedFromExport(nodes, edges)
 	if bl := s.Backlinks("mark://a/hub-only.md"); len(bl) != 0 {
 		t.Errorf("re-seed overwrote authoritative source: %v", bl)
+	}
+}
+
+func TestSeedOverlayProvenanceRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.json")
+	store, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed := graph.New()
+	failed.AddNode(&graph.Node{URL: "mark://a/a.md", Status: "error"})
+	store.Merge(failed, nil)
+	store.SeedFromExport([]StoredNode{{URL: "mark://a/a.md", Title: "Seed", Status: "ok"}}, nil)
+	if err := store.Save(); err != nil {
+		t.Fatal(err)
+	}
+	store, err = Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if node := store.GetNode("mark://a/a.md"); node == nil || !node.Seeded || node.CrawledAt.IsZero() {
+		t.Fatalf("loaded seed overlay = %+v", node)
+	}
+	store.SeedFromExport(nil, nil)
+	if node := store.GetNode("mark://a/a.md"); node == nil || !node.Seeded {
+		t.Fatalf("omitted overlay lost local marker: %+v", node)
+	}
+	fetched := graph.New()
+	fetched.AddNode(&graph.Node{URL: "mark://a/a.md", Title: "Local", Status: "ok"})
+	store.Merge(fetched, nil)
+	store.SeedFromExport([]StoredNode{{URL: "mark://a/a.md", Title: "New Seed", Status: "ok"}}, nil)
+	if node := store.GetNode("mark://a/a.md"); node == nil || node.Seeded || node.Title != "Local" {
+		t.Fatalf("seed replaced fetched local row: %+v", node)
 	}
 }
 
@@ -945,6 +985,31 @@ func TestSeedEtagsRoundTrip(t *testing.T) {
 	}
 	if got := s2.SeedEtag("other:6309"); got != "" {
 		t.Errorf("SeedEtag unknown host = %q, want empty", got)
+	}
+}
+
+func TestConcurrentSave(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.json")
+	store, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.SeedFromExport([]StoredNode{{URL: "mark://a/a.md", Status: "ok"}}, nil)
+	errCh := make(chan error, 20)
+	for range 20 {
+		go func() { errCh <- store.Save() }()
+	}
+	for range 20 {
+		if err := <-errCh; err != nil {
+			t.Errorf("Save: %v", err)
+		}
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if node := loaded.GetNode("mark://a/a.md"); node == nil || !node.Seeded {
+		t.Fatalf("saved node = %+v", node)
 	}
 }
 

--- a/client/graphstore/store_test.go
+++ b/client/graphstore/store_test.go
@@ -296,7 +296,7 @@ func TestLoadLegacyEdgesDefaultsCount(t *testing.T) {
 
 func TestLoadRejectsSchemaVersionMismatch(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "graph.json")
-	if err := os.WriteFile(path, []byte(`{"version":3,"nodes":[],"edges":[]}`), 0o644); err != nil {
+	if err := os.WriteFile(path, fmt.Appendf(nil, `{"version":%d,"nodes":[],"edges":[]}`, schemaVersion+1), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
@@ -945,6 +945,73 @@ func TestSeedEtagsRoundTrip(t *testing.T) {
 	}
 	if got := s2.SeedEtag("other:6309"); got != "" {
 		t.Errorf("SeedEtag unknown host = %q, want empty", got)
+	}
+}
+
+func TestLoadClearsPreOwnershipSeedEtags(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.json")
+	body := `{"version":2,"nodes":[],"edges":[],"seed_etags":{"hub":"stale"}}`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	store, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := store.SeedEtag("hub"); got != "" {
+		t.Fatalf("SeedEtag = %q, want refresh", got)
+	}
+}
+
+func TestReplaceSeedRemovesSourcesMissingFromCompleteGeneration(t *testing.T) {
+	store := New()
+	store.ReplaceSeed("hub", []StoredNode{
+		{URL: "mark://a/source.md", Status: "ok"},
+		{URL: "mark://a/target.md", Status: "ok"},
+	}, []StoredEdge{{From: "mark://a/source.md", To: "mark://a/target.md", Count: 1}})
+	if got := store.Backlinks("mark://a/target.md"); len(got) != 1 {
+		t.Fatalf("initial backlinks = %v", got)
+	}
+	store.ReplaceSeed("hub", nil, nil)
+	if got := store.Backlinks("mark://a/target.md"); len(got) != 0 {
+		t.Fatalf("backlinks after empty generation = %v", got)
+	}
+	if node := store.GetNode("mark://a/source.md"); node != nil {
+		t.Fatalf("omitted seeded node survived: %+v", node)
+	}
+}
+
+func TestReplaceSeedPreservesOverlappingOwnerGraph(t *testing.T) {
+	store := New()
+	store.ReplaceSeed("a", nil, []StoredEdge{{From: "mark://w/source.md", To: "mark://w/a.md", Count: 1}})
+	store.ReplaceSeed("b", nil, []StoredEdge{{From: "mark://w/source.md", To: "mark://w/b.md", Count: 1}})
+	store.ReplaceSeed("a", nil, nil)
+	if got := store.Backlinks("mark://w/a.md"); len(got) != 0 {
+		t.Fatalf("removed owner's edge survived: %v", got)
+	}
+	if got := store.Backlinks("mark://w/b.md"); len(got) != 1 {
+		t.Fatalf("overlapping owner's edge was erased: %v", got)
+	}
+}
+
+func TestReplaceSeedOwnershipPersists(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.json")
+	store, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.ReplaceSeed("a", nil, []StoredEdge{{From: "mark://w/source.md", To: "mark://w/a.md", Count: 1}})
+	store.ReplaceSeed("b", nil, []StoredEdge{{From: "mark://w/source.md", To: "mark://w/b.md", Count: 1}})
+	if err := store.Save(); err != nil {
+		t.Fatal(err)
+	}
+	store, err = Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.ReplaceSeed("a", nil, nil)
+	if got := store.Backlinks("mark://w/b.md"); len(got) != 1 {
+		t.Fatalf("persisted owner edge was erased: %v", got)
 	}
 }
 

--- a/client/internal/fedcrawl/crawl.go
+++ b/client/internal/fedcrawl/crawl.go
@@ -38,10 +38,15 @@ type Crawler struct {
 	tokens *tokens.Store
 
 	// Crawl results
-	mu      sync.Mutex
-	hashes  map[string][]index.Entry // content-hash -> all observed locations
-	servers map[string]bool          // discovered servers (host)
-	graph   *graph.Graph             // link graph accumulated during the walk (concurrency-safe itself)
+	runMu          sync.Mutex
+	mu             sync.Mutex
+	hashes         map[string][]index.Entry // content-hash -> all observed locations
+	servers        map[string]bool          // discovered servers (host)
+	graph          *graph.Graph             // link graph accumulated during the walk (concurrency-safe itself)
+	completedNodes []graphstore.StoredNode
+	completedEdges []graphstore.StoredEdge
+	publishable    bool
+	publishSem     chan struct{}
 }
 
 // NewCrawler creates a new federation crawler.
@@ -49,13 +54,14 @@ type Crawler struct {
 // Crawler methods guard access via c.state != nil and c.tokens != nil checks.
 func NewCrawler(cfg Config, client FetchClient, state *State, tokenStore *tokens.Store) *Crawler { //nolint:gocritic // hugeParam: Config by value is intentional for immutability
 	return &Crawler{
-		cfg:     cfg,
-		client:  client,
-		state:   state,
-		tokens:  tokenStore,
-		hashes:  make(map[string][]index.Entry),
-		servers: make(map[string]bool),
-		graph:   graph.New(),
+		cfg:        cfg,
+		client:     client,
+		state:      state,
+		tokens:     tokenStore,
+		hashes:     make(map[string][]index.Entry),
+		servers:    make(map[string]bool),
+		graph:      graph.New(),
+		publishSem: make(chan struct{}, 1),
 	}
 }
 
@@ -71,6 +77,9 @@ type CrawlResult struct {
 // Run executes the federation crawl starting from configured seeds.
 // It discovers servers, collects content hashes, and returns results.
 func (c *Crawler) Run(ctx context.Context) (*CrawlResult, error) {
+	c.runMu.Lock()
+	defer c.runMu.Unlock()
+
 	// Run is the package boundary, so enforce normalization even when callers
 	// construct a Crawler directly instead of using the agent command.
 	if err := c.cfg.Validate(); err != nil {
@@ -85,6 +94,7 @@ func (c *Crawler) Run(ctx context.Context) (*CrawlResult, error) {
 	c.hashes = make(map[string][]index.Entry)
 	c.servers = make(map[string]bool)
 	c.graph = graph.New()
+	c.publishable = false
 	c.mu.Unlock()
 
 	result := &CrawlResult{}
@@ -194,6 +204,13 @@ func (c *Crawler) Run(ctx context.Context) (*CrawlResult, error) {
 	result.HashesCollected = len(c.hashes)
 	result.Incomplete = incomplete.Load()
 	result.Errors = crawlErrors
+	g := c.graph
+	c.mu.Unlock()
+	nodes, edges := snapshotGraph(g)
+	c.mu.Lock()
+	c.completedNodes = nodes
+	c.completedEdges = edges
+	c.publishable = !result.Incomplete
 	c.mu.Unlock()
 
 	return result, nil
@@ -327,10 +344,8 @@ func (s *serverWalk) walkEntries(ctx context.Context, entries []listing.Entry, d
 			s.run.recordIncomplete("fetch %s%s: missing or invalid content-hash", s.host, fullPath)
 		}
 
-		// /graph.md is a generated projection of other documents' edges. Hash it
-		// like any document, but do not turn its table links into synthetic
-		// graph.md→node edges or use them to amplify the discovery frontier.
-		if fullPath != "/graph.md" {
+		// Generated graph exports are data, not authored discovery links.
+		if !isGeneratedGraphPath(fullPath) {
 			c.recordEdges(s.host, fullPath, doc.Response.Body, doc.Response.Metadata)
 			c.discoverServers(doc.Response.Body, s.host, s.run.queue, s.run.wg, s.run.recordIncomplete)
 		}
@@ -340,6 +355,10 @@ func (s *serverWalk) walkEntries(ctx context.Context, entries []listing.Entry, d
 	}
 
 	return nil
+}
+
+func isGeneratedGraphPath(docPath string) bool {
+	return docPath == "/graph.md" || docPath == graphstore.SnapshotManifestPath || strings.HasPrefix(docPath, "/graph/shards/")
 }
 
 func (s *serverWalk) walkDirectoryPages(ctx context.Context, dirPath string, depth int) error {
@@ -643,15 +662,23 @@ func isLoopbackHost(host string) bool {
 // format stays identical to mark_graph_export / mark_graph_publish — the same
 // document any agent or the library floor reads.
 func (c *Crawler) GraphExport() string {
-	// Snapshot the graph pointer under the lock: Run reassigns c.graph under
-	// c.mu, so an export racing a re-crawl must not read the field unguarded
-	// (the graph's own methods are synchronized; the field reassignment is not).
+	nodes, edges, _ := c.graphSnapshot()
+	return graphstore.BuildExport(time.Now(), nodes, edges)
+}
+
+func (c *Crawler) graphSnapshot() ([]graphstore.StoredNode, []graphstore.StoredEdge, bool) {
 	c.mu.Lock()
-	g := c.graph
+	nodes := append([]graphstore.StoredNode(nil), c.completedNodes...)
+	edges := append([]graphstore.StoredEdge(nil), c.completedEdges...)
+	publishable := c.publishable
 	c.mu.Unlock()
+	return nodes, edges, publishable
+}
+
+func snapshotGraph(g *graph.Graph) ([]graphstore.StoredNode, []graphstore.StoredEdge) {
 	store := graphstore.New()
 	store.Merge(g, nil)
-	return store.Export()
+	return store.Snapshot()
 }
 
 // PublishGraphToHubs publishes the link-graph export to each configured hub at
@@ -662,8 +689,19 @@ func (c *Crawler) PublishGraphToHubs(ctx context.Context, client PublishClient) 
 	if len(c.cfg.Hubs) == 0 {
 		return 0, nil
 	}
+	select {
+	case c.publishSem <- struct{}{}:
+		defer func() { <-c.publishSem }()
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	}
 
-	body := c.GraphExport()
+	nodes, edges, publishable := c.graphSnapshot()
+	if !publishable {
+		return 0, errors.New("no complete graph generation available")
+	}
+	exported := time.Now().UTC()
+	body := graphstore.BuildExport(exported, nodes, edges)
 	successCount := 0
 	var publishErrs []error
 
@@ -674,14 +712,40 @@ func (c *Crawler) PublishGraphToHubs(ctx context.Context, client PublishClient) 
 			continue
 		}
 		token := c.resolveToken(host)
+		published := false
+		if err := c.publishGraphSnapshot(ctx, client, host, nodes, edges, exported, token); err != nil {
+			publishErrs = append(publishErrs, fmt.Errorf("publish graph snapshot to hub %s: %w", hub, err))
+		} else {
+			published = true
+		}
 		if err := c.publishIndex(ctx, client, host, "/graph.md", body, token); err != nil {
 			publishErrs = append(publishErrs, fmt.Errorf("publish /graph.md to hub %s: %w", hub, err))
-			continue
+		} else {
+			published = true
 		}
-		successCount++
+		if published {
+			successCount++
+		}
 	}
 
 	return successCount, errors.Join(publishErrs...)
+}
+
+func (c *Crawler) publishGraphSnapshot(ctx context.Context, client PublishClient, host string, nodes []graphstore.StoredNode, edges []graphstore.StoredEdge, exported time.Time, token string) error {
+	_, err := graphstore.PublishSnapshot(ctx, graphstore.SnapshotPublishOptions{
+		ManifestPath: graphstore.SnapshotManifestPath,
+		Exported:     exported,
+		Nodes:        nodes,
+		Edges:        edges,
+	}, func(ioCtx context.Context, docPath string) (protocol.Response, error) {
+		result, err := client.FetchContext(ioCtx, host, docPath, token)
+		return result.Response, err
+	}, func(ioCtx context.Context, docPath, body string, expectedVersion int) (protocol.Response, error) {
+		meta := c.generatedArtifactMeta(docPath == graphstore.SnapshotManifestPath)
+		result, err := client.PublishContext(ioCtx, host, docPath, body, token, expectedVersion, meta)
+		return result.Response, err
+	})
+	return err
 }
 
 // PublishClient wraps the operations needed for publishing.
@@ -730,7 +794,7 @@ func (c *Crawler) publishIndex(ctx context.Context, client PublishClient, host, 
 
 	meta := c.generatedArtifactMeta(true)
 	// Retention bounds generated whole-document history (SPEC §9.9).
-	result, err := client.Publish(host, docPath, body, token, -1, meta)
+	result, err := client.PublishContext(ctx, host, docPath, body, token, -1, meta)
 	if err != nil {
 		return err
 	}

--- a/client/internal/fedcrawl/crawl.go
+++ b/client/internal/fedcrawl/crawl.go
@@ -358,7 +358,8 @@ func (s *serverWalk) walkEntries(ctx context.Context, entries []listing.Entry, d
 }
 
 func isGeneratedGraphPath(docPath string) bool {
-	return docPath == "/graph.md" || docPath == graphstore.SnapshotManifestPath || strings.HasPrefix(docPath, "/graph/shards/")
+	shardPrefix := graphstore.SnapshotShardRoot(graphstore.SnapshotManifestPath) + "/"
+	return docPath == "/graph.md" || docPath == graphstore.SnapshotManifestPath || strings.HasPrefix(docPath, shardPrefix)
 }
 
 func (s *serverWalk) walkDirectoryPages(ctx context.Context, dirPath string, depth int) error {

--- a/client/internal/fedcrawl/crawl_test.go
+++ b/client/internal/fedcrawl/crawl_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/client/graphstore"
 	"github.com/latebit-io/demarkus/client/index"
 	"github.com/latebit-io/demarkus/client/links"
 	"github.com/latebit-io/demarkus/protocol"
@@ -438,9 +439,14 @@ func TestCrawlerHashesGraphExportWithoutRecrawlingIt(t *testing.T) {
 	cfg.Seeds = []string{"mark://content"}
 
 	client := newMockClient()
-	client.addList("content:6309", "/", "- [index.md](index.md)\n- [graph.md](graph.md)\n")
+	client.addListPage("content:6309", "/", "", "- [graph/](graph/)\n- [graph.md](graph.md)\n- [index.md](index.md)\n", true, "")
+	client.addList("content:6309", "/graph/", "- [manifest.md](manifest.md)\n- [shards/](shards/)\n")
+	client.addList("content:6309", "/graph/shards/", "- [a/](a/)\n")
+	client.addList("content:6309", "/graph/shards/a/", "- [nodes-000.md](nodes-000.md)\n")
 	client.addDoc("content:6309", "/index.md", "# Content", "sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	client.addDoc("content:6309", "/graph.md", "# Document Graph\n\n[projected](mark://projected/index.md)", "sha256-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	client.addDoc("content:6309", "/graph/manifest.md", "# Graph Snapshot Manifest\n\n[projected](mark://projected/manifest.md)", "sha256-dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
+	client.addDoc("content:6309", "/graph/shards/a/nodes-000.md", "# Graph Snapshot Shard\n\n[projected](mark://projected/shard.md)", "sha256-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
 	client.addList("projected:6309", "/", "- [index.md](index.md)\n")
 	client.addDoc("projected:6309", "/index.md", "# Projected", "sha256-cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
 
@@ -449,12 +455,23 @@ func TestCrawlerHashesGraphExportWithoutRecrawlingIt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run() error: %v", err)
 	}
-	if result.ServersDiscovered != 1 || result.DocumentsCrawled != 2 || result.HashesCollected != 2 {
+	if result.ServersDiscovered != 1 || result.DocumentsCrawled != 4 || result.HashesCollected != 4 {
 		t.Fatalf("result = %+v, want graph hashed without projected server crawl", result)
 	}
 	graph := crawler.GraphExport()
-	if strings.Contains(graph, "/graph.md") || strings.Contains(graph, "mark://projected") {
+	if strings.Contains(graph, "/graph.md") || strings.Contains(graph, "/graph/") || strings.Contains(graph, "mark://projected") {
 		t.Errorf("generated graph export leaked into accumulated graph:\n%s", graph)
+	}
+}
+
+func TestGeneratedGraphPathScope(t *testing.T) {
+	for _, docPath := range []string{"/graph.md", "/graph/manifest.md", "/graph/shards/a/nodes-000.md"} {
+		if !isGeneratedGraphPath(docPath) {
+			t.Errorf("generated path %q was not recognized", docPath)
+		}
+	}
+	if isGeneratedGraphPath("/graph/authored.md") {
+		t.Fatal("authored /graph document was treated as generated")
 	}
 }
 
@@ -913,14 +930,67 @@ func TestCrawlerGraphExportAndPublish(t *testing.T) {
 	if n != 1 {
 		t.Errorf("published = %d, want 1", n)
 	}
-	var graphPublished bool
-	for _, call := range client.publishes {
+	manifestAt, legacyAt := -1, -1
+	for i, call := range client.publishes {
+		if call.Host == "hub.example.com:6309" && call.Path == graphstore.SnapshotManifestPath {
+			manifestAt = i
+		}
 		if call.Host == "hub.example.com:6309" && call.Path == "/graph.md" {
-			graphPublished = true
+			legacyAt = i
 		}
 	}
-	if !graphPublished {
-		t.Errorf("no /graph.md publish to the hub: %+v", client.publishes)
+	if manifestAt < 1 || legacyAt <= manifestAt {
+		t.Errorf("graph publish order manifest=%d legacy=%d calls=%+v", manifestAt, legacyAt, client.publishes)
+	}
+}
+
+func TestPublishGraphToHubsAttemptsSnapshotAndLegacyIndependently(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		failPath string
+		wantPath string
+	}{
+		{name: "snapshot failure still publishes legacy", failPath: graphstore.SnapshotManifestPath, wantPath: "/graph.md"},
+		{name: "legacy failure keeps snapshot", failPath: "/graph.md", wantPath: graphstore.SnapshotManifestPath},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Seeds = []string{"mark://content.example.com"}
+			cfg.Hubs = []string{"mark://hub.example.com"}
+			client := newMockClient()
+			client.addList("content.example.com:6309", "/", "")
+			client.publishStatuses["hub.example.com:6309"+test.failPath] = protocol.StatusServerError
+			crawler := NewCrawler(cfg, client, nil, nil)
+			if _, err := crawler.Run(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			count, err := crawler.PublishGraphToHubs(context.Background(), client)
+			if err == nil || count != 1 {
+				t.Fatalf("count=%d err=%v, want one partial publication and error", count, err)
+			}
+			published := false
+			for _, call := range client.publishes {
+				if call.Path == test.wantPath {
+					published = true
+				}
+			}
+			if !published {
+				t.Fatalf("successful counterpart %s was not attempted", test.wantPath)
+			}
+		})
+	}
+}
+
+func TestPublishGraphToHubsRequiresCompleteGeneration(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Hubs = []string{"mark://hub.example.com"}
+	client := newMockClient()
+	crawler := NewCrawler(cfg, client, nil, nil)
+	if _, err := crawler.PublishGraphToHubs(t.Context(), client); err == nil {
+		t.Fatal("published graph before a complete crawl")
+	}
+	if len(client.publishes) != 0 {
+		t.Fatalf("publishes = %d before complete crawl", len(client.publishes))
 	}
 }
 
@@ -1020,7 +1090,7 @@ func TestPublishRetentionMeta(t *testing.T) {
 			t.Fatal("expected publishes")
 		}
 		for _, call := range client.publishes {
-			isShard := strings.Contains(call.Path, ".shards/")
+			isShard := strings.Contains(call.Path, ".shards/") || strings.Contains(call.Path, "/graph/shards/")
 			if !isShard && call.Meta["retention"] != "20" {
 				t.Errorf("publish %s%s meta.retention = %q, want %q", call.Host, call.Path, call.Meta["retention"], "20")
 			}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1317,7 +1317,8 @@ Hubs are the entry points into the information graph:
 - Graph as content — `Store.Export()` renders the graph as publishable markdown with `mark://` links (six-column Edges table: `From | To | Rel | Label | Anchor | Count`); `ParseExport()` parses it back, accepting the legacy two-column shape too; CLI `demarkus graph export` and MCP `mark_graph_export` tool
 - Edge semantics — edges carry provenance (link label, source section anchor, occurrence count) and typed relations ingested from `rel-<predicate>` publisher metadata (ADR 0004)
 - Agent discovery — `mark_graph_publish` MCP tool exports and publishes the graph in one step; other agents crawl the published document to inherit the topology without recrawling original servers
-- Federation crawler exception — `demarkus-agent` already LISTs every document on each discovered server, so it hash-indexes canonical `/graph.md` but does not reinterpret that generated projection as authored edges or discovery links; graph consumers import exports through `ParseExport()` instead
+- Atomic graph snapshots — `demarkus-agent` publishes version-pinned node and edge shards under `/graph/`, commits `/graph/manifest.md` last, and then updates legacy `/graph.md`; seeders verify the complete snapshot before applying it
+- Federation crawler exception — generated `/graph.md` and `/graph/` documents are hash-indexed but never reinterpreted as authored edges or discovery links
 
 ## Security Considerations
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -975,6 +975,18 @@ Publishers require read access and publish access to both the manifest path and 
 - Version-pinned shards are immutable inputs to a manifest generation. Publishers MUST NOT apply retention that can prune a shard version while a reachable manifest references it.
 - Manifest retention does not imply shard retention. Shards remain unpruned until a reference-aware collector can prove no retained manifest version names them. A fixed shard window is unsafe because failed or concurrent staging can advance shard versions without advancing manifest history.
 
+### 12.2 Atomic Graph Snapshots
+
+Federation agents publish a strict graph snapshot at `/graph/manifest.md` alongside the legacy `/graph.md` export. The separate path keeps old graph consumers working during migration.
+
+The `demarkus-graph-snapshot/v1` manifest records export time, completeness, total node and edge counts, active slot, and immutable descriptors for `nodes` and `edges` shards. Shards use `demarkus-graph-snapshot-shard/v1`, contain a fenced JSON payload, and live under `/graph/shards/{a|b}/<kind>-<part>.md`.
+
+Publishers stage and verify the inactive slot before compare-and-swapping the manifest. Readers fetch every shard through its version path and verify version, byte count, content hash, kind, part, and aggregate counts before applying any rows. A failed fetch or integrity check leaves the previous local graph state and seed etag unchanged.
+
+Snapshot-aware readers prefer `/graph/manifest.md` and fall back to `/graph.md` only when the manifest is `not-found`. Federation agents publish the snapshot first and the legacy export second. Generated graph documents under `/graph/` are hash-indexed but MUST NOT be interpreted as authored discovery links.
+
+Manifest retention does not permit shard retention while a retained manifest can reference an older shard version. The same reference-aware collection requirement as hash-index shards applies.
+
 ## 13. Future Extensions
 
 The following features are planned but not part of this specification:

--- a/docs/rfc-review-faq.md
+++ b/docs/rfc-review-faq.md
@@ -76,7 +76,7 @@ so a deep crawl usually stops on the node cap rather than the depth limit).
 
 - Edges carry provenance: link label, source section anchor, occurrence count.
 - Typed relations come from `rel-<predicate>` publisher metadata, e.g. `rel-supersedes`.
-- Crawls persist to a graph store that answers `mark_backlinks`; seeded from a published `/graph.md`, local crawls take precedence.
+- Crawls persist to a graph store that answers `mark_backlinks`; seeded from a verified `/graph/manifest.md` snapshot with `/graph.md` fallback, local crawls take precedence.
 - `mark_graph_publish` republishes the store as a crawlable `/graph.md` (generated doc, default retention 20).
 
 ## How is the graph built world to world?
@@ -84,10 +84,10 @@ so a deep crawl usually stops on the node cap rather than the depth limit).
 A scheduled agent builds it; the broker reads what that agent publishes.
 
 - The agent is configured with a seed URL per content world and crawls each one. The hub is not crawled; it is where results are published.
-- It merges every world's edges into one graph and publishes it as `/graph.md` on the hub, alongside the content-hash index. Graph publishing is off by default and switched on in this deployment.
+- It merges every world's edges into one graph, publishes an atomic `/graph/manifest.md` snapshot, then updates compatible `/graph.md` on the hub alongside the content-hash index. Graph publishing is off by default and switched on in this deployment.
 - Each run rebuilds from scratch, so a world that fails to answer is skipped and drops out of the published graph until the next successful crawl.
 - Cross-world links are ordinary `mark://{worldName}/{path}` links, so an edge from one world to another is just a link the crawl followed.
-- The broker's own graph store is in-memory and pod-scoped. It loads the hub's `/graph.md` on demand, so a fresh pod answers backlinks without crawling.
+- The broker's own graph store is in-memory and pod-scoped. It loads the hub's verified snapshot, or legacy `/graph.md`, on demand so a fresh pod answers backlinks without crawling.
 - A world with no published graph falls back to on-demand `mark_graph` crawls only.
 
 ## Is edge information there to guide agents to relevant information?

--- a/docs/site/architecture/index.md
+++ b/docs/site/architecture/index.md
@@ -125,9 +125,9 @@ Markdown links form a natural **document graph**. The CLI, TUI, and MCP server i
 
 The client-side `graphstore` package persists crawled graph data at `~/.mark/graph.json`. All three tools share this store — a graph built by the CLI is visible in the TUI and queryable via MCP. Each crawl merges new nodes and edges into the existing graph, so knowledge accumulates across sessions.
 
-Backlinks ("what documents link here?") are derived from the stored graph with no server-side changes needed. The MCP `mark_backlinks` tool exposes this as a query for agents. The store is seeded on demand from the world's published `/graph.md` aggregate, so a fresh client answers backlinks before its first crawl; local crawls take precedence over seeded rows.
+Backlinks ("what documents link here?") are derived from the stored graph with no server-side changes needed. The MCP `mark_backlinks` tool exposes this as a query for agents. The store is seeded on demand from the world's atomic `/graph/manifest.md` snapshot, with `/graph.md` as a compatibility fallback, so a fresh client answers backlinks before its first crawl; local crawls take precedence over seeded rows.
 
-The graph itself is exportable as a publishable markdown document containing `mark://` links. `mark_graph_export` renders the graph; `mark_graph_publish` exports and publishes in one step. Other agents can crawl the published graph document to discover the topology without recrawling the original servers — enabling multi-agent discovery where agents share and merge knowledge maps.
+The graph itself is exportable as a publishable markdown document. `mark_graph_export` renders the graph; `mark_graph_publish` exports and publishes the legacy single-document form in one step. The federation agent additionally publishes version-pinned node and edge shards behind a manifest-last CAS, allowing clients to import a complete generation without recrawling original documents.
 
 ## Open Knowledge Format (OKF) Compatibility
 

--- a/docs/site/client/index.md
+++ b/docs/site/client/index.md
@@ -52,7 +52,7 @@ demarkus edit --insecure -auth $TOKEN mark://localhost:6309/new-doc.md
 demarkus graph --insecure -depth 3 mark://localhost:6309/index.md
 ```
 
-Graph results are persisted to `~/.mark/graph.json` and accumulate across sessions. Each crawl merges new nodes and edges into the existing graph, so your map of the `mark://` network grows over time. The MCP graph tools also seed the store from the connected world's published `/graph.md` aggregate, so backlinks answer even before your first crawl; locally crawled data always takes precedence.
+Graph results are persisted to `~/.mark/graph.json` and accumulate across sessions. Each crawl merges new nodes and edges into the existing graph, so your map of the `mark://` network grows over time. The MCP graph tools seed the store from the connected world's verified `/graph/manifest.md` snapshot, falling back to `/graph.md` for older publishers, so backlinks answer before your first crawl; locally crawled data always takes precedence.
 
 ### Open Knowledge Format codec
 

--- a/docs/site/deployment/appliance.md
+++ b/docs/site/deployment/appliance.md
@@ -61,7 +61,7 @@ Everything else is generated: the owner password, all Authelia secrets, the brok
 | Library | `demarkus-library` | loopback :8090 | reading room + cataloging desk (browser editing) |
 | Authelia | `demarkus-auth` | loopback :9091 | self-hosted OIDC provider |
 | Caddy | `caddy` | :80/:443 (public) | automatic HTTPS, routes the three subdomains |
-| Indexing agent | `demarkus-agent` | outbound | crawls the world, republishes `/graph.md` every 6h |
+| Indexing agent | `demarkus-agent` | outbound | crawls the world, publishes `/graph/manifest.md` snapshots and compatible `/graph.md` every 6h |
 | Soul cert sync | `demarkus-soul-certsync.timer` | — | copies Caddy's `soul.<host>` cert to the world every 12h (renewal) |
 
 Every service is a hardened systemd unit (`ProtectSystem=strict`, minimal `ReadWritePaths`, its own system user). No container runtime is installed; every component is a native binary.

--- a/docs/site/philosophy/agent-cookbook.md
+++ b/docs/site/philosophy/agent-cookbook.md
@@ -124,19 +124,19 @@ Maintains integrity and auditability.
 **Goal:** Share your crawled graph so other agents can discover the topology without recrawling.
 
 **Workflow:**
-1. Agent crawls a server or set of servers using `mark_graph` to build the local graph store.
-2. Agent publishes the graph using `mark_graph_publish` to a target server (e.g. `/graphs/my-graph.md`).
-3. Another agent fetches the published graph document with `mark_fetch`.
-4. The second agent runs `mark_graph` on the published graph document — the crawler follows all `mark://` links in the node table, reconstructing the topology without re-fetching every original document.
+1. The federation agent crawls its configured servers and publishes with `-publish-graph`.
+2. It commits an atomic `/graph/manifest.md` snapshot and then updates `/graph.md` for legacy readers.
+3. Another snapshot-aware MCP client or broker fetches and verifies the manifest's version-pinned shards.
+4. The client imports the complete generation into its graph store without re-fetching every original document.
 
 **Multi-agent variant:**
 - Agent A publishes its graph from crawling `mark://server-a.com`
 - Agent B publishes its graph from crawling `mark://server-b.com`
-- Agent C fetches both published graphs and crawls them — instantly inheriting both topologies
+- Agent C imports both verified snapshots, inheriting both topologies
 - Each agent's graph is versioned, so you can track how the network evolves
 
 **Why it works:**
-The exported graph is plain markdown with `mark://` links. The same link extraction the crawler already uses parses the graph document naturally. No special import format, no coordination protocol — just documents linking to documents.
+The manifest is an ordinary Mark document and each shard is immutable content pinned by version and hash. No server-side graph service is required; clients verify and import the snapshot using normal FETCH responses.
 
 ---
 

--- a/docs/site/tools/agent.md
+++ b/docs/site/tools/agent.md
@@ -133,8 +133,9 @@ hubs = ["mark://hub.example:6309"]
 
 Hubs are publish-only unless also listed in `seeds`. Links to a publish-only hub
 remain graph edges but do not enqueue the hub's generated artifacts for crawling.
-The crawler hashes `/graph.md`, but does not ingest its generated table links as
-authored edges or discovery targets; graph exports are projections, not sources.
+The crawler hashes `/graph.md` and the `/graph/` snapshot namespace, but does not
+ingest their generated links as authored edges or discovery targets. Graph
+exports are projections, not sources.
 
 ### Explicit Transport Endpoints
 
@@ -229,6 +230,12 @@ Published indexes enable content-addressed fetching. Resolution reads all shards
 # Resolve content by hash (requires hub with index)
 demarkus resolve sha256-abc123... mark://hub.example:6309/index.md
 ```
+
+## Atomic Graph Publishing
+
+With `-publish-graph`, the crawler publishes an atomic snapshot at `/graph/manifest.md` before updating the compatible `/graph.md` export. Snapshot shards live under `/graph/shards/a/` or `/graph/shards/b/`; the manifest pins each shard version and becomes visible only after every shard verifies successfully.
+
+Snapshot-aware clients and brokers prefer the manifest and fall back to `/graph.md` when it is absent. Retention applies to the manifest and legacy export only. Version-pinned shards remain unpruned until reference-aware garbage collection can prove they are unreachable.
 
 ## Authentication
 

--- a/tools/demarkus-broker/MCP-API.md
+++ b/tools/demarkus-broker/MCP-API.md
@@ -282,22 +282,24 @@ writers before publishing v2 at an existing legacy path.
 > persistence is parked for the post-broker design window.
 >
 > To make restarts cheap (not durable), the store is **seeded on
-> demand from the worlds' published `/graph.md`**: any
+> demand from the worlds' published graph**: any
 > `mark_backlinks` / `mark_graph` / `mark_explore` call checks every
-> configured world for a `/graph.md` aggregate (the hub is the one
-> that has it; conditional on the last seen etag, throttled to one
-> check per world per 5 minutes) and merges it into the store, so
-> cold pods answer backlinks without a crawl. Seed rows keyed by a configured world's internal dial address
+> configured world for `/graph/manifest.md`, loading its complete,
+> version-pinned shards when present and falling back to `/graph.md`
+> only when the manifest is `not-found`. Checks use the last seen etag,
+> run at most once per world per 5 minutes, and merge successful loads
+> into the store so cold pods answer backlinks without a crawl. Seed rows
+> keyed by a configured world's internal dial address
 > (the form the federation agent publishes) are translated to
 > `mark://{worldName}/...` so they answer world-name queries. Locally
 > crawled data always takes precedence over seeded rows, and a world
-> without `/graph.md` degrades to the unseeded behavior.
+> without either graph form degrades to the unseeded behavior.
 
 #### `mark_backlinks`
 
 Look up which documents link to a given URL, using the broker's
 graph store. Returns results from previous `mark_graph` runs and
-the world's published `/graph.md` seed; returns an empty hint if
+the world's published graph seed; returns an empty hint if
 neither has populated the relevant edges.
 Each backlink carries its provenance (link label, source section
 anchor, occurrence count) and typed relations like `[supersedes]`.

--- a/tools/demarkus-broker/MCP-API.md
+++ b/tools/demarkus-broker/MCP-API.md
@@ -337,7 +337,8 @@ legacy two-column `From | To` shape. Returns an empty hint if the store is empty
 Export the broker's graph store and publish it to a world in one
 step. `mark_graph_export` + `mark_publish` combined. This manual tool keeps the
 legacy single-document contract; federation-agent snapshots are loaded
-automatically from `/graph/manifest.md` when present.
+automatically from `/graph/manifest.md` when present. This tool does not seed
+the store itself; run `mark_graph`, `mark_backlinks`, or `mark_explore` first.
 
 | Param | Type | Required | Notes |
 | --- | --- | --- | --- |

--- a/tools/demarkus-broker/MCP-API.md
+++ b/tools/demarkus-broker/MCP-API.md
@@ -323,19 +323,19 @@ subsequent `mark_backlinks` / `mark_graph_export` /
 
 #### `mark_graph_export`
 
-Export the broker's graph store as a publishable markdown document
-containing `mark://` links. The Edges table carries six columns
+Export the broker's graph store as a publishable legacy markdown document.
+The Edges table carries six columns
 (`From | To | Rel | Label | Anchor | Count`); parsers also accept the
-legacy two-column `From | To` shape. Crawling the exported document
-naturally re-discovers the topology. Returns an empty hint if the
-store is empty.
+legacy two-column `From | To` shape. Returns an empty hint if the store is empty.
 
 (No parameters.)
 
 #### `mark_graph_publish`
 
 Export the broker's graph store and publish it to a world in one
-step. `mark_graph_export` + `mark_publish` combined.
+step. `mark_graph_export` + `mark_publish` combined. This manual tool keeps the
+legacy single-document contract; federation-agent snapshots are loaded
+automatically from `/graph/manifest.md` when present.
 
 | Param | Type | Required | Notes |
 | --- | --- | --- | --- |

--- a/tools/demarkus-broker/internal/broker/mcp_gateway.go
+++ b/tools/demarkus-broker/internal/broker/mcp_gateway.go
@@ -38,11 +38,10 @@ type mcpGateway struct {
 	// it is ephemeral per-pod state, consistent with the wire-shape-
 	// adapter framing.
 	fetchSeen *sessionSeen
-	// graphSeedMu guards graphSeedChecked: worldName → last /graph.md
-	// seed check, the per-pod throttle for seedWorldGraph. The seed
-	// etag itself lives in graphStore (SeedEtag), keyed by worldName.
-	graphSeedMu      sync.Mutex
-	graphSeedChecked map[string]time.Time
+	// graphSeedMu guards per-world refresh single-flight and successful checks.
+	graphSeedMu         sync.Mutex
+	graphSeedChecked    map[string]time.Time
+	graphSeedRefreshing map[string]chan struct{}
 }
 
 // newMCPGateway registers the 17 tools and wraps them in Streamable HTTP.

--- a/tools/demarkus-broker/internal/broker/mcp_tools_explore.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_explore.go
@@ -24,7 +24,7 @@ const exploreSectionCap = 10
 // of its parent directory. Mirrors client/cmd/demarkus-mcp markExplore;
 // the broker differences are the world-name URL shape and that backlinks
 // come from the broker's ephemeral graph store.
-func (g *mcpGateway) handleMarkExplore(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
+func (g *mcpGateway) handleMarkExplore(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
 	raw, err := req.RequireString("url")
 	if err != nil {
 		return mcp.NewToolResultError("url is required"), nil
@@ -72,7 +72,7 @@ func (g *mcpGateway) handleMarkExplore(_ context.Context, req mcp.CallToolReques
 		mdoutline.CappedList(&b, out, exploreSectionCap, "links")
 	}
 
-	g.seedGraphStore()
+	g.seedGraphStore(ctx)
 	g.writeBacklinksSection(&b, docURL)
 	g.writeSiblingsSection(&b, worldName, path)
 

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
@@ -94,9 +94,12 @@ const seedCheckInterval = 5 * time.Minute
 // seedGraphStore seeds from every configured world: only hubs publish
 // /graph.md and the broker does not know which world is the hub; the
 // per-world throttle bounds the cost.
-func (g *mcpGateway) seedGraphStore() {
+func (g *mcpGateway) seedGraphStore(ctx context.Context) {
 	for i := range g.srv.cfg.Worlds {
-		g.seedWorldGraph(g.srv.cfg.Worlds[i].Name)
+		if ctx.Err() != nil {
+			return
+		}
+		g.seedWorldGraph(ctx, g.srv.cfg.Worlds[i].Name)
 	}
 }
 
@@ -106,8 +109,16 @@ func (g *mcpGateway) seedGraphStore() {
 // Never fatal: every failure degrades silently to the unseeded store,
 // warn-logging real errors. Conditional on the stored seed etag; a
 // not-modified response keeps the previously seeded rows.
-func (g *mcpGateway) seedWorldGraph(worldName string) {
+func (g *mcpGateway) seedWorldGraph(ctx context.Context, worldName string) {
 	g.graphSeedMu.Lock()
+	if done := g.graphSeedRefreshing[worldName]; done != nil {
+		g.graphSeedMu.Unlock()
+		select {
+		case <-done:
+		case <-ctx.Done():
+		}
+		return
+	}
 	if last, ok := g.graphSeedChecked[worldName]; ok && time.Since(last) < seedCheckInterval {
 		g.graphSeedMu.Unlock()
 		return
@@ -115,30 +126,81 @@ func (g *mcpGateway) seedWorldGraph(worldName string) {
 	if g.graphSeedChecked == nil {
 		g.graphSeedChecked = make(map[string]time.Time)
 	}
-	g.graphSeedChecked[worldName] = time.Now()
+	if g.graphSeedRefreshing == nil {
+		g.graphSeedRefreshing = make(map[string]chan struct{})
+	}
+	done := make(chan struct{})
+	g.graphSeedRefreshing[worldName] = done
 	g.graphSeedMu.Unlock()
+	success := false
+	defer func() {
+		g.graphSeedMu.Lock()
+		if success {
+			g.graphSeedChecked[worldName] = time.Now()
+		}
+		close(done)
+		delete(g.graphSeedRefreshing, worldName)
+		g.graphSeedMu.Unlock()
+	}()
 
 	etag := g.graphStore.SeedEtag(worldName)
-	result, err := g.dispatcher.FetchConditional(worldName, "/graph.md", "", etag)
+	result, err := g.dispatcher.FetchConditionalContext(ctx, worldName, graphstore.SnapshotManifestPath, "", etag)
 	if err != nil {
 		g.log.Warn("graph seed fetch failed", "world", worldName, "err", err)
 		return
 	}
-	// not-modified means the stored seed is current; any other non-ok
-	// status (a world without /graph.md is normal) means nothing to seed.
-	if result.Response.Status != protocol.StatusOK {
+	if result.Response.Status == protocol.StatusNotModified {
+		success = true
+		return
+	}
+	if result.Response.Status == protocol.StatusOK {
+		nodes, edges, loadErr := graphstore.LoadSnapshot(graphstore.SnapshotManifestPath, result.Response, func(shardPath string) (protocol.Response, error) {
+			shard, fetchErr := g.dispatcher.FetchContext(ctx, worldName, shardPath, "")
+			return shard.Response, fetchErr
+		})
+		if loadErr != nil {
+			g.log.Warn("graph snapshot load failed", "world", worldName, "err", loadErr)
+			return
+		}
+		g.translateSeedURLs(nodes, edges)
+		g.graphStore.ReplaceSeed(worldName, nodes, edges)
+		if snapshotEtag := result.Response.Metadata["etag"]; snapshotEtag != "" {
+			g.graphStore.SetSeedEtag(worldName, snapshotEtag)
+		}
+		success = true
+		return
+	}
+	if result.Response.Status != protocol.StatusNotFound {
 		return
 	}
 
-	nodes, edges := graphstore.ParseExport(result.Response.Body)
-	if len(nodes) == 0 && len(edges) == 0 {
+	result, err = g.dispatcher.FetchConditionalContext(ctx, worldName, "/graph.md", "", etag)
+	if err != nil {
+		g.log.Warn("legacy graph seed fetch failed", "world", worldName, "err", err)
+		return
+	}
+	if result.Response.Status == protocol.StatusNotFound {
+		success = true
+		return
+	}
+	if result.Response.Status == protocol.StatusNotModified {
+		success = true
+		return
+	}
+	if result.Response.Status != protocol.StatusOK {
+		return
+	}
+	nodes, edges, parseErr := graphstore.ParseExportStrict(result.Response.Body)
+	if parseErr != nil {
+		g.log.Warn("legacy graph seed parse failed", "world", worldName, "err", parseErr)
 		return
 	}
 	g.translateSeedURLs(nodes, edges)
-	g.graphStore.SeedFromExport(nodes, edges)
+	g.graphStore.ReplaceSeed(worldName, nodes, edges)
 	if e := result.Response.Metadata["etag"]; e != "" {
 		g.graphStore.SetSeedEtag(worldName, e)
 	}
+	success = true
 }
 
 // translateSeedURLs rewrites world dial addresses to mark://{worldName}/...;
@@ -176,7 +238,7 @@ func (g *mcpGateway) translateSeedURLs(nodes []graphstore.StoredNode, edges []gr
 // world's published /graph.md first so cold pods still answer.
 // First-time callers on a world with no /graph.md see an empty
 // result (and a hint to run mark_graph first).
-func (g *mcpGateway) handleMarkBacklinks(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
+func (g *mcpGateway) handleMarkBacklinks(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
 	raw, err := req.RequireString("url")
 	if err != nil {
 		return mcp.NewToolResultError("url is required"), nil
@@ -186,7 +248,7 @@ func (g *mcpGateway) handleMarkBacklinks(_ context.Context, req mcp.CallToolRequ
 	if _, _, perr := parseToolURL(raw); perr != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", perr)), nil
 	}
-	g.seedGraphStore()
+	g.seedGraphStore(ctx)
 	backlinks := g.graphStore.BacklinksEnriched(raw)
 	if len(backlinks) == 0 {
 		return mcp.NewToolResultText(
@@ -221,7 +283,7 @@ func (g *mcpGateway) handleMarkGraph(ctx context.Context, req mcp.CallToolReques
 
 	// Seed before crawling so depth-limited crawls still benefit from
 	// hub context.
-	g.seedGraphStore()
+	g.seedGraphStore(ctx)
 
 	crawled, crawlErr := g.graphStore.CrawlAndPersist(
 		ctx,

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph.go
@@ -171,6 +171,7 @@ func (g *mcpGateway) seedWorldGraph(ctx context.Context, worldName string) {
 		return
 	}
 	if result.Response.Status != protocol.StatusNotFound {
+		g.log.Warn("graph snapshot fetch returned unexpected status", "world", worldName, "status", result.Response.Status)
 		return
 	}
 
@@ -188,6 +189,7 @@ func (g *mcpGateway) seedWorldGraph(ctx context.Context, worldName string) {
 		return
 	}
 	if result.Response.Status != protocol.StatusOK {
+		g.log.Warn("legacy graph seed fetch returned unexpected status", "world", worldName, "status", result.Response.Status)
 		return
 	}
 	nodes, edges, parseErr := graphstore.ParseExportStrict(result.Response.Body)

--- a/tools/demarkus-broker/internal/broker/mcp_tools_graph_seed_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_graph_seed_test.go
@@ -3,6 +3,7 @@ package broker
 import (
 	"context"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -44,6 +45,69 @@ func seedingDispatcher(etag string) *fakeDispatcher {
 	}
 }
 
+func brokerSnapshot(t *testing.T) (protocol.Response, map[string]protocol.Response) { //nolint:gocritic // fixture returns manifest and shard set
+	t.Helper()
+	exported := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
+	const base = "mark://team-a.team-a.svc.cluster.local:6309"
+	nodes := []graphstore.StoredNode{
+		{URL: base + "/a.md", Title: "Page A", Status: "ok", LinkCount: 1},
+		{URL: base + "/b.md", Title: "Page B", Status: "ok"},
+	}
+	edges := []graphstore.StoredEdge{{From: base + "/a.md", To: base + "/b.md", Count: 1}}
+	artifacts, err := graphstore.BuildSnapshotShards(graphstore.SnapshotManifestPath, graphstore.SnapshotSlotA, nodes, edges, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := make([]graphstore.SnapshotShardRef, len(artifacts))
+	shards := make(map[string]protocol.Response, len(artifacts))
+	for i, artifact := range artifacts {
+		refs[i] = artifact.Ref(i + 1)
+		shards[graphstore.SnapshotVersionPath(artifact.Path, i+1)] = protocol.Response{
+			Status: protocol.StatusOK, Body: artifact.Body,
+			Metadata: map[string]string{"version": strconv.Itoa(i + 1), "content-hash": artifact.ContentHash},
+		}
+	}
+	manifest, err := graphstore.BuildSnapshotManifest(graphstore.SnapshotManifestPath, graphstore.SnapshotManifest{
+		Exported: exported, Complete: true, Nodes: len(nodes), Edges: len(edges),
+		ActiveSlot: graphstore.SnapshotSlotA, Shards: refs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return protocol.Response{Status: protocol.StatusOK, Body: manifest, Metadata: map[string]string{
+		"etag": "snapshot-etag-1", "content-hash": graphstore.SnapshotBodyHash(manifest),
+	}}, shards
+}
+
+func TestSeedWorldGraphPrefersAtomicSnapshot(t *testing.T) {
+	manifest, shards := brokerSnapshot(t)
+	d := &fakeDispatcher{
+		fetchCondFn: func(_, path, _, _ string) (fetch.Result, error) {
+			if path == graphstore.SnapshotManifestPath {
+				return fetch.Result{Response: manifest}, nil
+			}
+			t.Fatalf("legacy path fetched despite snapshot: %s", path)
+			return fetch.Result{}, nil
+		},
+		fetchFn: func(_, path, _ string) (fetch.Result, error) {
+			return fetch.Result{Response: shards[path]}, nil
+		},
+	}
+	g := newGatewayWithDispatcher(t, mcpTestConfig(), d)
+	res, err := g.handleMarkBacklinks(withAliceClaims(context.Background()), callToolReq("mark_backlinks", map[string]any{
+		"url": "mark://team-a/b.md",
+	}))
+	if err != nil || res.IsError {
+		t.Fatalf("handleMarkBacklinks err=%v result=%+v", err, res)
+	}
+	if text := toolResultText(t, res); !strings.Contains(text, "mark://team-a/a.md") {
+		t.Fatalf("translated snapshot backlink missing: %s", text)
+	}
+	if got := g.graphStore.SeedEtag("team-a"); got != "snapshot-etag-1" {
+		t.Fatalf("seed etag = %q", got)
+	}
+}
+
 // agentContractGoldenPath is the real agent's in-cluster /graph.md, pinned
 // by fedcrawl's TestGraphExportContract; consuming it here is the other
 // half of the cross-module contract (producer drift regenerates it).
@@ -55,7 +119,7 @@ func agentContractGolden(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("read agent export contract golden (regenerate with: go test ./internal/fedcrawl -run TestGraphExportContract -update, in client/): %v", err)
 	}
-	return string(body)
+	return strings.Replace(string(body), "> Exported: GOLDEN", "> Exported: 2026-01-01T00:00:00Z", 1)
 }
 
 // TestSeedConsumesAgentExportContract: the real agent's export (the golden)
@@ -179,13 +243,13 @@ func TestSeedFindsAggregateOnAnotherWorld(t *testing.T) {
 	defer d.mu.Unlock()
 	probed := map[string]int{}
 	for _, c := range d.fetchCondCalls {
-		if c.path != "/graph.md" {
-			t.Errorf("seed probed %q, want /graph.md", c.path)
+		if c.path != graphstore.SnapshotManifestPath && c.path != "/graph.md" {
+			t.Errorf("seed probed unexpected path %q", c.path)
 		}
 		probed[c.worldName]++
 	}
-	if probed["team-a"] != 1 || probed["hub"] != 1 || len(probed) != 2 {
-		t.Errorf("seed probes = %v, want each configured world exactly once", probed)
+	if probed["team-a"] != 2 || probed["hub"] != 2 || len(probed) != 2 {
+		t.Errorf("seed probes = %v, want snapshot and legacy checks per world", probed)
 	}
 }
 
@@ -214,8 +278,8 @@ func TestHandleMarkBacklinksColdPodSeedsFromWorldGraph(t *testing.T) {
 	if len(d.fetchCalls) != 0 {
 		t.Errorf("plain fetches = %d, want 0 (no crawl needed)", len(d.fetchCalls))
 	}
-	if len(d.fetchCondCalls) != 1 || d.fetchCondCalls[0].path != "/graph.md" || d.fetchCondCalls[0].worldName != "team-a" {
-		t.Errorf("fetchCondCalls = %+v, want one /graph.md check on team-a", d.fetchCondCalls)
+	if len(d.fetchCondCalls) != 2 || d.fetchCondCalls[0].path != graphstore.SnapshotManifestPath || d.fetchCondCalls[1].path != "/graph.md" {
+		t.Errorf("fetchCondCalls = %+v, want snapshot then legacy checks", d.fetchCondCalls)
 	}
 }
 
@@ -277,8 +341,8 @@ func TestSeedWorldGraphThrottledWithinWindow(t *testing.T) {
 	}
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if len(d.fetchCondCalls) != 1 {
-		t.Errorf("seed checks = %d, want 1 (throttled)", len(d.fetchCondCalls))
+	if len(d.fetchCondCalls) != 2 {
+		t.Errorf("seed checks = %d, want one snapshot/legacy pair (throttled)", len(d.fetchCondCalls))
 	}
 }
 
@@ -308,8 +372,8 @@ func TestSeedWorldGraphEtagRoundTrip(t *testing.T) {
 	d.mu.Lock()
 	calls := append([]condCall(nil), d.fetchCondCalls...)
 	d.mu.Unlock()
-	if len(calls) != 2 || calls[0].etag != "" || calls[1].etag != "hub-etag-1" {
-		t.Errorf("etags sent = %+v, want [\"\" hub-etag-1]", calls)
+	if len(calls) != 4 || calls[0].etag != "" || calls[1].etag != "" || calls[2].etag != "hub-etag-1" || calls[3].etag != "hub-etag-1" {
+		t.Errorf("etags sent = %+v, want empty then stored etag for each snapshot/legacy pair", calls)
 	}
 	// not-modified keeps the seeded rows.
 	if text := toolResultText(t, res); !strings.Contains(text, "Page A") {

--- a/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
+++ b/tools/demarkus-broker/internal/broker/mcp_tools_read_test.go
@@ -121,6 +121,13 @@ func (f *fakeDispatcher) FetchConditional(worldName, path, token, etag string) (
 	return fn(worldName, path, token, etag)
 }
 
+func (f *fakeDispatcher) FetchConditionalContext(ctx context.Context, worldName, path, token, etag string) (fetch.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return fetch.Result{}, err
+	}
+	return f.FetchConditional(worldName, path, token, etag)
+}
+
 func (f *fakeDispatcher) List(worldName, path, token string, opts fetch.ListOptions) (fetch.Result, error) {
 	f.mu.Lock()
 	f.listCalls = append(f.listCalls, dispatchCall{worldName, path, token})

--- a/tools/demarkus-broker/internal/broker/world_pool.go
+++ b/tools/demarkus-broker/internal/broker/world_pool.go
@@ -25,6 +25,7 @@ type worldDispatcher interface {
 	Fetch(worldName, path, token string) (fetch.Result, error)
 	FetchContext(ctx context.Context, worldName, path, token string) (fetch.Result, error)
 	FetchConditional(worldName, path, token, etag string) (fetch.Result, error)
+	FetchConditionalContext(ctx context.Context, worldName, path, token, etag string) (fetch.Result, error)
 	List(worldName, path, token string, opts fetch.ListOptions) (fetch.Result, error)
 	Versions(worldName, path, token string) (fetch.Result, error)
 	Lookup(worldName, scope, query, token string, opts fetch.LookupOptions) (fetch.Result, error)
@@ -120,6 +121,14 @@ func (p *worldPool) FetchContext(ctx context.Context, worldName, path, token str
 		return fetch.Result{}, err
 	}
 	return c.FetchContext(ctx, host, path, token)
+}
+
+func (p *worldPool) FetchConditionalContext(ctx context.Context, worldName, path, token, etag string) (fetch.Result, error) {
+	c, host, err := p.clientFor(worldName)
+	if err != nil {
+		return fetch.Result{}, err
+	}
+	return c.FetchConditionalContext(ctx, host, path, token, etag)
 }
 
 // FetchConditional dispatches a FETCH with an explicit if-none-match etag


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added atomic, versioned graph snapshots with manifests, sharded data, integrity checks, and safe publication.
  * Graph consumers now prefer verified snapshots and fall back to legacy graph documents when unavailable.
  * Added complete graph seeding with ownership preservation and snapshot reuse.
  * Added stricter graph export validation and support for legacy export formats.

* **Bug Fixes**
  * Canceled requests now stop graph refreshes promptly.
  * Failed refreshes preserve existing graph data.
  * Concurrent refreshes are coordinated to prevent duplicate work.

* **Documentation**
  * Updated graph publishing, seeding, retention, and compatibility guidance for snapshot-based workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->