### PR TITLE
feat(plugins): call the canonical memory-* helper names

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "demarkus-memory",
       "source": "./plugins/claude-code",
       "description": "Zero-config local memory for Claude Code. Spawns a local demarkus-server and wires MCP tools for fetch/publish/append/graph/lookup over your own versioned markdown store, and self-documents sessions to it. /memory-join adds remote memories to a catalog with per-project binding and a destination gate; a join URL (host and token in one paste-able string) joins a remote memory in one step. With a promote destination configured — a joined knowledge system or a registered plain remote demarkus server — /promote lifts ready notes up to it, /promote-scan sweeps for candidates, an ADR publish nudges promotion, and /memory-refresh pulls promoted docs back as they evolve.",
-      "version": "0.13.73",
+      "version": "0.13.74",
       "category": "memory",
       "tags": ["memory", "demarkus", "mark-protocol", "local-first"],
       "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/claude-code"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-memory",
-  "version": "0.13.73",
+  "version": "0.13.74",
   "description": "Local, versioned memory for Claude Code via demarkus. Zero-config install: spawns a local demarkus-server, auto-generates a token, wires MCP tools for fetch/publish/append/graph/lookup, injects standing guidance so sessions self-document to the memory, and enforces a publish tag-gate so documents stay findable via lookup.",
   "author": {
     "name": "latebit",

--- a/plugins/claude-code/commands/memory-default.md
+++ b/plugins/claude-code/commands/memory-default.md
@@ -18,7 +18,7 @@ Reads and one-off writes to a *different* joined memory are unaffected: call
 1. **List the catalog.** Run:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-default --list --bind "${CLAUDE_PROJECT_DIR}"
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-default --list --bind "${CLAUDE_PROJECT_DIR}"
    ```
 
    When the command contains `<shell-escaped-absolute-project-dir>`, replace it with exactly one POSIX-shell-safe word, including correct escaping for embedded apostrophes; never wrap the raw path in literal single quotes.
@@ -37,7 +37,7 @@ Reads and one-off writes to a *different* joined memory are unaffected: call
 3. **Save it.** With the chosen `<slug>`:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-default --set '<slug>' --bind "${CLAUDE_PROJECT_DIR}"
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-default --set '<slug>' --bind "${CLAUDE_PROJECT_DIR}"
    ```
 
    - Only on exact `OK <chosen-slug>`, with the returned slug matching the selection, confirm: "This project now writes to memory **`<slug>`** by

--- a/plugins/claude-code/commands/memory-join.md
+++ b/plugins/claude-code/commands/memory-join.md
@@ -17,7 +17,7 @@ If no host was supplied, ask for it. If token requirements are unclear, ask befo
 1. Validate, register the catalog row, and bind the project:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-url> --bind "${CLAUDE_PROJECT_DIR}"
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-url> --bind "${CLAUDE_PROJECT_DIR}"
    ```
 
    Continue only on `OK` with `broker=1` and an `mcp-url=` value; on `FAIL`, surface the message and stop.
@@ -45,7 +45,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
 2. Validate, store credentials, add the memory catalog row, and bind the absolute current project directory:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-host> --bind "${CLAUDE_PROJECT_DIR}"
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-host> --bind "${CLAUDE_PROJECT_DIR}"
    ```
 
    For a tokened memory, have the user run this variant in their terminal so the token never appears in argv:
@@ -59,7 +59,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
    if ! stty echo; then printf '\nFailed to restore terminal echo; retrying on exit. Run `stty echo` manually if needed.\n' >&2; exit 1; fi
    trap - EXIT HUP INT TERM; printf '\n' >&2
    [ "$read_status" -eq 0 ] || { unset DEMARKUS_TOKEN; exit "$read_status"; }
-   printf '%s' "$DEMARKUS_TOKEN" | "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-host> --token-stdin --bind <shell-escaped-absolute-project-dir>
+   printf '%s' "$DEMARKUS_TOKEN" | "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-host> --token-stdin --bind <shell-escaped-absolute-project-dir>
    join_status=$?; unset DEMARKUS_TOKEN; exit "$join_status"
    )
    ```
@@ -71,7 +71,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
 3. Register the MCP server without putting the token in config.
 
    ```bash
-    claude mcp add '<slug>' --scope project -- "$HOME/.demarkus/bin/demarkus-plugin" mcp-serve --soul '<slug>'
+    claude mcp add '<slug>' --scope project -- "$HOME/.demarkus/bin/demarkus-plugin" mcp-serve --memory '<slug>'
    ```
 
 4. Confirm the slug, host, project binding, and whether a token file is used. State that the token is injected by `demarkus-plugin mcp-serve`, not stored in MCP config.

--- a/plugins/claude-code/commands/soul-default.md
+++ b/plugins/claude-code/commands/soul-default.md
@@ -18,7 +18,7 @@ Reads and one-off writes to a *different* joined memory are unaffected: call
 1. **List the catalog.** Run:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-default --list --bind "${CLAUDE_PROJECT_DIR}"
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-default --list --bind "${CLAUDE_PROJECT_DIR}"
    ```
 
    When the command contains `<shell-escaped-absolute-project-dir>`, replace it with exactly one POSIX-shell-safe word, including correct escaping for embedded apostrophes; never wrap the raw path in literal single quotes.
