### PR TITLE
fix(broker): resolve tenants by identity, pin slug across email changes

### DIFF
--- a/tools/internal/broker/authz.go
+++ b/tools/internal/broker/authz.go
@@ -91,6 +91,15 @@ func (errAmbiguousTenant) Error() string {
 // (identity = world): zero matches is ErrNotAuthorized, two or more is a
 // provisioning error and denies closed rather than guessing.
 func tenantWorldFor(cfg *Config, claims *Claims) (WorldConfig, error) {
+	// Identity index first: a provisioned tenant owns its pinned slug. A
+	// hit whose Allow rejects the caller means the record's email is
+	// stale; fail so EnsureTenant's slow path refreshes it.
+	if slug, ok := cfg.tenantSlugForIdentity(identityKey(cfg.OIDC.Issuer, claims.Subject)); ok {
+		if w, found := cfg.FindWorld(slug); found && worldAllows(&w.Allow, claims) {
+			return w, nil
+		}
+		return WorldConfig{}, ErrNotAuthorized
+	}
 	var match *WorldConfig
 	worlds := cfg.AllWorlds()
 	for j := range worlds {

--- a/tools/internal/broker/config.go
+++ b/tools/internal/broker/config.go
@@ -35,6 +35,9 @@ type Config struct {
 	// goes through AllWorlds / FindWorld so both sets are visible.
 	dynamicMu     sync.RWMutex
 	dynamicWorlds []WorldConfig
+	// dynamicTenants maps identityKey(issuer, subject) to the pinned
+	// slug, so tenant resolution survives email changes.
+	dynamicTenants map[string]string
 }
 
 // AllWorlds returns a snapshot of static plus dynamic worlds. The
@@ -65,9 +68,10 @@ func (c *Config) FindWorld(name string) (WorldConfig, bool) {
 	return WorldConfig{}, false
 }
 
-// SetDynamicWorlds replaces the dynamic tenant set. Static names win on
-// collision: a registry entry shadowing a static world is dropped.
-func (c *Config) SetDynamicWorlds(worlds []WorldConfig) {
+// SetDynamicWorlds replaces the dynamic tenant set and its identity
+// index (identityKey -> slug). Static names win on collision: a
+// registry entry shadowing a static world is dropped from both.
+func (c *Config) SetDynamicWorlds(worlds []WorldConfig, tenants map[string]string) {
 	static := make(map[string]bool, len(c.Worlds))
 	for j := range c.Worlds {
 		static[c.Worlds[j].Name] = true
@@ -78,9 +82,25 @@ func (c *Config) SetDynamicWorlds(worlds []WorldConfig) {
 			filtered = append(filtered, worlds[j])
 		}
 	}
+	index := make(map[string]string, len(tenants))
+	for key, slug := range tenants {
+		if !static[slug] {
+			index[key] = slug
+		}
+	}
 	c.dynamicMu.Lock()
 	c.dynamicWorlds = filtered
+	c.dynamicTenants = index
 	c.dynamicMu.Unlock()
+}
+
+// tenantSlugForIdentity resolves a provisioned identity to its pinned
+// world slug via the dynamic tenant index.
+func (c *Config) tenantSlugForIdentity(key string) (string, bool) {
+	c.dynamicMu.RLock()
+	defer c.dynamicMu.RUnlock()
+	slug, ok := c.dynamicTenants[key]
+	return slug, ok
 }
 
 // StorageConfig selects the credential-persistence backend. "kubernetes"

--- a/tools/internal/broker/mcp_tenant_test.go
+++ b/tools/internal/broker/mcp_tenant_test.go
@@ -457,6 +457,46 @@ func TestTenantGateProvisionsFirstArrival(t *testing.T) {
 	}
 }
 
+// TestTenantGateEmailChangeResolvesSameWorld: after an email change the
+// gate serves the ORIGINAL world (one slow-path refresh, then the
+// resolver fast path with no further EnsureTenant).
+func TestTenantGateEmailChangeResolvesSameWorld(t *testing.T) {
+	cfg := provisioningTestConfig(ProvisionOpen)
+	d := seededDispatcher()
+	g, buckets := memoryGatewayWithProvisioning(t, cfg, d)
+	h := g.tenantGate(g.toolHandlers()["mark_worlds"])
+
+	res, err := h(ctxWithClaims(context.Background(), eveClaims()), callToolReq("mark_worlds", nil))
+	if err != nil || res.IsError {
+		t.Fatalf("first arrival: err=%v res=%s", err, toolResultText(t, res))
+	}
+	slug := tenantSlug(cfg.OIDC.Issuer, "google|eve-123", "eve.adams@example.com")
+
+	moved := &Claims{Subject: "google|eve-123", Email: "Eve.Moved@elsewhere.io", EmailVerified: true}
+	res, err = h(ctxWithClaims(context.Background(), moved), callToolReq("mark_worlds", nil))
+	if err != nil || res.IsError {
+		t.Fatalf("post-change call: err=%v res=%s", err, toolResultText(t, res))
+	}
+	text := toolResultText(t, res)
+	if !strings.Contains(text, slug) {
+		t.Errorf("mark_worlds after email change = %q, want the original slug %q", text, slug)
+	}
+	if strings.Contains(text, "eve-moved-") {
+		t.Errorf("email change provisioned a second world: %q", text)
+	}
+
+	// Third call must ride the resolver fast path: the refresh already
+	// converged, so EnsureTenant (and its bucket re-ensure) stays idle.
+	ensured := len(buckets.created)
+	res, err = h(ctxWithClaims(context.Background(), moved), callToolReq("mark_worlds", nil))
+	if err != nil || res.IsError {
+		t.Fatalf("fast-path call: err=%v res=%s", err, toolResultText(t, res))
+	}
+	if len(buckets.created) != ensured {
+		t.Errorf("fast path re-ran EnsureTenant: bucket ensures %d -> %d", ensured, len(buckets.created))
+	}
+}
+
 // TestTenantGateProvisioningNotReadyMessage: when the backend has not
 // picked the new world up yet, the caller gets a clear retry message
 // instead of a transport error.

--- a/tools/internal/broker/provisioner.go
+++ b/tools/internal/broker/provisioner.go
@@ -200,9 +200,36 @@ func (p *Provisioner) DeprovisionTenant(ctx context.Context, slug string, delete
 	return found, nil
 }
 
-// applySnapshot publishes a registry snapshot to this pod's world set.
+// applySnapshot publishes a registry snapshot to this pod's world set
+// and identity index.
 func (p *Provisioner) applySnapshot(registry *tenantRegistry) {
-	p.cfg.SetDynamicWorlds(p.worldsFromRegistry(registry))
+	p.cfg.SetDynamicWorlds(p.worldsFromRegistry(registry), tenantIndexFromRegistry(registry))
+}
+
+// tenantIndexFromRegistry projects live records to identityKey -> slug;
+// tombstoned records stay out so a deprovision denies via the slow path.
+func tenantIndexFromRegistry(registry *tenantRegistry) map[string]string {
+	index := make(map[string]string, len(registry.Tenants))
+	for slug, record := range registry.Tenants {
+		if record.Deleting {
+			continue
+		}
+		index[identityKey(record.Issuer, record.Subject)] = slug
+	}
+	return index
+}
+
+// findTenantByIdentity resolves a registry record by stable identity;
+// the returned slug is the world name pinned at provision time. Slug
+// order keeps legacy duplicate-identity registries deterministic.
+func findTenantByIdentity(registry *tenantRegistry, issuer, subject string) (string, tenantRecord, bool) {
+	for _, slug := range sortedSlugs(registry) {
+		record := registry.Tenants[slug]
+		if record.Issuer == issuer && record.Subject == subject {
+			return slug, record, true
+		}
+	}
+	return "", tenantRecord{}, false
 }
 
 func (c *Config) registryRef() SecretRef {
@@ -292,7 +319,7 @@ func (p *Provisioner) admits(claims *Claims) error {
 
 // EnsureTenant provisions (or converges) the caller's world and returns
 // its broker-side WorldConfig. Every step is idempotent and keyed by
-// the identity-derived slug; any replica can re-run it safely.
+// the slug pinned in the registry; any replica can re-run it safely.
 func (p *Provisioner) EnsureTenant(ctx context.Context, claims *Claims) (WorldConfig, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -304,21 +331,27 @@ func (p *Provisioner) EnsureTenant(ctx context.Context, claims *Claims) (WorldCo
 
 	email := canonicalEmail(claims.Email)
 	issuer := p.cfg.OIDC.Issuer
-	slug := tenantSlug(issuer, claims.Subject, email)
-	worldID := tenantWorldID(issuer, claims.Subject)
 
-	// Step 1: registry entry (the create decision lives here, under the
-	// Secret's optimistic concurrency).
+	// Step 1: registry entry, under the Secret's optimistic concurrency.
+	// Lookup is by identity, never the recomputed slug: an email change
+	// refreshes the record instead of orphaning the world.
 	var snapshot tenantRegistry
+	var slug string
 	created := false
 	err := p.store.Mutate(ctx, p.cfg.registryRef(), func(existing []byte) ([]byte, error) {
 		registry, decodeErr := decodeRegistry(existing)
 		if decodeErr != nil {
 			return nil, decodeErr
 		}
-		if record, ok := registry.Tenants[slug]; ok {
+		created = false
+		if found, record, ok := findTenantByIdentity(&registry, issuer, claims.Subject); ok {
 			if record.Deleting {
 				return nil, ErrTenantDeprovisioning
+			}
+			slug = found
+			if record.Email != email {
+				record.Email = email
+				registry.Tenants[slug] = record
 			}
 		} else {
 			if gateErr := p.admits(claims); gateErr != nil {
@@ -328,11 +361,12 @@ func (p *Provisioner) EnsureTenant(ctx context.Context, claims *Claims) (WorldCo
 			if maxTenants > 0 && len(registry.Tenants) >= maxTenants {
 				return nil, ErrTenantCapacity
 			}
+			slug = tenantSlug(issuer, claims.Subject, email)
 			registry.Tenants[slug] = tenantRecord{
 				Email:   email,
 				Issuer:  issuer,
 				Subject: claims.Subject,
-				WorldID: worldID,
+				WorldID: tenantWorldID(issuer, claims.Subject),
 				Created: p.clock().UTC().Format(time.RFC3339),
 			}
 			created = true

--- a/tools/internal/broker/provisioner.go
+++ b/tools/internal/broker/provisioner.go
@@ -206,30 +206,45 @@ func (p *Provisioner) applySnapshot(registry *tenantRegistry) {
 	p.cfg.SetDynamicWorlds(p.worldsFromRegistry(registry), tenantIndexFromRegistry(registry))
 }
 
-// tenantIndexFromRegistry projects live records to identityKey -> slug;
+// tenantIndexFromRegistry projects live records to identityKey -> slug.
+// First live slug in sorted order wins (matches findTenantByIdentity);
 // tombstoned records stay out so a deprovision denies via the slow path.
 func tenantIndexFromRegistry(registry *tenantRegistry) map[string]string {
 	index := make(map[string]string, len(registry.Tenants))
-	for slug, record := range registry.Tenants {
+	for _, slug := range sortedSlugs(registry) {
+		record := registry.Tenants[slug]
 		if record.Deleting {
 			continue
 		}
-		index[identityKey(record.Issuer, record.Subject)] = slug
+		key := identityKey(record.Issuer, record.Subject)
+		if _, ok := index[key]; !ok {
+			index[key] = slug
+		}
 	}
 	return index
 }
 
 // findTenantByIdentity resolves a registry record by stable identity;
-// the returned slug is the world name pinned at provision time. Slug
-// order keeps legacy duplicate-identity registries deterministic.
+// the slug is the world name pinned at provision time. First sorted
+// live slug wins (matches the index); tombstoned only when none live.
 func findTenantByIdentity(registry *tenantRegistry, issuer, subject string) (string, tenantRecord, bool) {
+	var tombSlug string
+	var tombRecord tenantRecord
+	tombFound := false
 	for _, slug := range sortedSlugs(registry) {
 		record := registry.Tenants[slug]
-		if record.Issuer == issuer && record.Subject == subject {
-			return slug, record, true
+		if record.Issuer != issuer || record.Subject != subject {
+			continue
 		}
+		if record.Deleting {
+			if !tombFound {
+				tombSlug, tombRecord, tombFound = slug, record, true
+			}
+			continue
+		}
+		return slug, record, true
 	}
-	return "", tenantRecord{}, false
+	return tombSlug, tombRecord, tombFound
 }
 
 func (c *Config) registryRef() SecretRef {

--- a/tools/internal/broker/provisioner_test.go
+++ b/tools/internal/broker/provisioner_test.go
@@ -3,6 +3,7 @@ package broker
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"os"
@@ -378,13 +379,86 @@ func TestEnsureTenantTombstonedDeniedAfterEmailChange(t *testing.T) {
 	}
 	// Crash the deprovision after phase 1 so the tombstone persists.
 	failing.hook = func() { panic(errAbortMutate) }
+	var recovered any
+	var deprovisionErr error
 	func() {
-		defer func() { _ = recover() }()
-		_, _ = p.DeprovisionTenant(context.Background(), world.Name, false)
+		defer func() { recovered = recover() }()
+		_, deprovisionErr = p.DeprovisionTenant(context.Background(), world.Name, false)
 	}()
+	if recoveredErr, ok := recovered.(error); !ok || !errors.Is(recoveredErr, errAbortMutate) {
+		t.Fatalf("recovered %v (deprovision err %v), want the injected abort panic", recovered, deprovisionErr)
+	}
 
 	if _, err := p.EnsureTenant(context.Background(), movedEveClaims()); !errors.Is(err, ErrTenantDeprovisioning) {
 		t.Fatalf("err = %v, want ErrTenantDeprovisioning", err)
+	}
+}
+
+// TestLegacyDuplicateIdentityResolvesDeterministically: two records for
+// one identity (the pre-pinning orphan bug) resolve identically on both
+// paths; tombstoning the pinned duplicate moves both to the live one.
+func TestLegacyDuplicateIdentityResolvesDeterministically(t *testing.T) {
+	cfg := provisioningTestConfig(ProvisionOpen)
+	store := newProvisionerStore()
+	p := newTestProvisioner(cfg, store, &fakeBuckets{})
+
+	seedRegistry := func(registry *tenantRegistry) {
+		encoded, err := json.Marshal(registry)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Mutate(context.Background(), cfg.registryRef(), func([]byte) ([]byte, error) {
+			return encoded, nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	record := func(email string, deleting bool) tenantRecord {
+		return tenantRecord{
+			Email: email, Issuer: cfg.OIDC.Issuer, Subject: "google|eve-123",
+			WorldID: tenantWorldID(cfg.OIDC.Issuer, "google|eve-123"), Deleting: deleting,
+		}
+	}
+	seedRegistry(&tenantRegistry{Tenants: map[string]tenantRecord{
+		"a-eve-0000": record("eve.adams@example.com", false),
+		"b-eve-1111": record("eve.old@example.com", false),
+	}})
+
+	// Both paths pin the first sorted slug.
+	world, err := p.EnsureTenant(context.Background(), eveClaims())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if world.Name != "a-eve-0000" {
+		t.Errorf("EnsureTenant resolved %q, want the first sorted slug a-eve-0000", world.Name)
+	}
+	w, err := tenantWorldFor(cfg, eveClaims())
+	if err != nil {
+		t.Fatalf("tenantWorldFor: %v", err)
+	}
+	if w.Name != world.Name {
+		t.Errorf("fast path resolved %q, EnsureTenant %q", w.Name, world.Name)
+	}
+
+	// Tombstoning the pinned duplicate (the orphan-cleanup flow) moves
+	// resolution to the live record instead of denying the tenant.
+	seedRegistry(&tenantRegistry{Tenants: map[string]tenantRecord{
+		"a-eve-0000": record("eve.adams@example.com", true),
+		"b-eve-1111": record("eve.old@example.com", false),
+	}})
+	world, err = p.EnsureTenant(context.Background(), eveClaims())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if world.Name != "b-eve-1111" {
+		t.Errorf("EnsureTenant with tombstoned duplicate resolved %q, want b-eve-1111", world.Name)
+	}
+	w, err = tenantWorldFor(cfg, eveClaims())
+	if err != nil {
+		t.Fatalf("tenantWorldFor with tombstoned duplicate: %v", err)
+	}
+	if w.Name != world.Name {
+		t.Errorf("fast path resolved %q, EnsureTenant %q", w.Name, world.Name)
 	}
 }
 

--- a/tools/internal/broker/provisioner_test.go
+++ b/tools/internal/broker/provisioner_test.go
@@ -15,8 +15,10 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 // provisionerStore backs provisioner tests with the real Kubernetes
@@ -185,6 +187,204 @@ func TestEnsureTenantProvisionsAndConverges(t *testing.T) {
 	registry := string(store.get(cfg.registryRef()))
 	if strings.Count(registry, `"email"`) != 1 {
 		t.Errorf("registry has duplicate tenants:\n%s", registry)
+	}
+}
+
+// movedEveClaims is eve after an email change touching both the local
+// part and the domain: the recomputed slug would differ entirely.
+func movedEveClaims() *Claims {
+	return &Claims{Subject: "google|eve-123", Email: "Eve.Moved@elsewhere.io", EmailVerified: true}
+}
+
+// registryUpdateCount counts Secret update writes against the tenant
+// registry, so tests can assert exactly when a refresh persists.
+func registryUpdateCount(store *provisionerStore, cfg *Config) int {
+	count := 0
+	for _, action := range store.clientset.Actions() {
+		update, ok := action.(k8stesting.UpdateAction)
+		if !ok || action.GetVerb() != "update" {
+			continue
+		}
+		secret, ok := update.GetObject().(*corev1.Secret)
+		if !ok || secret.Name != cfg.Provisioning.RegistrySecret {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+// TestEnsureTenantEmailChangeKeepsWorld: an email change (new local
+// part AND domain) resolves to the ORIGINAL world; no second world
+// appears anywhere and the record's email is refreshed.
+func TestEnsureTenantEmailChangeKeepsWorld(t *testing.T) {
+	cfg := provisioningTestConfig(ProvisionOpen)
+	store := newProvisionerStore()
+	p := newTestProvisioner(cfg, store, &fakeBuckets{})
+	original, err := p.EnsureTenant(context.Background(), eveClaims())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	world, err := p.EnsureTenant(context.Background(), movedEveClaims())
+	if err != nil {
+		t.Fatalf("EnsureTenant after email change: %v", err)
+	}
+	if world.Name != original.Name {
+		t.Errorf("email change moved the world: %q -> %q", original.Name, world.Name)
+	}
+	if len(world.Allow.Emails) != 1 || world.Allow.Emails[0] != "eve.moved@elsewhere.io" {
+		t.Errorf("returned world allow = %+v, want the new canonical email", world.Allow)
+	}
+
+	registry := string(store.get(cfg.registryRef()))
+	if strings.Count(registry, `"email"`) != 1 {
+		t.Errorf("email change duplicated the tenant:\n%s", registry)
+	}
+	if !strings.Contains(registry, "eve.moved@elsewhere.io") || strings.Contains(registry, "eve.adams@example.com") {
+		t.Errorf("record email not refreshed:\n%s", registry)
+	}
+	fragment := string(store.get(cfg.worldsFragmentRef()))
+	if strings.Count(fragment, "name: ") != 1 {
+		t.Errorf("email change grew the fragment:\n%s", fragment)
+	}
+	// Dynamic world set converged on the new email for this pod.
+	w, ok := cfg.FindWorld(original.Name)
+	if !ok {
+		t.Fatal("original world missing from dynamic set")
+	}
+	if len(w.Allow.Emails) != 1 || w.Allow.Emails[0] != "eve.moved@elsewhere.io" {
+		t.Errorf("dynamic world allow = %+v, want the new email", w.Allow)
+	}
+}
+
+// TestEnsureTenantEmailRefreshOnceThenFastPath: the refresh writes the
+// registry exactly once, after which tenantWorldFor resolves the tenant
+// without EnsureTenant.
+func TestEnsureTenantEmailRefreshOnceThenFastPath(t *testing.T) {
+	cfg := provisioningTestConfig(ProvisionOpen)
+	store := newProvisionerStore()
+	p := newTestProvisioner(cfg, store, &fakeBuckets{})
+	if _, err := p.EnsureTenant(context.Background(), eveClaims()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stale record: identity index hits but Allow rejects the new email,
+	// denying so the slow path runs once and refreshes.
+	if _, err := tenantWorldFor(cfg, movedEveClaims()); !errors.Is(err, ErrNotAuthorized) {
+		t.Fatalf("pre-refresh tenantWorldFor err = %v, want ErrNotAuthorized", err)
+	}
+
+	before := registryUpdateCount(store, cfg)
+	world, err := p.EnsureTenant(context.Background(), movedEveClaims())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := registryUpdateCount(store, cfg); got != before+1 {
+		t.Errorf("registry updates during refresh = %d, want exactly 1", got-before)
+	}
+
+	// Fast path: the resolver answers by identity index, no provisioner.
+	w, err := tenantWorldFor(cfg, movedEveClaims())
+	if err != nil {
+		t.Fatalf("post-refresh tenantWorldFor: %v", err)
+	}
+	if w.Name != world.Name {
+		t.Errorf("fast path world = %q, want %q", w.Name, world.Name)
+	}
+
+	// A repeat EnsureTenant is a no-op on the registry.
+	after := registryUpdateCount(store, cfg)
+	if _, err := p.EnsureTenant(context.Background(), movedEveClaims()); err != nil {
+		t.Fatal(err)
+	}
+	if got := registryUpdateCount(store, cfg); got != after {
+		t.Errorf("converged EnsureTenant wrote the registry %d more times", got-after)
+	}
+}
+
+// TestEnsureTenantSharedLocalPartDistinctWorlds: two identities whose
+// emails share a local part keep distinct worlds and resolve to their
+// own.
+func TestEnsureTenantSharedLocalPartDistinctWorlds(t *testing.T) {
+	cfg := provisioningTestConfig(ProvisionOpen)
+	store := newProvisionerStore()
+	p := newTestProvisioner(cfg, store, &fakeBuckets{})
+	eveWorld, err := p.EnsureTenant(context.Background(), eveClaims())
+	if err != nil {
+		t.Fatal(err)
+	}
+	twin := &Claims{Subject: "google|mallory", Email: "eve.adams@other.org", EmailVerified: true}
+	twinWorld, err := p.EnsureTenant(context.Background(), twin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if twinWorld.Name == eveWorld.Name {
+		t.Fatalf("shared local part collapsed two identities into %q", eveWorld.Name)
+	}
+	w, err := tenantWorldFor(cfg, twin)
+	if err != nil {
+		t.Fatalf("tenantWorldFor(twin): %v", err)
+	}
+	if w.Name != twinWorld.Name {
+		t.Errorf("twin resolved to %q, want %q", w.Name, twinWorld.Name)
+	}
+}
+
+// TestEnsureTenantRaceEmailChangeConverges: two provisioners racing on
+// one identity, one carrying a changed email, converge on one slug.
+func TestEnsureTenantRaceEmailChangeConverges(t *testing.T) {
+	cfg := provisioningTestConfig(ProvisionOpen)
+	raw := newProvisionerStore()
+	hooked := &hookedStore{SecretStore: raw, ref: cfg.registryRef()}
+	p := newTestProvisioner(cfg, hooked, &fakeBuckets{})
+	sibling := newTestProvisioner(provisioningTestConfig(ProvisionOpen), raw, &fakeBuckets{})
+
+	// Right before p's registry mutate: the sibling provisions eve under
+	// her original email, so p's create decision must become a hit.
+	var originalWorld WorldConfig
+	hooked.hook = func() {
+		var hookErr error
+		if originalWorld, hookErr = sibling.EnsureTenant(context.Background(), eveClaims()); hookErr != nil {
+			t.Errorf("racing EnsureTenant(original email): %v", hookErr)
+		}
+	}
+	world, err := p.EnsureTenant(context.Background(), movedEveClaims())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if world.Name != originalWorld.Name {
+		t.Errorf("race produced two slugs: %q vs %q", world.Name, originalWorld.Name)
+	}
+	registry := string(raw.get(cfg.registryRef()))
+	if strings.Count(registry, `"email"`) != 1 {
+		t.Errorf("race duplicated the tenant:\n%s", registry)
+	}
+	if !strings.Contains(registry, "eve.moved@elsewhere.io") {
+		t.Errorf("race lost the email refresh:\n%s", registry)
+	}
+}
+
+// TestEnsureTenantTombstonedDeniedAfterEmailChange: the tombstone still
+// blocks re-provisioning when the caller's email has changed.
+func TestEnsureTenantTombstonedDeniedAfterEmailChange(t *testing.T) {
+	cfg := provisioningTestConfig(ProvisionOpen)
+	raw := newProvisionerStore()
+	failing := &hookedStore{SecretStore: raw, ref: cfg.worldsFragmentRef()}
+	p := newTestProvisioner(cfg, failing, &fakeBuckets{})
+	world, err := p.EnsureTenant(context.Background(), eveClaims())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Crash the deprovision after phase 1 so the tombstone persists.
+	failing.hook = func() { panic(errAbortMutate) }
+	func() {
+		defer func() { _ = recover() }()
+		_, _ = p.DeprovisionTenant(context.Background(), world.Name, false)
+	}()
+
+	if _, err := p.EnsureTenant(context.Background(), movedEveClaims()); !errors.Is(err, ErrTenantDeprovisioning) {
+		t.Fatalf("err = %v, want ErrTenantDeprovisioning", err)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tenant access remains linked to the originally provisioned workspace when an email address changes.
  - Different identities sharing an email address are handled separately.
  - Tenant records refresh automatically when identity details change.

- **Bug Fixes**
  - Prevented duplicate workspace creation during email changes or concurrent provisioning.
  - Blocked reprovisioning for deactivated tenants.
  - Improved authorization for explicitly assigned tenants, denying access when assignment rules are not satisfied.
  - Ensured legacy tenant records resolve consistently without creating duplicate workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->