### PR TITLE
fix(broker): permit zero static worlds with provisioning; wildcard ce…

### DIFF
--- a/deploy/helm/demarkus-knowledge-server/templates/certificate.yaml
+++ b/deploy/helm/demarkus-knowledge-server/templates/certificate.yaml
@@ -20,4 +20,10 @@ spec:
     - {{ lower . | quote }}
     {{- end }}
     {{- end }}
+    {{- if .Values.dynamicWorlds.enabled }}
+    {{- /* Dynamic tenant authorities are <slug>.<service-dns>; one
+         wildcard covers every provisioned world without reissuing. */}}
+    - {{ printf "%s.%s.svc.cluster.local" (include "demarkus-knowledge-server.fullname" .) .Release.Namespace | quote }}
+    - {{ printf "*.%s.%s.svc.cluster.local" (include "demarkus-knowledge-server.fullname" .) .Release.Namespace | quote }}
+    {{- end }}
 {{- end }}

--- a/deploy/helm/demarkus-knowledge-server/tests/certificate_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/certificate_test.yaml
@@ -57,4 +57,7 @@ tests:
     asserts:
       - contains:
           path: spec.dnsNames
+          content: "RELEASE-NAME-demarkus-knowledge-server.NAMESPACE.svc.cluster.local"
+      - contains:
+          path: spec.dnsNames
           content: "*.RELEASE-NAME-demarkus-knowledge-server.NAMESPACE.svc.cluster.local"

--- a/deploy/helm/demarkus-knowledge-server/tests/certificate_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/certificate_test.yaml
@@ -47,3 +47,14 @@ tests:
       - equal:
           path: metadata.annotations["example.com/owner"]
           value: platform
+
+  - it: covers dynamic tenant authorities with a service wildcard
+    set:
+      tls.existingSecret: ""
+      tls.certManager.enabled: true
+      worlds: []
+      dynamicWorlds.enabled: true
+    asserts:
+      - contains:
+          path: spec.dnsNames
+          content: "*.RELEASE-NAME-demarkus-knowledge-server.NAMESPACE.svc.cluster.local"

--- a/tools/internal/broker/config.go
+++ b/tools/internal/broker/config.go
@@ -703,8 +703,10 @@ func (c *Config) validate() error {
 	if err := c.OIDC.validate(); err != nil {
 		return err
 	}
-	if len(c.Worlds) == 0 {
-		return fmt.Errorf("at least one world is required")
+	// Zero static worlds is legal when provisioning is enabled: the
+	// whole world set then arrives dynamically via the registry.
+	if len(c.Worlds) == 0 && !c.Provisioning.Enabled() {
+		return fmt.Errorf("at least one world is required (or enable provisioning)")
 	}
 	seen := make(map[string]bool, len(c.Worlds))
 	seenSecretRefs := make(map[[2]string]string, len(c.Worlds))

--- a/tools/internal/broker/config_test.go
+++ b/tools/internal/broker/config_test.go
@@ -91,6 +91,16 @@ func writeConfig(t *testing.T, body string) string {
 	return path
 }
 
+// mustReplace guards fixture surgery: a stale needle would silently
+// return the original config and the case would stop covering its branch.
+func mustReplace(t *testing.T, s, old, replacement string) string {
+	t.Helper()
+	if !strings.Contains(s, old) {
+		t.Fatalf("fixture replacement missed: %q not present", old)
+	}
+	return strings.Replace(s, old, replacement, 1)
+}
+
 func TestLoadConfig(t *testing.T) {
 	// applyEnvOverrides reads BROKER_SIGNING_KEY and
 	// OIDC_CLIENT_SECRET from the process environment. Without
@@ -138,8 +148,8 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			name: "no worlds is legal with provisioning enabled",
-			body: strings.Replace(validConfig, validWorldBlock,
-				"worlds: []\nprovisioning:\n  mode: open\n  maxTenants: 10\n  authorityDomain: memory.svc\n  dialAddress: memory.svc:6309\n  bucketPrefix: p-\n  bucketProject: p\n  serverNamespace: ns\n", 1),
+			body: mustReplace(t, validConfig, validWorldBlock,
+				"worlds: []\nprovisioning:\n  mode: open\n  maxTenants: 10\n  authorityDomain: memory.svc\n  dialAddress: memory.svc:6309\n  bucketPrefix: p-\n  bucketProject: p\n  serverNamespace: ns\n"),
 		},
 		{
 			name:    "duplicate world name",

--- a/tools/internal/broker/config_test.go
+++ b/tools/internal/broker/config_test.go
@@ -137,6 +137,11 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: "at least one world is required",
 		},
 		{
+			name: "no worlds is legal with provisioning enabled",
+			body: strings.Replace(validConfig, validWorldBlock,
+				"worlds: []\nprovisioning:\n  mode: open\n  maxTenants: 10\n  authorityDomain: memory.svc\n  dialAddress: memory.svc:6309\n  bucketPrefix: p-\n  bucketProject: p\n  serverNamespace: ns\n", 1),
+		},
+		{
 			name:    "duplicate world name",
 			body:    validConfig + "  - name: team-a\n    namespace: team-a\n    tokensSecret: team-a-tokens\n    defaultToken:\n      paths: [\"/x\"]\n",
 			wantErr: `duplicate name "team-a"`,

--- a/tools/internal/broker/provisioning_config.go
+++ b/tools/internal/broker/provisioning_config.go
@@ -91,6 +91,7 @@ func (p *ProvisioningConfig) validate(fileBackend bool) error {
 		"provisioning.authorityDomain": p.AuthorityDomain,
 		"provisioning.dialAddress":     p.DialAddress,
 		"provisioning.bucketPrefix":    p.BucketPrefix,
+		"provisioning.bucketProject":   p.BucketProject,
 		"provisioning.serverNamespace": p.ServerNamespace,
 		"provisioning.worldsSecret":    p.WorldsSecret,
 		"provisioning.tokensSecret":    p.TokensSecret,


### PR DESCRIPTION
…rt for dynamic worlds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled deployments with dynamically provisioned tenant authorities and no statically configured worlds.
  * Certificates now include the service’s internal DNS name and a wildcard for tenant authorities.

* **Bug Fixes**
  * Updated configuration validation to allow world-less setups when provisioning is enabled.
  * Added validation requiring a storage bucket project for dynamic provisioning.
  * Improved certificate handling for dynamically provisioned tenant authorities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->