### PR TITLE
feat(knowledge-server): bootstrap per-world token secrets 

### DIFF
--- a/deploy/helm/demarkus-knowledge-server/README.md
+++ b/deploy/helm/demarkus-knowledge-server/README.md
@@ -9,12 +9,20 @@ stores each world in its own pre-provisioned GCS bucket.
 - Kubernetes 1.25+
 - GKE Workload Identity, or an existing Kubernetes ServiceAccount with equivalent identity
 - One initialized GCS bucket and immutable world ID per world
-- One existing token Secret per world
 - One existing multi-SAN TLS Secret, or cert-manager and a suitable Issuer
 - Policy document at `/.well-known/demarkus/policy.md` in every bucket
 
-The chart never creates buckets, PVCs, token Secrets, or TLS Secrets. The
-optional `Certificate` asks cert-manager to populate the referenced TLS Secret.
+The chart never creates buckets, PVCs, or TLS Secrets. The optional
+`Certificate` asks cert-manager to populate the referenced TLS Secret.
+
+Token Secrets are runtime-owned (the broker appends minted hashes to
+`tokens.toml`), so the chart never templates them either. Instead a
+pre-install/pre-upgrade bootstrap Job (`tokens.bootstrap`, enabled by
+default) creates any missing `<world>.tokenSecret` with a publish-only
+admin entry and hands off; existing Secrets are left untouched. With
+`tokens.emitRawValues: true` it also writes the raw token to a
+`<world>-token-values` Secret. Disable `tokens.bootstrap.enabled` to
+provision token Secrets some other way.
 
 Initialize each bucket with `demarkus-knowledge-bootstrap -bucket gs://<bucket>
 -world-id <uuid> -policy-file <policy.md>`, which writes the world skeleton and

--- a/deploy/helm/demarkus-knowledge-server/README.md
+++ b/deploy/helm/demarkus-knowledge-server/README.md
@@ -22,7 +22,9 @@ default) creates any missing `<world>.tokenSecret` with a publish-only
 admin entry and hands off; existing Secrets are left untouched. With
 `tokens.emitRawValues: true` it also writes the raw token to a
 `<world>-token-values` Secret. Disable `tokens.bootstrap.enabled` to
-provision token Secrets some other way.
+provision token Secrets some other way. The Job's `tokens.bootstrap.image`
+defaults to kubectl 1.35, which supports API servers 1.34–1.36; override it
+to match older clusters (kubectl's skew policy is ±1 minor).
 
 Initialize each bucket with `demarkus-knowledge-bootstrap -bucket gs://<bucket>
 -world-id <uuid> -policy-file <policy.md>`, which writes the world skeleton and

--- a/deploy/helm/demarkus-knowledge-server/templates/_helpers.tpl
+++ b/deploy/helm/demarkus-knowledge-server/templates/_helpers.tpl
@@ -201,6 +201,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- fail (printf "%s.tokenSecret.key is required" $location) -}}
 {{- end -}}
 {{- end -}}
+{{- /* The bootstrap Job generates one <world>-token-values Secret per world;
+       a primary tokenSecret.name colliding with any generated name would make
+       the world mount raw, non-TOML content. */ -}}
+{{- if and .Values.tokens.bootstrap.enabled .Values.tokens.emitRawValues -}}
+{{- range $index, $world := .Values.worlds -}}
+{{- $rawName := printf "%s-token-values" $world.name -}}
+{{- if hasKey $tokenSecrets $rawName -}}
+{{- fail (printf "worlds[%d]: generated raw Secret name %q collides with a tokenSecret.name" $index $rawName) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/deploy/helm/demarkus-knowledge-server/templates/_helpers.tpl
+++ b/deploy/helm/demarkus-knowledge-server/templates/_helpers.tpl
@@ -202,13 +202,24 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 {{- /* The bootstrap Job generates one <world>-token-values Secret per world;
-       a primary tokenSecret.name colliding with any generated name would make
-       the world mount raw, non-TOML content. */ -}}
+       a generated name colliding with a tokenSecret.name or another
+       chart-owned Secret would hand a consumer the wrong data. */ -}}
 {{- if and .Values.tokens.bootstrap.enabled .Values.tokens.emitRawValues -}}