@@ -37,7 +37,7 @@ Reads and one-off writes to a *different* joined memory are unaffected: call
 3. **Save it.** With the chosen `<slug>`:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-default --set '<slug>' --bind "${CLAUDE_PROJECT_DIR}"
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-default --set '<slug>' --bind "${CLAUDE_PROJECT_DIR}"
    ```
 
    - Only on exact `OK <chosen-slug>`, with the returned slug matching the selection, confirm: "This project now writes to memory **`<slug>`** by

--- a/plugins/claude-code/commands/soul-join.md
+++ b/plugins/claude-code/commands/soul-join.md
@@ -17,7 +17,7 @@ If no host was supplied, ask for it. If token requirements are unclear, ask befo
 1. Validate, register the catalog row, and bind the project:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-url> --bind "${CLAUDE_PROJECT_DIR}"
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-url> --bind "${CLAUDE_PROJECT_DIR}"
    ```
 
    Continue only on `OK` with `broker=1` and an `mcp-url=` value; on `FAIL`, surface the message and stop.
@@ -45,7 +45,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
 2. Validate, store credentials, add the memory catalog row, and bind the absolute current project directory:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-host> --bind "${CLAUDE_PROJECT_DIR}"
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-host> --bind "${CLAUDE_PROJECT_DIR}"
    ```
 
    For a tokened memory, have the user run this variant in their terminal so the token never appears in argv:
@@ -59,7 +59,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
    if ! stty echo; then printf '\nFailed to restore terminal echo; retrying on exit. Run `stty echo` manually if needed.\n' >&2; exit 1; fi
    trap - EXIT HUP INT TERM; printf '\n' >&2
    [ "$read_status" -eq 0 ] || { unset DEMARKUS_TOKEN; exit "$read_status"; }
-   printf '%s' "$DEMARKUS_TOKEN" | "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-host> --token-stdin --bind <shell-escaped-absolute-project-dir>
+   printf '%s' "$DEMARKUS_TOKEN" | "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-host> --token-stdin --bind <shell-escaped-absolute-project-dir>
    join_status=$?; unset DEMARKUS_TOKEN; exit "$join_status"
    )
    ```
@@ -71,7 +71,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
 3. Register the MCP server without putting the token in config.
 
    ```bash
-    claude mcp add '<slug>' --scope project -- "$HOME/.demarkus/bin/demarkus-plugin" mcp-serve --soul '<slug>'
+    claude mcp add '<slug>' --scope project -- "$HOME/.demarkus/bin/demarkus-plugin" mcp-serve --memory '<slug>'
    ```
 
 4. Confirm the slug, host, project binding, and whether a token file is used. State that the token is injected by `demarkus-plugin mcp-serve`, not stored in MCP config.

--- a/plugins/claude-code/hooks/session-journal-nudge.sh
+++ b/plugins/claude-code/hooks/session-journal-nudge.sh
@@ -83,8 +83,10 @@ if grep -qE '"name":"(Edit|Write|NotebookEdit)"' "${tpath}"; then
 fi
 
 # Non-blocking: a nudge failure is logged, never allowed to block the Stop hook.
-if ! out="$("${BIN}" nudge --event session-end --changed-files="${changed_files}" --memory-write="${memory_write}" --format claude < /dev/null)"; then
-  echo "[demarkus-memory] session-end nudge failed (exit $?); skipping" >&2
+status=0
+out="$("${BIN}" nudge --event session-end --changed-files="${changed_files}" --memory-write="${memory_write}" --format claude < /dev/null)" || status=$?
+if [[ "${status}" -ne 0 ]]; then
+  echo "[demarkus-memory] session-end nudge failed (exit ${status}); skipping" >&2
   out=""
 fi
 if [[ -n "${out}" ]]; then

--- a/plugins/claude-code/hooks/session-journal-nudge.sh
+++ b/plugins/claude-code/hooks/session-journal-nudge.sh
@@ -73,16 +73,16 @@ sentinel="${TMPDIR:-/tmp}/demarkus-memory-nudge-${sid//[^A-Za-z0-9_-]/_}"
 [[ -e "${sentinel}" ]] && exit 0
 [[ -n "${tpath}" && -r "${tpath}" ]] || exit 0
 
-soul_write="false"
+memory_write="false"
 if grep -qE '"attributionMcpTool":"mark_(publish|append)"|"name":"mcp__[^"]*mark_(publish|append)"' "${tpath}"; then
-  soul_write="true"
+  memory_write="true"
 fi
 changed_files="false"
 if grep -qE '"name":"(Edit|Write|NotebookEdit)"' "${tpath}"; then
   changed_files="true"
 fi
 
