### PR TITLE
docs(plugins,broker): hub rule in remember skill, knowledge template

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "demarkus-memory",
       "source": "./plugins/claude-code",
       "description": "Zero-config local memory for Claude Code. Spawns a local demarkus-server and wires MCP tools for fetch/publish/append/graph/lookup over your own versioned markdown store, and self-documents sessions to it. /soul-join adds remote souls to a catalog with per-project binding and a destination gate; a join URL (host and token in one paste-able string) joins a remote soul in one step. With a promote destination configured (a joined knowledge system or a registered plain remote demarkus server), /promote lifts ready notes up to it, /promote-scan sweeps for candidates, an ADR publish nudges promotion, and /soul-refresh pulls promoted docs back as they evolve.",
-      "version": "0.13.89",
+      "version": "0.13.90",
       "category": "memory",
       "tags": ["memory", "demarkus", "mark-protocol", "local-first"],
       "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/claude-code"
@@ -19,7 +19,7 @@
       "name": "demarkus-knowledge",
       "source": "./plugins/claude-code-knowledge",
       "description": "Join an organizational demarkus knowledge system from Claude Code ; a shared, broker-fronted, versioned markdown catalog. Steers sessions to the shared catalog, enforces publishing policy, and curates promoted notes. Runs no local server; a shared helper binary provides gates and guidance.",
-      "version": "0.5.94",
+      "version": "0.5.95",
       "category": "memory",
       "tags": ["memory", "knowledge-base", "demarkus", "mark-protocol", "broker", "team"],
       "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/claude-code-knowledge"

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "demarkus-memory",
       "source": "plugins/cursor-memory",
       "description": "Zero-config local memory for Cursor. Spawns a local demarkus-server and wires MCP tools for fetch/publish/append/graph/lookup over your own versioned markdown store, and self-documents sessions to it. /soul-join adds remote souls with per-project binding and a destination gate; /promote lifts ready notes to a joined knowledge system.",
-      "version": "0.13.89",
+      "version": "0.13.90",
       "category": "memory",
       "tags": ["memory", "demarkus", "mark-protocol", "local-first"]
     }

