### PR TITLE
fix(plugins): journal nudge waits for background agents

### DIFF
--- a/plugins/claude-code/hooks/session-journal-nudge.sh
+++ b/plugins/claude-code/hooks/session-journal-nudge.sh
@@ -1,96 +1,12 @@
 #!/usr/bin/env bash
-# Stop adapter for the session-end journal nudge. The Stop mechanics are
-# Claude-specific and stay here: parse the payload, guard against re-blocking,
-# and derive the two signals (did the session change files? did it write to a
-# memory?) from the transcript. The DECISION + text comes from the shared
-# demarkus-plugin binary. Self-contained (no lib.sh) — the small JSON field
-# extractor is inlined so the bash infra can be fully retired.
-#
-# Stop hooks surface a message only by blocking (decision:block forces one more
-# turn). Two loop guards prevent wedging: stop_hook_active, and a per-session
-# sentinel so it fires at most once. Fails open on anything unexpected.
-
+# Stop adapter for the session-end journal nudge. The shared demarkus-plugin
+# binary reads the Stop payload, scans the transcript, applies the loop guards
+# (stop_hook_active, once-per-session sentinel) and emits decision:block.
+# Fails open: a missing binary or a failed nudge never blocks the Stop.
 set -uo pipefail
-
 BIN="${HOME}/.demarkus/bin/demarkus-plugin"
 [ -x "${BIN}" ] || exit 0
