### PR TITLE
chore(tools):add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,11 +5,20 @@ Implementation Code
 -------------------
 SPDX-License-Identifier: AGPL-3.0-only
 
-All implementation code in this repository is licensed under the
-GNU Affero General Public License, version 3 only (AGPL-3.0-only).
+All implementation code in this repository, except the `plugins/` directory,
+is licensed under the GNU Affero General Public License, version 3 only
+(AGPL-3.0-only). This covers the core: protocol, server, knowledge server,
+client, and tools.
 
 Canonical license text:
 https://www.gnu.org/licenses/agpl-3.0.txt
+
+Plugins
+-------
+SPDX-License-Identifier: MIT
+
+Everything under `plugins/` is licensed under the MIT License; see
+`plugins/LICENSE`.
 
 Protocol Specification and Related Docs
 ---------------------------------------

--- a/docs/adr/0009-license-split-core-agpl-plugins-mit.md
+++ b/docs/adr/0009-license-split-core-agpl-plugins-mit.md
@@ -1,0 +1,21 @@
+# ADR 0009: AGPL for the core, MIT for plugins and satellites
+
+Status: accepted 2026-08-27
+
+## Context
+
+The monorepo licensed all implementation code AGPL-3.0-only. Ecosystem repos (demarkus-library, demarkus-knowledge-system-deploy, the pi plugin mirrors) shipped no license at all, and GitHub could not detect the monorepo's combined pointer file.
+
+## Decision
+
+- The core (protocol, server, knowledge server, client, tools) stays AGPL-3.0-only.
+- Everything under `plugins/` is MIT (`plugins/LICENSE`); the pi mirror directories carry their own MIT copy so the subtree force-push ships it.
+- demarkus-library is MIT.
+- demarkus-knowledge-system-deploy is MIT (it is a template others copy).
+- The protocol specification remains CC0-1.0 (`LICENSE-PROTOCOL`).
+
+## Consequences
+
+- Agent-harness integrations adopt plugins without AGPL obligations; network use of the servers still triggers AGPL source offers.
+- Standalone plugin repos get GitHub-detectable full license texts.
+- demarkus-hub and obsidian-demarkus still carry GPLv3; both are being phased out rather than relicensed.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -12,3 +12,4 @@ Decision records binding the protocol, spec, and repo; git is canonical, and eac
 | [0006](0006-postgres-backend-is-an-optional-build.md) | The Postgres backend is an optional build, not a dependency | accepted 2026-08-20 |
 | [0007](0007-sni-virtual-world-routing.md) | SNI selects a virtual Mark server | accepted 2026-08-22 |
 | [0008](0008-gcs-root-cas-storage.md) | GCS world state commits through one root CAS | accepted 2026-08-22 |
+| [0009](0009-license-split-core-agpl-plugins-mit.md) | AGPL for the core, MIT for plugins and satellites | accepted 2026-08-27 |

--- a/plugins/LICENSE
+++ b/plugins/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 latebit-io
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/pi-knowledge/LICENSE
+++ b/plugins/pi-knowledge/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 latebit-io
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/pi-memory/LICENSE
+++ b/plugins/pi-memory/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 latebit-io
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an architecture decision record documenting the project’s licensing structure and coverage.
  - Updated the decision index to include the new licensing decision.

- **Legal**
  - Clarified that the core implementation remains under AGPL-3.0-only.
  - Added MIT license notices for plugin components, including knowledge and memory plugins.
  - Documented applicable licensing terms, attribution requirements, and warranty disclaimers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->