### PR TITLE
fix(broker): allowlist Cursor's private-use scheme redirect at DCR

### DIFF
--- a/docs/adr/0011-native-scheme-redirect-allowlist.md
+++ b/docs/adr/0011-native-scheme-redirect-allowlist.md
@@ -1,0 +1,42 @@
+# ADR 0011: Allowlisted private-use scheme redirects for MCP hosts
+
+Status: proposed (2026-09-06).
+
+## Context
+
+The broker's RFC 7591 registration endpoint accepts two redirect shapes: http
+loopback (RFC 8252 section 7.3) and absolute https (the web-client shape from
+ADR 0001). Claude Code registers a loopback callback and works. Cursor
+registers `cursor://anysphere.cursor-mcp/oauth/callback`, a private-use URI
+scheme (RFC 8252 section 7.1), and `parseRedirectURIs` fails the whole
+registration with `invalid_redirect_uri`. Cursor retries the same registration
+on every Connect and never reaches the browser.
+
+Dropping unsupported entries instead of failing does not help: Cursor sends the
+custom-scheme callback and uses it at authorize time, so a registration without
+it fails one step later at the redirect trust check.
+
+## Decision
+
+`validateClientRedirectURI` accepts a third shape: an exact match against a
+package-level allowlist of known private-use scheme callbacks. The allowlist
+ships with the Cursor entry. Matching is byte-for-byte on the full URI, never
+on the scheme alone, so an unknown host cannot register `cursor://evil/...`.
+
+The authorize leg is unchanged. It already trusts whatever redirect the DCR
+record holds for the client id, so admitting the URI at registration is the
+whole change.
+
+No config knob. A second host that needs its own callback adds a line to the
+allowlist and a test. A knob nobody turns off is not worth its surface.
+
+## Consequences
+
+- Cursor completes the MCP OAuth flow against the broker without a local
+  proxy.
+- Custom-scheme callbacks can be claimed by another app on the same OS. RFC
+  8252 accepts this for public clients because PKCE binds the code to the
+  verifier the real client holds. The broker already requires PKCE S256 on the
+  authorization code grant, and the allowlist keeps the exposure to callbacks
+  we chose to trust.
+- Adding a host is a code change and a release, not an operator setting.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -14,3 +14,4 @@ Decision records binding the protocol, spec, and repo; git is canonical, and eac
 | [0008](0008-gcs-root-cas-storage.md) | GCS world state commits through one root CAS | accepted 2026-08-22 |
 | [0009](0009-license-split-core-agpl-plugins-mit.md) | AGPL for the core, MIT for plugins and satellites | accepted 2026-08-27 |
 | [0010](0010-remove-postgres-backend.md) | Remove the Postgres backend | accepted 2026-08-27 |
+| [0011](0011-native-scheme-redirect-allowlist.md) | Allowlisted private-use scheme redirects for MCP hosts | proposed 2026-09-06 |

--- a/tools/internal/broker/dynamic_clients.go
+++ b/tools/internal/broker/dynamic_clients.go
@@ -149,11 +149,23 @@ func (s *DynamicClientStore) Lookup(ctx context.Context, clientID string) (dynam
 	return record, found, nil
 }
 
+// nativeRedirectURIs: exact-match allowlist of private-use scheme
+// callbacks (RFC 8252 §7.1) MCP hosts register via DCR. Whole URIs,
+// never schemes; rationale in ADR 0011.
+var nativeRedirectURIs = map[string]struct{}{
+	"cursor://anysphere.cursor-mcp/oauth/callback": {},
+}
+
+func isNativeRedirectURI(raw string) bool {
+	_, ok := nativeRedirectURIs[raw]
+	return ok
+}
+
 // validateClientRedirectURI accepts only trustable redirect shapes:
-// http loopback (RFC 8252 natives), or the webClients registry's
-// https shape (absolute, no userinfo, no fragment) — one rule set.
+// http loopback, an allowlisted native-scheme callback, or the
+// webClients https shape (absolute, no userinfo, no fragment).
 func validateClientRedirectURI(raw string) error {
-	if isLoopbackRedirectURI(raw) {
+	if isLoopbackRedirectURI(raw) || isNativeRedirectURI(raw) {
 		return nil
 	}
 	return validateWebRedirectURI(raw)

--- a/tools/internal/broker/dynamic_clients_test.go
+++ b/tools/internal/broker/dynamic_clients_test.go
@@ -108,7 +108,11 @@ func TestAuthorizeTrustsAllowlistedNativeSchemeRedirect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("register: %v", err)
 	}
-	defer func() { _ = reg.Body.Close() }()
+	defer func() {
+		if err := reg.Body.Close(); err != nil {
+			t.Errorf("close register body: %v", err)
+		}
+	}()
 	if reg.StatusCode != http.StatusCreated {
 		t.Fatalf("register status = %d, want 201", reg.StatusCode)
 	}
@@ -130,9 +134,16 @@ func TestAuthorizeTrustsAllowlistedNativeSchemeRedirect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("authorize: %v", err)
 	}
-	_ = resp.Body.Close()
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("close authorize body: %v", err)
+	}
 	if resp.StatusCode != http.StatusFound {
 		t.Fatalf("authorize with allowlisted native redirect = %d, want 302 to IdP", resp.StatusCode)
+	}
+	// The client redirect never rides in Location: it lives in the
+	// auth-code record and is replayed at /auth/callback.
+	if loc := resp.Header.Get("Location"); !strings.HasPrefix(loc, "https://idp.example.com/authorize") {
+		t.Errorf("redirected to %q, want IdP authorize URL", loc)
 	}
 }
 

--- a/tools/internal/broker/dynamic_clients_test.go
+++ b/tools/internal/broker/dynamic_clients_test.go
@@ -80,6 +80,9 @@ func TestRegisterRejectsInvalidRedirectURIs(t *testing.T) {
 		`{"redirect_uris":["https://user:pw@host.example/cb"]}`,
 		`{"redirect_uris":["https://host.example/cb#frag"]}`,
 		`{"redirect_uris":[42]}`,
+		`{"redirect_uris":["cursor://evil.example/oauth/callback"]}`,
+		`{"redirect_uris":["windsurf://anysphere.cursor-mcp/oauth/callback"]}`,
+		`{"redirect_uris":["https://host.example/cb","cursor://evil.example/oauth/callback"]}`,
 	} {
 		resp, err := client.Post(srv.URL+"/register", "application/json", strings.NewReader(body))
 		if err != nil {
@@ -89,6 +92,47 @@ func TestRegisterRejectsInvalidRedirectURIs(t *testing.T) {
 		if resp.StatusCode != http.StatusBadRequest {
 			t.Errorf("register %s = %d, want 400", body, resp.StatusCode)
 		}
+	}
+}
+
+// Cursor registers a private-use scheme callback (RFC 8252 §7.1).
+// The exact allowlisted URI registers and is trusted at authorize.
+func TestAuthorizeTrustsAllowlistedNativeSchemeRedirect(t *testing.T) {
+	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{authURL: "https://idp.example.com/authorize"}, fake.NewSimpleClientset())
+	client := testClient(srv)
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	const callback = "cursor://anysphere.cursor-mcp/oauth/callback"
+	reg, err := client.Post(srv.URL+"/register", "application/json",
+		strings.NewReader(`{"client_name":"Cursor","redirect_uris":["`+callback+`"]}`))
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	defer func() { _ = reg.Body.Close() }()
+	if reg.StatusCode != http.StatusCreated {
+		t.Fatalf("register status = %d, want 201", reg.StatusCode)
+	}
+	var regDoc struct {
+		ClientID     string   `json:"client_id"`
+		RedirectURIs []string `json:"redirect_uris"`
+	}
+	if err := json.NewDecoder(reg.Body).Decode(&regDoc); err != nil {
+		t.Fatalf("decode register response: %v", err)
+	}
+	if len(regDoc.RedirectURIs) != 1 || regDoc.RedirectURIs[0] != callback {
+		t.Fatalf("redirect_uris echoed = %v, want [%s]", regDoc.RedirectURIs, callback)
+	}
+
+	q := authorizeQuery()
+	q.Set("client_id", regDoc.ClientID)
+	q.Set("redirect_uri", callback)
+	resp, err := client.Get(srv.URL + "/oauth/authorize?" + q.Encode())
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("authorize with allowlisted native redirect = %d, want 302 to IdP", resp.StatusCode)
 	}
 }
 