-out="$("${BIN}" nudge --event session-end --changed-files="${changed_files}" --soul-write="${soul_write}" --format claude < /dev/null || true)"
+out="$("${BIN}" nudge --event session-end --changed-files="${changed_files}" --memory-write="${memory_write}" --format claude < /dev/null || true)"
 if [[ -n "${out}" ]]; then
   : > "${sentinel}" 2>/dev/null || true
   printf '%s\n' "${out}"

--- a/plugins/claude-code/hooks/session-journal-nudge.sh
+++ b/plugins/claude-code/hooks/session-journal-nudge.sh
@@ -82,7 +82,11 @@ if grep -qE '"name":"(Edit|Write|NotebookEdit)"' "${tpath}"; then
   changed_files="true"
 fi
 
-out="$("${BIN}" nudge --event session-end --changed-files="${changed_files}" --memory-write="${memory_write}" --format claude < /dev/null || true)"
+# Non-blocking: a nudge failure is logged, never allowed to block the Stop hook.
+if ! out="$("${BIN}" nudge --event session-end --changed-files="${changed_files}" --memory-write="${memory_write}" --format claude < /dev/null)"; then
+  echo "[demarkus-memory] session-end nudge failed (exit $?); skipping" >&2
+  out=""
+fi
 if [[ -n "${out}" ]]; then
   : > "${sentinel}" 2>/dev/null || true
   printf '%s\n' "${out}"

--- a/plugins/opencode-memory/CHANGELOG.md
+++ b/plugins/opencode-memory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.76
+
+- Call the canonical `memory-*` helper names now that the pinned binary (tools 0.27.0) provides them: `registry memory-join`, `registry memory-default`, `mcp-serve --memory`, and the `memoryWrite` session-end signal. The `soul-*` names stay accepted by the binary for one more release; MCP entries registered earlier with `--soul` keep working.
+
 ## 0.13.73
 
 - Rename the personal store from "soul" to "memory" across guidance, commands, and the skill: `/soul-*` commands become `/memory-*` (`/memory`, `/memory-init`, `/memory-join`, `/memory-context`, `/memory-journal`, `/memory-status`, `/memory-doctor`, `/memory-refresh`, `/memory-default`); the `soul-memory` skill becomes `memory`. The old command names keep working as deprecated aliases for one release. On-disk state under `~/.demarkus` is unchanged.

--- a/plugins/opencode-memory/commands/memory-default.md
+++ b/plugins/opencode-memory/commands/memory-default.md
@@ -18,7 +18,7 @@ the destination server's `mark_*` tools directly. This command only moves the de
 1. **List the catalog.** Run:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-default --list --bind <shell-escaped-absolute-project-dir>
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-default --list --bind <shell-escaped-absolute-project-dir>
    ```
 
    When the command contains `<shell-escaped-absolute-project-dir>`, replace it with exactly one POSIX-shell-safe word, including correct escaping for embedded apostrophes; never wrap the raw path in literal single quotes.
@@ -37,7 +37,7 @@ the destination server's `mark_*` tools directly. This command only moves the de
 3. **Save it.** With the chosen `<slug>`:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-default --set '<slug>' --bind <shell-escaped-absolute-project-dir>
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-default --set '<slug>' --bind <shell-escaped-absolute-project-dir>
    ```
 
    - Only on exact `OK <chosen-slug>`, with the returned slug matching the selection, confirm: "This project now writes to memory **`<slug>`** by

--- a/plugins/opencode-memory/commands/memory-join.md
+++ b/plugins/opencode-memory/commands/memory-join.md
@@ -17,7 +17,7 @@ If no host was supplied, ask for it. If token requirements are unclear, ask befo
 1. Validate, register the catalog row, and bind the project:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-url> --bind <shell-escaped-absolute-project-dir>
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-url> --bind <shell-escaped-absolute-project-dir>
    ```
 
    Continue only on `OK` with `broker=1` and an `mcp-url=` value; on `FAIL`, surface the message and stop.
@@ -33,7 +33,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
 1. Validate, store credentials, add the memory catalog row, and bind the absolute current project directory:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-host> --bind <shell-escaped-absolute-project-dir>
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-host> --bind <shell-escaped-absolute-project-dir>
    ```
 
    For a tokened memory, have the user run this variant in their terminal so the token never appears in argv:
@@ -47,7 +47,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
    if ! stty echo; then printf '\nFailed to restore terminal echo; retrying on exit. Run `stty echo` manually if needed.\n' >&2; exit 1; fi
    trap - EXIT HUP INT TERM; printf '\n' >&2
    [ "$read_status" -eq 0 ] || { unset DEMARKUS_TOKEN; exit "$read_status"; }