+{{- $reserved := dict -}}
+{{- if .Values.dynamicWorlds.enabled -}}
+{{- $_ := set $reserved .Values.dynamicWorlds.worldsSecret "dynamicWorlds.worldsSecret" -}}
+{{- $_ := set $reserved .Values.dynamicWorlds.tokensSecret "dynamicWorlds.tokensSecret" -}}
+{{- end -}}
+{{- if .Values.tls.existingSecret -}}
+{{- $_ := set $reserved .Values.tls.existingSecret "tls.existingSecret" -}}
+{{- end -}}
 {{- range $index, $world := .Values.worlds -}}
 {{- $rawName := printf "%s-token-values" $world.name -}}
 {{- if hasKey $tokenSecrets $rawName -}}
 {{- fail (printf "worlds[%d]: generated raw Secret name %q collides with a tokenSecret.name" $index $rawName) -}}
+{{- end -}}
+{{- if hasKey $reserved $rawName -}}
+{{- fail (printf "worlds[%d]: generated raw Secret name %q collides with %s" $index $rawName (get $reserved $rawName)) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/demarkus-knowledge-server/templates/_helpers.tpl
+++ b/deploy/helm/demarkus-knowledge-server/templates/_helpers.tpl
@@ -202,3 +202,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Admin token paths/operations, rendered as a quoted, comma-joined TOML array
+body (e.g. `"/**"` or `"publish"`). Used by the token-bootstrap Job to build
+the admin entry in tokens.toml.
+*/}}
+{{- define "demarkus-knowledge-server.tokenAdminPaths" -}}
+{{- range $i, $p := .Values.tokens.admin.paths }}{{ if $i }}, {{ end }}{{ $p | quote }}{{- end -}}
+{{- end -}}
+{{- define "demarkus-knowledge-server.tokenAdminOps" -}}
+{{- range $i, $o := .Values.tokens.admin.operations }}{{ if $i }}, {{ end }}{{ $o | quote }}{{- end -}}
+{{- end -}}

