### PR TITLE
feat(broker): make Deployment rollout strategy configurable

### DIFF
--- a/deploy/helm/demarkus-knowledge-broker/README.md
+++ b/deploy/helm/demarkus-knowledge-broker/README.md
@@ -6,8 +6,10 @@ Secrets.
 
 ## What this chart ships
 
-- Multi-replica `Deployment` (default 2) with `RollingUpdate` strategy
-  and `PodDisruptionBudget` (`minAvailable: 1`).
+- Multi-replica `Deployment` (default 2) with a configurable `strategy`
+  (default `RollingUpdate`, `maxUnavailable: 0`, `maxSurge: 1`, so even a
+  single replica rolls without a serving gap) and `PodDisruptionBudget`
+  (`minAvailable: 1`).
 - Chart-managed broker config Secret with auto-generated cookie HMAC key
   preserved across `helm upgrade` via `lookup`.
 - Per-world `Role` + `RoleBinding` in each world's namespace

--- a/deploy/helm/demarkus-knowledge-broker/templates/deployment.yaml
+++ b/deploy/helm/demarkus-knowledge-broker/templates/deployment.yaml
@@ -7,10 +7,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
-      maxSurge: 1
+    {{- toYaml .Values.strategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "demarkus-knowledge-broker.selectorLabels" . | nindent 6 }}

--- a/deploy/helm/demarkus-knowledge-broker/templates/deployment.yaml
+++ b/deploy/helm/demarkus-knowledge-broker/templates/deployment.yaml
@@ -7,7 +7,11 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
-    {{- toYaml .Values.strategy | nindent 4 }}
+    type: {{ .Values.strategy.type }}
+    {{- if eq .Values.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      {{- toYaml .Values.strategy.rollingUpdate | nindent 6 }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "demarkus-knowledge-broker.selectorLabels" . | nindent 6 }}

--- a/deploy/helm/demarkus-knowledge-broker/tests/deployment_test.yaml
+++ b/deploy/helm/demarkus-knowledge-broker/tests/deployment_test.yaml
@@ -29,6 +29,28 @@ tests:
       - equal:
           path: spec.strategy.type
           value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
+
+  - it: strategy is overridable so operators can trade surge for availability
+    template: deployment.yaml
+    set:
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+          maxSurge: 0
+    asserts:
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 0
 
   - it: container image uses AppVersion when image.tag empty and relies on ENTRYPOINT
     template: deployment.yaml

--- a/deploy/helm/demarkus-knowledge-broker/tests/deployment_test.yaml
+++ b/deploy/helm/demarkus-knowledge-broker/tests/deployment_test.yaml
@@ -52,6 +52,17 @@ tests:
           path: spec.strategy.rollingUpdate.maxSurge
           value: 0
 
+  - it: Recreate strategy omits rollingUpdate, which the API forbids alongside it
+    template: deployment.yaml
+    set:
+      strategy.type: Recreate
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - notExists:
+          path: spec.strategy.rollingUpdate
+
   - it: container image uses AppVersion when image.tag empty and relies on ENTRYPOINT
     template: deployment.yaml
     asserts:

--- a/deploy/helm/demarkus-knowledge-broker/values.yaml
+++ b/deploy/helm/demarkus-knowledge-broker/values.yaml
@@ -22,6 +22,7 @@ replicaCount: 2
 # Rollout strategy. maxUnavailable: 0 keeps the old pod serving until the
 # new one is Ready, so a single-replica deployment still rolls without a
 # gap; the OAuth stores are per-pod memory, so single-replica is common.
+# rollingUpdate is rendered only when type is RollingUpdate.
 strategy:
   type: RollingUpdate
   rollingUpdate:

--- a/deploy/helm/demarkus-knowledge-broker/values.yaml
+++ b/deploy/helm/demarkus-knowledge-broker/values.yaml
@@ -19,6 +19,15 @@ imagePullSecrets: []
 # leader-election overhead.
 replicaCount: 2
 
+# Rollout strategy. maxUnavailable: 0 keeps the old pod serving until the
+# new one is Ready, so a single-replica deployment still rolls without a
+# gap; the OAuth stores are per-pod memory, so single-replica is common.
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+
 server:
   # HTTP listen port inside the pod. The broker speaks plain HTTP — the
   # Ingress (shipped in the Ingress slice) terminates TLS. The pod listens

--- a/deploy/helm/demarkus-memory-broker/README.md
+++ b/deploy/helm/demarkus-memory-broker/README.md
@@ -23,8 +23,10 @@ Secrets, hot-reloads the fragment, and bootstraps the world. See
 
 ## What this chart ships
 
-- Multi-replica `Deployment` (default 2) with `RollingUpdate` strategy
-  and `PodDisruptionBudget` (`minAvailable: 1`).
+- Multi-replica `Deployment` (default 2) with a configurable `strategy`
+  (default `RollingUpdate`, `maxUnavailable: 0`, `maxSurge: 1`, so even a
+  single replica rolls without a serving gap) and `PodDisruptionBudget`
+  (`minAvailable: 1`).
 - Chart-managed broker config Secret with auto-generated cookie HMAC key
   preserved across `helm upgrade` via `lookup`.
 - Per-world `Role` + `RoleBinding` in each world's namespace

--- a/deploy/helm/demarkus-memory-broker/templates/deployment.yaml
+++ b/deploy/helm/demarkus-memory-broker/templates/deployment.yaml
@@ -7,10 +7,11 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: {{ .Values.strategy.type }}
+    {{- if eq .Values.strategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: 1
-      maxSurge: 1
+      {{- toYaml .Values.strategy.rollingUpdate | nindent 6 }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "demarkus-memory-broker.selectorLabels" . | nindent 6 }}

--- a/deploy/helm/demarkus-memory-broker/tests/deployment_test.yaml
+++ b/deploy/helm/demarkus-memory-broker/tests/deployment_test.yaml
@@ -29,6 +29,39 @@ tests:
       - equal:
           path: spec.strategy.type
           value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
+
+  - it: strategy is overridable so operators can trade surge for availability
+    template: deployment.yaml
+    set:
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+          maxSurge: 0
+    asserts:
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 0
+
+  - it: Recreate strategy omits rollingUpdate, which the API forbids alongside it
+    template: deployment.yaml
+    set:
+      strategy.type: Recreate
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - notExists:
+          path: spec.strategy.rollingUpdate
 
   - it: container image uses AppVersion when image.tag empty and relies on ENTRYPOINT
     template: deployment.yaml

--- a/deploy/helm/demarkus-memory-broker/values.yaml
+++ b/deploy/helm/demarkus-memory-broker/values.yaml
@@ -19,6 +19,16 @@ imagePullSecrets: []
 # leader-election overhead.
 replicaCount: 2
 
+# Rollout strategy. maxUnavailable: 0 keeps the old pod serving until the
+# new one is Ready, so a single-replica deployment still rolls without a
+# gap; the OAuth stores are per-pod memory, so single-replica is common.
+# rollingUpdate is rendered only when type is RollingUpdate.
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+
 server:
   # HTTP listen port inside the pod. The broker speaks plain HTTP — the
   # Ingress (shipped in the Ingress slice) terminates TLS. The pod listens


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable deployment rollout strategies for Helm deployments.
  - Default rolling updates maintain zero unavailable replicas and allow one additional replica during updates.
  - Deployment availability and surge limits can be customized.
  - Deployments can use a recreate strategy when preferred, without rolling-update settings.

- **Documentation**
  - Updated deployment documentation with rollout defaults and zero-downtime behavior for single-replica deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->