-   printf '%s' "$DEMARKUS_TOKEN" | "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-host> --token-stdin --bind <shell-escaped-absolute-project-dir>
+   printf '%s' "$DEMARKUS_TOKEN" | "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-host> --token-stdin --bind <shell-escaped-absolute-project-dir>
    join_status=$?; unset DEMARKUS_TOKEN; exit "$join_status"
    )
    ```

--- a/plugins/opencode-memory/commands/soul-default.md
+++ b/plugins/opencode-memory/commands/soul-default.md
@@ -18,7 +18,7 @@ the destination server's `mark_*` tools directly. This command only moves the de
 1. **List the catalog.** Run:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-default --list --bind <shell-escaped-absolute-project-dir>
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-default --list --bind <shell-escaped-absolute-project-dir>
    ```
 
    When the command contains `<shell-escaped-absolute-project-dir>`, replace it with exactly one POSIX-shell-safe word, including correct escaping for embedded apostrophes; never wrap the raw path in literal single quotes.
@@ -37,7 +37,7 @@ the destination server's `mark_*` tools directly. This command only moves the de
 3. **Save it.** With the chosen `<slug>`:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-default --set '<slug>' --bind <shell-escaped-absolute-project-dir>
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-default --set '<slug>' --bind <shell-escaped-absolute-project-dir>
    ```
 
    - Only on exact `OK <chosen-slug>`, with the returned slug matching the selection, confirm: "This project now writes to memory **`<slug>`** by

--- a/plugins/opencode-memory/commands/soul-join.md
+++ b/plugins/opencode-memory/commands/soul-join.md
@@ -17,7 +17,7 @@ If no host was supplied, ask for it. If token requirements are unclear, ask befo
 1. Validate, register the catalog row, and bind the project:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-url> --bind <shell-escaped-absolute-project-dir>
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-url> --bind <shell-escaped-absolute-project-dir>
    ```
 
    Continue only on `OK` with `broker=1` and an `mcp-url=` value; on `FAIL`, surface the message and stop.
@@ -33,7 +33,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
 1. Validate, store credentials, add the memory catalog row, and bind the absolute current project directory:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-host> --bind <shell-escaped-absolute-project-dir>
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-host> --bind <shell-escaped-absolute-project-dir>
    ```
 
    For a tokened memory, have the user run this variant in their terminal so the token never appears in argv:
@@ -47,7 +47,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
    if ! stty echo; then printf '\nFailed to restore terminal echo; retrying on exit. Run `stty echo` manually if needed.\n' >&2; exit 1; fi
    trap - EXIT HUP INT TERM; printf '\n' >&2
    [ "$read_status" -eq 0 ] || { unset DEMARKUS_TOKEN; exit "$read_status"; }
-   printf '%s' "$DEMARKUS_TOKEN" | "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-host> --token-stdin --bind <shell-escaped-absolute-project-dir>
+   printf '%s' "$DEMARKUS_TOKEN" | "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-host> --token-stdin --bind <shell-escaped-absolute-project-dir>
    join_status=$?; unset DEMARKUS_TOKEN; exit "$join_status"
    )
    ```

--- a/plugins/opencode-memory/package.json
+++ b/plugins/opencode-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-opencode-memory",
-  "version": "0.13.75",
+  "version": "0.13.76",
   "description": "Local, versioned memory for OpenCode via demarkus. Provisions a local demarkus-server, auto-generates a token, wires the demarkus-memory MCP server, injects standing guidance so sessions self-document to the memory, and enforces a publish tag-gate plus a destination gate.",
   "author": "latebit",
   "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/opencode-memory",

