### PR TITLE
feat(server): retune body-match ranking on the retrieval benchmark

### DIFF
--- a/docs/adr/0012-lookup-body-match.md
+++ b/docs/adr/0012-lookup-body-match.md
@@ -49,7 +49,9 @@ The spec fixes recall and leaves order to the implementation:
 - Importance is a prior among matches and never admits a non-match. Ties
   break by path then anchor. Nothing else about order is specified. The
   reference server ranks by BM25 with heading and tag terms weighted higher,
-  scaled by `0.7 + 0.3 * importance`.
+  a catalog answer boosted, scaled by an importance prior with a floor and
+  demoted under a `journal` path segment; the values live in `bodymatch.go`
+  and are retuned on the retrieval benchmark.
 - Body rows carry `#anchor` in the path, `title › heading` in the title, and
   a fifth `Snippet` column of one line at most 240 bytes.
 

--- a/server/internal/catalog/bodymatch.go
+++ b/server/internal/catalog/bodymatch.go
@@ -1,8 +1,9 @@
 package catalog
 
 import (
+	"cmp"
 	"math"
-	"sort"
+	"slices"
 	"strings"
 	"unicode/utf8"
 )
@@ -17,10 +18,19 @@ const (
 	docWeight   = 2.0
 )
 
+// Reference ranking knobs tuned on the retrieval benchmark (plan:
+// token-efficient retrieval, workstream 3): the importance prior's floor,
+// the boost for a tags-or-title match, and the multiplier under journal/.
+const (
+	priorFloor    = 0.3
+	catalogBoost  = 2.0
+	journalDemote = 0.5
+)
+
 type bodyCandidate struct {
 	entry   *Entry
 	sec     *section
-	catalog bool // tags or title carry every term: ranks before section rows
+	catalog bool // tags or title carry every term: one boosted bare-path row
 	score   float64
 }
 
@@ -121,14 +131,17 @@ func (c *Catalog) scanBody(terms []term, scope string, filter []Predicate) *body
 	return scan
 }
 
