### PR TITLE
feat(broker): trust MCP hosts' registered redirect URIs (RFC 7591)

### DIFF
--- a/deploy/helm/demarkus-knowledge-broker/templates/_helpers.tpl
+++ b/deploy/helm/demarkus-knowledge-broker/templates/_helpers.tpl
@@ -66,6 +66,11 @@ Names for the chart-managed Secrets.
 {{- default (printf "%s-refresh-tokens" (include "demarkus-knowledge-broker.fullname" .)) .Values.server.refreshTokensSecret -}}
 {{- end -}}
 
+{{/* Dynamic-clients Secret: RFC 7591 registrations (client_id -> redirect URIs). */}}
+{{- define "demarkus-knowledge-broker.dynamicClientsSecretName" -}}
+{{- default (printf "%s-dynamic-clients" (include "demarkus-knowledge-broker.fullname" .)) .Values.server.dynamicClientsSecret -}}
+{{- end -}}
+
 {{/*
 Per-world write-token Secret name. The broker provisions one of
 these lazily on the first write to each world (see

--- a/deploy/helm/demarkus-knowledge-broker/templates/rbac-broker-ns.yaml
+++ b/deploy/helm/demarkus-knowledge-broker/templates/rbac-broker-ns.yaml
@@ -50,6 +50,7 @@ rules:
     resources: ["secrets"]
     resourceNames:
       - {{ include "demarkus-knowledge-broker.refreshTokensSecretName" . | quote }}
+      - {{ include "demarkus-knowledge-broker.dynamicClientsSecretName" . | quote }}
     verbs: ["get", "update"]
   {{- if .Values.worlds }}
   - apiGroups: [""]

--- a/deploy/helm/demarkus-knowledge-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-knowledge-broker/templates/secret-config.yaml
@@ -79,6 +79,7 @@ stringData:
       stateTTL: {{ .Values.server.stateTTL | quote }}
       brokerNamespace: {{ include "demarkus-knowledge-broker.brokerNamespace" . | quote }}
       refreshTokensSecret: {{ include "demarkus-knowledge-broker.refreshTokensSecretName" . | quote }}
+      dynamicClientsSecret: {{ include "demarkus-knowledge-broker.dynamicClientsSecretName" . | quote }}
       refreshTokenTTL: {{ .Values.server.refreshTokenTTL | quote }}
       idTokenTTL: {{ .Values.server.idTokenTTL | quote }}
       publicURL: {{ required "server.publicURL is required" .Values.server.publicURL | quote }}

--- a/deploy/helm/demarkus-knowledge-broker/templates/secret-dynamic-clients.yaml
+++ b/deploy/helm/demarkus-knowledge-broker/templates/secret-dynamic-clients.yaml
@@ -1,0 +1,20 @@
+{{/*
+Dynamic-clients Secret: the broker writes the RFC 7591 registration
+map (client_id -> redirect URIs) here at runtime. Same lifecycle
+invariants as secret-refresh-tokens.yaml (resource-policy: keep +
+lookup-skip); the rationale lives there once.
+*/}}
+{{- $brokerNs := include "demarkus-knowledge-broker.brokerNamespace" . -}}
+{{- if not (lookup "v1" "Secret" $brokerNs (include "demarkus-knowledge-broker.dynamicClientsSecretName" .)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "demarkus-knowledge-broker.dynamicClientsSecretName" . }}
+  namespace: {{ $brokerNs }}
+  labels:
+    {{- include "demarkus-knowledge-broker.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+type: Opaque
+data: {}
+{{- end }}

--- a/deploy/helm/demarkus-knowledge-broker/templates/secret-dynamic-clients.yaml
+++ b/deploy/helm/demarkus-knowledge-broker/templates/secret-dynamic-clients.yaml
@@ -1,8 +1,6 @@
 {{/*
-Dynamic-clients Secret: the broker writes the RFC 7591 registration
-map (client_id -> redirect URIs) here at runtime. Same lifecycle
-invariants as secret-refresh-tokens.yaml (resource-policy: keep +
-lookup-skip); the rationale lives there once.
+RFC 7591 registration map, broker-written at runtime. Same lifecycle
+invariants as secret-refresh-tokens.yaml (keep + lookup-skip).
 */}}
 {{- $brokerNs := include "demarkus-knowledge-broker.brokerNamespace" . -}}
 {{- if not (lookup "v1" "Secret" $brokerNs (include "demarkus-knowledge-broker.dynamicClientsSecretName" .)) }}

--- a/deploy/helm/demarkus-knowledge-broker/tests/rbac_test.yaml
+++ b/deploy/helm/demarkus-knowledge-broker/tests/rbac_test.yaml
@@ -91,6 +91,7 @@ tests:
           path: rules[2].resourceNames
           value:
             - "RELEASE-NAME-demarkus-knowledge-broker-refresh-tokens"
+            - "RELEASE-NAME-demarkus-knowledge-broker-dynamic-clients"
       - equal:
           path: rules[2].verbs
           value: ["get", "update"]

--- a/deploy/helm/demarkus-knowledge-broker/values.yaml
+++ b/deploy/helm/demarkus-knowledge-broker/values.yaml
@@ -84,10 +84,9 @@ server:
   # chart lifecycle events never invalidate live refresh tokens.
   refreshTokensSecret: ""
 
-  # Secret name for the RFC 7591 dynamic-client registration map
-  # (client_id -> redirect URIs; MCP hosts register their callbacks
-  # here). Default derived from the release name; created with
-  # helm.sh/resource-policy: keep like the refresh-tokens Secret.
+  # RFC 7591 dynamic-client registration map (kept Secret, like
+  # refreshTokensSecret). Renaming it after install orphans existing
+  # registrations; connected MCP hosts must then re-register.
   dynamicClientsSecret: ""
 
   # MCP gateway listener (knowledge-system layer; plan: Broker MCP

--- a/deploy/helm/demarkus-knowledge-broker/values.yaml
+++ b/deploy/helm/demarkus-knowledge-broker/values.yaml
@@ -84,6 +84,12 @@ server:
   # chart lifecycle events never invalidate live refresh tokens.
   refreshTokensSecret: ""
 
+  # Secret name for the RFC 7591 dynamic-client registration map
+  # (client_id -> redirect URIs; MCP hosts register their callbacks
+  # here). Default derived from the release name; created with
+  # helm.sh/resource-policy: keep like the refresh-tokens Secret.
+  dynamicClientsSecret: ""
+
   # MCP gateway listener (knowledge-system layer; plan: Broker MCP
   # Gateway). The gateway is ALWAYS ON — every broker is a
   # knowledge-system gateway, there is no `enabled` knob. Operators

--- a/deploy/helm/demarkus-memory-broker/templates/_helpers.tpl
+++ b/deploy/helm/demarkus-memory-broker/templates/_helpers.tpl
@@ -66,6 +66,11 @@ Names for the chart-managed Secrets.
 {{- default (printf "%s-refresh-tokens" (include "demarkus-memory-broker.fullname" .)) .Values.server.refreshTokensSecret -}}
 {{- end -}}
 
+{{/* Dynamic-clients Secret: RFC 7591 registrations (client_id -> redirect URIs). */}}
+{{- define "demarkus-memory-broker.dynamicClientsSecretName" -}}
+{{- default (printf "%s-dynamic-clients" (include "demarkus-memory-broker.fullname" .)) .Values.server.dynamicClientsSecret -}}
+{{- end -}}
+
 {{/*
 Per-world write-token Secret name. The broker provisions one of
 these lazily on the first write to each world (see

--- a/deploy/helm/demarkus-memory-broker/templates/rbac-broker-ns.yaml
+++ b/deploy/helm/demarkus-memory-broker/templates/rbac-broker-ns.yaml
@@ -50,6 +50,7 @@ rules:
     resources: ["secrets"]
     resourceNames:
       - {{ include "demarkus-memory-broker.refreshTokensSecretName" . | quote }}
+      - {{ include "demarkus-memory-broker.dynamicClientsSecretName" . | quote }}
     verbs: ["get", "update"]
   {{- if ne (include "demarkus-memory-broker.provisioningMode" .) "static" }}
   {{- /* Dynamic provisioning: runtime-created Secret names cannot be

--- a/deploy/helm/demarkus-memory-broker/templates/secret-config.yaml
+++ b/deploy/helm/demarkus-memory-broker/templates/secret-config.yaml
@@ -79,6 +79,7 @@ stringData:
       stateTTL: {{ .Values.server.stateTTL | quote }}
       brokerNamespace: {{ include "demarkus-memory-broker.brokerNamespace" . | quote }}
       refreshTokensSecret: {{ include "demarkus-memory-broker.refreshTokensSecretName" . | quote }}
+      dynamicClientsSecret: {{ include "demarkus-memory-broker.dynamicClientsSecretName" . | quote }}
       refreshTokenTTL: {{ .Values.server.refreshTokenTTL | quote }}
       idTokenTTL: {{ .Values.server.idTokenTTL | quote }}
       publicURL: {{ required "server.publicURL is required" .Values.server.publicURL | quote }}

--- a/deploy/helm/demarkus-memory-broker/templates/secret-dynamic-clients.yaml
+++ b/deploy/helm/demarkus-memory-broker/templates/secret-dynamic-clients.yaml
@@ -1,8 +1,6 @@
 {{/*
-Dynamic-clients Secret: the broker writes the RFC 7591 registration
-map (client_id -> redirect URIs) here at runtime. Same lifecycle
-invariants as secret-refresh-tokens.yaml (resource-policy: keep +
-lookup-skip); the rationale lives there once.
+RFC 7591 registration map, broker-written at runtime. Same lifecycle
+invariants as secret-refresh-tokens.yaml (keep + lookup-skip).
 */}}
 {{- $brokerNs := include "demarkus-memory-broker.brokerNamespace" . -}}
 {{- if not (lookup "v1" "Secret" $brokerNs (include "demarkus-memory-broker.dynamicClientsSecretName" .)) }}

--- a/deploy/helm/demarkus-memory-broker/templates/secret-dynamic-clients.yaml
+++ b/deploy/helm/demarkus-memory-broker/templates/secret-dynamic-clients.yaml
@@ -1,0 +1,20 @@
+{{/*
+Dynamic-clients Secret: the broker writes the RFC 7591 registration
+map (client_id -> redirect URIs) here at runtime. Same lifecycle
+invariants as secret-refresh-tokens.yaml (resource-policy: keep +
+lookup-skip); the rationale lives there once.
+*/}}
+{{- $brokerNs := include "demarkus-memory-broker.brokerNamespace" . -}}
+{{- if not (lookup "v1" "Secret" $brokerNs (include "demarkus-memory-broker.dynamicClientsSecretName" .)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "demarkus-memory-broker.dynamicClientsSecretName" . }}
+  namespace: {{ $brokerNs }}
+  labels:
+    {{- include "demarkus-memory-broker.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+type: Opaque
+data: {}
+{{- end }}

--- a/deploy/helm/demarkus-memory-broker/tests/rbac_test.yaml
+++ b/deploy/helm/demarkus-memory-broker/tests/rbac_test.yaml
@@ -92,6 +92,7 @@ tests:
           path: rules[2].resourceNames
           value:
             - "RELEASE-NAME-demarkus-memory-broker-refresh-tokens"
+            - "RELEASE-NAME-demarkus-memory-broker-dynamic-clients"
       - equal:
           path: rules[2].verbs
           value: ["get", "update"]

--- a/deploy/helm/demarkus-memory-broker/values.yaml
+++ b/deploy/helm/demarkus-memory-broker/values.yaml
@@ -84,6 +84,12 @@ server:
   # chart lifecycle events never invalidate live refresh tokens.
   refreshTokensSecret: ""
 
+  # Secret name for the RFC 7591 dynamic-client registration map
+  # (client_id -> redirect URIs; MCP hosts register their callbacks
+  # here). Default derived from the release name; created with
+  # helm.sh/resource-policy: keep like the refresh-tokens Secret.
+  dynamicClientsSecret: ""
+
   # MCP gateway listener (memory service surface; see plan: Memory Broker
   # Gateway). The gateway is ALWAYS ON — every broker is a
   # memory gateway, there is no `enabled` knob. Operators

--- a/deploy/helm/demarkus-memory-broker/values.yaml
+++ b/deploy/helm/demarkus-memory-broker/values.yaml
@@ -84,10 +84,9 @@ server:
   # chart lifecycle events never invalidate live refresh tokens.
   refreshTokensSecret: ""
 
-  # Secret name for the RFC 7591 dynamic-client registration map
-  # (client_id -> redirect URIs; MCP hosts register their callbacks
-  # here). Default derived from the release name; created with
-  # helm.sh/resource-policy: keep like the refresh-tokens Secret.
+  # RFC 7591 dynamic-client registration map (kept Secret, like
+  # refreshTokensSecret). Renaming it after install orphans existing
+  # registrations; connected MCP hosts must then re-register.
   dynamicClientsSecret: ""
 
   # MCP gateway listener (memory service surface; see plan: Memory Broker

--- a/tools/internal/broker/config.go
+++ b/tools/internal/broker/config.go
@@ -126,7 +126,8 @@ func (c *Config) validateStorage() error {
 // broker-state file: two stores mutating one document corrupts it.
 func (c *Config) validateFilePaths() error {
 	seen := map[string]string{
-		filepath.Clean(c.refreshTokensRef().Path): "storage.dir refresh-tokens state",
+		filepath.Clean(c.refreshTokensRef().Path):  "storage.dir refresh-tokens state",
+		filepath.Clean(c.dynamicClientsRef().Path): "storage.dir dynamic-clients state",
 	}
 	for i := range c.Worlds {
 		w := &c.Worlds[i]
@@ -290,6 +291,10 @@ type ServerConfig struct {
 	// universe-onboarding PR4; defaulted in validate when omitted so
 	// existing dev configs upgrade without an explicit value.
 	RefreshTokensSecret string `yaml:"refreshTokensSecret"`
+	// DynamicClientsSecret is the broker-namespace Secret holding the
+	// RFC 7591 registration map (client_id → redirect URIs); written
+	// on /register, read on /oauth/authorize. Defaulted in validate.
+	DynamicClientsSecret string `yaml:"dynamicClientsSecret"`
 	// RefreshTokenTTL is the lifetime of a newly-issued refresh token.
 	// Default 90 days. Tokens past their TTL are rejected at refresh
 	// time and reaped by the periodic Sweeper. Operators tighten this
@@ -802,6 +807,9 @@ func (o *OIDCConfig) validate() error {
 func (s *ServerConfig) applyRefreshDefaults() error {
 	if s.RefreshTokensSecret == "" {
 		s.RefreshTokensSecret = defaultRefreshTokensSecret
+	}
+	if s.DynamicClientsSecret == "" {
+		s.DynamicClientsSecret = defaultDynamicClientsSecret
 	}
 	if s.RefreshTokenTTL == 0 {
 		s.RefreshTokenTTL = defaultRefreshTokenTTL

--- a/tools/internal/broker/dynamic_clients.go
+++ b/tools/internal/broker/dynamic_clients.go
@@ -3,7 +3,6 @@ package broker
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"slices"
@@ -69,10 +68,6 @@ func decodeDynamicClients(existing []byte) (map[string]dynamicClientRecord, erro
 	return clients, nil
 }
 
-// ErrDynamicClientCapacity is returned when the registration map is
-// full even after pruning expired entries.
-var ErrDynamicClientCapacity = errors.New("broker: dynamic client registry at capacity")
-
 // Register persists a new registration under clientID.
 func (s *DynamicClientStore) Register(ctx context.Context, clientID string, redirectURIs []string, name string) error {
 	now := s.clock().UTC()
@@ -86,8 +81,18 @@ func (s *DynamicClientStore) Register(ctx context.Context, clientID string, redi
 				delete(clients, id)
 			}
 		}
-		if len(clients) >= maxDynamicClients {
-			return nil, ErrDynamicClientCapacity
+		// At capacity, evict the oldest instead of refusing: refusal
+		// would let anonymous churn deny new hosts, while an evicted
+		// live host just re-registers on its next connect.
+		for len(clients) >= maxDynamicClients {
+			oldestID := ""
+			var oldest time.Time
+			for id, record := range clients {
+				if oldestID == "" || record.Created.Before(oldest) {
+					oldestID, oldest = id, record.Created
+				}
+			}
+			delete(clients, oldestID)
 		}
 		clients[clientID] = dynamicClientRecord{
 			RedirectURIs: redirectURIs,

--- a/tools/internal/broker/dynamic_clients.go
+++ b/tools/internal/broker/dynamic_clients.go
@@ -25,6 +25,18 @@ const DynamicClientsSecretKey = "dynamic-clients.json"
 // unauthenticated storage-growth surface.
 const maxDynamicClients = 2000
 
+// maxDynamicClientsBytes caps the SERIALIZED map, well under the 1MiB
+// Kubernetes Secret limit: record count alone cannot bound bytes.
+const maxDynamicClientsBytes = 512 << 10
+
+// Per-registration shape bounds; count and byte caps only hold when a
+// single anonymous registration cannot be arbitrarily large.
+const (
+	maxRedirectURIsPerClient = 8
+	maxRedirectURILen        = 512
+	maxClientNameLen         = 128
+)
+
 // dynamicClientTTL expires registrations. MCP hosts re-register
 // cheaply on their next connect, so expiry only costs a re-dance.
 const dynamicClientTTL = 90 * 24 * time.Hour
@@ -81,25 +93,37 @@ func (s *DynamicClientStore) Register(ctx context.Context, clientID string, redi
 				delete(clients, id)
 			}
 		}
-		// At capacity, evict the oldest instead of refusing: refusal
-		// would let anonymous churn deny new hosts, while an evicted
-		// live host just re-registers on its next connect.
-		for len(clients) >= maxDynamicClients {
-			oldestID := ""
-			var oldest time.Time
-			for id, record := range clients {
-				if oldestID == "" || record.Created.Before(oldest) {
-					oldestID, oldest = id, record.Created
-				}
-			}
-			delete(clients, oldestID)
-		}
 		clients[clientID] = dynamicClientRecord{
 			RedirectURIs: redirectURIs,
 			ClientName:   name,
 			Created:      now,
 		}
-		return json.Marshal(clients)
+		// Over capacity (count OR serialized bytes), evict oldest
+		// rather than refuse: refusal lets anonymous churn deny new
+		// hosts; an evicted live host re-registers on next connect.
+		for {
+			encoded, encErr := json.Marshal(clients)
+			if encErr != nil {
+				return nil, encErr
+			}
+			if len(clients) <= maxDynamicClients && len(encoded) <= maxDynamicClientsBytes {
+				return encoded, nil
+			}
+			oldestID := ""
+			var oldest time.Time
+			for id, record := range clients {
+				if id == clientID {
+					continue // never evict the registration being added
+				}
+				if oldestID == "" || record.Created.Before(oldest) {
+					oldestID, oldest = id, record.Created
+				}
+			}
+			if oldestID == "" {
+				return encoded, nil // only the new record remains
+			}
+			delete(clients, oldestID)
+		}
 	})
 }
 

--- a/tools/internal/broker/dynamic_clients.go
+++ b/tools/internal/broker/dynamic_clients.go
@@ -1,0 +1,143 @@
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"time"
+)
+
+// RFC 7591 dynamic client registrations with persisted redirect URIs:
+// MCP hosts register their https callbacks and the authorize leg
+// trusts exactly what was recorded here.
+
+// defaultDynamicClientsSecret names the broker-namespace Secret
+// holding the registration map when the operator does not override it.
+const defaultDynamicClientsSecret = "demarkus-broker-dynamic-clients"
+
+// DynamicClientsSecretKey is the data key inside the Secret.
+const DynamicClientsSecretKey = "dynamic-clients.json"
+
+// maxDynamicClients caps the registration map. Registration is
+// anonymous-open (RFC 7591 §2), so without a cap the Secret is an
+// unauthenticated storage-growth surface.
+const maxDynamicClients = 2000
+
+// dynamicClientTTL expires registrations. MCP hosts re-register
+// cheaply on their next connect, so expiry only costs a re-dance.
+const dynamicClientTTL = 90 * 24 * time.Hour
+
+// dynamicClientRecord is one registration's persisted state.
+type dynamicClientRecord struct {
+	RedirectURIs []string  `json:"redirectURIs"`
+	ClientName   string    `json:"clientName,omitempty"`
+	Created      time.Time `json:"created"`
+}
+
+func (r *dynamicClientRecord) expired(now time.Time) bool {
+	return now.Sub(r.Created) > dynamicClientTTL
+}
+
+func (r *dynamicClientRecord) allowsRedirect(uri string) bool {
+	return slices.Contains(r.RedirectURIs, uri)
+}
+
+// DynamicClientStore persists RFC 7591 registrations in one Secret,
+// sharing the refresh-store pattern: optimistic-concurrency Mutate,
+// prune-on-write expiry, survives restarts and replicas.
+type DynamicClientStore struct {
+	cfg   *Config
+	store SecretStore
+	clock func() time.Time
+}
+
+// NewDynamicClientStore builds the store over the broker's SecretStore.
+func NewDynamicClientStore(cfg *Config, store SecretStore) *DynamicClientStore {
+	return &DynamicClientStore{cfg: cfg, store: store, clock: time.Now}
+}
+
+func decodeDynamicClients(existing []byte) (map[string]dynamicClientRecord, error) {
+	clients := map[string]dynamicClientRecord{}
+	if len(existing) > 0 {
+		if err := json.Unmarshal(existing, &clients); err != nil {
+			return nil, fmt.Errorf("broker: decode dynamic-clients state: %w", err)
+		}
+	}
+	return clients, nil
+}
+
+// ErrDynamicClientCapacity is returned when the registration map is
+// full even after pruning expired entries.
+var ErrDynamicClientCapacity = errors.New("broker: dynamic client registry at capacity")
+
+// Register persists a new registration under clientID.
+func (s *DynamicClientStore) Register(ctx context.Context, clientID string, redirectURIs []string, name string) error {
+	now := s.clock().UTC()
+	return s.store.Mutate(ctx, s.cfg.dynamicClientsRef(), func(existing []byte) ([]byte, error) {
+		clients, err := decodeDynamicClients(existing)
+		if err != nil {
+			return nil, err
+		}
+		for id, record := range clients {
+			if record.expired(now) {
+				delete(clients, id)
+			}
+		}
+		if len(clients) >= maxDynamicClients {
+			return nil, ErrDynamicClientCapacity
+		}
+		clients[clientID] = dynamicClientRecord{
+			RedirectURIs: redirectURIs,
+			ClientName:   name,
+			Created:      now,
+		}
+		return json.Marshal(clients)
+	})
+}
+
+// Lookup returns the registration for clientID when present and not
+// expired. Read-only: the Mutate no-op write suppression means no
+// Secret update is issued.
+func (s *DynamicClientStore) Lookup(ctx context.Context, clientID string) (dynamicClientRecord, bool, error) {
+	var record dynamicClientRecord
+	found := false
+	err := s.store.Mutate(ctx, s.cfg.dynamicClientsRef(), func(existing []byte) ([]byte, error) {
+		clients, decodeErr := decodeDynamicClients(existing)
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+		if r, ok := clients[clientID]; ok && !r.expired(s.clock().UTC()) {
+			record, found = r, true
+		}
+		return existing, nil
+	})
+	if err != nil {
+		return dynamicClientRecord{}, false, err
+	}
+	return record, found, nil
+}
+
+// validateClientRedirectURI accepts only trustable redirect shapes:
+// http loopback (RFC 8252 natives), or the webClients registry's
+// https shape (absolute, no userinfo, no fragment) — one rule set.
+func validateClientRedirectURI(raw string) error {
+	if isLoopbackRedirectURI(raw) {
+		return nil
+	}
+	return validateWebRedirectURI(raw)
+}
+
+func (c *Config) dynamicClientsRef() SecretRef {
+	ref := SecretRef{
+		Namespace: c.Server.BrokerNamespace,
+		Name:      c.Server.DynamicClientsSecret,
+		Key:       DynamicClientsSecretKey,
+	}
+	if c.fileBackend() {
+		ref.Path = filepath.Join(c.Storage.Dir, DynamicClientsSecretKey)
+	}
+	return ref
+}

--- a/tools/internal/broker/dynamic_clients_test.go
+++ b/tools/internal/broker/dynamic_clients_test.go
@@ -1,11 +1,14 @@
 package broker
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -86,5 +89,69 @@ func TestRegisterRejectsInvalidRedirectURIs(t *testing.T) {
 		if resp.StatusCode != http.StatusBadRequest {
 			t.Errorf("register %s = %d, want 400", body, resp.StatusCode)
 		}
+	}
+}
+
+// Per-registration shape bounds keep the count and byte caps honest.
+func TestRegisterRejectsOversizedMetadata(t *testing.T) {
+	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+	client := testClient(srv)
+
+	manyURIs := make([]string, maxRedirectURIsPerClient+1)
+	for i := range manyURIs {
+		manyURIs[i] = fmt.Sprintf(`"https://host.example/cb%d"`, i)
+	}
+	longURI := "https://host.example/" + strings.Repeat("a", maxRedirectURILen)
+	longName := strings.Repeat("n", maxClientNameLen+1)
+	for _, body := range []string{
+		`{"redirect_uris":[` + strings.Join(manyURIs, ",") + `]}`,
+		`{"redirect_uris":["` + longURI + `"]}`,
+		`{"client_name":"` + longName + `","redirect_uris":["https://host.example/cb"]}`,
+	} {
+		resp, err := client.Post(srv.URL+"/register", "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("register: %v", err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("oversized registration = %d, want 400", resp.StatusCode)
+		}
+	}
+}
+
+// The serialized map must stay under the byte cap: max-size hostile
+// registrations trigger oldest-first eviction, never unbounded growth.
+func TestDynamicClientStoreEnforcesByteCap(t *testing.T) {
+	cfg := testConfig()
+	cfg.Server.DynamicClientsSecret = "dyn-clients"
+	clientset := fake.NewSimpleClientset()
+	store := NewDynamicClientStore(cfg, NewK8sSecretStore(clientset))
+
+	uris := make([]string, maxRedirectURIsPerClient)
+	for i := range uris {
+		uris[i] = "https://host.example/" + strings.Repeat("x", maxRedirectURILen-30) + fmt.Sprint(i)
+	}
+	// Enough max-size records to exceed the byte cap several times over.
+	n := maxDynamicClientsBytes/(maxRedirectURIsPerClient*maxRedirectURILen) + 20
+	for i := range n {
+		if err := store.Register(context.Background(), fmt.Sprintf("client-%04d", i), uris, strings.Repeat("n", maxClientNameLen)); err != nil {
+			t.Fatalf("register %d: %v", i, err)
+		}
+	}
+
+	secret, err := clientset.CoreV1().Secrets(cfg.Server.BrokerNamespace).Get(context.Background(), "dyn-clients", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("read secret: %v", err)
+	}
+	payload := secret.Data[DynamicClientsSecretKey]
+	if len(payload) > maxDynamicClientsBytes {
+		t.Errorf("serialized map = %d bytes, want <= %d", len(payload), maxDynamicClientsBytes)
+	}
+	// Oldest evicted, newest kept.
+	if _, found, _ := store.Lookup(context.Background(), "client-0000"); found {
+		t.Error("oldest registration survived byte-cap eviction")
+	}
+	if _, found, _ := store.Lookup(context.Background(), fmt.Sprintf("client-%04d", n-1)); !found {
+		t.Error("newest registration missing after eviction")
 	}
 }

--- a/tools/internal/broker/dynamic_clients_test.go
+++ b/tools/internal/broker/dynamic_clients_test.go
@@ -1,0 +1,90 @@
+package broker
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// Register-then-authorize: the MCP-host path. A dynamically registered
+// https redirect is trusted; an unregistered one stays refused.
+func TestAuthorizeTrustsDynamicallyRegisteredRedirect(t *testing.T) {
+	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{authURL: "https://idp.example.com/authorize"}, fake.NewSimpleClientset())
+	client := testClient(srv)
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	const callback = "https://claude.ai/api/mcp/auth_callback"
+	reg, err := client.Post(srv.URL+"/register", "application/json",
+		strings.NewReader(`{"client_name":"Claude","redirect_uris":["`+callback+`"]}`))
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	defer func() { _ = reg.Body.Close() }()
+	if reg.StatusCode != http.StatusCreated {
+		t.Fatalf("register status = %d, want 201", reg.StatusCode)
+	}
+	var regDoc struct {
+		ClientID string `json:"client_id"`
+	}
+	if err := json.NewDecoder(reg.Body).Decode(&regDoc); err != nil {
+		t.Fatalf("decode register response: %v", err)
+	}
+
+	q := authorizeQuery()
+	q.Set("client_id", regDoc.ClientID)
+	q.Set("redirect_uri", callback)
+	resp, err := client.Get(srv.URL + "/oauth/authorize?" + q.Encode())
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("authorize with registered https redirect = %d, want 302 to IdP", resp.StatusCode)
+	}
+
+	// Same redirect under an UNREGISTERED client_id stays refused.
+	q.Set("client_id", "not-registered")
+	resp2, err := client.Get(srv.URL + "/oauth/authorize?" + q.Encode())
+	if err != nil {
+		t.Fatalf("authorize unregistered: %v", err)
+	}
+	_ = resp2.Body.Close()
+	if resp2.StatusCode != http.StatusBadRequest {
+		t.Errorf("authorize with unregistered client = %d, want 400", resp2.StatusCode)
+	}
+	// A registered client presenting a DIFFERENT redirect is refused.
+	q.Set("client_id", regDoc.ClientID)
+	q.Set("redirect_uri", "https://attacker.example/steal")
+	resp3, err := client.Get(srv.URL + "/oauth/authorize?" + q.Encode())
+	if err != nil {
+		t.Fatalf("authorize wrong redirect: %v", err)
+	}
+	_ = resp3.Body.Close()
+	if resp3.StatusCode != http.StatusBadRequest {
+		t.Errorf("authorize with unregistered redirect = %d, want 400", resp3.StatusCode)
+	}
+}
+
+func TestRegisterRejectsInvalidRedirectURIs(t *testing.T) {
+	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{}, fake.NewSimpleClientset())
+	client := testClient(srv)
+	for _, body := range []string{
+		`{"redirect_uris":[]}`,
+		`{"redirect_uris":["http://attacker.example/cb"]}`,
+		`{"redirect_uris":["https://user:pw@host.example/cb"]}`,
+		`{"redirect_uris":["https://host.example/cb#frag"]}`,
+		`{"redirect_uris":[42]}`,
+	} {
+		resp, err := client.Post(srv.URL+"/register", "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("register %s: %v", body, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("register %s = %d, want 400", body, resp.StatusCode)
+		}
+	}
+}

--- a/tools/internal/broker/dynamic_clients_test.go
+++ b/tools/internal/broker/dynamic_clients_test.go
@@ -148,10 +148,18 @@ func TestDynamicClientStoreEnforcesByteCap(t *testing.T) {
 		t.Errorf("serialized map = %d bytes, want <= %d", len(payload), maxDynamicClientsBytes)
 	}
 	// Oldest evicted, newest kept.
-	if _, found, _ := store.Lookup(context.Background(), "client-0000"); found {
+	_, found, err := store.Lookup(context.Background(), "client-0000")
+	if err != nil {
+		t.Fatalf("lookup oldest: %v", err)
+	}
+	if found {
 		t.Error("oldest registration survived byte-cap eviction")
 	}
-	if _, found, _ := store.Lookup(context.Background(), fmt.Sprintf("client-%04d", n-1)); !found {
+	_, found, err = store.Lookup(context.Background(), fmt.Sprintf("client-%04d", n-1))
+	if err != nil {
+		t.Fatalf("lookup newest: %v", err)
+	}
+	if !found {
 		t.Error("newest registration missing after eviction")
 	}
 }

--- a/tools/internal/broker/oauth_authorize.go
+++ b/tools/internal/broker/oauth_authorize.go
@@ -6,41 +6,9 @@ import (
 	"strings"
 )
 
-// oauthAuthorize implements GET / POST /oauth/authorize — the RFC
-// 6749 §4.1.1 authorization endpoint, scoped to the
-// `response_type=code` + PKCE-S256 flow MCP clients drive against
-// the broker. The handler does not bounce to an IdP directly; the
-// broker is its own AS to the MCP client, and the IdP dance is
-// resumed by /auth/callback via the signed State cookie's
-// AuthCodeID field (mirroring the existing DeviceCode dispatch).
-//
-// Two-phase validation matches RFC 6749 §4.1.2.1: errors that
-// happen BEFORE the redirect_uri is trusted (missing client_id,
-// unacceptable redirect_uri) surface as a JSON 400 directly to the
-// user agent. Errors AFTER trust is established (bad response_type,
-// missing PKCE, store failure) redirect to the client's
-// redirect_uri with `error=...&state=...` so the MCP SDK can surface
-// the failure programmatically.
-//
-// Redirect trust is two-class: a client_id registered in the
-// WebClients registry (confidential web app) must present an exact
-// match against its registered https redirect allowlist; every other
-// client_id is the native/public path and must present a loopback
-// redirect per RFC 8252 §7.3. Whether the grant then requires client
-// authentication at the token endpoint is decided there by the same
-// registry lookup — the auth-code store's client_id binding
-// guarantees the two lookups see the same client.
-//
-// PKCE is required: the broker accepts only `code_challenge_method=
-// S256` and rejects requests missing `code_challenge`. OAuth 2.1
-// guidance + the MCP authorization spec both require this; with no
-// legacy clients to placate, the broker fails closed.
-//
-// Method handling: GET (per RFC 6749 §3.1) is the canonical entry;
-// POST is accepted on the same handler. r.URL.Query() covers both
-// because Go's net/http populates form values on POST too, but we
-// stick to query semantics so signed-state state cookie set here
-// doesn't depend on POST body parsing.
+// oauthAuthorize: RFC 6749 §4.1.1 endpoint, code + PKCE-S256 only;
+// pre-trust errors return JSON 400, post-trust errors redirect. Trust
+// is WebClients allowlist, RFC 7591 registration, or loopback.
 func (s *Server) oauthAuthorize(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-store")
 
@@ -70,13 +38,19 @@ func (s *Server) oauthAuthorize(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else if !isLoopbackRedirectURI(redirectURI) {
-		// RFC 8252 §7.3: native apps MUST use loopback. Any other
-		// host is a configuration mistake or an attack; either way
-		// the broker refuses BEFORE the redirect is trusted, so the
-		// error stays on the broker's surface (no 302 to a hostile
-		// host).
-		writeAuthorizeJSONError(w, "invalid_request", "redirect_uri must be loopback (http://127.0.0.1:PORT or http://localhost:PORT)")
-		return
+		// Non-loopback public client: trusted only when an RFC 7591
+		// registration recorded this exact redirect (MCP-host path);
+		// refused BEFORE trust, so no 302 to a hostile host.
+		record, ok, lookupErr := s.dynamicClients.Lookup(r.Context(), clientID)
+		if lookupErr != nil {
+			s.log.ErrorContext(r.Context(), "broker: authorize: dynamic client lookup failed", "err", lookupErr)
+			writeAuthorizeJSONError(w, "server_error", "client registry unavailable; try again")
+			return
+		}
+		if !ok || !record.allowsRedirect(redirectURI) {
+			writeAuthorizeJSONError(w, "invalid_request", "redirect_uri is not registered for this client; register it via the RFC 7591 registration_endpoint or use a loopback redirect")
+			return
+		}
 	}
 
 	// redirect_uri is now trusted. All subsequent errors redirect.

--- a/tools/internal/broker/register.go
+++ b/tools/internal/broker/register.go
@@ -79,10 +79,10 @@ func (s *Server) register(w http.ResponseWriter, r *http.Request) {
 	name := ""
 	if rawName, present := doc["client_name"]; present {
 		var isString bool
-		if name, isString = rawName.(string); !isString {
+		if name, isString = rawName.(string); !isString || len(name) > maxClientNameLen {
 			writeJSON(w, http.StatusBadRequest, map[string]string{
 				"error":             "invalid_client_metadata",
-				"error_description": "client_name must be a string",
+				"error_description": fmt.Sprintf("client_name must be a string of at most %d bytes", maxClientNameLen),
 			})
 			return
 		}
@@ -126,11 +126,17 @@ func parseRedirectURIs(raw any) ([]string, error) {
 	if !ok || len(list) == 0 {
 		return nil, fmt.Errorf("redirect_uris must be a non-empty array of strings")
 	}
+	if len(list) > maxRedirectURIsPerClient {
+		return nil, fmt.Errorf("redirect_uris must not exceed %d entries", maxRedirectURIsPerClient)
+	}
 	uris := make([]string, 0, len(list))
 	for _, entry := range list {
 		u, ok := entry.(string)
 		if !ok {
 			return nil, fmt.Errorf("redirect_uris must be a non-empty array of strings")
+		}
+		if len(u) > maxRedirectURILen {
+			return nil, fmt.Errorf("redirect_uri must not exceed %d bytes", maxRedirectURILen)
 		}
 		if err := validateClientRedirectURI(u); err != nil {
 			return nil, err

--- a/tools/internal/broker/register.go
+++ b/tools/internal/broker/register.go
@@ -86,7 +86,17 @@ func (s *Server) register(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-		name, _ := doc["client_name"].(string)
+		name := ""
+		if rawName, present := doc["client_name"]; present {
+			var isString bool
+			if name, isString = rawName.(string); !isString {
+				writeJSON(w, http.StatusBadRequest, map[string]string{
+					"error":             "invalid_client_metadata",
+					"error_description": "client_name must be a string",
+				})
+				return
+			}
+		}
 		if regErr := s.dynamicClients.Register(r.Context(), clientID, redirectURIs, name); regErr != nil {
 			s.log.ErrorContext(r.Context(), "broker: register: persist registration failed", "err", regErr)
 			writeJSON(w, http.StatusServiceUnavailable, map[string]string{

--- a/tools/internal/broker/register.go
+++ b/tools/internal/broker/register.go
@@ -74,6 +74,20 @@ func (s *Server) register(w http.ResponseWriter, r *http.Request) {
 	doc["token_endpoint_auth_method"] = "none"
 	doc["grant_types"] = []string{"authorization_code", "urn:ietf:params:oauth:grant-type:device_code"}
 
+	// A present client_name must be a string regardless of the other
+	// fields: a 201 echoing invalid metadata would mislead the caller.
+	name := ""
+	if rawName, present := doc["client_name"]; present {
+		var isString bool
+		if name, isString = rawName.(string); !isString {
+			writeJSON(w, http.StatusBadRequest, map[string]string{
+				"error":             "invalid_client_metadata",
+				"error_description": "client_name must be a string",
+			})
+			return
+		}
+	}
+
 	// redirect_uris, when supplied, are validated and PERSISTED: the
 	// authorize leg trusts non-loopback redirects only for a client_id
 	// whose registration records them (the MCP-host path).
@@ -85,17 +99,6 @@ func (s *Server) register(w http.ResponseWriter, r *http.Request) {
 				"error_description": parseErr.Error(),
 			})
 			return
-		}
-		name := ""
-		if rawName, present := doc["client_name"]; present {
-			var isString bool
-			if name, isString = rawName.(string); !isString {
-				writeJSON(w, http.StatusBadRequest, map[string]string{
-					"error":             "invalid_client_metadata",
-					"error_description": "client_name must be a string",
-				})
-				return
-			}
 		}
 		if regErr := s.dynamicClients.Register(r.Context(), clientID, redirectURIs, name); regErr != nil {
 			s.log.ErrorContext(r.Context(), "broker: register: persist registration failed", "err", regErr)

--- a/tools/internal/broker/register.go
+++ b/tools/internal/broker/register.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 )
@@ -16,51 +17,13 @@ import (
 // registration payload.
 const maxRegisterBodySize = 64 << 10
 
-// clientIDByteLen is the entropy budget for the issued client_id. 16
-// bytes (128 bits) is the IETF's secure-random recommendation for
-// opaque identifiers — collision-resistant against any realistic
-// caller volume and short enough that the base64url-encoded form fits
-// inside a single log line. The broker does not persist these, so the
-// only constraint is that two concurrent /register calls never
-// collide.
+// clientIDByteLen: 128-bit client_id entropy — collision-resistant
+// (registrations persist keyed on it) yet short enough for log lines.
 const clientIDByteLen = 16
 
-// registerHandler implements RFC 7591 Dynamic Client Registration.
-//
-// Why this exists: MCP clients (the model-context-protocol SDK that
-// Claude Code uses to talk to the broker's /mcp gateway) refuse to
-// proceed against an authorization server whose discovery doc omits
-// `registration_endpoint` — the SDK is built to RFC 7591 + MCP-auth-
-// spec assumptions and short-circuits with "Incompatible auth server"
-// when the field is missing. Surfacing /register makes the broker a
-// well-formed MCP authorization server.
-//
-// What this is NOT: a client database. The broker has no read of
-// `client_id` anywhere on the device-flow path — device.go:108 accepts
-// any non-empty value, no lookup, no policy. Real access control lives
-// at the id_token verification + per-world `Allow` list. So /register
-// rubber-stamps any caller: mints a random `client_id`, echoes the
-// request metadata, returns. No persistence, no validation beyond
-// shape. If the broker ever grows client_id-level enforcement
-// (per-client audit, registered redirect_uri checks, rate buckets keyed
-// on client_id), THAT is the moment to add storage and replace this
-// handler — adding it speculatively now would be vestigial state.
-//
-// Per RFC 7591:
-//   - §3.1 request is a JSON object with client metadata
-//   - §3.2.1 success response is 201 Created with the same JSON object
-//     augmented with `client_id` (required) and `client_id_issued_at`
-//     (recommended)
-//   - §3.2.2 error response is 400 Bad Request with
-//     `error: invalid_client_metadata` (we only surface this for
-//     malformed JSON; everything else is accepted)
-//
-// Authentication: none. The endpoint is anonymous-open (RFC 7591 §2 —
-// "open registration"). The broker's IP rate limiter (ipRateLimit
-// middleware in server.go) caps the per-IP /register rate so a single
-// host can't flood the endpoint; cluster-wide rate limiting is a
-// future enhancement if the open posture turns out to be exploitable
-// at scale.
+// register implements RFC 7591 Dynamic Client Registration (MCP SDKs
+// require a registration_endpoint). redirect_uris are validated and
+// persisted so authorize can trust an MCP host's https callback.
 func (s *Server) register(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxRegisterBodySize+1))
 	if err != nil {
@@ -103,28 +66,36 @@ func (s *Server) register(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	// Broker-issued fields win over any caller-supplied client_id /
-	// client_id_issued_at in the request body. token_endpoint_auth_method
-	// is pinned to "none" because the broker's device-flow path is
-	// PKCE-only (no client_secret); echoing back the caller's value
-	// would let a misconfigured client think it needs a secret it
-	// will never get.
-	//
-	// grant_types is force-pinned to device_code for the same reason
-	// the broker pins token_endpoint_auth_method: it's the only grant
-	// type the token endpoint actually accepts. Echoing the caller's
-	// requested grant_types (e.g. ["authorization_code"]) would
-	// silently rubber-stamp a registration whose downstream auth
-	// dance is guaranteed to fail at /device/token. RFC 7591 §3.2.2
-	// further says the AS MUST respond with invalid_client_metadata
-	// when it does not allow a requested grant type; here we
-	// normalize rather than reject to keep the spec-following
-	// authorization_code-first MCP clients moving — they get a clear
-	// signal in the response about what the broker actually supports.
+	// Broker-issued fields win over caller-supplied values:
+	// auth-method pinned to "none" (PKCE-only, no client_secret) and
+	// grant_types to what the token endpoint actually accepts.
 	doc["client_id"] = clientID
 	doc["client_id_issued_at"] = s.clock().Unix()
 	doc["token_endpoint_auth_method"] = "none"
-	doc["grant_types"] = []string{"urn:ietf:params:oauth:grant-type:device_code"}
+	doc["grant_types"] = []string{"authorization_code", "urn:ietf:params:oauth:grant-type:device_code"}
+
+	// redirect_uris, when supplied, are validated and PERSISTED: the
+	// authorize leg trusts non-loopback redirects only for a client_id
+	// whose registration records them (the MCP-host path).
+	if uris, ok := doc["redirect_uris"]; ok {
+		redirectURIs, parseErr := parseRedirectURIs(uris)
+		if parseErr != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{
+				"error":             "invalid_redirect_uri",
+				"error_description": parseErr.Error(),
+			})
+			return
+		}
+		name, _ := doc["client_name"].(string)
+		if regErr := s.dynamicClients.Register(r.Context(), clientID, redirectURIs, name); regErr != nil {
+			s.log.ErrorContext(r.Context(), "broker: register: persist registration failed", "err", regErr)
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+				"error":             "invalid_client_metadata",
+				"error_description": "registration could not be persisted; try again",
+			})
+			return
+		}
+	}
 	// Cache-Control: no-store mirrors the OAuth token-endpoint
 	// posture from RFC 6749 §5.1 — the response carries a freshly
 	// minted credential-shaped identifier and should never be cached
@@ -132,6 +103,28 @@ func (s *Server) register(w http.ResponseWriter, r *http.Request) {
 	// credential-issuing endpoint hygiene says set it anyway.
 	w.Header().Set("Cache-Control", "no-store")
 	writeJSON(w, http.StatusCreated, doc)
+}
+
+// parseRedirectURIs decodes and validates RFC 7591 redirect_uris:
+// a non-empty JSON string array whose entries are https URLs or http
+// loopback, with no userinfo and no fragment.
+func parseRedirectURIs(raw any) ([]string, error) {
+	list, ok := raw.([]any)
+	if !ok || len(list) == 0 {
+		return nil, fmt.Errorf("redirect_uris must be a non-empty array of strings")
+	}
+	uris := make([]string, 0, len(list))
+	for _, entry := range list {
+		u, ok := entry.(string)
+		if !ok {
+			return nil, fmt.Errorf("redirect_uris must be a non-empty array of strings")
+		}
+		if err := validateClientRedirectURI(u); err != nil {
+			return nil, err
+		}
+		uris = append(uris, u)
+	}
+	return uris, nil
 }
 
 // newClientID returns a fresh base64url-encoded random client_id. The

--- a/tools/internal/broker/register_test.go
+++ b/tools/internal/broker/register_test.go
@@ -80,8 +80,8 @@ func TestRegister(t *testing.T) {
 				t.Errorf("token_endpoint_auth_method = %v, want \"none\"", got["token_endpoint_auth_method"])
 			}
 			grants, _ := got["grant_types"].([]any)
-			if len(grants) != 1 || grants[0] != "urn:ietf:params:oauth:grant-type:device_code" {
-				t.Errorf("grant_types = %v, want [\"urn:ietf:params:oauth:grant-type:device_code\"]", got["grant_types"])
+			if len(grants) != 2 || grants[0] != "authorization_code" || grants[1] != "urn:ietf:params:oauth:grant-type:device_code" {
+				t.Errorf("grant_types = %v, want [authorization_code, device_code]", got["grant_types"])
 			}
 			if cc := resp.Header.Get("Cache-Control"); cc != "no-store" {
 				t.Errorf("Cache-Control = %q, want \"no-store\"", cc)
@@ -157,8 +157,8 @@ func TestRegisterBrokerFieldsOverrideRequest(t *testing.T) {
 		t.Errorf("token_endpoint_auth_method = %v, want \"none\"", got["token_endpoint_auth_method"])
 	}
 	grants, _ := got["grant_types"].([]any)
-	if len(grants) != 1 || grants[0] != "urn:ietf:params:oauth:grant-type:device_code" {
-		t.Errorf("grant_types = %v, want force-pinned to device_code only", got["grant_types"])
+	if len(grants) != 2 || grants[0] != "authorization_code" || grants[1] != "urn:ietf:params:oauth:grant-type:device_code" {
+		t.Errorf("grant_types = %v, want force-pinned to the broker's supported grants", got["grant_types"])
 	}
 }
 

--- a/tools/internal/broker/server.go
+++ b/tools/internal/broker/server.go
@@ -49,6 +49,10 @@ type Server struct {
 	// injects one SecretStore shared with the write-token store.
 	refreshStore *RefreshStore
 
+	// dynamicClients persists RFC 7591 registrations so the authorize
+	// leg can trust an MCP host's registered https redirect URIs.
+	dynamicClients *DynamicClientStore
+
 	// idTokenSigner mints broker-signed id_tokens on the
 	// /device/token refresh-grant path and serves its public key at
 	// /.well-known/jwks.json. May be nil in tests that don't
@@ -168,6 +172,7 @@ func NewServer(cfg *Config, signer *Signer, verifier Verifier, store SecretStore
 		deviceStore:       newDeviceStore(clock, deviceTTL, pollInterval),
 		authCodeStore:     newAuthCodeStore(clock, defaultPendingAuthCodeTTL, defaultAuthCodeTTL),
 		refreshStore:      NewRefreshStore(cfg, store),
+		dynamicClients:    NewDynamicClientStore(cfg, store),
 		worldWriteTokens:  newWorldWriteTokenStore(cfg, store),
 		trustForwardedFor: cfg.RateLimit.TrustForwardedFor,
 	}

--- a/tools/internal/broker/server.go
+++ b/tools/internal/broker/server.go
@@ -148,6 +148,9 @@ func NewServer(cfg *Config, signer *Signer, verifier Verifier, store SecretStore
 	if cfg.Server.RefreshTokensSecret == "" {
 		cfg.Server.RefreshTokensSecret = defaultRefreshTokensSecret
 	}
+	if cfg.Server.DynamicClientsSecret == "" {
+		cfg.Server.DynamicClientsSecret = defaultDynamicClientsSecret
+	}
 	if cfg.Server.RefreshTokenTTL <= 0 {
 		cfg.Server.RefreshTokenTTL = defaultRefreshTokenTTL
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added persistent dynamic client registration for authorization-code and device-code flows.
  - Registered clients support validated HTTPS or loopback redirect URIs with exact matching.
  - Registrations persist across restarts, expire automatically, and enforce storage limits.
  - Helm deployments now provision retained registration storage with configurable naming.

- **Bug Fixes**
  - Improved handling of missing, mismatched, or unavailable registrations.
  - Strengthened redirect URI validation and authorization checks.
  - Added scoped access controls for registration storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->