--- a/plugins/opencode-memory/src/demarkus-memory.ts
+++ b/plugins/opencode-memory/src/demarkus-memory.ts
@@ -253,11 +253,9 @@ export const DemarkusMemoryPlugin = async ({ client, directory }: { client: Toas
         enabled: true,
       };
 
-      // Joined remote memories: the binary's `registry mcp add` writes pi's MCP
-      // config, which OpenCode never reads, so wire every memory in the shared
-      // catalog here. The binary owns the catalog format (TSV: slug host
-      // insecure token-file, "#" comments); follow-up: query it via a
-      // `registry memory-list` subcommand instead of parsing the file.
+      // OpenCode never reads the MCP config `registry mcp add` writes, so wire
+      // every joined memory from the shared catalog here (TSV, "#" comments).
+      // Follow-up: read it via `registry memory-default --list` instead.
       try {
         const memories = readFileSync(join(homedir(), ".demarkus", "souls"), "utf8");
         for (const rawLine of memories.split("\n")) {
@@ -267,7 +265,9 @@ export const DemarkusMemoryPlugin = async ({ client, directory }: { client: Toas
           if (!slug || slug === MCP_SERVER_NAME) continue;
           config.mcp[slug] = config.mcp[slug] ?? {
             type: "local",
-            command: [BIN, "mcp-serve", "--memory", slug],
+            // --soul, not --memory: this hook can run before the fire-and-forget
+            // bootstrap has replaced an older binary. Switch when --soul is removed.
+            command: [BIN, "mcp-serve", "--soul", slug],
             enabled: true,
           };
         }

--- a/plugins/opencode-memory/src/demarkus-memory.ts
+++ b/plugins/opencode-memory/src/demarkus-memory.ts
@@ -94,7 +94,7 @@ async function callGuidance(): Promise<string | null> {
   return o === null ? null : (o.context ?? "");
 }
 
-function isSoulWrite(toolName: string): boolean {
+function isMemoryWrite(toolName: string): boolean {
   return /mark_(publish|append)$/.test(toolName);
 }
 
@@ -108,7 +108,7 @@ interface SessionState {
   guidanceDelivered: boolean;
   idleNudged: boolean;
   changedFiles: boolean;
-  soulWrite: boolean;
+  memoryWrite: boolean;
 }
 
 // run executes a provisioning step; resolves "" on success, a warning on failure.
@@ -205,7 +205,7 @@ export const DemarkusMemoryPlugin = async ({ client, directory }: { client: Toas
   const state = (id: string): SessionState => {
     let s = sessions.get(id);
     if (!s) {
-      s = { guidanceDelivered: false, idleNudged: false, changedFiles: false, soulWrite: false };
+      s = { guidanceDelivered: false, idleNudged: false, changedFiles: false, memoryWrite: false };
       sessions.set(id, s);
     }
     return s;
@@ -257,7 +257,7 @@ export const DemarkusMemoryPlugin = async ({ client, directory }: { client: Toas
       // config, which OpenCode never reads, so wire every memory in the shared
       // catalog here. The binary owns the catalog format (TSV: slug host
       // insecure token-file, "#" comments); follow-up: query it via a
-      // `registry soul-list` subcommand instead of parsing the file.
+      // `registry memory-list` subcommand instead of parsing the file.
       try {
         const memories = readFileSync(join(homedir(), ".demarkus", "souls"), "utf8");
         for (const rawLine of memories.split("\n")) {
@@ -267,7 +267,7 @@ export const DemarkusMemoryPlugin = async ({ client, directory }: { client: Toas
           if (!slug || slug === MCP_SERVER_NAME) continue;
           config.mcp[slug] = config.mcp[slug] ?? {
             type: "local",
-            command: [BIN, "mcp-serve", "--soul", slug], // pinned binary predates --memory
+            command: [BIN, "mcp-serve", "--memory", slug],
             enabled: true,
           };
         }
@@ -344,7 +344,7 @@ export const DemarkusMemoryPlugin = async ({ client, directory }: { client: Toas
       input: { tool: string; sessionID?: string; callID?: string },
       output: { args: Record<string, unknown> },
     ) => {
-      if (!isSoulWrite(input.tool) || !adapters.has("memory")) return;
+      if (!isMemoryWrite(input.tool) || !adapters.has("memory")) return;
       const decision = await callGate(input.tool, output.args ?? {}, directory);
       if (decision.decision === "block") {
         throw new Error(decision.reason ?? "demarkus-memory gate blocked this write");
@@ -368,11 +368,11 @@ export const DemarkusMemoryPlugin = async ({ client, directory }: { client: Toas
     ) => {
       if (!adapters.has("memory")) return;
       const s = state(input.sessionID ?? "default");
-      if (!isSoulWrite(input.tool)) {
+      if (!isMemoryWrite(input.tool)) {
         if (isFileMutation(input.tool)) s.changedFiles = true;
         return;
       }
-      s.soulWrite = true;
+      s.memoryWrite = true;
 
       const key = `${input.sessionID}:${input.callID}`;
       const warn = pendingWarns.get(key);
@@ -411,12 +411,12 @@ export const DemarkusMemoryPlugin = async ({ client, directory }: { client: Toas
       const s = state(event.properties?.sessionID ?? "default");
       // Pre-filter with the same signals the binary checks, so the common
       // nothing-to-say case doesn't spawn a subprocess after every turn.
-      if (s.idleNudged || !s.changedFiles || s.soulWrite) return;
+      if (s.idleNudged || !s.changedFiles || s.memoryWrite) return;
       s.idleNudged = true;
       const nudge = await callNudge({
         event: "session-end",
         changedFiles: s.changedFiles,
-        soulWrite: s.soulWrite,
+        memoryWrite: s.memoryWrite,
       });
       if (nudge) await toast(nudge);
     },

--- a/plugins/pi-memory/CHANGELOG.md
+++ b/plugins/pi-memory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.75
+
+- Call the canonical `memory-*` helper names now that the pinned binary (tools 0.27.0) provides them: `registry memory-join`, `registry memory-default`, `mcp-serve --memory`, and the `memoryWrite` session-end signal. The `soul-*` names stay accepted by the binary for one more release; MCP entries registered earlier with `--soul` keep working.
+
 ## 0.13.72
 
 - Rename the personal store from "soul" to "memory" across guidance, commands, and the skill: `/soul-*` commands become `/memory-*`; the `soul-memory` skill becomes `memory`. The old command names keep working as deprecated aliases for one release. On-disk state under `~/.demarkus` is unchanged.

--- a/plugins/pi-memory/commands/memory-default.md
+++ b/plugins/pi-memory/commands/memory-default.md
@@ -18,7 +18,7 @@ the destination server's `mark_*` tools directly. This command only moves the de
 1. **List the catalog.** Run:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-default --list --bind <shell-escaped-absolute-project-dir>
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-default --list --bind <shell-escaped-absolute-project-dir>
    ```
 
    When the command contains `<shell-escaped-absolute-project-dir>`, replace it with exactly one POSIX-shell-safe word, including correct escaping for embedded apostrophes; never wrap the raw path in literal single quotes.
@@ -37,7 +37,7 @@ the destination server's `mark_*` tools directly. This command only moves the de
 3. **Save it.** With the chosen `<slug>`:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-default --set '<slug>' --bind <shell-escaped-absolute-project-dir>
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-default --set '<slug>' --bind <shell-escaped-absolute-project-dir>
    ```
 
    - Only on exact `OK <chosen-slug>`, with the returned slug matching the selection, confirm: "This project now writes to memory **`<slug>`** by

--- a/plugins/pi-memory/commands/memory-join.md
+++ b/plugins/pi-memory/commands/memory-join.md
@@ -17,7 +17,7 @@ If no host was supplied, ask for it. If token requirements are unclear, ask befo
 1. Validate, register the catalog row, and bind the project:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-url> --bind <shell-escaped-absolute-project-dir>
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-url> --bind <shell-escaped-absolute-project-dir>
    ```
 
    Continue only on `OK` with `broker=1` and an `mcp-url=` value; on `FAIL`, surface the message and stop.
@@ -33,7 +33,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
 1. Validate, store credentials, add the memory catalog row, and bind the absolute current project directory:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-host> --bind <shell-escaped-absolute-project-dir>
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-host> --bind <shell-escaped-absolute-project-dir>
    ```
 
    For a tokened memory, have the user run this variant in their terminal so the token never appears in argv:
@@ -47,7 +47,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
    if ! stty echo; then printf '\nFailed to restore terminal echo; retrying on exit. Run `stty echo` manually if needed.\n' >&2; exit 1; fi
    trap - EXIT HUP INT TERM; printf '\n' >&2
    [ "$read_status" -eq 0 ] || { unset DEMARKUS_TOKEN; exit "$read_status"; }
-   printf '%s' "$DEMARKUS_TOKEN" | "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-host> --token-stdin --bind <shell-escaped-absolute-project-dir>
+   printf '%s' "$DEMARKUS_TOKEN" | "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-host> --token-stdin --bind <shell-escaped-absolute-project-dir>
    join_status=$?; unset DEMARKUS_TOKEN; exit "$join_status"
    )
    ```
@@ -59,7 +59,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
 2. Register the MCP server without putting the token in config.
 
    ```bash
-    "$HOME/.demarkus/bin/demarkus-plugin" registry mcp add '<slug>' "$HOME/.demarkus/bin/demarkus-plugin" mcp-serve --soul '<slug>'
+    "$HOME/.demarkus/bin/demarkus-plugin" registry mcp add '<slug>' "$HOME/.demarkus/bin/demarkus-plugin" mcp-serve --memory '<slug>'
    ```
 
    Reconnect MCP servers through the harness or restart Pi.

--- a/plugins/pi-memory/commands/soul-default.md
+++ b/plugins/pi-memory/commands/soul-default.md
@@ -18,7 +18,7 @@ the destination server's `mark_*` tools directly. This command only moves the de
 1. **List the catalog.** Run:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-default --list --bind <shell-escaped-absolute-project-dir>
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-default --list --bind <shell-escaped-absolute-project-dir>
    ```
 
    When the command contains `<shell-escaped-absolute-project-dir>`, replace it with exactly one POSIX-shell-safe word, including correct escaping for embedded apostrophes; never wrap the raw path in literal single quotes.
@@ -37,7 +37,7 @@ the destination server's `mark_*` tools directly. This command only moves the de
 3. **Save it.** With the chosen `<slug>`:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-default --set '<slug>' --bind <shell-escaped-absolute-project-dir>
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-default --set '<slug>' --bind <shell-escaped-absolute-project-dir>
    ```
 
    - Only on exact `OK <chosen-slug>`, with the returned slug matching the selection, confirm: "This project now writes to memory **`<slug>`** by

--- a/plugins/pi-memory/commands/soul-join.md
+++ b/plugins/pi-memory/commands/soul-join.md
@@ -17,7 +17,7 @@ If no host was supplied, ask for it. If token requirements are unclear, ask befo
 1. Validate, register the catalog row, and bind the project:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-url> --bind <shell-escaped-absolute-project-dir>
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-url> --bind <shell-escaped-absolute-project-dir>
    ```
 
    Continue only on `OK` with `broker=1` and an `mcp-url=` value; on `FAIL`, surface the message and stop.
@@ -33,7 +33,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
 1. Validate, store credentials, add the memory catalog row, and bind the absolute current project directory:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-host> --bind <shell-escaped-absolute-project-dir>
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-host> --bind <shell-escaped-absolute-project-dir>
    ```
 
    For a tokened memory, have the user run this variant in their terminal so the token never appears in argv:
@@ -47,7 +47,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
    if ! stty echo; then printf '\nFailed to restore terminal echo; retrying on exit. Run `stty echo` manually if needed.\n' >&2; exit 1; fi
    trap - EXIT HUP INT TERM; printf '\n' >&2
    [ "$read_status" -eq 0 ] || { unset DEMARKUS_TOKEN; exit "$read_status"; }
-   printf '%s' "$DEMARKUS_TOKEN" | "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-host> --token-stdin --bind <shell-escaped-absolute-project-dir>
+   printf '%s' "$DEMARKUS_TOKEN" | "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-host> --token-stdin --bind <shell-escaped-absolute-project-dir>
    join_status=$?; unset DEMARKUS_TOKEN; exit "$join_status"
    )
    ```
@@ -59,7 +59,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
 2. Register the MCP server without putting the token in config.
 
    ```bash
-    "$HOME/.demarkus/bin/demarkus-plugin" registry mcp add '<slug>' "$HOME/.demarkus/bin/demarkus-plugin" mcp-serve --soul '<slug>'
+    "$HOME/.demarkus/bin/demarkus-plugin" registry mcp add '<slug>' "$HOME/.demarkus/bin/demarkus-plugin" mcp-serve --memory '<slug>'
    ```
 
    Reconnect MCP servers through the harness or restart Pi.

--- a/plugins/pi-memory/package.json
+++ b/plugins/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-pi-memory",
-  "version": "0.13.74",
+  "version": "0.13.75",
   "description": "Local, versioned memory for the pi coding agent via demarkus. Provisions a local demarkus-server, auto-generates a token, wires the demarkus-memory MCP server through pi-mcp-adapter, injects standing guidance so sessions self-document to the memory, and enforces a publish tag-gate plus a destination gate so documents stay findable and land on the right memory.",
   "author": "latebit",
   "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/pi-memory",

--- a/plugins/pi-memory/src/index.ts
+++ b/plugins/pi-memory/src/index.ts
@@ -226,7 +226,7 @@ export default function demarkusMemoryExtension(pi: ExtensionAPI): void {
     const nudge = await callNudge({
       event: "session-end",
       changedFiles: activity.changedFiles,
-      soulWrite: activity.hadSoulWrite,
+      memoryWrite: activity.hadMemoryWrite,
     });
     if (nudge) ctx.ui.notify(nudge, "info");
   });

--- a/plugins/pi-memory/src/nudges.ts
+++ b/plugins/pi-memory/src/nudges.ts
@@ -6,19 +6,19 @@
 
 // Memory writes can arrive wrapped in the pi-mcp-adapter "mcp" proxy tool, so
 // unwrap input.tool before parsing the verb out of the tool name.
-function isSoulWrite(toolName: string, input: Record<string, unknown>): boolean {
+function isMemoryWrite(toolName: string, input: Record<string, unknown>): boolean {
   let name = toolName;
   if (name === "mcp" && typeof input.tool === "string") name = input.tool;
   return /mark_(publish|append)$/.test(name);
 }
 
 export class SessionActivity {
-  private soulWrite = false;
+  private memoryWrite = false;
   private fileMutation = false;
 
   observe(toolName: string, input: Record<string, unknown> = {}): void {
-    if (isSoulWrite(toolName, input)) {
-      this.soulWrite = true;
+    if (isMemoryWrite(toolName, input)) {
+      this.memoryWrite = true;
       return;
     }
     if (/(^|_)(Edit|Write|NotebookEdit)$/.test(toolName) || ["edit", "write"].includes(toolName)) {
@@ -29,7 +29,7 @@ export class SessionActivity {
   get changedFiles(): boolean {
     return this.fileMutation;
   }
-  get hadSoulWrite(): boolean {
-    return this.soulWrite;
+  get hadMemoryWrite(): boolean {
+    return this.memoryWrite;
   }
 }

--- a/plugins/prompt-source/memory/commands/memory-default.md.tmpl
+++ b/plugins/prompt-source/memory/commands/memory-default.md.tmpl
@@ -16,7 +16,7 @@ Reads and one-off writes to a *different* joined memory are unaffected: call
 1. **List the catalog.** Run:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-default --list --bind {{if eq .Harness "claude"}}"${CLAUDE_PROJECT_DIR}"{{else}}<shell-escaped-absolute-project-dir>{{end}}
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-default --list --bind {{if eq .Harness "claude"}}"${CLAUDE_PROJECT_DIR}"{{else}}<shell-escaped-absolute-project-dir>{{end}}
    ```
 
    When the command contains `<shell-escaped-absolute-project-dir>`, replace it with exactly one POSIX-shell-safe word, including correct escaping for embedded apostrophes; never wrap the raw path in literal single quotes.
@@ -36,7 +36,7 @@ Reads and one-off writes to a *different* joined memory are unaffected: call
 3. **Save it.** With the chosen `<slug>`:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-default --set '<slug>' --bind {{if eq .Harness "claude"}}"${CLAUDE_PROJECT_DIR}"{{else}}<shell-escaped-absolute-project-dir>{{end}}
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-default --set '<slug>' --bind {{if eq .Harness "claude"}}"${CLAUDE_PROJECT_DIR}"{{else}}<shell-escaped-absolute-project-dir>{{end}}
    ```
 
    - Only on exact `OK <chosen-slug>`, with the returned slug matching the selection, confirm: "This project now writes to memory **`<slug>`** by

--- a/plugins/prompt-source/memory/commands/memory-join.md.tmpl
+++ b/plugins/prompt-source/memory/commands/memory-join.md.tmpl
@@ -15,7 +15,7 @@ If no host was supplied, ask for it. If token requirements are unclear, ask befo
 1. Validate, register the catalog row, and bind the project:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-url> --bind {{if eq .Harness "claude"}}"${CLAUDE_PROJECT_DIR}"{{else}}<shell-escaped-absolute-project-dir>{{end}}
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-url> --bind {{if eq .Harness "claude"}}"${CLAUDE_PROJECT_DIR}"{{else}}<shell-escaped-absolute-project-dir>{{end}}
    ```
 
    Continue only on `OK` with `broker=1` and an `mcp-url=` value; on `FAIL`, surface the message and stop.
@@ -44,7 +44,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
 2.{{else}}1.{{end}} Validate, store credentials, add the memory catalog row, and bind the absolute current project directory:
 
    ```bash
-   "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-host> --bind {{if eq .Harness "claude"}}"${CLAUDE_PROJECT_DIR}"{{else}}<shell-escaped-absolute-project-dir>{{end}}
+   "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-host> --bind {{if eq .Harness "claude"}}"${CLAUDE_PROJECT_DIR}"{{else}}<shell-escaped-absolute-project-dir>{{end}}
    ```
 
    For a tokened memory, have the user run this variant in their terminal so the token never appears in argv:
@@ -58,7 +58,7 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
    if ! stty echo; then printf '\nFailed to restore terminal echo; retrying on exit. Run `stty echo` manually if needed.\n' >&2; exit 1; fi
    trap - EXIT HUP INT TERM; printf '\n' >&2
    [ "$read_status" -eq 0 ] || { unset DEMARKUS_TOKEN; exit "$read_status"; }
-   printf '%s' "$DEMARKUS_TOKEN" | "$HOME/.demarkus/bin/demarkus-plugin" registry soul-join <shell-escaped-host> --token-stdin --bind <shell-escaped-absolute-project-dir>
+   printf '%s' "$DEMARKUS_TOKEN" | "$HOME/.demarkus/bin/demarkus-plugin" registry memory-join <shell-escaped-host> --token-stdin --bind <shell-escaped-absolute-project-dir>
    join_status=$?; unset DEMARKUS_TOKEN; exit "$join_status"
    )
    ```
@@ -70,10 +70,10 @@ For a hosted memory, skip the QUIC join and MCP-registration steps below, but st
 {{if eq .Harness "claude"}}3.{{else}}2.{{end}} Register the MCP server without putting the token in config.
 
 {{if eq .Harness "claude"}}   ```bash
-    claude mcp add '<slug>' --scope project -- "$HOME/.demarkus/bin/demarkus-plugin" mcp-serve --soul '<slug>'
+    claude mcp add '<slug>' --scope project -- "$HOME/.demarkus/bin/demarkus-plugin" mcp-serve --memory '<slug>'
    ```
 {{else if eq .Harness "pi"}}   ```bash
-    "$HOME/.demarkus/bin/demarkus-plugin" registry mcp add '<slug>' "$HOME/.demarkus/bin/demarkus-plugin" mcp-serve --soul '<slug>'
+    "$HOME/.demarkus/bin/demarkus-plugin" registry mcp add '<slug>' "$HOME/.demarkus/bin/demarkus-plugin" mcp-serve --memory '<slug>'
    ```
 
    Reconnect MCP servers through the harness or restart {{.Agent}}.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Standardized memory workflows across supported plugins with `memory-*` commands and terminology.
  * Memory joining now consistently supports hosted, direct, QUIC, and token-based flows.
  * MCP registration and session activity tracking now use memory-specific options and signals.

* **Documentation**
  * Added changelog entries covering canonical command names and continued compatibility with legacy aliases.

* **Chores**
  * Incremented plugin and package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->