-// rankBody scores, normalizes by the best, applies the importance prior,
-// and sorts: catalog rows first as catalog mode would order them, then
-// sections by score, then the spec's path-then-anchor tiebreak.
+// rankBody scores (catalog rows boosted), normalizes by the best, applies
+// the prior, and sorts by score, then the spec's path-then-anchor tiebreak.
 func rankBody(scan *bodyScan, terms []term) {
 	found := scan.found
+	idf := idfs(scan, len(terms))
 	maxScore := 0.0
 	for i := range found {
-		found[i].score = bm25(&found[i], terms, scan.df, scan.sections, scan.avgLength)
+		found[i].score = bm25(&found[i], terms, idf, scan.avgLength)
+		if found[i].catalog {
+			found[i].score *= catalogBoost
+		}
 		maxScore = max(maxScore, found[i].score)
 	}
 	for i := range found {
@@ -136,39 +149,52 @@ func rankBody(scan *bodyScan, terms []term) {
 		if maxScore > 0 {
 			norm = found[i].score / maxScore
 		}
-		found[i].score = norm * (0.7 + 0.3*found[i].entry.Importance)
+		found[i].score = norm * prior(found[i].entry)
 	}
-	sort.SliceStable(found, func(i, j int) bool {
-		a, b := found[i], found[j]
-		if a.catalog != b.catalog {
-			return a.catalog
-		}
+	slices.SortStableFunc(found, func(a, b bodyCandidate) int {
 		if a.score != b.score {
-			return a.score > b.score
+			return cmp.Compare(b.score, a.score)
 		}
-		if a.entry.Path != b.entry.Path {
-			return a.entry.Path < b.entry.Path
+		if c := cmp.Compare(a.entry.Path, b.entry.Path); c != 0 {
+			return c
 		}
-		return a.sec.anchor < b.sec.anchor
+		return cmp.Compare(a.sec.anchor, b.sec.anchor)
 	})
 }
 
+// prior scales a normalized score by declared importance, then by the
+// document's path demotion.
+func prior(e *Entry) float64 {
+	return (priorFloor + (1-priorFloor)*e.Importance) * e.demote
+}
+
+// idfs is the BM25 inverse document frequency per term over the scanned
+// sections, fixed for the query.
+func idfs(scan *bodyScan, n int) []float64 {
+	idf := make([]float64, n)
+	sections := float64(scan.sections)
+	for j := range idf {
+		df := float64(scan.df[j])
+		idf[j] = math.Log(1 + (sections-df+0.5)/(df+0.5))
+	}
+	return idf
+}
+
 // bm25 scores one candidate: the text part per term plus the trail and
-// document weights when the term was found there.
-func bm25(cand *bodyCandidate, terms []term, df []int, sections int, avgLength float64) float64 {
+// document weights when the term was found there; idf is per term.
+func bm25(cand *bodyCandidate, terms []term, idf []float64, avgLength float64) float64 {
 	score := 0.0
 	lengthNorm := 1 - bm25B + bm25B*float64(cand.sec.length)/max(avgLength, 1)
 	for j, t := range terms {
-		idf := math.Log(1 + (float64(sections)-float64(df[j])+0.5)/(float64(df[j])+0.5))
 		if i, ok := termIndex(cand.sec.tokens, t); ok {
 			tf := float64(cand.sec.tf[i])
-			score += idf * tf * (bm25K1 + 1) / (tf + bm25K1*lengthNorm)
+			score += idf[j] * tf * (bm25K1 + 1) / (tf + bm25K1*lengthNorm)
 		}
 		if hasTerm(cand.sec.trail, t) {
-			score += idf * trailWeight
+			score += idf[j] * trailWeight
 		}
 		if hasTerm(cand.entry.terms, t) {
-			score += idf * docWeight
+			score += idf[j] * docWeight
 		}
 	}
 	return score

--- a/server/internal/catalog/bodymatch_test.go
+++ b/server/internal/catalog/bodymatch_test.go
@@ -6,10 +6,12 @@ import (
 	"time"
 )
 
+// putDoc publishes one document into the catalog with the given metadata.
 func putDoc(c *Catalog, path, body string, meta map[string]string) {
 	c.Put(path, meta, []byte(body), time.Now())
 }
 
+// locations joins result locations in rank order for one-line assertions.
 func locations(rs []Result) string {
 	out := make([]string, len(rs))
 	for i := range rs {

--- a/server/internal/catalog/bodymatch_test.go
+++ b/server/internal/catalog/bodymatch_test.go
@@ -1,0 +1,77 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func putDoc(c *Catalog, path, body string, meta map[string]string) {
+	c.Put(path, meta, []byte(body), time.Now())
+}
+
+func locations(rs []Result) string {
+	out := make([]string, len(rs))
+	for i := range rs {
+		out[i] = rs[i].Location()
+	}
+	return strings.Join(out, ",")
+}
+
+// TestReferenceRanking pins the order rules outside the spec: journal paths
+// demoted, a tags-or-title match boosted over a mere mention, a
+// heading-and-text section over a lower-importance tagged journal.
+func TestReferenceRanking(t *testing.T) {
+	tests := []struct {
+		name  string
+		docs  func(c *Catalog)
+		query string
+		want  string
+	}{
+		{
+			name: "journal path sorts below an equal document elsewhere",
+			docs: func(c *Catalog) {
+				putDoc(c, "/journal/2026-01-01.md", "# Day\n\nshared phrase kiwi\n", map[string]string{"importance": "0.6"})
+				putDoc(c, "/notes.md", "# Notes\n\nshared phrase kiwi\n", map[string]string{"importance": "0.6"})
+			},
+			query: "kiwi",
+			want:  "/notes.md#notes,/journal/2026-01-01.md#day",
+		},
+		{
+			name: "nested journal segment is demoted once",
+			docs: func(c *Catalog) {
+				putDoc(c, "/sub/journal/2026-01-01.md", "# Day\n\nshared phrase kiwi\n", map[string]string{"importance": "0.6"})
+				putDoc(c, "/notes.md", "# Notes\n\nshared phrase kiwi\n", map[string]string{"importance": "0.6"})
+			},
+			query: "kiwi",
+			want:  "/notes.md#notes,/sub/journal/2026-01-01.md#day",
+		},
+		{
+			name: "tagged document outranks a section that only mentions the term",
+			docs: func(c *Catalog) {
+				putDoc(c, "/plans/mango.md", "# Mango plan\n\n## Goal\n\nRipen the mango.\n", map[string]string{"tags": "mango,fruit", "importance": "0.5"})
+				putDoc(c, "/plans/other.md", "# Other\n\n## Mango\n\nA mango is mentioned here and mango again.\n", map[string]string{"importance": "0.9"})
+			},
+			query: "mango",
+			want:  "/plans/mango.md,/plans/other.md#mango",
+		},
+		{
+			name: "heading and text section outranks a lower-importance tagged journal",
+			docs: func(c *Catalog) {
+				putDoc(c, "/journal/2026-01-02.md", "# Day two\n\nFixed the papaya bug.\n", map[string]string{"tags": "papaya", "importance": "0.55"})
+				putDoc(c, "/debugging.md", "# Debugging\n\n## Papaya reverts on restart\n\nThe papaya path is rewritten by the watcher.\n", map[string]string{"tags": "debugging", "importance": "0.85"})
+			},
+			query: "papaya",
+			want:  "/debugging.md#papaya-reverts-on-restart,/journal/2026-01-02.md",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := New()
+			tt.docs(c)
+			if got := locations(mustLookup(t, c, tt.query, Options{Match: MatchBody})); got != tt.want {
+				t.Errorf("body lookup %q = %s, want %s", tt.query, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/internal/catalog/catalog.go
+++ b/server/internal/catalog/catalog.go
@@ -15,6 +15,7 @@ package catalog
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -33,7 +34,8 @@ type Entry struct {
 	Modified   time.Time
 	Metadata   map[string]string // declared publisher metadata, for filter predicates
 
-	terms []term // tag and title tokens for body match; set by Set
+	terms  []term  // tag and title tokens for body match; set by Set
+	demote float64 // body-match prior multiplier from the path; set by Set
 }
 
 // Result is a ranked LOOKUP match. Anchor, Heading, and Snippet are set
@@ -118,11 +120,15 @@ func (c *Catalog) Put(docPath string, meta map[string]string, body []byte, modif
 	c.sections[e.Path] = doc
 }
 
-// prepare canonicalizes the path and derives the tag and title terms that
-// body match consults; every entry passes through here before storage.
+// prepare canonicalizes the path and derives what body match consults (tag
+// and title terms, path demotion); every entry passes through here first.
 func (e *Entry) prepare() {
 	e.Path = store.CanonicalPath(e.Path)
 	e.terms = termSet(append(append([]string(nil), e.Tags...), e.Title))
+	e.demote = 1
+	if slices.Contains(strings.Split(strings.Trim(e.Path, "/"), "/"), "journal") {
+		e.demote = journalDemote
+	}
 }
 
 // SetSections installs a prebuilt section index for a document, for stores

--- a/server/internal/catalog/rank_corpus_test.go
+++ b/server/internal/catalog/rank_corpus_test.go
@@ -1,0 +1,94 @@
+package catalog
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/latebit-io/demarkus/protocol/store"
+)
+
+// TestRankCorpus reports the target's body-mode rank per benchmark question
+// over a real corpus, for tuning weights without a full MCP run. It runs
+// only with DEMARKUS_RANK_CORPUS (a file-store root) and
+// DEMARKUS_RANK_QUESTIONS (a retrieval-bench fixture) set; DEMARKUS_RANK_SHOW
+// lists question ids whose top rows to print.
+func TestRankCorpus(t *testing.T) {
+	root, questions := os.Getenv("DEMARKUS_RANK_CORPUS"), os.Getenv("DEMARKUS_RANK_QUESTIONS")
+	if root == "" || questions == "" {
+		t.Skip("set DEMARKUS_RANK_CORPUS and DEMARKUS_RANK_QUESTIONS")
+	}
+	st, err := store.Open(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cat := New()
+	if err := st.WalkCurrent(func(d store.CurrentDoc) error {
+		cat.Put(d.Path, d.Metadata, d.Body, d.Modified)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(questions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Mirrors retrievalbench.QuestionSet, which this module cannot import.
+	var fixture struct {
+		Scope     string `json:"scope"`
+		Questions []struct {
+			ID             string `json:"id"`
+			Category       string `json:"category"`
+			Query          string `json:"query"`
+			Question       string `json:"question"`
+			ExpectedPath   string `json:"expected_path"`
+			ExpectedAnchor string `json:"expected_anchor"`
+		} `json:"questions"`
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&fixture); err != nil {
+		t.Fatal(err)
+	}
+	if len(fixture.Questions) == 0 {
+		t.Fatalf("%s: no questions", questions)
+	}
+	show := os.Getenv("DEMARKUS_RANK_SHOW")
+	var sb strings.Builder
+	over, hits, exact := 0, 0, 0
+	for _, q := range fixture.Questions {
+		rs, err := cat.Lookup(q.Query, Options{Match: MatchBody, Max: 10})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rank, exactRank := 0, 0
+		for i := range rs {
+			if rs[i].Path != q.ExpectedPath {
+				continue
+			}
+			if rank == 0 {
+				rank = i + 1
+			}
+			if exactRank == 0 && (rs[i].Anchor == q.ExpectedAnchor || rs[i].Anchor == "") {
+				exactRank = i + 1
+			}
+		}
+		if rank > 0 && rank <= 5 {
+			hits++
+			over += rank - 1
+		}
+		if exactRank > 0 && exactRank <= 5 {
+			exact++
+		}
+		fmt.Fprintf(&sb, "  %s rank=%d exact=%d\n", q.ID, rank, exactRank)
+		if strings.Contains(show, q.ID) {
+			for i := range rs[:min(5, len(rs))] {
+				fmt.Fprintf(&sb, "      %d %.2f terms=%d %s\n", i+1, rs[i].Importance, len(rs[i].terms), rs[i].Location())
+			}
+		}
+	}
+	t.Logf("hits(top5)=%d exact=%d decoys-above=%d\n%s", hits, exact, over, sb.String())
+}

--- a/server/internal/catalog/rank_corpus_test.go
+++ b/server/internal/catalog/rank_corpus_test.go
@@ -12,10 +12,8 @@ import (
 )
 
 // TestRankCorpus reports the target's body-mode rank per benchmark question
-// over a real corpus, for tuning weights without a full MCP run. It runs
-// only with DEMARKUS_RANK_CORPUS (a file-store root) and
-// DEMARKUS_RANK_QUESTIONS (a retrieval-bench fixture) set; DEMARKUS_RANK_SHOW
-// lists question ids whose top rows to print.
+// over a real file store, so weights can be tuned without a full MCP run.
+// Opt-in through the DEMARKUS_RANK_* variables read below.
 func TestRankCorpus(t *testing.T) {
 	root, questions := os.Getenv("DEMARKUS_RANK_CORPUS"), os.Getenv("DEMARKUS_RANK_QUESTIONS")
 	if root == "" || questions == "" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved body-search result ranking for more relevant matches.
  - Matches in headings and tags receive greater weight than ordinary mentions.
  - Catalog answers receive an additional ranking boost.
  - Results are adjusted based on document importance, with a minimum weighting applied.
  - Pages under “journal” path segments are ranked lower when appropriate.

- **Documentation**
  - Updated technical documentation to describe body-match ranking behavior and weighting rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->