--- a/deploy/helm/demarkus-knowledge-server/templates/token-bootstrap.yaml
+++ b/deploy/helm/demarkus-knowledge-server/templates/token-bootstrap.yaml
@@ -1,0 +1,150 @@
+{{- if and .Values.tokens.bootstrap.enabled .Values.worlds }}
+{{- /* Token Secrets are runtime-owned, not desired-state: the broker appends
+       to tokens.toml and the admin hash must match the raw value, so a
+       reconciler must never template them. Ported from demarkus-server's
+       tokenBootstrap; loops every static world and skips existing Secrets. */}}
+{{- $sa := printf "%s-token-bootstrap" (include "demarkus-knowledge-server.fullname" .) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $sa }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "demarkus-knowledge-server.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-wave: "-10"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $sa }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "demarkus-knowledge-server.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-wave: "-10"
+rules:
+  # Bootstrap-only: read to detect an existing (runtime-owned) Secret and skip;
+  # create + annotate to write the initial pair. No update/delete — the Job
+  # never overwrites what the broker owns.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $sa }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "demarkus-knowledge-server.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-wave: "-10"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $sa }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $sa }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $sa }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "demarkus-knowledge-server.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-wave: "-5"
+spec:
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        {{- include "demarkus-knowledge-server.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ $sa }}
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        # fsGroup so the non-root user can write the scratch emptyDir below
+        # (kubectl wants a writable cache dir under a read-only root fs).
+        fsGroup: 65532
+      containers:
+        - name: bootstrap
+          image: {{ .Values.tokens.bootstrap.image | quote }}
+          imagePullPolicy: {{ .Values.tokens.bootstrap.imagePullPolicy | default "IfNotPresent" }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: scratch
+              mountPath: /tmp
+          env:
+            # HOME on the writable scratch volume → kubectl's cache/discovery
+            # writes succeed under readOnlyRootFilesystem.
+            - name: HOME
+              value: /tmp
+            - name: NS
+              value: {{ .Release.Namespace | quote }}
+            - name: LABEL
+              value: {{ .Values.tokens.admin.label | quote }}
+            # Explicit token (optional); empty ⇒ fresh 64-char token per world.
+            - name: EXPLICIT_TOKEN
+              value: {{ .Values.tokens.admin.token | quote }}
+            - name: EMIT_RAW
+              value: {{ .Values.tokens.emitRawValues | quote }}
+            # One "<world> <tokensSecret> <tomlKey>" triple per line.
+            - name: WORLDS
+              value: |-
+                {{- range .Values.worlds }}
+                {{ .name }} {{ .tokenSecret.name }} {{ .tokenSecret.key }}
+                {{- end }}
+          command: ["/bin/sh", "-eu", "-c"]
+          args:
+            - |
+              echo "$WORLDS" | while read -r WORLD SECRET KEY; do
+                [ -n "$WORLD" ] || continue
+                if kubectl -n "$NS" get secret "$SECRET" >/dev/null 2>&1; then
+                  echo "world $WORLD: tokens secret $SECRET exists; handing off to runtime owners (broker). no-op."
+                  continue
+                fi
+                TOKEN="$EXPLICIT_TOKEN"
+                if [ -z "$TOKEN" ]; then
+                  TOKEN=$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 64)
+                fi
+                HASH="sha256-$(printf %s "$TOKEN" | sha256sum | cut -d' ' -f1)"
+                TOML=$(printf '[tokens.%s]\nhash = "%s"\npaths = [{{ include "demarkus-knowledge-server.tokenAdminPaths" . }}]\noperations = [{{ include "demarkus-knowledge-server.tokenAdminOps" . }}]\n' "$LABEL" "$HASH")
+                kubectl -n "$NS" create secret generic "$SECRET" --from-literal="$KEY=$TOML"
+                kubectl -n "$NS" patch secret "$SECRET" -p '{"metadata":{"annotations":{"helm.sh/resource-policy":"keep"}}}'
+                if [ "$EMIT_RAW" = "true" ]; then
+                  kubectl -n "$NS" create secret generic "$WORLD-token-values" --from-literal="$LABEL=$TOKEN"
+                  kubectl -n "$NS" patch secret "$WORLD-token-values" -p '{"metadata":{"annotations":{"helm.sh/resource-policy":"keep","demarkus.io/raw-tokens":"true"}}}'
+                fi
+                echo "world $WORLD: bootstrapped $SECRET (emit-raw=$EMIT_RAW), hash $HASH."
+              done
+      volumes:
+        - name: scratch
+          emptyDir: {}
+{{- end }}

--- a/deploy/helm/demarkus-knowledge-server/templates/token-bootstrap.yaml
+++ b/deploy/helm/demarkus-knowledge-server/templates/token-bootstrap.yaml
@@ -1,3 +1,4 @@
+{{- include "demarkus-knowledge-server.validate" . -}}
 {{- if and .Values.tokens.bootstrap.enabled .Values.worlds }}
 {{- /* Token Secrets are runtime-owned: the broker appends to tokens.toml and
        the admin hash must match the raw value, so a reconciler must never
@@ -40,7 +41,9 @@ rules:
     resourceNames:
       {{- range .Values.worlds }}
       - {{ .tokenSecret.name | quote }}
+      {{- if $.Values.tokens.emitRawValues }}
       - {{ printf "%s-token-values" .name | quote }}
+      {{- end }}
       {{- end }}
   - apiGroups: [""]
     resources: ["secrets"]

--- a/deploy/helm/demarkus-knowledge-server/templates/token-bootstrap.yaml
+++ b/deploy/helm/demarkus-knowledge-server/templates/token-bootstrap.yaml
@@ -1,8 +1,7 @@
 {{- if and .Values.tokens.bootstrap.enabled .Values.worlds }}
-{{- /* Token Secrets are runtime-owned, not desired-state: the broker appends
-       to tokens.toml and the admin hash must match the raw value, so a
-       reconciler must never template them. Ported from demarkus-server's
-       tokenBootstrap; loops every static world and skips existing Secrets. */}}
+{{- /* Token Secrets are runtime-owned: the broker appends to tokens.toml and
+       the admin hash must match the raw value, so a reconciler must never
+       template them; this Job creates missing ones and hands off. */}}
 {{- $sa := printf "%s-token-bootstrap" (include "demarkus-knowledge-server.fullname" .) -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -32,12 +31,20 @@ metadata:
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/sync-wave: "-10"
 rules:
-  # Bootstrap-only: read to detect an existing (runtime-owned) Secret and skip;
-  # create + annotate to write the initial pair. No update/delete — the Job
-  # never overwrites what the broker owns.
+  # Bootstrap-only: get/patch scoped to the world token Secrets; create in a
+  # separate unscoped rule (RBAC cannot restrict creates by resourceNames).
+  # No update/delete — the Job never overwrites what the broker owns.
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "create", "patch"]
+    verbs: ["get", "patch"]
+    resourceNames:
+      {{- range .Values.worlds }}
+      - {{ .tokenSecret.name | quote }}
+      - {{ printf "%s-token-values" .name | quote }}
+      {{- end }}
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -126,22 +133,35 @@ spec:
             - |
               echo "$WORLDS" | while read -r WORLD SECRET KEY; do
                 [ -n "$WORLD" ] || continue
-                if kubectl -n "$NS" get secret "$SECRET" >/dev/null 2>&1; then
+                # Plain assignment so an API/auth error exits non-zero and
+                # fails the Job (set -e); only a clean empty result proceeds.
+                EXISTING=$(kubectl -n "$NS" get secret "$SECRET" --ignore-not-found -o name)
+                if [ -n "$EXISTING" ]; then
                   echo "world $WORLD: tokens secret $SECRET exists; handing off to runtime owners (broker). no-op."
                   continue
                 fi
                 TOKEN="$EXPLICIT_TOKEN"
-                if [ -z "$TOKEN" ]; then
+                if [ "$EMIT_RAW" = "true" ]; then
+                  # Raw Secret is written first and is the retry-safe source of
+                  # truth until the primary lands: a rerun after a partial
+                  # failure re-reads the same token instead of minting a new one.
+                  RAW=$(kubectl -n "$NS" get secret "$WORLD-token-values" --ignore-not-found -o jsonpath="{.data.$LABEL}")
+                  if [ -n "$RAW" ]; then
+                    TOKEN=$(printf %s "$RAW" | base64 -d)
+                  else
+                    if [ -z "$TOKEN" ]; then
+                      TOKEN=$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 64)
+                    fi
+                    kubectl -n "$NS" create secret generic "$WORLD-token-values" --from-literal="$LABEL=$TOKEN"
+                    kubectl -n "$NS" patch secret "$WORLD-token-values" -p '{"metadata":{"annotations":{"helm.sh/resource-policy":"keep","demarkus.io/raw-tokens":"true"}}}'
+                  fi
+                elif [ -z "$TOKEN" ]; then
                   TOKEN=$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 64)
                 fi
                 HASH="sha256-$(printf %s "$TOKEN" | sha256sum | cut -d' ' -f1)"
                 TOML=$(printf '[tokens.%s]\nhash = "%s"\npaths = [{{ include "demarkus-knowledge-server.tokenAdminPaths" . }}]\noperations = [{{ include "demarkus-knowledge-server.tokenAdminOps" . }}]\n' "$LABEL" "$HASH")
                 kubectl -n "$NS" create secret generic "$SECRET" --from-literal="$KEY=$TOML"
                 kubectl -n "$NS" patch secret "$SECRET" -p '{"metadata":{"annotations":{"helm.sh/resource-policy":"keep"}}}'
-                if [ "$EMIT_RAW" = "true" ]; then
-                  kubectl -n "$NS" create secret generic "$WORLD-token-values" --from-literal="$LABEL=$TOKEN"
-                  kubectl -n "$NS" patch secret "$WORLD-token-values" -p '{"metadata":{"annotations":{"helm.sh/resource-policy":"keep","demarkus.io/raw-tokens":"true"}}}'
-                fi
                 echo "world $WORLD: bootstrapped $SECRET (emit-raw=$EMIT_RAW), hash $HASH."
               done
       volumes:

--- a/deploy/helm/demarkus-knowledge-server/tests/token-bootstrap_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/token-bootstrap_test.yaml
@@ -1,0 +1,61 @@
+suite: token bootstrap
+templates:
+  - token-bootstrap.yaml
+values:
+  - fixtures/valid-values.yaml
+tests:
+  - it: renders the bootstrap Job as a PreSync hook with one line per world
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: PreSync
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: spec.template.spec.containers[0].env[5].name
+          value: WORLDS
+      - equal:
+          path: spec.template.spec.containers[0].env[5].value
+          value: |-
+            team-a team-a-tokens tokens.toml
+            team-b team-b-tokens tokens.toml
+
+  - it: grants only get/create/patch on secrets
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - equal:
+          path: rules[0].verbs
+          value: ["get", "create", "patch"]
+
+  - it: renders publish-only recursive admin defaults into the script
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'paths = \["/\*\*"\]'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'operations = \["publish"\]'
+
+  - it: is omitted when bootstrap is disabled
+    set:
+      tokens.bootstrap.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: is omitted when only dynamic worlds are configured
+    set:
+      worlds: []
+      dynamicWorlds.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/demarkus-knowledge-server/tests/token-bootstrap_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/token-bootstrap_test.yaml
@@ -45,6 +45,34 @@ tests:
       - notExists:
           path: rules[1].resourceNames
 
+  - it: omits raw-token secret names when emitRawValues is disabled
+    set:
+      tokens.emitRawValues: false
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - equal:
+          path: rules[0].resourceNames
+          value:
+            - team-a-tokens
+            - team-b-tokens
+
+  - it: rejects a tokenSecret name colliding with a generated raw secret name
+    set:
+      worlds:
+        - name: team-a
+          authorities: [team-a.example.com]
+          bucket: {url: gs://deployment-team-a, worldID: 52b471f7-8d38-4c89-b44a-6f4f8b1a4f48}
+          tokenSecret: {name: team-a-tokens, key: tokens.toml}
+        - name: team-b
+          authorities: [team-b.example.com]
+          bucket: {url: gs://deployment-team-b, worldID: 42b471f7-8d38-4c89-b44a-6f4f8b1a4f49}
+          tokenSecret: {name: team-a-token-values, key: tokens.toml}
+    asserts:
+      - failedTemplate:
+          errorMessage: 'worlds[0]: generated raw Secret name "team-a-token-values" collides with a tokenSecret.name'
+
   - it: renders publish-only recursive admin defaults into the script
     documentSelector:
       path: kind

--- a/deploy/helm/demarkus-knowledge-server/tests/token-bootstrap_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/token-bootstrap_test.yaml
@@ -73,6 +73,23 @@ tests:
       - failedTemplate:
           errorMessage: 'worlds[0]: generated raw Secret name "team-a-token-values" collides with a tokenSecret.name'
 
+  - it: rejects a raw secret name colliding with dynamic-worlds secrets
+    set:
+      dynamicWorlds:
+        enabled: true
+        worldsSecret: team-a-token-values
+        tokensSecret: memory-worlds-tokens
+    asserts:
+      - failedTemplate:
+          errorMessage: 'worlds[0]: generated raw Secret name "team-a-token-values" collides with dynamicWorlds.worldsSecret'
+
+  - it: rejects a raw secret name colliding with the TLS secret
+    set:
+      tls.existingSecret: team-b-token-values
+    asserts:
+      - failedTemplate:
+          errorMessage: 'worlds[1]: generated raw Secret name "team-b-token-values" collides with tls.existingSecret'
+
   - it: renders publish-only recursive admin defaults into the script
     documentSelector:
       path: kind

--- a/deploy/helm/demarkus-knowledge-server/tests/token-bootstrap_test.yaml
+++ b/deploy/helm/demarkus-knowledge-server/tests/token-bootstrap_test.yaml
@@ -24,14 +24,26 @@ tests:
             team-a team-a-tokens tokens.toml
             team-b team-b-tokens tokens.toml
 
-  - it: grants only get/create/patch on secrets
+  - it: scopes get/patch to world token secrets and keeps create unscoped
     documentSelector:
       path: kind
       value: Role
     asserts:
       - equal:
           path: rules[0].verbs
-          value: ["get", "create", "patch"]
+          value: ["get", "patch"]
+      - equal:
+          path: rules[0].resourceNames
+          value:
+            - team-a-tokens
+            - team-a-token-values
+            - team-b-tokens
+            - team-b-token-values
+      - equal:
+          path: rules[1].verbs
+          value: ["create"]
+      - notExists:
+          path: rules[1].resourceNames
 
   - it: renders publish-only recursive admin defaults into the script
     documentSelector:

--- a/deploy/helm/demarkus-knowledge-server/values.yaml
+++ b/deploy/helm/demarkus-knowledge-server/values.yaml
@@ -38,8 +38,8 @@ tokens:
   # templates them. Disable only if tokens are provisioned some other way.
   bootstrap:
     enabled: true
-    # Needs kubectl + sh + coreutils. Pinned within one minor of the cluster
-    # per the kubectl version-skew policy; bump with cluster upgrades.
+    # Needs kubectl + sh + coreutils. kubectl supports only ±1 minor of the
+    # API server, so override this to match your cluster (default fits 1.34+).
     image: docker.io/alpine/k8s:1.35.5
     imagePullPolicy: IfNotPresent
 

--- a/deploy/helm/demarkus-knowledge-server/values.yaml
+++ b/deploy/helm/demarkus-knowledge-server/values.yaml
@@ -12,9 +12,36 @@ server:
   maxIncomingStreams: 128
   idleTimeout: 30s
 
-# Supply at least one world. Buckets, policy documents, and token Secrets
-# must exist before installation; this chart does not provision them.
+# Supply at least one world. Buckets and policy documents must exist before
+# installation; token Secrets are bootstrapped per world by the pre-install
+# Job below (tokens.bootstrap) unless already present.
 worlds: []
+
+tokens:
+  admin:
+    label: admin
+    # Recursive: `/*` is root-level only (Go path.Match).
+    paths: ["/**"]
+    # Publish-only: any token with `read` flips a world into
+    # read-auth-required mode and breaks the broker's open reads.
+    operations: ["publish"]
+    # Explicit token shared by every bootstrapped world; if empty, a fresh
+    # 64-char token is generated per world.
+    token: ""
+
+  # When true, also create a <world>-token-values Secret with the raw value.
+  # Required when the broker / federation agent manages the world.
+  emitRawValues: true
+
+  # Token Secrets are runtime-owned (the broker appends to tokens.toml), so a
+  # pre-install Job creates any missing ones out-of-band and the chart never
+  # templates them. Disable only if tokens are provisioned some other way.
+  bootstrap:
+    enabled: true
+    # Needs kubectl + sh + coreutils. Pinned within one minor of the cluster
+    # per the kubectl version-skew policy; bump with cluster upgrades.
+    image: docker.io/alpine/k8s:1.35.5
+    imagePullPolicy: IfNotPresent
 
 # Dynamic tenant worlds (memory-broker plan Phase 3): the memory broker
 # writes the two Secrets below and the server hot-reloads them at


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional automatic bootstrapping of per-world token Secrets during Helm installation.
  * Existing token Secrets are preserved; missing tokens can be generated or explicitly configured.
  * Added optional raw token Secret output for external integrations.
  * Added configuration for admin token paths and publish-only operations.
  * Bootstrap can be disabled for externally managed provisioning.

* **Bug Fixes**
  * Added validation to detect conflicting Secret names.

* **Documentation**
  * Clarified TLS, bucket policy, token bootstrap, and resource prerequisites.
  * Documented resources the chart does not create.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->