-
-# stop_hook_fields — read a flat Stop payload on stdin, emit 3 lines:
-# session_id, transcript_path, stop_hook_active ("true"/"false"). Pure awk,
-# string-boundary aware (a quote inside a value can't end the string early).
-stop_hook_fields() {
-  awk '
-    { data = data $0 "\n" }
-    END {
-      n = split(data, ch, ""); depth = 0; inStr = 0; esc = 0; buf = ""; curkey = ""
-      sid = ""; tpath = ""; active = "false"
-      for (i = 1; i <= n; i++) {
-        c = ch[i]
-        if (inStr) {
-          if (esc) { buf = buf c; esc = 0; continue }
-          if (c == "\\") { buf = buf c; esc = 1; continue }
-          if (c == "\"") { inStr = 0; onstr(buf); buf = ""; continue }
-          buf = buf c; continue
-        }
-        if (c == "\"") { inStr = 1; buf = ""; continue }
-        if (c == " " || c == "\t" || c == "\n" || c == "\r") continue
-        if (c == "{") { depth++; expect[depth] = "key"; continue }
-        if (c == "[") { depth++; expect[depth] = "val"; continue }
-        if (c == "}" || c == "]") { depth--; continue }
-        if (c == ":") { expect[depth] = "val"; continue }
-        if (c == ",") { expect[depth] = "key"; continue }
-        sv = c
-        while (i + 1 <= n) {
-          d = ch[i+1]
-          if (d == "," || d == "}" || d == "]" || d == " " || d == "\t" || d == "\n" || d == "\r") break
-          sv = sv d; i++
-        }
-        if (depth == 1 && curkey == "stop_hook_active") active = sv
-        expect[depth] = "key"
-      }
-      print sid; print tpath; print active
-    }
-    function onstr(s) {
-      if (depth == 1 && expect[depth] == "key") { curkey = s; return }
-      if (depth == 1) {
-        if (curkey == "session_id") sid = s
-        else if (curkey == "transcript_path") tpath = s
-        else if (curkey == "stop_hook_active") active = s
-      }
-    }
-  '
+"${BIN}" nudge --event session-end --format claude || {
+  echo "[demarkus-memory] session-end nudge failed (exit $?); skipping" >&2
 }
-
-input="$(cat)"
-parsed="$(printf '%s' "${input}" | stop_hook_fields)" || exit 0
-sid="$(sed -n '1p' <<<"${parsed}")"
-tpath="$(sed -n '2p' <<<"${parsed}")"
-active="$(sed -n '3p' <<<"${parsed}")"
-
-[[ "${active}" == "true" ]] && exit 0
-[[ -n "${sid}" ]] || exit 0
-sentinel="${TMPDIR:-/tmp}/demarkus-memory-nudge-${sid//[^A-Za-z0-9_-]/_}"
-[[ -e "${sentinel}" ]] && exit 0
-[[ -n "${tpath}" && -r "${tpath}" ]] || exit 0
-
-memory_write="false"
-if grep -qE '"attributionMcpTool":"mark_(publish|append)"|"name":"mcp__[^"]*mark_(publish|append)"' "${tpath}"; then
-  memory_write="true"
-fi
-changed_files="false"
-if grep -qE '"name":"(Edit|Write|NotebookEdit)"' "${tpath}"; then
-  changed_files="true"
-fi
-
-# Non-blocking: a nudge failure is logged, never allowed to block the Stop hook.
-status=0
-out="$("${BIN}" nudge --event session-end --changed-files="${changed_files}" --memory-write="${memory_write}" --format claude < /dev/null)" || status=$?
-if [[ "${status}" -ne 0 ]]; then
-  echo "[demarkus-memory] session-end nudge failed (exit ${status}); skipping" >&2
-  out=""
-fi
-if [[ -n "${out}" ]]; then
-  : > "${sentinel}" 2>/dev/null || true
-  printf '%s\n' "${out}"
-fi
 exit 0

--- a/tools/demarkus-plugin/internal/nudge/nudge.go
+++ b/tools/demarkus-plugin/internal/nudge/nudge.go
@@ -20,10 +20,9 @@ type Input struct {
 	Prompt  string         `json:"prompt"`
 	Tool    string         `json:"tool"`
 	Input   map[string]any `json:"input"`
-	// session-end signals (computed by the adapter: Claude from the transcript,
-	// pi from in-session activity tracking).
-	ChangedFiles bool `json:"changedFiles"`
-	MemoryWrite  bool `json:"memoryWrite"`
+	// session-end signals: supplied by the adapter (pi, Cursor) or derived from
+	// TranscriptPath (Claude); the two sources are OR-merged.
+	Signals
 	// LegacyMemoryWrite is the pre-rename key older adapters still send.
 	LegacyMemoryWrite bool `json:"soulWrite"`
 	// Claude hook payload fields (used when Tool/Input are absent) so an adapter
@@ -33,6 +32,10 @@ type Input struct {
 	ToolInput map[string]any `json:"tool_input"`
 	// Cursor reports the MCP server apart from the tool name.
 	McpServerName string `json:"mcp_server_name"`
+	// Claude Stop payload, piped raw by the Stop adapter.
+	SessionID      string `json:"session_id"`
+	TranscriptPath string `json:"transcript_path"`
+	StopHookActive bool   `json:"stop_hook_active"`
 }
 
 // Output carries the nudge text, empty when nothing should be surfaced.
@@ -129,11 +132,23 @@ func promote(in *Input) (Output, error) {
 }
 
 func sessionEnd(in *Input) (Output, error) {
+	if in.StopHookActive {
+		return Output{}, nil // already blocked once this turn
+	}
 	present, err := config.LocalMemoryPresent()
-	if err != nil {
+	if err != nil || !present {
 		return Output{}, err
 	}
-	if present && in.ChangedFiles && !in.MemoryWrite {
+	if in.TranscriptPath != "" {
+		sig, err := ScanTranscript(in.TranscriptPath)
+		if err != nil {
+			return Output{}, err
+		}
+		in.ChangedFiles = in.ChangedFiles || sig.ChangedFiles
+		in.MemoryWrite = in.MemoryWrite || sig.MemoryWrite
+		in.PendingBackground = in.PendingBackground || sig.PendingBackground
+	}
+	if in.ChangedFiles && !in.MemoryWrite && !in.PendingBackground {
 		return Output{Nudge: journalNudge}, nil
 	}
 	return Output{}, nil

--- a/tools/demarkus-plugin/internal/nudge/nudge_test.go
+++ b/tools/demarkus-plugin/internal/nudge/nudge_test.go
@@ -86,20 +86,48 @@ func TestPromoteNoDestination(t *testing.T) {
 
 func TestSessionEnd(t *testing.T) {
 	setupHome(t, map[string]string{"plugin-memory.conf": "SOUL_DIR=/x\nPORT=6310\nMODE=default\n"})
-	if eval(t, &Input{Event: "session-end", ChangedFiles: true, MemoryWrite: false}) == "" {
+	sig := func(changed, write, pending bool) *Input {
+		return &Input{Event: "session-end", Signals: Signals{ChangedFiles: changed, MemoryWrite: write, PendingBackground: pending}}
+	}
+	if eval(t, sig(true, false, false)) == "" {
 		t.Error("changed files + no memory write → journal nudge")
 	}
-	if eval(t, &Input{Event: "session-end", ChangedFiles: true, MemoryWrite: true}) != "" {
+	if eval(t, sig(true, true, false)) != "" {
 		t.Error("a memory write suppresses the nudge")
 	}
-	if eval(t, &Input{Event: "session-end", ChangedFiles: false, MemoryWrite: false}) != "" {
+	if eval(t, sig(false, false, false)) != "" {
 		t.Error("no file changes → no nudge")
+	}
+	if eval(t, sig(true, false, true)) != "" {
+		t.Error("a pending background agent means the session is paused, not over")
+	}
+	in := sig(true, false, false)
+	in.StopHookActive = true
+	if eval(t, in) != "" {
+		t.Error("stop_hook_active=true must not block again")
+	}
+}
+
+func TestSessionEndScansTranscript(t *testing.T) {
+	setupHome(t, map[string]string{"plugin-memory.conf": "SOUL_DIR=/x\nPORT=6310\nMODE=default\n"})
+	path := filepath.Join(t.TempDir(), "t.jsonl")
+	if err := os.WriteFile(path, []byte(editLine+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if eval(t, &Input{Event: "session-end", TranscriptPath: path}) == "" {
+		t.Error("an Edit in the transcript should nudge")
+	}
+	if eval(t, &Input{Event: "session-end", TranscriptPath: path, Signals: Signals{MemoryWrite: true}}) != "" {
+		t.Error("adapter-supplied memoryWrite OR-merges with the scan")
+	}
+	if _, err := Evaluate(&Input{Event: "session-end", TranscriptPath: filepath.Join(t.TempDir(), "missing")}); err == nil {
+		t.Error("unreadable transcript must surface an error, not nudge silently")
 	}
 }
 
 func TestSessionEndAcceptsLegacySoulWriteKey(t *testing.T) {
 	setupHome(t, map[string]string{"plugin-memory.conf": "SOUL_DIR=/x\nPORT=1\nMODE=default\n"})
-	if eval(t, &Input{Event: "session-end", ChangedFiles: true, LegacyMemoryWrite: true}) != "" {
+	if eval(t, &Input{Event: "session-end", Signals: Signals{ChangedFiles: true}, LegacyMemoryWrite: true}) != "" {
 		t.Error("legacy soulWrite=true must suppress the journal nudge like memoryWrite=true")
 	}
 }

--- a/tools/demarkus-plugin/internal/nudge/transcript.go
+++ b/tools/demarkus-plugin/internal/nudge/transcript.go
@@ -1,0 +1,139 @@
+package nudge
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"regexp"
+
+	"github.com/latebit-io/demarkus/tools/demarkus-plugin/internal/config"
+)
+
+// Signals are the session-end facts an adapter supplies or the transcript
+// scan derives.
+type Signals struct {
+	ChangedFiles bool `json:"changedFiles"`
+	MemoryWrite  bool `json:"memoryWrite"`
+	// PendingBackground: a background agent or command has not reported back,
+	// so this Stop is a pause mid-task, not the session's end.
+	PendingBackground bool `json:"pendingBackground"`
+}
+
+var (
+	notifiedIDRe        = regexp.MustCompile(`<tool-use-id>([^<]+)</tool-use-id>`)
+	taskNotificationTag = []byte("<task-notification>")
+	attributionMarkers  = [][]byte{[]byte(`"attributionMcpTool":"mark_publish"`), []byte(`"attributionMcpTool":"mark_append"`)}
+	toolBlockMarkers    = [][]byte{[]byte(`"tool_use"`), []byte(`"tool_result"`)}
+)
+
+// transcriptLine is the slice of a Claude Code JSONL record the scan reads.
+// toolUseResult is harness metadata beside the message; isAsync marks an Agent
+// launch, backgroundTaskId a backgrounded Bash command.
+type transcriptLine struct {
+	Message struct {
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+	ToolUseResult struct {
+		IsAsync          bool   `json:"isAsync"`
+		BackgroundTaskID string `json:"backgroundTaskId"`
+	} `json:"toolUseResult"`
+}
+
+type contentBlock struct {
+	Type      string `json:"type"`
+	Name      string `json:"name"`        // tool_use
+	ToolUseID string `json:"tool_use_id"` // tool_result
+}
+
+// ScanTranscript derives the session-end signals from a Claude Code JSONL
+// transcript. Facts come from tool_use blocks and harness metadata only, so
+// tool output, pasted text, and the system-prompt snapshot cannot fake them.
+func ScanTranscript(path string) (Signals, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return Signals{}, err
+	}
+	defer f.Close() //nolint:errcheck // read-only handle
+	return scanTranscript(f)
+}
+
+type scanner struct {
+	sig     Signals
+	pending map[string]bool // background tool_use ids without a task-notification yet
+}
+
+func scanTranscript(r io.Reader) (Signals, error) {
+	s := scanner{pending: map[string]bool{}}
+	// ReadBytes, not bufio.Scanner: tool results make single lines well past
+	// any fixed token cap.
+	br := bufio.NewReader(r)
+	for {
+		line, err := br.ReadBytes('\n')
+		if len(line) > 0 {
+			s.line(line)
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return s.sig, err
+		}
+	}
+	s.sig.PendingBackground = len(s.pending) > 0
+	return s.sig, nil
+}
+
+func (s *scanner) line(line []byte) {
+	if !s.sig.MemoryWrite && containsAny(line, attributionMarkers) {
+		s.sig.MemoryWrite = true
+	}
+	// Completion notices arrive as queued commands, not content blocks; the
+	// tool-use id is the only join key to the launch.
+	if bytes.Contains(line, taskNotificationTag) {
+		for _, m := range notifiedIDRe.FindAllSubmatch(line, -1) {
+			delete(s.pending, string(m[1]))
+		}
+	}
+	if !containsAny(line, toolBlockMarkers) {
+		return // fast reject; the parse below stays authoritative
+	}
+	var tl transcriptLine
+	if err := json.Unmarshal(line, &tl); err != nil {
+		return // partial or foreign line: nothing to learn from it
+	}
+	if len(tl.Message.Content) == 0 || tl.Message.Content[0] != '[' {
+		return // string content carries no tool blocks
+	}
+	var blocks []contentBlock
+	if err := json.Unmarshal(tl.Message.Content, &blocks); err != nil {
+		return
+	}
+	background := tl.ToolUseResult.IsAsync || tl.ToolUseResult.BackgroundTaskID != ""
+	for _, b := range blocks {
+		switch b.Type {
+		case "tool_use":
+			switch b.Name {
+			case "Edit", "MultiEdit", "Write", "NotebookEdit":
+				s.sig.ChangedFiles = true
+			}
+			if pt, ok := config.ParseTool(b.Name); ok && (pt.Verb == "publish" || pt.Verb == "append") {
+				s.sig.MemoryWrite = true
+			}
+		case "tool_result":
+			if background {
+				s.pending[b.ToolUseID] = true
+			}
+		}
+	}
+}
+
+func containsAny(line []byte, needles [][]byte) bool {
+	for _, n := range needles {
+		if bytes.Contains(line, n) {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/demarkus-plugin/internal/nudge/transcript.go
+++ b/tools/demarkus-plugin/internal/nudge/transcript.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/latebit-io/demarkus/tools/demarkus-plugin/internal/config"
 )
@@ -24,7 +26,6 @@ type Signals struct {
 var (
 	notifiedIDRe        = regexp.MustCompile(`<tool-use-id>([^<]+)</tool-use-id>`)
 	taskNotificationTag = []byte("<task-notification>")
-	attributionMarkers  = [][]byte{[]byte(`"attributionMcpTool":"mark_publish"`), []byte(`"attributionMcpTool":"mark_append"`)}
 	toolBlockMarkers    = [][]byte{[]byte(`"tool_use"`), []byte(`"tool_result"`)}
 )
 
@@ -32,6 +33,12 @@ var (
 // toolUseResult is harness metadata beside the message; isAsync marks an Agent
 // launch, backgroundTaskId a backgrounded Bash command.
 type transcriptLine struct {
+	Type       string `json:"type"`
+	Content    string `json:"content"` // queue-operation: the queued prompt
+	Attachment struct {
+		Type   string `json:"type"`
+		Prompt string `json:"prompt"`
+	} `json:"attachment"`
 	Message struct {
 		Content json.RawMessage `json:"content"`
 	} `json:"message"`
@@ -45,12 +52,36 @@ type contentBlock struct {
 	Type      string `json:"type"`
 	Name      string `json:"name"`        // tool_use
 	ToolUseID string `json:"tool_use_id"` // tool_result
+	Input     struct {
+		FilePath     string `json:"file_path"`
+		NotebookPath string `json:"notebook_path"`
+	} `json:"input"`
 }
 
 // ScanTranscript derives the session-end signals from a Claude Code JSONL
-// transcript. Facts come from tool_use blocks and harness metadata only, so
-// tool output, pasted text, and the system-prompt snapshot cannot fake them.
+// transcript plus its subagents' (<dir>/<session>/subagents/*.jsonl), which
+// contribute edits and memory writes only: their pending work is not the session's.
 func ScanTranscript(path string) (Signals, error) {
+	sig, err := scanFile(path)
+	if err != nil {
+		return Signals{}, err
+	}
+	subs, err := filepath.Glob(filepath.Join(strings.TrimSuffix(path, ".jsonl"), "subagents", "*.jsonl"))
+	if err != nil {
+		return Signals{}, err
+	}
+	for _, sub := range subs {
+		ss, err := scanFile(sub)
+		if err != nil {
+			return Signals{}, err
+		}
+		sig.ChangedFiles = sig.ChangedFiles || ss.ChangedFiles
+		sig.MemoryWrite = sig.MemoryWrite || ss.MemoryWrite
+	}
+	return sig, nil
+}
+
+func scanFile(path string) (Signals, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return Signals{}, err
@@ -85,23 +116,21 @@ func scanTranscript(r io.Reader) (Signals, error) {
 	return s.sig, nil
 }
 
+// line reads tool_use blocks and harness metadata only, so tool output, pasted
+// text, and the system-prompt snapshot cannot fake a signal.
 func (s *scanner) line(line []byte) {
-	if !s.sig.MemoryWrite && containsAny(line, attributionMarkers) {
-		s.sig.MemoryWrite = true
-	}
-	// Completion notices arrive as queued commands, not content blocks; the
-	// tool-use id is the only join key to the launch.
-	if bytes.Contains(line, taskNotificationTag) {
-		for _, m := range notifiedIDRe.FindAllSubmatch(line, -1) {
-			delete(s.pending, string(m[1]))
-		}
-	}
-	if !containsAny(line, toolBlockMarkers) {
+	hasNotification := bytes.Contains(line, taskNotificationTag)
+	if !hasNotification && !containsAny(line, toolBlockMarkers) {
 		return // fast reject; the parse below stays authoritative
 	}
 	var tl transcriptLine
 	if err := json.Unmarshal(line, &tl); err != nil {
 		return // partial or foreign line: nothing to learn from it
+	}
+	if hasNotification {
+		for _, m := range notifiedIDRe.FindAllStringSubmatch(notificationText(&tl), -1) {
+			delete(s.pending, m[1])
+		}
 	}
 	if len(tl.Message.Content) == 0 || tl.Message.Content[0] != '[' {
 		return // string content carries no tool blocks
@@ -116,7 +145,9 @@ func (s *scanner) line(line []byte) {
 		case "tool_use":
 			switch b.Name {
 			case "Edit", "MultiEdit", "Write", "NotebookEdit":
-				s.sig.ChangedFiles = true
+				if !isScratchPath(b.Input.FilePath) && !isScratchPath(b.Input.NotebookPath) {
+					s.sig.ChangedFiles = true
+				}
 			}
 			if pt, ok := config.ParseTool(b.Name); ok && (pt.Verb == "publish" || pt.Verb == "append") {
 				s.sig.MemoryWrite = true
@@ -127,6 +158,41 @@ func (s *scanner) line(line []byte) {
 			}
 		}
 	}
+}
+
+// notificationText: the harness-written prompt carrying a task-notification
+// (queue entry, queued-command attachment, or string user turn). Tool results
+// are arrays, so a notification quoted inside tool output never joins.
+func notificationText(tl *transcriptLine) string {
+	switch tl.Type {
+	case "queue-operation":
+		return tl.Content
+	case "attachment":
+		if tl.Attachment.Type == "queued_command" {
+			return tl.Attachment.Prompt
+		}
+	case "user":
+		var text string
+		if len(tl.Message.Content) > 0 && tl.Message.Content[0] == '"' && json.Unmarshal(tl.Message.Content, &text) == nil {
+			return text
+		}
+	}
+	return ""
+}
+
+// isScratchPath: temp files and the harness scratchpad are not project work
+// worth a journal entry. An unknown (empty) path counts as project work.
+func isScratchPath(p string) bool {
+	if p == "" {
+		return false
+	}
+	p = filepath.Clean(p)
+	for _, prefix := range []string{os.TempDir(), "/tmp", "/private/tmp"} {
+		if strings.HasPrefix(p, filepath.Clean(prefix)+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return strings.Contains(p, string(filepath.Separator)+"scratchpad"+string(filepath.Separator))
 }
 
 func containsAny(line []byte, needles [][]byte) bool {

--- a/tools/demarkus-plugin/internal/nudge/transcript.go
+++ b/tools/demarkus-plugin/internal/nudge/transcript.go
@@ -72,6 +72,9 @@ func ScanTranscript(path string) (Signals, error) {
 	}
 	for _, sub := range subs {
 		ss, err := scanFile(sub)
+		if os.IsNotExist(err) {
+			continue // rotated away between Glob and Open; supplementary, not fatal
+		}
 		if err != nil {
 			return Signals{}, err
 		}

--- a/tools/demarkus-plugin/internal/nudge/transcript_test.go
+++ b/tools/demarkus-plugin/internal/nudge/transcript_test.go
@@ -1,0 +1,76 @@
+package nudge
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	snapshotLine = `{"type":"attachment","attachment":{"type":"prompt_snapshot","systemPrompt":["tools: {\"name\":\"Edit\"} \"name\":\"Write\""]}}`
+	editLine     = `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_e1","name":"Edit","input":{"file_path":"/x"}}]}}`
+	appendLine   = `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_m1","name":"mcp__soul__mark_append","input":{}}]}}`
+	agentLine    = `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_a1","name":"Agent","input":{"prompt":"find referrers"}}]}}`
+	launchLine   = `{"type":"user","message":{"content":[{"tool_use_id":"toolu_a1","type":"tool_result","content":[{"type":"text","text":"Async agent launched successfully."}]}]},"toolUseResult":{"isAsync":true,"status":"async_launched","agentId":"a1"}}`
+	syncLine     = `{"type":"user","message":{"content":[{"tool_use_id":"toolu_a1","type":"tool_result","content":[{"type":"text","text":"done"}]}]},"toolUseResult":{"status":"completed"}}`
+	notifyLine   = `{"type":"queue-operation","operation":"enqueue","content":"<task-notification>\n<task-id>a1</task-id>\n<tool-use-id>toolu_a1</tool-use-id>\n<status>completed</status>\n</task-notification>"}`
+	bashLine     = `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_b1","name":"Bash","input":{"command":"make"}}]}}`
+	bashBgLine   = `{"type":"user","message":{"content":[{"tool_use_id":"toolu_b1","type":"tool_result","content":"Command running in background with ID: abc."}]},"toolUseResult":{"stdout":"","backgroundTaskId":"abc"}}`
+	bashOutLine  = `{"type":"user","message":{"content":[{"tool_use_id":"toolu_b1","type":"tool_result","content":"grep hit: Async agent launched successfully isAsync backgroundTaskId"}]},"toolUseResult":{"stdout":"x"}}`
+	userTextLine = `{"type":"user","message":{"role":"user","content":"please run {\"name\":\"Write\"} for me"}}`
+)
+
+func scan(t *testing.T, lines ...string) Signals {
+	t.Helper()
+	sig, err := scanTranscript(strings.NewReader(strings.Join(lines, "\n") + "\n"))
+	if err != nil {
+		t.Fatalf("scanTranscript: %v", err)
+	}
+	return sig
+}
+
+func TestScanIgnoresToolNamesInsideText(t *testing.T) {
+	sig := scan(t, snapshotLine, userTextLine)
+	if sig.ChangedFiles || sig.MemoryWrite || sig.PendingBackground {
+		t.Errorf("text mentioning tool names must not count: %+v", sig)
+	}
+}
+
+func TestScanDetectsEditsAndMemoryWrites(t *testing.T) {
+	if !scan(t, snapshotLine, editLine).ChangedFiles {
+		t.Error("Edit tool_use should set ChangedFiles")
+	}
+	if !scan(t, appendLine).MemoryWrite {
+		t.Error("mark_append tool_use should set MemoryWrite")
+	}
+	if !scan(t, `{"type":"file-history-snapshot","attributionMcpTool":"mark_publish"}`).MemoryWrite {
+		t.Error("attributionMcpTool marker should set MemoryWrite")
+	}
+}
+
+func TestScanPendingAgent(t *testing.T) {
+	if !scan(t, agentLine, launchLine).PendingBackground {
+		t.Error("launched agent without a task-notification is pending")
+	}
+	if scan(t, agentLine, launchLine, notifyLine).PendingBackground {
+		t.Error("notified agent is no longer pending")
+	}
+	if scan(t, agentLine, syncLine).PendingBackground {
+		t.Error("a foreground agent result is not pending")
+	}
+}
+
+func TestScanPendingBackgroundBash(t *testing.T) {
+	if !scan(t, bashLine, bashBgLine).PendingBackground {
+		t.Error("background command without a notification is pending")
+	}
+	if scan(t, bashLine, bashOutLine).PendingBackground {
+		t.Error("ordinary Bash output quoting the markers must not count")
+	}
+}
+
+func TestScanTolerantOfPartialLines(t *testing.T) {
+	sig := scan(t, "not json", editLine, `{"type":"assistant","message":{"content":[{"type":"tool_use"`)
+	if !sig.ChangedFiles {
+		t.Error("valid lines still scanned around malformed ones")
+	}
+}

--- a/tools/demarkus-plugin/internal/nudge/transcript_test.go
+++ b/tools/demarkus-plugin/internal/nudge/transcript_test.go
@@ -1,6 +1,8 @@
 package nudge
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -13,9 +15,15 @@ const (
 	launchLine   = `{"type":"user","message":{"content":[{"tool_use_id":"toolu_a1","type":"tool_result","content":[{"type":"text","text":"Async agent launched successfully."}]}]},"toolUseResult":{"isAsync":true,"status":"async_launched","agentId":"a1"}}`
 	syncLine     = `{"type":"user","message":{"content":[{"tool_use_id":"toolu_a1","type":"tool_result","content":[{"type":"text","text":"done"}]}]},"toolUseResult":{"status":"completed"}}`
 	notifyLine   = `{"type":"queue-operation","operation":"enqueue","content":"<task-notification>\n<task-id>a1</task-id>\n<tool-use-id>toolu_a1</tool-use-id>\n<status>completed</status>\n</task-notification>"}`
+	notifyAttach = `{"type":"attachment","attachment":{"type":"queued_command","prompt":"<task-notification><tool-use-id>toolu_a1</tool-use-id></task-notification>"}}`
+	notifyUser   = `{"type":"user","message":{"role":"user","content":"<task-notification><tool-use-id>toolu_a1</tool-use-id></task-notification>"}}`
+	notifyBash   = `{"type":"queue-operation","content":"<task-notification><tool-use-id>toolu_b1</tool-use-id></task-notification>"}`
+	spoofNotify  = `{"type":"user","message":{"content":[{"tool_use_id":"toolu_x","type":"tool_result","content":"grep: <task-notification><tool-use-id>toolu_a1</tool-use-id></task-notification>"}]}}`
+	spoofAttrib  = `{"type":"user","message":{"content":[{"tool_use_id":"toolu_x","type":"tool_result","content":"\"attributionMcpTool\":\"mark_publish\""}]}}`
 	bashLine     = `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_b1","name":"Bash","input":{"command":"make"}}]}}`
 	bashBgLine   = `{"type":"user","message":{"content":[{"tool_use_id":"toolu_b1","type":"tool_result","content":"Command running in background with ID: abc."}]},"toolUseResult":{"stdout":"","backgroundTaskId":"abc"}}`
 	bashOutLine  = `{"type":"user","message":{"content":[{"tool_use_id":"toolu_b1","type":"tool_result","content":"grep hit: Async agent launched successfully isAsync backgroundTaskId"}]},"toolUseResult":{"stdout":"x"}}`
+	scratchLine  = `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_s1","name":"Write","input":{"file_path":"/private/tmp/claude-501/proj/sess/scratchpad/review.diff"}}]}}`
 	userTextLine = `{"type":"user","message":{"role":"user","content":"please run {\"name\":\"Write\"} for me"}}`
 )
 
@@ -42,8 +50,8 @@ func TestScanDetectsEditsAndMemoryWrites(t *testing.T) {
 	if !scan(t, appendLine).MemoryWrite {
 		t.Error("mark_append tool_use should set MemoryWrite")
 	}
-	if !scan(t, `{"type":"file-history-snapshot","attributionMcpTool":"mark_publish"}`).MemoryWrite {
-		t.Error("attributionMcpTool marker should set MemoryWrite")
+	if scan(t, spoofAttrib).MemoryWrite {
+		t.Error("a memory-write marker quoted in tool output must not count")
 	}
 }
 
@@ -51,8 +59,13 @@ func TestScanPendingAgent(t *testing.T) {
 	if !scan(t, agentLine, launchLine).PendingBackground {
 		t.Error("launched agent without a task-notification is pending")
 	}
-	if scan(t, agentLine, launchLine, notifyLine).PendingBackground {
-		t.Error("notified agent is no longer pending")
+	for name, notify := range map[string]string{"queue": notifyLine, "attachment": notifyAttach, "user": notifyUser} {
+		if scan(t, agentLine, launchLine, notify).PendingBackground {
+			t.Errorf("%s notification should clear the pending agent", name)
+		}
+	}
+	if !scan(t, agentLine, launchLine, spoofNotify).PendingBackground {
+		t.Error("a notification quoted inside tool output must not clear pending")
 	}
 	if scan(t, agentLine, syncLine).PendingBackground {
 		t.Error("a foreground agent result is not pending")
@@ -63,6 +76,9 @@ func TestScanPendingBackgroundBash(t *testing.T) {
 	if !scan(t, bashLine, bashBgLine).PendingBackground {
 		t.Error("background command without a notification is pending")
 	}
+	if scan(t, bashLine, bashBgLine, notifyBash).PendingBackground {
+		t.Error("notified background command is no longer pending")
+	}
 	if scan(t, bashLine, bashOutLine).PendingBackground {
 		t.Error("ordinary Bash output quoting the markers must not count")
 	}
@@ -72,5 +88,48 @@ func TestScanTolerantOfPartialLines(t *testing.T) {
 	sig := scan(t, "not json", editLine, `{"type":"assistant","message":{"content":[{"type":"tool_use"`)
 	if !sig.ChangedFiles {
 		t.Error("valid lines still scanned around malformed ones")
+	}
+}
+
+func TestScanIgnoresScratchEdits(t *testing.T) {
+	if scan(t, scratchLine).ChangedFiles {
+		t.Error("a Write into the scratchpad is not project work")
+	}
+	tmpLine := `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t","name":"Edit","input":{"file_path":"` + filepath.Join(os.TempDir(), "x.go") + `"}}]}}`
+	if scan(t, tmpLine).ChangedFiles {
+		t.Error("an Edit under the temp dir is not project work")
+	}
+	if !scan(t, editLine).ChangedFiles {
+		t.Error("an Edit with a project path still counts")
+	}
+}
+
+func TestScanIncludesSubagentTranscripts(t *testing.T) {
+	dir := t.TempDir()
+	main := filepath.Join(dir, "sess.jsonl")
+	subdir := filepath.Join(dir, "sess", "subagents")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(path, body string) {
+		if err := os.WriteFile(path, []byte(body+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(main, editLine)
+	write(filepath.Join(subdir, "agent-1.jsonl"), appendLine)
+	write(filepath.Join(subdir, "agent-2.jsonl"), agentLine+"\n"+launchLine)
+	sig, err := ScanTranscript(main)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sig.MemoryWrite {
+		t.Error("a subagent's mark_append counts as the session recording")
+	}
+	if sig.PendingBackground {
+		t.Error("a subagent's own pending children must not hold the session")
+	}
+	if !sig.ChangedFiles {
+		t.Error("main transcript edit still counts")
 	}
 }

--- a/tools/demarkus-plugin/internal/nudge/transcript_test.go
+++ b/tools/demarkus-plugin/internal/nudge/transcript_test.go
@@ -133,3 +133,27 @@ func TestScanIncludesSubagentTranscripts(t *testing.T) {
 		t.Error("main transcript edit still counts")
 	}
 }
+
+func TestScanSubagentVanishedIsNotFatal(t *testing.T) {
+	dir := t.TempDir()
+	main := filepath.Join(dir, "sess.jsonl")
+	subdir := filepath.Join(dir, "sess", "subagents")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(main, []byte(editLine+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A dangling symlink globs but fails to open with ENOENT, like a file
+	// rotated away between Glob and Open.
+	if err := os.Symlink(filepath.Join(dir, "gone.jsonl"), filepath.Join(subdir, "agent-1.jsonl")); err != nil {
+		t.Fatal(err)
+	}
+	sig, err := ScanTranscript(main)
+	if err != nil {
+		t.Fatalf("vanished subagent transcript must not fail the scan: %v", err)
+	}
+	if !sig.ChangedFiles {
+		t.Error("main transcript signals survive a missing subagent file")
+	}
+}

--- a/tools/demarkus-plugin/main.go
+++ b/tools/demarkus-plugin/main.go
@@ -128,8 +128,16 @@ func cmdNudge() {
 		return // nothing to surface
 	}
 	if sentinel != "" {
-		if err := os.WriteFile(sentinel, nil, 0o600); err != nil {
+		// O_EXCL: concurrent Stops race to one nudge; a pre-existing path or
+		// symlink in the shared temp dir is refused, not truncated.
+		f, err := os.OpenFile(sentinel, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err != nil {
+			if os.IsExist(err) {
+				return
+			}
 			fmt.Fprintln(os.Stderr, "[demarkus-plugin] nudge: sentinel: "+err.Error())
+		} else if err := f.Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "[demarkus-plugin] nudge: sentinel close: "+err.Error())
 		}
 	}
 	if *format == "cursor" {

--- a/tools/demarkus-plugin/main.go
+++ b/tools/demarkus-plugin/main.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/latebit-io/demarkus/tools/demarkus-plugin/internal/gate"
@@ -67,6 +69,8 @@ func printUsage() {
 	fmt.Fprintf(os.Stderr, "  version   Print version and exit\n")
 }
 
+var sentinelSafeRe = regexp.MustCompile(`[^A-Za-z0-9_-]`)
+
 // cmdNudge reads a nudge request as JSON on stdin and emits the reminder in
 // the adapter's --format shape (json | claude | cursor). Empty nudge → no
 // output; fails silent.
@@ -106,6 +110,15 @@ func cmdNudge() {
 		in.MemoryWrite = *memoryWrite
 	}
 
+	// Claude's Stop fires at every turn end and the nudge blocks a turn, so it
+	// fires once per session: a sentinel keyed on session_id in the temp dir.
+	var sentinel string
+	if *format == "claude" && in.Event == "session-end" && in.SessionID != "" {
+		sentinel = filepath.Join(os.TempDir(), "demarkus-memory-nudge-"+sentinelSafeRe.ReplaceAllString(in.SessionID, "_"))
+		if _, err := os.Stat(sentinel); err == nil {
+			return
+		}
+	}
 	out, err := nudge.Evaluate(&in)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "[demarkus-plugin] nudge: evaluate: "+err.Error())
@@ -113,6 +126,11 @@ func cmdNudge() {
 	}
 	if out.Nudge == "" {
 		return // nothing to surface
+	}
+	if sentinel != "" {
+		if err := os.WriteFile(sentinel, nil, 0o600); err != nil {
+			fmt.Fprintln(os.Stderr, "[demarkus-plugin] nudge: sentinel: "+err.Error())
+		}
 	}
 	if *format == "cursor" {
 		switch in.Event {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-end guidance now accounts for activity in Claude Code transcripts and subagent sessions, including project file changes, memory updates, and background tasks.
  * Guidance is suppressed while background work or another session-end hook is active.
  * Repeated session-end prompts are automatically deduplicated.

* **Bug Fixes**
  * Malformed or incomplete transcript entries no longer prevent valid activity from being recognized.
  * Scratch-file activity is excluded from guidance decisions.
  * Missing tools or guidance failures remain non-blocking and are logged without interrupting workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->