--- a/tools/internal/broker/dynamic_clients_test.go
+++ b/tools/internal/broker/dynamic_clients_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/cookiejar"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -96,10 +99,22 @@ func TestRegisterRejectsInvalidRedirectURIs(t *testing.T) {
 }
 
 // Cursor registers a private-use scheme callback (RFC 8252 §7.1).
-// The exact allowlisted URI registers and is trusted at authorize.
+// The exact allowlisted URI registers, is trusted at authorize, and
+// is replayed by /auth/callback with the authorization code.
 func TestAuthorizeTrustsAllowlistedNativeSchemeRedirect(t *testing.T) {
-	srv, _ := newTestServer(t, testConfig(), &fakeVerifier{authURL: "https://idp.example.com/authorize"}, fake.NewSimpleClientset())
+	verifier := &fakeVerifier{
+		authURL: "https://idp.example.com/authorize",
+		claims:  Claims{Subject: "google|123", Email: "alice@example.com", EmailVerified: true},
+	}
+	cfg := testConfig()
+	cfg.Server.PublicURL = "https://broker.example.com"
+	srv, _ := newTestServer(t, cfg, verifier, fake.NewSimpleClientset())
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
 	client := testClient(srv)
+	client.Jar = jar
 	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 
 	const callback = "cursor://anysphere.cursor-mcp/oauth/callback"
@@ -130,20 +145,58 @@ func TestAuthorizeTrustsAllowlistedNativeSchemeRedirect(t *testing.T) {
 	q := authorizeQuery()
 	q.Set("client_id", regDoc.ClientID)
 	q.Set("redirect_uri", callback)
-	resp, err := client.Get(srv.URL + "/oauth/authorize?" + q.Encode())
+	authResp, err := client.Get(srv.URL + "/oauth/authorize?" + q.Encode())
 	if err != nil {
 		t.Fatalf("authorize: %v", err)
 	}
-	if err := resp.Body.Close(); err != nil {
+	if err := authResp.Body.Close(); err != nil {
 		t.Errorf("close authorize body: %v", err)
 	}
-	if resp.StatusCode != http.StatusFound {
-		t.Fatalf("authorize with allowlisted native redirect = %d, want 302 to IdP", resp.StatusCode)
+	if authResp.StatusCode != http.StatusFound {
+		t.Fatalf("authorize with allowlisted native redirect = %d, want 302 to IdP", authResp.StatusCode)
 	}
-	// The client redirect never rides in Location: it lives in the
-	// auth-code record and is replayed at /auth/callback.
-	if loc := resp.Header.Get("Location"); !strings.HasPrefix(loc, "https://idp.example.com/authorize") {
-		t.Errorf("redirected to %q, want IdP authorize URL", loc)
+	idpRedirect, err := url.Parse(authResp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse IdP redirect: %v", err)
+	}
+	if !strings.HasPrefix(idpRedirect.String(), "https://idp.example.com/authorize") {
+		t.Fatalf("redirected to %q, want IdP authorize URL", idpRedirect)
+	}
+	nonce := idpRedirect.Query().Get("state")
+	if nonce == "" {
+		t.Fatal("missing IdP state nonce")
+	}
+
+	// The IdP returns; the jar replays the state cookie and the
+	// broker must 302 to the native callback with the code.
+	cbReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		srv.URL+"/auth/callback?code=idp-code-abc&state="+url.QueryEscape(nonce), http.NoBody)
+	cbResp, err := client.Do(cbReq)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	defer func() {
+		if err := cbResp.Body.Close(); err != nil {
+			t.Errorf("close callback body: %v", err)
+		}
+	}()
+	if cbResp.StatusCode != http.StatusFound {
+		body, _ := io.ReadAll(cbResp.Body)
+		t.Fatalf("callback status = %d, want 302; body=%s", cbResp.StatusCode, body)
+	}
+	clientRedirect, err := url.Parse(cbResp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse client redirect: %v", err)
+	}
+	if clientRedirect.Scheme != "cursor" || clientRedirect.Host != "anysphere.cursor-mcp" || clientRedirect.Path != "/oauth/callback" {
+		t.Errorf("client redirect = %q, want %s", clientRedirect, callback)
+	}
+	cq := clientRedirect.Query()
+	if cq.Get("code") == "" {
+		t.Error("missing code on client redirect")
+	}
+	if got := cq.Get("state"); got != "client-state-nonce" {
+		t.Errorf("state passthrough mismatch: got %q", got)
 	}
 }
 

--- a/tools/internal/broker/dynamic_clients_test.go
+++ b/tools/internal/broker/dynamic_clients_test.go
@@ -169,8 +169,11 @@ func TestAuthorizeTrustsAllowlistedNativeSchemeRedirect(t *testing.T) {
 
 	// The IdP returns; the jar replays the state cookie and the
 	// broker must 302 to the native callback with the code.
-	cbReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
+	cbReq, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
 		srv.URL+"/auth/callback?code=idp-code-abc&state="+url.QueryEscape(nonce), http.NoBody)
+	if err != nil {
+		t.Fatalf("build callback request: %v", err)
+	}
 	cbResp, err := client.Do(cbReq)
 	if err != nil {
 		t.Fatalf("callback: %v", err)
@@ -181,7 +184,10 @@ func TestAuthorizeTrustsAllowlistedNativeSchemeRedirect(t *testing.T) {
 		}
 	}()
 	if cbResp.StatusCode != http.StatusFound {
-		body, _ := io.ReadAll(cbResp.Body)
+		body, readErr := io.ReadAll(cbResp.Body)
+		if readErr != nil {
+			t.Errorf("read callback body: %v", readErr)
+		}
 		t.Fatalf("callback status = %d, want 302; body=%s", cbResp.StatusCode, body)
 	}
 	clientRedirect, err := url.Parse(cbResp.Header.Get("Location"))

--- a/tools/internal/broker/register.go
+++ b/tools/internal/broker/register.go
@@ -119,8 +119,8 @@ func (s *Server) register(w http.ResponseWriter, r *http.Request) {
 }
 
 // parseRedirectURIs decodes and validates RFC 7591 redirect_uris:
-// a non-empty JSON string array whose entries are https URLs or http
-// loopback, with no userinfo and no fragment.
+// a non-empty JSON string array whose entries are https URLs, http
+// loopback, or an allowlisted native-scheme callback.
 func parseRedirectURIs(raw any) ([]string, error) {
 	list, ok := raw.([]any)
 	if !ok || len(list) == 0 {

--- a/tools/internal/broker/register.go
+++ b/tools/internal/broker/register.go
@@ -118,9 +118,9 @@ func (s *Server) register(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, doc)
 }
 
-// parseRedirectURIs decodes and validates RFC 7591 redirect_uris:
-// a non-empty JSON string array whose entries are https URLs, http
-// loopback, or an allowlisted native-scheme callback.
+// parseRedirectURIs decodes and validates RFC 7591 redirect_uris: a
+// non-empty JSON string array of absolute https URLs (no userinfo, no
+// fragment), http loopback, or an allowlisted native-scheme callback.
 func parseRedirectURIs(raw any) ([]string, error) {
 	list, ok := raw.([]any)
 	if !ok || len(list) == 0 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Cursor’s approved native callback URI during client registration and authorization.
  - Redirect validation now requires exact matches for approved native callback addresses while continuing to support permitted loopback and HTTPS redirects.

- **Bug Fixes**
  - Prevented unapproved native-scheme callback URIs, including non-allowlisted Cursor and Windsurf callbacks, from being accepted.

- **Documentation**
  - Documented the approved native redirect policy and related security considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->