--- a/plugins/claude-code-knowledge/.claude-plugin/plugin.json
+++ b/plugins/claude-code-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-knowledge",
-  "version": "0.5.94",
+  "version": "0.5.95",
   "description": "Join an organizational demarkus knowledge system from Claude Code. Registers the broker as an OAuth MCP server, steers sessions to the shared catalog, and enforces publishing policy. Runs no local server; a shared helper binary provides gates and guidance.",
   "author": {
     "name": "latebit",

--- a/plugins/claude-code-knowledge/examples/knowledge-system/README.md
+++ b/plugins/claude-code-knowledge/examples/knowledge-system/README.md
@@ -11,7 +11,7 @@ mark://root/.well-known/demarkus/policy.md     ← strictness + required tags (s
 mark://root/.well-known/demarkus/template.md   ← required per-world structure (the canonical layout)
 ```
 
-`template.md` is the canonical per-world layout; publish a copy of it to `root` (tailored as needed). `policy.md` is the example in this directory.
+`template.md` is the canonical per-world layout (world hub, descriptor, `/projects/<slug>/` subtrees, hub and metadata rules); publish a copy of it to `root`, tailored as needed. `policy.md` and `template.md` are the examples in this directory.
 
 ## Per-world descriptors (`world.md`)
 

--- a/plugins/claude-code-knowledge/examples/knowledge-system/template.md
+++ b/plugins/claude-code-knowledge/examples/knowledge-system/template.md
@@ -1,0 +1,33 @@
+# Knowledge System Template
+
+Audience: anyone creating or extending a world in this knowledge system. The canonical per-world layout; agents route new documents to these paths instead of inventing parallel structures. Published once at `mark://root/.well-known/demarkus/template.md`; joined agents fetch it with `force: true` and follow it. Writing rules live in the [style guide](/.well-known/demarkus/style.md); tag rules in the [policy](/.well-known/demarkus/policy.md).
+
+## World layout
+
+- `/index.md`: the world hub. Links to every top-level section and project, one line each. Untyped.
+- `/.well-known/demarkus/world.md`: the world descriptor (team, domain, partition role, autonomy ceiling). Per-world, owner-published.
+- `/projects/<slug>/`: one subtree per project, laid out as below. `<slug>` is the repository name, lowercase.
+- Shared, cross-project documents sit at the top level next to `/index.md` and are linked from it.
+
+## Project layout
+
+Each `/projects/<slug>/` subtree:
+
+- `index.md`: project hub, links every document below. Untyped, `category:navigation`.
+- `architecture.md`: system design, module boundaries, key decisions. Type `Architecture`.
+- `adr/index.md` and `adr/<NNNN>-<title>.md`: decision records, numbered sequentially. Type `Decision`; `rel-supersedes` metadata when one replaces another.
+- `guidelines.md`: hard code-quality rules. Type `Guide`, `category:standards`.
+- `patterns.md`: implementation, testing, and workflow patterns. Type `Guide`.
+- `debugging.md`: lessons from bugs and investigations, one uniquely titled section each. Type `Guide`.
+- `roadmap.md`: what is next, active, done, and deliberately not prioritized. Type `Plan`.
+- `plans/<name>.md`: one document per larger piece of work, linked from the project hub. Type `Plan`.
+
+## Hubs
+
+Every hub (`/index.md`, project `index.md`, `adr/index.md`, any link page) is a link page: links plus one line each, no content copied from children, each child links back, about 40 outbound documents before a second-level hub. A document that outgrows one fetch splits into a hub plus topic files. Full rule in the style guide.
+
+## Metadata
+
+- Every publish sets `tags` (subjects from the content plus the policy's required axes, at minimum `category:<value>`), `importance` (0 to 1; 0.8 and above for hubs, architecture, and key decisions), and `type` where the layout names one.
+- Metadata travels in the publish `metadata` object, never in the body.
+- Never set `retention` on curated documents.

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-memory",
-  "version": "0.13.89",
+  "version": "0.13.90",
   "description": "Local, versioned memory for Claude Code via demarkus. Zero-config install: spawns a local demarkus-server, auto-generates a token, wires MCP tools for fetch/publish/append/graph/lookup, injects standing guidance so sessions self-document to your soul, and enforces a publish tag-gate so documents stay findable via lookup.",
   "author": {
     "name": "latebit",

--- a/plugins/claude-code/skills/remember/SKILL.md
+++ b/plugins/claude-code/skills/remember/SKILL.md
@@ -44,6 +44,7 @@ Read the last line first: trailing `STALE <slug>` → bound soul unavailable; te
 Canonical layout below. A `/project-template.md` at the soul root overrides it: fetch with `force: true` and follow it when present, even above the normal full-body threshold. Only `not-found` means no override; an outline-only response or any other fetch failure (transport, auth, server error) is a real error: surface it and stop, no silent fallback. Each `/<project>/` subtree:
 
 - `/<project>/index.md`: project hub; links every doc below, anchors discovery
+- Hub rule (`index.md`, any link page): links plus one line each; no content, status, or summaries copied from children; each child links back to its hub; about 40 outbound documents, then a second-level hub; a document that outgrows one fetch splits into a hub plus topic files. Real relations go in `rel-*` metadata, not hub adjacency.
 - `/<project>/architecture.md`: system design, module boundaries, key decisions
 - `/<project>/patterns.md`: code patterns, conventions, idioms
 - `/<project>/guidelines.md`: hard code-quality rules; read before writing code

--- a/plugins/cursor-memory/.cursor-plugin/plugin.json
+++ b/plugins/cursor-memory/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-memory",
-  "version": "0.13.89",
+  "version": "0.13.90",
   "description": "Local, versioned memory for Cursor via demarkus. Zero-config install: spawns a local demarkus-server, auto-generates a token, wires MCP tools for fetch/publish/append/graph/lookup, injects standing guidance so sessions self-document to your soul, and enforces a publish tag-gate so documents stay findable via lookup.",
   "author": {
     "name": "latebit"

--- a/plugins/cursor-memory/CHANGELOG.md
+++ b/plugins/cursor-memory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.90
+
+`remember` skill: hub rule for `index.md` and any link page (links plus one line each, nothing copied from children, children link back, about 40 outbound documents, split an outgrown document into a hub plus topic files).
+
 ## 0.13.89
 
 Docs follow the vocabulary: "memory" is the store concept, "soul" is your own instance. README and manifest descriptions say soul where they mean the bound store.

--- a/plugins/cursor-memory/skills/remember/SKILL.md
+++ b/plugins/cursor-memory/skills/remember/SKILL.md
@@ -44,6 +44,7 @@ Replace `<shell-escaped-absolute-project-dir>` with exactly one POSIX-shell-safe
 Canonical layout below. A `/project-template.md` at the soul root overrides it: fetch with `force: true` and follow it when present, even above the normal full-body threshold. Only `not-found` means no override; an outline-only response or any other fetch failure (transport, auth, server error) is a real error: surface it and stop, no silent fallback. Each `/<project>/` subtree:
 
 - `/<project>/index.md`: project hub; links every doc below, anchors discovery
+- Hub rule (`index.md`, any link page): links plus one line each; no content, status, or summaries copied from children; each child links back to its hub; about 40 outbound documents, then a second-level hub; a document that outgrows one fetch splits into a hub plus topic files. Real relations go in `rel-*` metadata, not hub adjacency.
 - `/<project>/architecture.md`: system design, module boundaries, key decisions
 - `/<project>/patterns.md`: code patterns, conventions, idioms
 - `/<project>/guidelines.md`: hard code-quality rules; read before writing code

--- a/plugins/opencode-memory/CHANGELOG.md
+++ b/plugins/opencode-memory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.92
+
+`remember` skill: hub rule for `index.md` and any link page (links plus one line each, nothing copied from children, children link back, about 40 outbound documents, split an outgrown document into a hub plus topic files).
+
 ## 0.13.91
 
 Docs follow the vocabulary: "memory" is the store concept, "soul" is your own instance. README and manifest descriptions say soul where they mean the bound store.

--- a/plugins/opencode-memory/package.json
+++ b/plugins/opencode-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-opencode-memory",
-  "version": "0.13.91",
+  "version": "0.13.92",
   "description": "Local, versioned memory for OpenCode via demarkus. Provisions a local demarkus-server, auto-generates a token, wires the demarkus-memory MCP server, injects standing guidance so sessions self-document to your soul, and enforces a publish tag-gate plus a destination gate.",
   "author": "latebit",
   "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/opencode-memory",

--- a/plugins/opencode-memory/skills/remember/SKILL.md
+++ b/plugins/opencode-memory/skills/remember/SKILL.md
@@ -44,6 +44,7 @@ Replace `<shell-escaped-absolute-project-dir>` with exactly one POSIX-shell-safe
 Canonical layout below. A `/project-template.md` at the soul root overrides it: fetch with `force: true` and follow it when present, even above the normal full-body threshold. Only `not-found` means no override; an outline-only response or any other fetch failure (transport, auth, server error) is a real error: surface it and stop, no silent fallback. Each `/<project>/` subtree:
 
 - `/<project>/index.md`: project hub; links every doc below, anchors discovery
+- Hub rule (`index.md`, any link page): links plus one line each; no content, status, or summaries copied from children; each child links back to its hub; about 40 outbound documents, then a second-level hub; a document that outgrows one fetch splits into a hub plus topic files. Real relations go in `rel-*` metadata, not hub adjacency.
 - `/<project>/architecture.md`: system design, module boundaries, key decisions
 - `/<project>/patterns.md`: code patterns, conventions, idioms
 - `/<project>/guidelines.md`: hard code-quality rules; read before writing code

--- a/plugins/pi-memory/CHANGELOG.md
+++ b/plugins/pi-memory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.91
+
+`remember` skill: hub rule for `index.md` and any link page (links plus one line each, nothing copied from children, children link back, about 40 outbound documents, split an outgrown document into a hub plus topic files).
+
 ## 0.13.90
 
 Docs follow the vocabulary: "memory" is the store concept, "soul" is your own instance. README and manifest descriptions say soul where they mean the bound store. `package.json` now points pi at `skills/remember/SKILL.md`; it still named the pre-rename `skills/memory` path, so the skill was not registered.

--- a/plugins/pi-memory/package.json
+++ b/plugins/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demarkus-pi-memory",
-  "version": "0.13.90",
+  "version": "0.13.91",
   "description": "Local, versioned memory for the pi coding agent via demarkus. Provisions a local demarkus-server, auto-generates a token, wires the demarkus-memory MCP server through pi-mcp-adapter, injects standing guidance so sessions self-document to your soul, and enforces a publish tag-gate plus a destination gate so documents stay findable and land on the right soul.",
   "author": "latebit",
   "homepage": "https://github.com/latebit-io/demarkus/tree/main/plugins/pi-memory",

--- a/plugins/pi-memory/skills/remember/SKILL.md
+++ b/plugins/pi-memory/skills/remember/SKILL.md
@@ -44,6 +44,7 @@ Replace `<shell-escaped-absolute-project-dir>` with exactly one POSIX-shell-safe
 Canonical layout below. A `/project-template.md` at the soul root overrides it: fetch with `force: true` and follow it when present, even above the normal full-body threshold. Only `not-found` means no override; an outline-only response or any other fetch failure (transport, auth, server error) is a real error: surface it and stop, no silent fallback. Each `/<project>/` subtree:
 
 - `/<project>/index.md`: project hub; links every doc below, anchors discovery
+- Hub rule (`index.md`, any link page): links plus one line each; no content, status, or summaries copied from children; each child links back to its hub; about 40 outbound documents, then a second-level hub; a document that outgrows one fetch splits into a hub plus topic files. Real relations go in `rel-*` metadata, not hub adjacency.
 - `/<project>/architecture.md`: system design, module boundaries, key decisions
 - `/<project>/patterns.md`: code patterns, conventions, idioms
 - `/<project>/guidelines.md`: hard code-quality rules; read before writing code

--- a/plugins/prompt-source/memory/skills/remember/SKILL.md.tmpl
+++ b/plugins/prompt-source/memory/skills/remember/SKILL.md.tmpl
@@ -44,6 +44,7 @@ Before the first `mark_*` call, resolve which {{.Store}} this project uses; a pr
 Canonical layout below. A `/project-template.md` at the {{.Store}} root overrides it: fetch with `force: true` and follow it when present, even above the normal full-body threshold. Only `not-found` means no override; an outline-only response or any other fetch failure (transport, auth, server error) is a real error: surface it and stop, no silent fallback. Each `/<project>/` subtree:
 
 - `/<project>/index.md`: project hub; links every doc below, anchors discovery
+- Hub rule (`index.md`, any link page): links plus one line each; no content, status, or summaries copied from children; each child links back to its hub; about 40 outbound documents, then a second-level hub; a document that outgrows one fetch splits into a hub plus topic files. Real relations go in `rel-*` metadata, not hub adjacency.
 - `/<project>/architecture.md`: system design, module boundaries, key decisions
 - `/<project>/patterns.md`: code patterns, conventions, idioms
 - `/<project>/guidelines.md`: hard code-quality rules; read before writing code

--- a/tools/internal/broker/memoryseed/template.md
+++ b/tools/internal/broker/memoryseed/template.md
@@ -14,6 +14,7 @@ The canonical layout for this memory. Agents route new knowledge to these docume
 ## Rules
 
 - Keep `/index.md` current: it is the discovery backstop for anything a catalog lookup cannot surface.
+- Hubs (`/index.md`, any link page) are link pages: links plus one line each, nothing copied from children, each child links back; about 40 outbound documents, then a second-level hub.
 - Tag every publish (`tags`, `importance` in the metadata object); prefer one well-tagged document over scattered fragments.
 - Capture the non-obvious (why a decision was made, a gotcha); skip trivia and anything derivable from code or history.
 - Never store secrets or credentials.

--- a/tools/internal/broker/memoryseed/template.md
+++ b/tools/internal/broker/memoryseed/template.md
@@ -14,7 +14,7 @@ The canonical layout for this memory. Agents route new knowledge to these docume
 ## Rules
 
 - Keep `/index.md` current: it is the discovery backstop for anything a catalog lookup cannot surface.
-- Hubs (`/index.md`, any link page) are link pages: links plus one line each, nothing copied from children, each child links back; about 40 outbound documents, then a second-level hub.
+- Hubs (`/index.md`, any link page) are link pages: links plus one line each, nothing copied from children, each child links back; about 40 outbound documents, then a second-level hub. A document that outgrows one fetch splits into a hub plus topic files. Real relations go in `rel-*` metadata, not hub adjacency.
 - Tag every publish (`tags`, `importance` in the metadata object); prefer one well-tagged document over scattered fragments.
 - Capture the non-obvious (why a decision was made, a gotcha); skip trivia and anything derivable from code or history.
 - Never store secrets or credentials.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added knowledge-system templates defining world and project layouts, linking conventions, document types, and publishing metadata.
  - Added guidance for scalable hub pages, including child backlinks, concise link descriptions, and splitting oversized documents.

- **Documentation**
  - Expanded knowledge-system documentation to clarify canonical layouts and customizable examples.
  - Documented updated memory skill hub-linking rules across supported integrations.

- **Chores**
  - Updated plugin and package versions across marketplace listings and supported integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->