### PR TITLE
fix(tools): version-probe the reused server and warn on drift

### DIFF
--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -1797,10 +1797,10 @@ func execRefusal(p string) string {
 	return ""
 }
 
-// binaryReplaceSkew absorbs the one-second granularity of ps lstart and the
-// ordinary gap between installing a binary and launching it, so only a genuine
-// later replacement warns.
-var binaryReplaceSkew = 5 * time.Second
+// binaryReplaceSkew covers the one-second truncation of ps lstart on the only
+// platform still reduced to comparing mtimes: macOS, whose ps reads an exact
+// start time that only the display rounds down. Linux ps is not this accurate.
+const binaryReplaceSkew = time.Second
 
 // lstartLayouts covers both C-locale ps orderings: BSD/macOS puts the day of the
 // month before the month name, GNU after it.
@@ -1875,15 +1875,42 @@ func reuseDriftWarning(pid int) string {
 	return ""
 }
 
+// exeReplaced compares pid's running image against the file at exe. Linux
+// refuses to rewrite a running executable (ETXTBSY), so every real replacement
+// swaps the inode and procfs still names the original: exact, with no window.
+func exeReplaced(pid int, exe string) (replaced, ok bool) {
+	if _, err := os.Stat("/proc/self"); err != nil {
+		return false, false // no procfs: mtime is the only signal left
+	}
+	var running, onDisk syscall.Stat_t
+	if err := syscall.Stat(fmt.Sprintf("/proc/%d/exe", pid), &running); err != nil {
+		return false, true // procfs is here but will not answer; claim nothing
+	}
+	if err := syscall.Stat(exe, &onDisk); err != nil {
+		return false, true
+	}
+	return running.Dev != onDisk.Dev || running.Ino != onDisk.Ino, true
+}
+
+// binaryReplaced reports whether pid runs code the file at exe no longer holds.
+// The mtime comparison is the fallback, not a supplement: Linux ps derives
+// lstart from a whole-second boot time and can place a start after the build.
+func binaryReplaced(pid int, exe string) bool {
+	if replaced, ok := exeReplaced(pid, exe); ok {
+		return replaced
+	}
+	info, err := os.Stat(exe)
+	if err != nil {
+		return false
+	}
+	started, ok := processStart(pid)
+	return ok && info.ModTime().After(started.Add(binaryReplaceSkew))
+}
+
 // replacedBinaryWarning reports a process still serving code from memory after
 // its binary was rewritten. Empty when current or undeterminable.
 func replacedBinaryWarning(pid int, exe, got string) string {
-	info, err := os.Stat(exe)
-	if err != nil {
-		return ""
-	}
-	started, ok := processStart(pid)
-	if !ok || !info.ModTime().After(started.Add(binaryReplaceSkew)) {
+	if !binaryReplaced(pid, exe) {
 		return ""
 	}
 	installed := "the installed build"

--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -889,7 +889,8 @@ func tokensPathOfServer(args string, pid int) string {
 	if p := flagValue(args, tokensFlagRe); p != "" {
 		return p
 	}
-	return procEnv(pid, "DEMARKUS_TOKENS")
+	tokens, _ := procEnv(pid, "DEMARKUS_TOKENS")
+	return tokens
 }
 
 // procArgv returns the process's exact argument vector from /proc, nil where
@@ -934,11 +935,18 @@ func pidOfServerAtRootProbed(root string) (int, bool) {
 		return 0, false
 	}
 	for _, pid := range pids {
-		args := psArgs(pid)
+		args, ran := psArgs(pid)
+		if !ran {
+			return 0, false // a skipped candidate could be the server we want
+		}
 		if argsRootMatches(args, root) {
 			return pid, true
 		}
-		if procEnv(pid, "DEMARKUS_ROOT") == root {
+		env, ran := procEnv(pid, "DEMARKUS_ROOT")
+		if !ran {
+			return 0, false
+		}
+		if env == root {
 			return pid, true
 		}
 	}
@@ -956,14 +964,15 @@ func pidIsServerAtRoot(pid int, root string) bool {
 	if !lockdir.PidAlive(pid) {
 		return false
 	}
-	args := psArgs(pid)
+	args, _ := psArgs(pid)
 	if !strings.Contains(args, "demarkus-server") {
 		return false
 	}
 	if argsRootMatches(args, root) {
 		return true
 	}
-	return procEnv(pid, "DEMARKUS_ROOT") == root
+	env, _ := procEnv(pid, "DEMARKUS_ROOT")
+	return env == root
 }
 
 // argsRootMatches mirrors the bash literal substring match for "-root TARGET" /
@@ -988,14 +997,17 @@ func findRunningDemarkus() (string, bool) {
 	}
 	var lines []string
 	for _, pid := range pids {
-		args := psArgs(pid)
+		args, ran := psArgs(pid)
+		if !ran {
+			return "", false // an unlistable process is not an absent one
+		}
 		if args == "" {
 			continue
 		}
 		port := portOfServer(args, pid)
 		root := flagValue(args, rootFlagRe)
 		if root == "" {
-			root = procEnv(pid, "DEMARKUS_ROOT")
+			root, _ = procEnv(pid, "DEMARKUS_ROOT")
 		}
 		if root == "" {
 			root = "(unknown)"
@@ -1011,7 +1023,7 @@ func portOfServer(args string, pid int) string {
 	if p := flagValue(args, portFlagRe); p != "" {
 		return p
 	}
-	if p := procEnv(pid, "DEMARKUS_PORT"); p != "" {
+	if p, _ := procEnv(pid, "DEMARKUS_PORT"); p != "" {
 		return p
 	}
 	return strconv.Itoa(demarkusProtocolPort)
@@ -1518,7 +1530,7 @@ func doReuse(port int, root string) error {
 	}
 	targetPID := pidOfServerAtRoot(root)
 	if targetPID > 0 {
-		targetArgs := psArgs(targetPID)
+		targetArgs, _ := psArgs(targetPID)
 		if targetArgs != "" {
 			// Compare parsed values, not text: "06309" and "6309" are the same port.
 			raw := portOfServer(targetArgs, targetPID)
@@ -1630,7 +1642,7 @@ func VerifyAuth() (string, error) {
 	pid := pidOfServerAtRoot(cfg.MemoryDir)
 	serverPort := ""
 	if pid > 0 {
-		args := psArgs(pid)
+		args, _ := psArgs(pid)
 		tokensTOML = tokensPathOfServer(args, pid)
 		serverPort = portOfServer(args, pid)
 	}
@@ -1693,10 +1705,13 @@ func Status() (string, error) {
 // not run: another user's process, or a file someone else can rewrite. Owner and
 // path come from one observation, so a recycled PID cannot split the two.
 func serverExecutable(pid int) string {
-	// Readlink on another user's process fails unless we are privileged, so
-	// success already ties the path to a process we own.
 	exe, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
 	if err == nil {
+		// Readlink fails on a foreign process only while unprivileged, so as
+		// root it proves nothing: check the process owner explicitly.
+		if !procIsOurs(pid) {
+			return ""
+		}
 		exe = strings.TrimSuffix(exe, " (deleted)")
 	} else {
 		exe = psOwnedExecutable(pid)
@@ -1705,6 +1720,16 @@ func serverExecutable(pid int) string {
 		return ""
 	}
 	return exe
+}
+
+// procIsOurs reports whether /proc/<pid> is owned by this user. False where
+// procfs is absent, leaving the ps path to establish ownership instead.
+func procIsOurs(pid int) bool {
+	var st syscall.Stat_t
+	if err := syscall.Stat(fmt.Sprintf("/proc/%d", pid), &st); err != nil {
+		return false
+	}
+	return int(st.Uid) == os.Getuid()
 }
 
 // psOwnedExecutable reads pid's owner and executable in a single ps observation
@@ -1974,31 +1999,37 @@ func pgrepDemarkusServer() ([]int, bool) {
 // psArgs returns the full command line (args) of pid, or "". The leading/trailing
 // space wrapping matches the bash " -root … " word-boundary matching done by
 // argsRootMatches (ps -o args= gives no leading space, so we add one).
-func psArgs(pid int) string {
-	args, _ := probeBounded(nil, "ps", "-p", strconv.Itoa(pid), "-o", "args=")
-	if args == "" {
-		return ""
+func psArgs(pid int) (string, bool) {
+	args, ran := probeBounded(nil, "ps", "-p", strconv.Itoa(pid), "-o", "args=")
+	if !ran {
+		return "", false
 	}
-	return " " + args
+	if args == "" {
+		return "", true
+	}
+	return " " + args, true
 }
 
 // procEnv returns the value of env var name for pid, or "". Portable across
 // Linux (/proc/<pid>/environ) and macOS (ps eww).
-func procEnv(pid int, name string) string {
+func procEnv(pid int, name string) (string, bool) {
 	if b, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid)); err == nil {
 		for kv := range bytes.SplitSeq(b, []byte{0}) {
 			s := string(kv)
 			if v, ok := strings.CutPrefix(s, name+"="); ok {
-				return v
+				return v, true
 			}
 		}
-		return ""
+		return "", true
 	}
-	env, _ := probeBounded(nil, "ps", "eww", "-p", strconv.Itoa(pid))
+	env, ran := probeBounded(nil, "ps", "eww", "-p", strconv.Itoa(pid))
+	if !ran {
+		return "", false
+	}
 	for tok := range strings.FieldsSeq(env) {
 		if v, ok := strings.CutPrefix(tok, name+"="); ok {
-			return v
+			return v, true
 		}
 	}
-	return ""
+	return "", true
 }

--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -1671,31 +1671,61 @@ func Status() (string, error) {
 	return fmt.Sprintf("mode=%s memory=%s port=%s: %s\ndesired=%s", cfg.Mode, cfg.MemoryDir, cfg.Port, verdict, desiredVersions()), nil
 }
 
-// serverExecutable resolves pid's executable path: /proc/<pid>/exe where that
-// exists, else ps comm=, which is a full path on macOS but a truncated name on
-// Linux, so a non-absolute answer is discarded rather than guessed at.
+// serverExecutable resolves pid's executable, refusing anything this plugin must
+// not run: another user's process, or a file someone else can rewrite. Owner and
+// path come from one observation, so a recycled PID cannot split the two.
 func serverExecutable(pid int) string {
-	if p, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid)); err == nil {
-		return strings.TrimSuffix(p, " (deleted)")
+	// Readlink on another user's process fails unless we are privileged, so
+	// success already ties the path to a process we own.
+	exe, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
+	if err == nil {
+		exe = strings.TrimSuffix(exe, " (deleted)")
+	} else {
+		exe = psOwnedExecutable(pid)
 	}
-	p := psBounded(nil, "-p", strconv.Itoa(pid), "-o", "comm=")
-	if !filepath.IsAbs(p) {
+	if !filepath.IsAbs(exe) {
 		return ""
 	}
-	return p
+	return exe
 }
 
-// processUID reports pid's owner, ok false when it cannot be determined.
-func processUID(pid int) (int, bool) {
-	var st syscall.Stat_t
-	if err := syscall.Stat(fmt.Sprintf("/proc/%d", pid), &st); err == nil {
-		return int(st.Uid), true
+// psOwnedExecutable reads pid's owner and executable in a single ps observation
+// so the two cannot describe different processes. Empty unless the owner is us,
+// or where ps reports a bare name (Linux comm) rather than a path.
+func psOwnedExecutable(pid int) string {
+	line := psBounded(nil, "-p", strconv.Itoa(pid), "-o", "uid=,comm=")
+	uidField, exe, found := strings.Cut(strings.TrimSpace(line), " ")
+	if !found {
+		return ""
 	}
-	uid, err := strconv.Atoi(psBounded(nil, "-p", strconv.Itoa(pid), "-o", "uid="))
+	uid, err := strconv.Atoi(uidField)
+	if err != nil || uid != os.Getuid() {
+		return ""
+	}
+	return strings.TrimSpace(exe)
+}
+
+// execRefusal explains why the probe must not run p, empty when it is safe: a
+// regular executable owned by us or root that other users cannot rewrite.
+func execRefusal(p string) string {
+	info, err := os.Stat(p)
 	if err != nil {
-		return 0, false
+		return "cannot be read"
 	}
-	return uid, true
+	if !info.Mode().IsRegular() || info.Mode()&0o111 == 0 {
+		return "is not a regular executable"
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return "is writable by other users"
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "has unreadable ownership"
+	}
+	if int(st.Uid) != os.Getuid() && st.Uid != 0 {
+		return "is owned by another user"
+	}
+	return ""
 }
 
 // binaryReplaceSkew absorbs the one-second granularity of ps lstart and the
@@ -1710,9 +1740,8 @@ var lstartLayouts = []string{"Mon _2 Jan 15:04:05 2006", "Mon Jan _2 15:04:05 20
 // processStart reports when pid started. ok is false whenever that cannot be
 // established, which every caller treats as "stay silent".
 func processStart(pid int) (time.Time, bool) {
-	if info, err := os.Stat(fmt.Sprintf("/proc/%d", pid)); err == nil {
-		return info.ModTime(), true
-	}
+	// /proc/<pid> ModTime is not a defined start time: it can reflect when the
+	// procfs entry was instantiated, which hides a replacement. ps lstart is.
 	out := psBounded([]string{"LC_ALL=C"}, "-p", strconv.Itoa(pid), "-o", "lstart=") // lstart is locale-formatted
 	if out == "" {
 		return time.Time{}, false
@@ -1750,14 +1779,12 @@ func semverLess(a, b string) (less, ok bool) {
 // below the pinned floor, or a process predating the binary it was started from.
 // Empty when current or undeterminable; never restarts a server it does not own.
 func reuseDriftWarning(pid int) string {
-	// The probe runs the adopted process's own executable, so a PID belonging to
-	// another user would have us execute a path they chose. Ours or nothing.
-	if uid, ok := processUID(pid); !ok || uid != os.Getuid() {
-		return ""
-	}
 	exe := serverExecutable(pid)
 	if exe == "" {
 		return ""
+	}
+	if why := execRefusal(exe); why != "" {
+		return fmt.Sprintf("cannot version-check the reused demarkus server (pid %d): its binary %s %s, so this plugin will not run it. Drift goes unreported until that is fixed.", pid, exe, why)
 	}
 	got := binaryVersionAt(exe)
 	if less, ok := semverLess(got, serverVersion); ok && less {

--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -375,11 +375,26 @@ func binaryVersion(name string) string {
 	if err != nil {
 		return ""
 	}
+	return binaryVersionAt(p)
+}
+
+// versionProbeTimeout bounds the probe: the drift check runs it on an adopted
+// binary this plugin did not install, and a hung one would stall session start.
+const versionProbeTimeout = 2 * time.Second
+
+// binaryVersionAt runs --version on an executable path. Empty when the path is
+// missing, not executable, or the binary is too old or too slow to answer.
+func binaryVersionAt(p string) string {
 	info, err := os.Stat(p)
 	if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
 		return ""
 	}
-	cmd := exec.Command(p, "--version")
+	ctx, cancel := context.WithTimeout(context.Background(), versionProbeTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, p, "--version")
+	// Killing the probe is not enough: a grandchild inherits the stdout pipe and
+	// Output() blocks on it, so WaitDelay force-closes the pipes after the kill.
+	cmd.WaitDelay = versionProbeTimeout
 	cmd.Stderr = io.Discard
 	out, err := cmd.Output()
 	if err != nil {
@@ -1634,10 +1649,101 @@ func Status() (string, error) {
 	return fmt.Sprintf("mode=%s memory=%s port=%s: %s\ndesired=%s", cfg.Mode, cfg.MemoryDir, cfg.Port, verdict, desiredVersions()), nil
 }
 
-// HealthWarning echoes a one-line human warning when the configured memory server
-// does not appear to be up, empty when it looks healthy. Best-effort, probe-only
-// (no QUIC round-trip): for managed modes it trusts the .pid liveness;
-// for reuse it scans for the adopted process. (lib.sh server_health_warning.)
+// serverExecutable resolves pid's executable path: /proc/<pid>/exe where that
+// exists, else ps comm=, which is a full path on macOS but a truncated name on
+// Linux, so a non-absolute answer is discarded rather than guessed at.
+func serverExecutable(pid int) string {
+	if p, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid)); err == nil {
+		return strings.TrimSuffix(p, " (deleted)")
+	}
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=").Output()
+	if err != nil {
+		return ""
+	}
+	p := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(p) {
+		return ""
+	}
+	return p
+}
+
+// binaryReplaceSkew absorbs the one-second granularity of ps lstart and the
+// ordinary gap between installing a binary and launching it, so only a genuine
+// later replacement warns.
+const binaryReplaceSkew = 5 * time.Second
+
+// lstartLayouts covers both C-locale ps orderings: BSD/macOS puts the day of the
+// month before the month name, GNU after it.
+var lstartLayouts = []string{"Mon _2 Jan 15:04:05 2006", "Mon Jan _2 15:04:05 2006"}
+
+// processStart reports when pid started. ok is false whenever that cannot be
+// established, which every caller treats as "stay silent".
+func processStart(pid int) (time.Time, bool) {
+	if info, err := os.Stat(fmt.Sprintf("/proc/%d", pid)); err == nil {
+		return info.ModTime(), true
+	}
+	cmd := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "lstart=")
+	cmd.Env = append(os.Environ(), "LC_ALL=C") // lstart is locale-formatted
+	out, err := cmd.Output()
+	if err != nil {
+		return time.Time{}, false
+	}
+	s := strings.Join(strings.Fields(string(out)), " ")
+	for _, layout := range lstartLayouts {
+		if t, err := time.ParseInLocation(layout, s, time.Local); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// semverLess orders two x.y.z strings. ok is false when either side is not a
+// plain release version, where no ordering is meaningful.
+func semverLess(a, b string) (less, ok bool) {
+	if !semverRe.MatchString(a) || !semverRe.MatchString(b) {
+		return false, false
+	}
+	as, bs := strings.Split(a, "."), strings.Split(b, ".")
+	for i := range 3 {
+		ai, _ := strconv.Atoi(as[i])
+		bi, _ := strconv.Atoi(bs[i])
+		if ai != bi {
+			return ai < bi, true
+		}
+	}
+	return false, true
+}
+
+// reuseDriftWarning reports an adopted server whose code is behind: a binary
+// below the pinned floor, or a process predating the binary it was started from.
+// Empty when current or undeterminable; never restarts a server it does not own.
+func reuseDriftWarning(pid int) string {
+	exe := serverExecutable(pid)
+	if exe == "" {
+		return ""
+	}
+	got := binaryVersionAt(exe)
+	if less, ok := semverLess(got, serverVersion); ok && less {
+		return fmt.Sprintf("the reused demarkus server (pid %d, %s) is version %s, below the %s this plugin expects; features the plugin assumes may be missing. Upgrade that server, or run /soul-init to let the plugin manage one.", pid, exe, got, serverVersion)
+	}
+	info, err := os.Stat(exe)
+	if err != nil {
+		return ""
+	}
+	started, ok := processStart(pid)
+	if !ok || !info.ModTime().After(started.Add(binaryReplaceSkew)) {
+		return ""
+	}
+	installed := "the installed build"
+	if got != "" {
+		installed = got
+	}
+	return fmt.Sprintf("the reused demarkus server (pid %d) started before its binary %s was replaced, so it is still serving the old code rather than %s. Restart that server to pick it up.", pid, exe, installed)
+}
+
+// HealthWarning echoes a one-line warning when the configured memory server is
+// down or behind, empty when healthy. Probe-only (no QUIC round-trip): managed
+// modes trust .pid liveness, reuse also drift-checks the adopted process.
 func HealthWarning() (string, error) {
 	cfg, err := loadConfig()
 	if err != nil {
@@ -1656,8 +1762,12 @@ func HealthWarning() (string, error) {
 			return fmt.Sprintf("the demarkus-memory server is not running (no live process for %s). Memory tools (mark_fetch/mark_publish/mark_lookup/...) will fail until it restarts; run /soul-init to restart, or /soul-status to diagnose.", cfg.MemoryDir), nil
 		}
 	case "reuse":
-		if pidOfServerAtRoot(cfg.MemoryDir) == 0 {
+		pid := pidOfServerAtRoot(cfg.MemoryDir)
+		if pid == 0 {
 			return fmt.Sprintf("demarkus-memory is configured to reuse a server rooted at %s, but none is running. Memory tools will fail until it is started; start that server or run /soul-init to reconfigure.", cfg.MemoryDir), nil
+		}
+		if w := reuseDriftWarning(pid); w != "" {
+			return w, nil
 		}
 	}
 	return "", nil

--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -386,13 +386,13 @@ const (
 	probeKillGrace      = 500 * time.Millisecond
 )
 
-// psBounded runs ps under the probe budget so an unresponsive ps cannot stall
-// session start. Empty on any failure, matching its callers' best-effort
-// contract. env is appended to the environment; nil inherits it unchanged.
-func psBounded(env []string, args ...string) string {
+// probeBounded runs a read-only discovery command under the probe budget, so a
+// stalled ps or pgrep cannot block session start or /soul-status. Empty on any
+// failure, matching its callers' best-effort contract; nil env inherits ours.
+func probeBounded(env []string, name string, args ...string) string {
 	ctx, cancel := context.WithTimeout(context.Background(), versionProbeTimeout-probeKillGrace)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "ps", args...)
+	cmd := exec.CommandContext(ctx, name, args...)
 	if env != nil {
 		cmd.Env = append(os.Environ(), env...)
 	}
@@ -1693,7 +1693,7 @@ func serverExecutable(pid int) string {
 // so the two cannot describe different processes. Empty unless the owner is us,
 // or where ps reports a bare name (Linux comm) rather than a path.
 func psOwnedExecutable(pid int) string {
-	line := psBounded(nil, "-p", strconv.Itoa(pid), "-o", "uid=,comm=")
+	line := probeBounded(nil, "ps", "-p", strconv.Itoa(pid), "-o", "uid=,comm=")
 	uidField, exe, found := strings.Cut(strings.TrimSpace(line), " ")
 	if !found {
 		return ""
@@ -1742,7 +1742,7 @@ var lstartLayouts = []string{"Mon _2 Jan 15:04:05 2006", "Mon Jan _2 15:04:05 20
 func processStart(pid int) (time.Time, bool) {
 	// /proc/<pid> ModTime is not a defined start time: it can reflect when the
 	// procfs entry was instantiated, which hides a replacement. ps lstart is.
-	out := psBounded([]string{"LC_ALL=C"}, "-p", strconv.Itoa(pid), "-o", "lstart=") // lstart is locale-formatted
+	out := probeBounded([]string{"LC_ALL=C"}, "ps", "-p", strconv.Itoa(pid), "-o", "lstart=") // lstart is locale-formatted
 	if out == "" {
 		return time.Time{}, false
 	}
@@ -1787,9 +1787,28 @@ func reuseDriftWarning(pid int) string {
 		return fmt.Sprintf("cannot version-check the reused demarkus server (pid %d): its binary %s %s, so this plugin will not run it. Drift goes unreported until that is fixed.", pid, exe, why)
 	}
 	got := binaryVersionAt(exe)
-	if less, ok := semverLess(got, serverVersion); ok && less {
+	less, ordered := semverLess(got, serverVersion)
+	if ordered && less {
 		return fmt.Sprintf("the reused demarkus server (pid %d, %s) is version %s, below the %s this plugin expects; features the plugin assumes may be missing. Upgrade that server, or run /soul-init to let the plugin manage one.", pid, exe, got, serverVersion)
 	}
+	// The replacement check speaks first: it needs no parsed version, and names
+	// the more specific problem when both are true.
+	if w := replacedBinaryWarning(pid, exe, got); w != "" {
+		return w
+	}
+	if !ordered {
+		reported := "no version"
+		if got != "" {
+			reported = strconv.Quote(got)
+		}
+		return fmt.Sprintf("cannot version-check the reused demarkus server (pid %d): its binary %s reports %s rather than a release, so drift against %s goes unreported.", pid, exe, reported, serverVersion)
+	}
+	return ""
+}
+
+// replacedBinaryWarning reports a process still serving code from memory after
+// its binary was rewritten. Empty when current or undeterminable.
+func replacedBinaryWarning(pid int, exe, got string) string {
 	info, err := os.Stat(exe)
 	if err != nil {
 		return ""
@@ -1904,13 +1923,13 @@ func tailFile(path string, n int) string {
 // pgrepDemarkusServer returns the PIDs of processes whose command line contains
 // "demarkus-server", sorted ascending (deterministic, matching pgrep order).
 func pgrepDemarkusServer() []int {
-	out, err := exec.Command("pgrep", "-f", "demarkus-server").Output()
-	if err != nil {
+	out := probeBounded(nil, "pgrep", "-f", "demarkus-server")
+	if out == "" {
 		return nil
 	}
 	var pids []int
 	self := os.Getpid()
-	for ln := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+	for ln := range strings.SplitSeq(out, "\n") {
 		ln = strings.TrimSpace(ln)
 		if ln == "" {
 			continue
@@ -1929,11 +1948,7 @@ func pgrepDemarkusServer() []int {
 // space wrapping matches the bash " -root … " word-boundary matching done by
 // argsRootMatches (ps -o args= gives no leading space, so we add one).
 func psArgs(pid int) string {
-	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "args=").Output()
-	if err != nil {
-		return ""
-	}
-	args := strings.TrimSpace(string(out))
+	args := probeBounded(nil, "ps", "-p", strconv.Itoa(pid), "-o", "args=")
 	if args == "" {
 		return ""
 	}
@@ -1952,11 +1967,7 @@ func procEnv(pid int, name string) string {
 		}
 		return ""
 	}
-	out, err := exec.Command("ps", "eww", "-p", strconv.Itoa(pid)).Output()
-	if err != nil {
-		return ""
-	}
-	for tok := range strings.FieldsSeq(string(out)) {
+	for tok := range strings.FieldsSeq(probeBounded(nil, "ps", "eww", "-p", strconv.Itoa(pid))) {
 		if v, ok := strings.CutPrefix(tok, name+"="); ok {
 			return v
 		}

--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -378,9 +378,31 @@ func binaryVersion(name string) string {
 	return binaryVersionAt(p)
 }
 
-// versionProbeTimeout bounds the probe: the drift check runs it on an adopted
-// binary this plugin did not install, and a hung one would stall session start.
-const versionProbeTimeout = 2 * time.Second
+// versionProbeTimeout is the whole budget for one probe: the drift check runs it
+// on an adopted binary this plugin did not install, and a hung one would stall
+// session start. probeKillGrace is the slice of it reserved for pipe cleanup.
+const (
+	versionProbeTimeout = 2 * time.Second
+	probeKillGrace      = 500 * time.Millisecond
+)
+
+// psBounded runs ps under the probe budget so an unresponsive ps cannot stall
+// session start. Empty on any failure, matching its callers' best-effort
+// contract. env is appended to the environment; nil inherits it unchanged.
+func psBounded(env []string, args ...string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), versionProbeTimeout-probeKillGrace)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "ps", args...)
+	if env != nil {
+		cmd.Env = append(os.Environ(), env...)
+	}
+	cmd.WaitDelay = probeKillGrace
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
 
 // binaryVersionAt runs --version on an executable path. Empty when the path is
 // missing, not executable, or the binary is too old or too slow to answer.
@@ -389,12 +411,12 @@ func binaryVersionAt(p string) string {
 	if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
 		return ""
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), versionProbeTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), versionProbeTimeout-probeKillGrace)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, p, "--version")
 	// Killing the probe is not enough: a grandchild inherits the stdout pipe and
 	// Output() blocks on it, so WaitDelay force-closes the pipes after the kill.
-	cmd.WaitDelay = versionProbeTimeout
+	cmd.WaitDelay = probeKillGrace
 	cmd.Stderr = io.Discard
 	out, err := cmd.Output()
 	if err != nil {
@@ -1656,21 +1678,30 @@ func serverExecutable(pid int) string {
 	if p, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid)); err == nil {
 		return strings.TrimSuffix(p, " (deleted)")
 	}
-	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=").Output()
-	if err != nil {
-		return ""
-	}
-	p := strings.TrimSpace(string(out))
+	p := psBounded(nil, "-p", strconv.Itoa(pid), "-o", "comm=")
 	if !filepath.IsAbs(p) {
 		return ""
 	}
 	return p
 }
 
+// processUID reports pid's owner, ok false when it cannot be determined.
+func processUID(pid int) (int, bool) {
+	var st syscall.Stat_t
+	if err := syscall.Stat(fmt.Sprintf("/proc/%d", pid), &st); err == nil {
+		return int(st.Uid), true
+	}
+	uid, err := strconv.Atoi(psBounded(nil, "-p", strconv.Itoa(pid), "-o", "uid="))
+	if err != nil {
+		return 0, false
+	}
+	return uid, true
+}
+
 // binaryReplaceSkew absorbs the one-second granularity of ps lstart and the
 // ordinary gap between installing a binary and launching it, so only a genuine
 // later replacement warns.
-const binaryReplaceSkew = 5 * time.Second
+var binaryReplaceSkew = 5 * time.Second
 
 // lstartLayouts covers both C-locale ps orderings: BSD/macOS puts the day of the
 // month before the month name, GNU after it.
@@ -1682,13 +1713,11 @@ func processStart(pid int) (time.Time, bool) {
 	if info, err := os.Stat(fmt.Sprintf("/proc/%d", pid)); err == nil {
 		return info.ModTime(), true
 	}
-	cmd := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "lstart=")
-	cmd.Env = append(os.Environ(), "LC_ALL=C") // lstart is locale-formatted
-	out, err := cmd.Output()
-	if err != nil {
+	out := psBounded([]string{"LC_ALL=C"}, "-p", strconv.Itoa(pid), "-o", "lstart=") // lstart is locale-formatted
+	if out == "" {
 		return time.Time{}, false
 	}
-	s := strings.Join(strings.Fields(string(out)), " ")
+	s := strings.Join(strings.Fields(out), " ")
 	for _, layout := range lstartLayouts {
 		if t, err := time.ParseInLocation(layout, s, time.Local); err == nil {
 			return t, true
@@ -1705,8 +1734,11 @@ func semverLess(a, b string) (less, ok bool) {
 	}
 	as, bs := strings.Split(a, "."), strings.Split(b, ".")
 	for i := range 3 {
-		ai, _ := strconv.Atoi(as[i])
-		bi, _ := strconv.Atoi(bs[i])
+		ai, aerr := strconv.Atoi(as[i])
+		bi, berr := strconv.Atoi(bs[i])
+		if aerr != nil || berr != nil {
+			return false, false // a component beyond int range has no usable order
+		}
 		if ai != bi {
 			return ai < bi, true
 		}
@@ -1718,6 +1750,11 @@ func semverLess(a, b string) (less, ok bool) {
 // below the pinned floor, or a process predating the binary it was started from.
 // Empty when current or undeterminable; never restarts a server it does not own.
 func reuseDriftWarning(pid int) string {
+	// The probe runs the adopted process's own executable, so a PID belonging to
+	// another user would have us execute a path they chose. Ours or nothing.
+	if uid, ok := processUID(pid); !ok || uid != os.Getuid() {
+		return ""
+	}
 	exe := serverExecutable(pid)
 	if exe == "" {
 		return ""

--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -417,8 +417,11 @@ func binaryVersionAt(p string) string {
 	ctx, cancel := context.WithTimeout(context.Background(), versionProbeTimeout-probeKillGrace)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, p, "--version")
-	// Killing the probe is not enough: a grandchild inherits the stdout pipe and
-	// Output() blocks on it, so WaitDelay force-closes the pipes after the kill.
+	// Own group, killed whole: a --version that forks leaves the grandchild
+	// holding the stdout pipe, and a kill aimed only at the direct child never
+	// unblocks Output() (measured: the probe hangs indefinitely).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) }
 	cmd.WaitDelay = probeKillGrace
 	cmd.Stderr = io.Discard
 	out, err := cmd.Output()
@@ -879,18 +882,17 @@ func flagValue(args string, re *regexp.Regexp) string {
 	return ""
 }
 
-// tokensPathOfServer returns the tokens.toml the server actually reads
-// (-tokens flag, else DEMARKUS_TOKENS env), or "" when undiscoverable. Exact
-// /proc argv wins over the flattened ps string, which truncates on whitespace.
-func tokensPathOfServer(args string, pid int) string {
+// tokensPathOfServer returns the tokens.toml the server actually reads (-tokens
+// flag, else DEMARKUS_TOKENS env). ok is false when the env probe could not run,
+// where "" means unknown, not none, and no conventional fallback is safe.
+func tokensPathOfServer(args string, pid int) (string, bool) {
 	if p := tokensFromArgv(procArgv(pid)); p != "" {
-		return p
+		return p, true
 	}
 	if p := flagValue(args, tokensFlagRe); p != "" {
-		return p
+		return p, true
 	}
-	tokens, _ := procEnv(pid, "DEMARKUS_TOKENS")
-	return tokens
+	return procEnv(pid, "DEMARKUS_TOKENS")
 }
 
 // procArgv returns the process's exact argument vector from /proc, nil where
@@ -1528,9 +1530,15 @@ func doReuse(port int, root string) error {
 		// is down rather than falling back to the convention.
 		tokensTOML = prior.TokensTOML
 	}
-	targetPID := pidOfServerAtRoot(root)
+	targetPID, ran := pidOfServerAtRootProbed(root)
+	if !ran {
+		return fmt.Errorf("cannot tell whether a demarkus-server is running at root %s: process discovery did not complete; re-run /soul-init", root)
+	}
 	if targetPID > 0 {
-		targetArgs, _ := psArgs(targetPID)
+		targetArgs, argsRan := psArgs(targetPID)
+		if !argsRan {
+			return fmt.Errorf("cannot inspect the demarkus-server at root %s (pid %d): process discovery did not complete; re-run /soul-init", root, targetPID)
+		}
 		if targetArgs != "" {
 			// Compare parsed values, not text: "06309" and "6309" are the same port.
 			raw := portOfServer(targetArgs, targetPID)
@@ -1538,7 +1546,13 @@ func doReuse(port int, root string) error {
 				return fmt.Errorf("the demarkus-server at root %s (pid %d) is listening on port %s, not %d; re-run with --port %s", root, targetPID, raw, port, raw)
 			}
 		}
-		if discovered := tokensPathOfServer(targetArgs, targetPID); discovered != "" && discovered != tokensTOML {
+		// An unidentified registry must stop here: ensureTokenEntry would
+		// otherwise write the conventional file the server never reads.
+		discovered, known := tokensPathOfServer(targetArgs, targetPID)
+		if !known {
+			return fmt.Errorf("cannot tell which token registry the demarkus-server at root %s (pid %d) reads: environment discovery did not complete; re-run /soul-init", root, targetPID)
+		}
+		if discovered != "" && discovered != tokensTOML {
 			// An explicit path that does not resolve is a hard stop: writing the
 			// conventional file instead would mutate a registry the server never
 			// reads (a flattened ps string can truncate paths with whitespace).
@@ -1639,11 +1653,23 @@ func VerifyAuth() (string, error) {
 	// Name the registry for the report: the running server's own -tokens or
 	// DEMARKUS_TOKENS wins; otherwise the path provisioning would use.
 	tokensTOML := ""
-	pid := pidOfServerAtRoot(cfg.MemoryDir)
+	pid, ran := pidOfServerAtRootProbed(cfg.MemoryDir)
+	if !ran {
+		return fmt.Sprintf("cannot verify: process discovery did not complete for %s; re-run /soul-status", cfg.MemoryDir), nil
+	}
 	serverPort := ""
 	if pid > 0 {
-		args, _ := psArgs(pid)
-		tokensTOML = tokensPathOfServer(args, pid)
+		args, argsRan := psArgs(pid)
+		if !argsRan {
+			return fmt.Sprintf("cannot verify: cannot inspect server pid %d; process discovery did not complete", pid), nil
+		}
+		// Falling through to cfg.TokensTOML or the default would name a registry
+		// we could not read; say so instead.
+		discovered, known := tokensPathOfServer(args, pid)
+		if !known {
+			return fmt.Sprintf("cannot verify: cannot tell which token registry server pid %d reads; environment discovery did not complete", pid), nil
+		}
+		tokensTOML = discovered
 		serverPort = portOfServer(args, pid)
 	}
 	if tokensTOML == "" {

--- a/tools/demarkus-plugin/internal/provision/provision.go
+++ b/tools/demarkus-plugin/internal/provision/provision.go
@@ -389,7 +389,7 @@ const (
 // probeBounded runs a read-only discovery command under the probe budget, so a
 // stalled ps or pgrep cannot block session start or /soul-status. Empty on any
 // failure, matching its callers' best-effort contract; nil env inherits ours.
-func probeBounded(env []string, name string, args ...string) string {
+func probeBounded(env []string, name string, args ...string) (string, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), versionProbeTimeout-probeKillGrace)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, name, args...)
@@ -399,9 +399,12 @@ func probeBounded(env []string, name string, args ...string) string {
 	cmd.WaitDelay = probeKillGrace
 	out, err := cmd.Output()
 	if err != nil {
-		return ""
+		// A clean non-zero exit is an answer (pgrep says "no match" that way);
+		// only a failure to run at all leaves us without one.
+		var exit *exec.ExitError
+		return "", errors.As(err, &exit) && ctx.Err() == nil
 	}
-	return strings.TrimSpace(string(out))
+	return strings.TrimSpace(string(out)), true
 }
 
 // binaryVersionAt runs --version on an executable path. Empty when the path is
@@ -919,16 +922,27 @@ func tokensFromArgv(argv []string) string {
 // pidOfServerAtRoot returns the PID of a demarkus-server whose -root flag (or
 // DEMARKUS_ROOT env) equals root (literal match), or 0 when none match.
 func pidOfServerAtRoot(root string) int {
-	for _, pid := range pgrepDemarkusServer() {
+	pid, _ := pidOfServerAtRootProbed(root)
+	return pid
+}
+
+// pidOfServerAtRootProbed adds whether process discovery ran at all, so callers
+// that would otherwise announce "no server" can say they could not look.
+func pidOfServerAtRootProbed(root string) (int, bool) {
+	pids, ran := pgrepDemarkusServer()
+	if !ran {
+		return 0, false
+	}
+	for _, pid := range pids {
 		args := psArgs(pid)
 		if argsRootMatches(args, root) {
-			return pid
+			return pid, true
 		}
 		if procEnv(pid, "DEMARKUS_ROOT") == root {
-			return pid
+			return pid, true
 		}
 	}
-	return 0
+	return 0, true
 }
 
 // pidIsServerAtRoot reports whether pid is a LIVE demarkus-server whose -root
@@ -967,9 +981,13 @@ func argsRootMatches(args, target string) bool {
 // findRunningDemarkus emits "PID PORT ROOT" per running demarkus-server, one per
 // line (empty when none). Args take precedence over env; falls back to
 // DEMARKUS_PORT/DEMARKUS_ROOT env, then the protocol default port / "(unknown)" root.
-func findRunningDemarkus() string {
+func findRunningDemarkus() (string, bool) {
+	pids, ran := pgrepDemarkusServer()
+	if !ran {
+		return "", false
+	}
 	var lines []string
-	for _, pid := range pgrepDemarkusServer() {
+	for _, pid := range pids {
 		args := psArgs(pid)
 		if args == "" {
 			continue
@@ -984,7 +1002,7 @@ func findRunningDemarkus() string {
 		}
 		lines = append(lines, fmt.Sprintf("%d %s %s", pid, port, root))
 	}
-	return strings.Join(lines, "\n")
+	return strings.Join(lines, "\n"), true
 }
 
 // portOfServer returns the port the server listens on (-port flag in args,
@@ -1693,7 +1711,7 @@ func serverExecutable(pid int) string {
 // so the two cannot describe different processes. Empty unless the owner is us,
 // or where ps reports a bare name (Linux comm) rather than a path.
 func psOwnedExecutable(pid int) string {
-	line := probeBounded(nil, "ps", "-p", strconv.Itoa(pid), "-o", "uid=,comm=")
+	line, _ := probeBounded(nil, "ps", "-p", strconv.Itoa(pid), "-o", "uid=,comm=")
 	uidField, exe, found := strings.Cut(strings.TrimSpace(line), " ")
 	if !found {
 		return ""
@@ -1742,7 +1760,7 @@ var lstartLayouts = []string{"Mon _2 Jan 15:04:05 2006", "Mon Jan _2 15:04:05 20
 func processStart(pid int) (time.Time, bool) {
 	// /proc/<pid> ModTime is not a defined start time: it can reflect when the
 	// procfs entry was instantiated, which hides a replacement. ps lstart is.
-	out := probeBounded([]string{"LC_ALL=C"}, "ps", "-p", strconv.Itoa(pid), "-o", "lstart=") // lstart is locale-formatted
+	out, _ := probeBounded([]string{"LC_ALL=C"}, "ps", "-p", strconv.Itoa(pid), "-o", "lstart=") // lstart is locale-formatted
 	if out == "" {
 		return time.Time{}, false
 	}
@@ -1787,14 +1805,14 @@ func reuseDriftWarning(pid int) string {
 		return fmt.Sprintf("cannot version-check the reused demarkus server (pid %d): its binary %s %s, so this plugin will not run it. Drift goes unreported until that is fixed.", pid, exe, why)
 	}
 	got := binaryVersionAt(exe)
+	// Replacement first: got describes the binary on disk, so once it has been
+	// swapped the below-pin text would report a version nothing is serving.
+	if w := replacedBinaryWarning(pid, exe, got); w != "" {
+		return w
+	}
 	less, ordered := semverLess(got, serverVersion)
 	if ordered && less {
 		return fmt.Sprintf("the reused demarkus server (pid %d, %s) is version %s, below the %s this plugin expects; features the plugin assumes may be missing. Upgrade that server, or run /soul-init to let the plugin manage one.", pid, exe, got, serverVersion)
-	}
-	// The replacement check speaks first: it needs no parsed version, and names
-	// the more specific problem when both are true.
-	if w := replacedBinaryWarning(pid, exe, got); w != "" {
-		return w
 	}
 	if !ordered {
 		reported := "no version"
@@ -1845,7 +1863,10 @@ func HealthWarning() (string, error) {
 			return fmt.Sprintf("the demarkus-memory server is not running (no live process for %s). Memory tools (mark_fetch/mark_publish/mark_lookup/...) will fail until it restarts; run /soul-init to restart, or /soul-status to diagnose.", cfg.MemoryDir), nil
 		}
 	case "reuse":
-		pid := pidOfServerAtRoot(cfg.MemoryDir)
+		pid, ran := pidOfServerAtRootProbed(cfg.MemoryDir)
+		if !ran {
+			return fmt.Sprintf("cannot tell whether the reused server rooted at %s is running: process discovery did not complete. Run /soul-status to retry.", cfg.MemoryDir), nil
+		}
 		if pid == 0 {
 			return fmt.Sprintf("demarkus-memory is configured to reuse a server rooted at %s, but none is running. Memory tools will fail until it is started; start that server or run /soul-init to reconfigure.", cfg.MemoryDir), nil
 		}
@@ -1859,7 +1880,10 @@ func HealthWarning() (string, error) {
 // DetectServers reports running demarkus-server processes as "NO_SERVER" or
 // "SERVERS\n<PID PORT ROOT>..." lines, matching the old detect script.
 func DetectServers() (string, error) {
-	results := findRunningDemarkus()
+	results, ran := findRunningDemarkus()
+	if !ran {
+		return "", errors.New("could not list processes: the discovery probe did not run")
+	}
 	if results == "" {
 		return "NO_SERVER", nil
 	}
@@ -1922,10 +1946,13 @@ func tailFile(path string, n int) string {
 
 // pgrepDemarkusServer returns the PIDs of processes whose command line contains
 // "demarkus-server", sorted ascending (deterministic, matching pgrep order).
-func pgrepDemarkusServer() []int {
-	out := probeBounded(nil, "pgrep", "-f", "demarkus-server")
+func pgrepDemarkusServer() ([]int, bool) {
+	out, ran := probeBounded(nil, "pgrep", "-f", "demarkus-server")
+	if !ran {
+		return nil, false
+	}
 	if out == "" {
-		return nil
+		return nil, true
 	}
 	var pids []int
 	self := os.Getpid()
@@ -1941,14 +1968,14 @@ func pgrepDemarkusServer() []int {
 		pids = append(pids, pid)
 	}
 	sort.Ints(pids)
-	return pids
+	return pids, true
 }
 
 // psArgs returns the full command line (args) of pid, or "". The leading/trailing
 // space wrapping matches the bash " -root … " word-boundary matching done by
 // argsRootMatches (ps -o args= gives no leading space, so we add one).
 func psArgs(pid int) string {
-	args := probeBounded(nil, "ps", "-p", strconv.Itoa(pid), "-o", "args=")
+	args, _ := probeBounded(nil, "ps", "-p", strconv.Itoa(pid), "-o", "args=")
 	if args == "" {
 		return ""
 	}
@@ -1967,7 +1994,8 @@ func procEnv(pid int, name string) string {
 		}
 		return ""
 	}
-	for tok := range strings.FieldsSeq(probeBounded(nil, "ps", "eww", "-p", strconv.Itoa(pid))) {
+	env, _ := probeBounded(nil, "ps", "eww", "-p", strconv.Itoa(pid))
+	for tok := range strings.FieldsSeq(env) {
 		if v, ok := strings.CutPrefix(tok, name+"="); ok {
 			return v
 		}

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -968,11 +968,26 @@ func TestServerExecutable(t *testing.T) {
 }
 
 // TestReuseDriftWarningQuietOnHealthy guards the false-positive direction: a
-// live process whose binary predates it must produce no warning, or every
-// session start would nag. The test binary itself is exactly that shape.
+// server at the pin whose binary predates it must say nothing, or every session
+// start would nag.
 func TestReuseDriftWarningQuietOnHealthy(t *testing.T) {
-	if w := reuseDriftWarning(os.Getpid()); w != "" {
-		t.Errorf("reuseDriftWarning(self) = %q, want empty", w)
+	t.Setenv("STUB_VERSION", serverVersion)
+	pid := startStub(t, buildVersionStub(t))
+	if w := reuseDriftWarning(pid); w != "" {
+		t.Errorf("reuseDriftWarning(current server) = %q, want empty", w)
+	}
+}
+
+// TestReuseDriftWarningUnreadableVersion covers the gap that let an unprobeable
+// server read as healthy: no usable version is a lost check, not a clean one.
+func TestReuseDriftWarningUnreadableVersion(t *testing.T) {
+	t.Setenv("STUB_VERSION", "dev")
+	exe := buildVersionStub(t)
+	pid := startStub(t, exe)
+
+	w := reuseDriftWarning(pid)
+	if !strings.Contains(w, "cannot version-check") || !strings.Contains(w, "dev") {
+		t.Errorf("reuseDriftWarning = %q, want a refusal naming the reported build", w)
 	}
 }
 

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -1023,7 +1023,7 @@ func TestBinaryVersionAtKillsForkedChild(t *testing.T) {
 	beat := filepath.Join(dir, "beat")
 	forker := filepath.Join(dir, "forks")
 	script := "#!/bin/sh\n" +
-		"( while :; do sleep 1; printf x >> \"" + beat + "\"; done ) &\n" +
+		"( while :; do printf x >> \"" + beat + "\"; sleep 1; done ) &\n" +
 		"sleep 60\n"
 	if err := os.WriteFile(forker, []byte(script), 0o755); err != nil {
 		t.Fatalf("write stub: %v", err)
@@ -1049,7 +1049,7 @@ func TestBinaryVersionAtKillsForkedChild(t *testing.T) {
 	}
 	before := beatSize()
 	if before < 0 {
-		t.Skip("the forked child never wrote; nothing to prove about killing it")
+		t.Fatal("the forked child never wrote its heartbeat; descendant cleanup went unverified")
 	}
 	time.Sleep(2 * time.Second)
 	if after := beatSize(); after != before {
@@ -1093,6 +1093,20 @@ func buildVersionStub(t *testing.T) string {
 	return exe
 }
 
+// replaceBinary swaps exe for a fresh copy the way an installer does, by rename.
+// The running process keeps the original inode, which is the only replacement
+// Linux allows at all: it refuses to rewrite a running executable.
+func replaceBinary(t *testing.T, exe string) {
+	t.Helper()
+	staged := exe + ".next"
+	if err := installFile(exe, staged, 0o755); err != nil {
+		t.Fatalf("stage replacement: %v", err)
+	}
+	if err := os.Rename(staged, exe); err != nil {
+		t.Fatalf("replace %s: %v", exe, err)
+	}
+}
+
 // startStub runs the stub so it stays alive and returns its pid.
 func startStub(t *testing.T, exe string) int {
 	t.Helper()
@@ -1130,17 +1144,29 @@ func TestReuseDriftWarningBinaryReplaced(t *testing.T) {
 		t.Fatalf("before replacement: reuseDriftWarning = %q, want empty", w)
 	}
 
-	old := binaryReplaceSkew
-	binaryReplaceSkew = 0
-	t.Cleanup(func() { binaryReplaceSkew = old })
-
-	// ps lstart is second-granular, so let the clock cross a second boundary or
-	// the replacement can read as simultaneous with the process start.
+	// A second past the start clears binaryReplaceSkew where mtime is the only
+	// signal; procfs sees the swapped inode without waiting.
 	time.Sleep(1100 * time.Millisecond)
-	now := time.Now()
-	if err := os.Chtimes(exe, now, now); err != nil {
-		t.Fatalf("touch stub: %v", err)
+	replaceBinary(t, exe)
+
+	w := reuseDriftWarning(pid)
+	if !strings.Contains(w, "replaced") || !strings.Contains(w, exe) {
+		t.Errorf("reuseDriftWarning = %q, want it to report %s was replaced", w, exe)
 	}
+}
+
+// TestReuseDriftWarningAtomicReplaceAtStart covers the window the mtime
+// comparison cannot see: a swap in the same second as the launch, caught only by
+// procfs inode identity.
+func TestReuseDriftWarningAtomicReplaceAtStart(t *testing.T) {
+	if _, err := os.Stat("/proc/self"); err != nil {
+		t.Skip("no procfs: the sub-second window is irreducible without inode identity")
+	}
+	t.Setenv("STUB_VERSION", serverVersion) // at the pin, so only the swap can warn
+	exe := buildVersionStub(t)
+	pid := startStub(t, exe)
+
+	replaceBinary(t, exe) // no delay: the window the mtime comparison cannot see
 
 	w := reuseDriftWarning(pid)
 	if !strings.Contains(w, "replaced") || !strings.Contains(w, exe) {
@@ -1227,15 +1253,8 @@ func TestReuseDriftWarningReplacedBelowPin(t *testing.T) {
 	exe := buildVersionStub(t)
 	pid := startStub(t, exe)
 
-	old := binaryReplaceSkew
-	binaryReplaceSkew = 0
-	t.Cleanup(func() { binaryReplaceSkew = old })
-
-	time.Sleep(1100 * time.Millisecond) // ps lstart is second-granular
-	now := time.Now()
-	if err := os.Chtimes(exe, now, now); err != nil {
-		t.Fatalf("touch stub: %v", err)
-	}
+	time.Sleep(1100 * time.Millisecond) // clears binaryReplaceSkew where mtime is the only signal
+	replaceBinary(t, exe)
 
 	w := reuseDriftWarning(pid)
 	if !strings.Contains(w, "replaced") {

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -913,10 +913,7 @@ func TestProcessStart(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start sleep: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
-	})
+	t.Cleanup(func() { stopProcess(t, cmd) })
 
 	started, ok := processStart(cmd.Process.Pid)
 	if !ok {
@@ -928,8 +925,7 @@ func TestProcessStart(t *testing.T) {
 
 	// Kill it, then ask about a pid that is certainly gone.
 	pid := cmd.Process.Pid
-	_ = cmd.Process.Kill()
-	_ = cmd.Wait()
+	stopProcess(t, cmd)
 	if _, ok := processStart(pid); ok {
 		t.Errorf("processStart(dead pid) ok = true, want false")
 	}
@@ -948,10 +944,7 @@ func TestServerExecutable(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start sleep: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
-	})
+	t.Cleanup(func() { stopProcess(t, cmd) })
 
 	exe := serverExecutable(cmd.Process.Pid)
 	if exe == "" {
@@ -993,7 +986,98 @@ func TestBinaryVersionAtTimeout(t *testing.T) {
 	if got := binaryVersionAt(hang); got != "" {
 		t.Errorf("binaryVersionAt(hanging) = %q, want empty", got)
 	}
-	if d := time.Since(start); d > 10*time.Second {
-		t.Errorf("binaryVersionAt(hanging) took %v, want bounded near %v", d, versionProbeTimeout)
+	if d := time.Since(start); d > versionProbeTimeout+time.Second {
+		t.Errorf("binaryVersionAt(hanging) took %v, want within the %v budget", d, versionProbeTimeout)
+	}
+}
+
+// stopProcess ends a helper process started by a test. Wait's error is the kill
+// we just sent, so only a Kill failure is worth reporting.
+func stopProcess(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+	if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		t.Errorf("kill test process %d: %v", cmd.Process.Pid, err)
+	}
+	_ = cmd.Wait() // reaps the process
+}
+
+// buildVersionStub compiles a real executable that answers --version from the
+// environment. It has to be compiled: ps reports a shell script's interpreter
+// rather than the script, so a script would never reach the probe under test.
+func buildVersionStub(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module versionstub\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	src := "package main\n\n" +
+		"import (\n\t\"fmt\"\n\t\"os\"\n\t\"time\"\n)\n\n" +
+		"func main() {\n" +
+		"\tif len(os.Args) > 1 {\n\t\tfmt.Println(os.Getenv(\"STUB_VERSION\"))\n\t\treturn\n\t}\n" +
+		"\ttime.Sleep(5 * time.Minute)\n}\n"
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write stub source: %v", err)
+	}
+	exe := filepath.Join(dir, "demarkus-server")
+	build := exec.Command("go", "build", "-o", exe, ".")
+	build.Dir = dir
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Skipf("cannot build version stub: %v\n%s", err, out)
+	}
+	return exe
+}
+
+// startStub runs the stub so it stays alive and returns its pid.
+func startStub(t *testing.T, exe string) int {
+	t.Helper()
+	cmd := exec.Command(exe)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start stub: %v", err)
+	}
+	t.Cleanup(func() { stopProcess(t, cmd) })
+	return cmd.Process.Pid
+}
+
+// TestReuseDriftWarningBelowPin exercises the branch the whole change exists
+// for: an adopted server older than the pinned floor, named in the warning.
+func TestReuseDriftWarningBelowPin(t *testing.T) {
+	t.Setenv("STUB_VERSION", "0.1.0")
+	exe := buildVersionStub(t)
+	pid := startStub(t, exe)
+
+	w := reuseDriftWarning(pid)
+	for _, want := range []string{"0.1.0", serverVersion, exe} {
+		if !strings.Contains(w, want) {
+			t.Errorf("reuseDriftWarning = %q, want it to name %q", w, want)
+		}
+	}
+}
+
+// TestReuseDriftWarningBinaryReplaced covers the second branch: a process at the
+// pinned version whose binary was swapped underneath it.
+func TestReuseDriftWarningBinaryReplaced(t *testing.T) {
+	t.Setenv("STUB_VERSION", serverVersion) // at the pin, so only the swap can warn
+	exe := buildVersionStub(t)
+	pid := startStub(t, exe)
+
+	if w := reuseDriftWarning(pid); w != "" {
+		t.Fatalf("before replacement: reuseDriftWarning = %q, want empty", w)
+	}
+
+	old := binaryReplaceSkew
+	binaryReplaceSkew = 0
+	t.Cleanup(func() { binaryReplaceSkew = old })
+
+	// ps lstart is second-granular, so let the clock cross a second boundary or
+	// the replacement can read as simultaneous with the process start.
+	time.Sleep(1100 * time.Millisecond)
+	now := time.Now()
+	if err := os.Chtimes(exe, now, now); err != nil {
+		t.Fatalf("touch stub: %v", err)
+	}
+
+	w := reuseDriftWarning(pid)
+	if !strings.Contains(w, "replaced") || !strings.Contains(w, exe) {
+		t.Errorf("reuseDriftWarning = %q, want it to report %s was replaced", w, exe)
 	}
 }

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -1200,3 +1200,35 @@ func TestReuseDriftWarningReplacedBelowPin(t *testing.T) {
 		t.Errorf("reuseDriftWarning = %q, want the replacement reported, not the on-disk version", w)
 	}
 }
+
+// TestProcIsOurs pins the explicit owner check that stops a privileged plugin
+// resolving a foreign process's executable through /proc/<pid>/exe.
+func TestProcIsOurs(t *testing.T) {
+	if _, err := os.Stat("/proc/self"); err != nil {
+		// No procfs: serverExecutable takes the ps path, which carries its own
+		// owner check, and procIsOurs is expected to refuse everything.
+		if procIsOurs(os.Getpid()) {
+			t.Error("procIsOurs reported true without procfs; the ps path must own that decision")
+		}
+		return
+	}
+	if !procIsOurs(os.Getpid()) {
+		t.Error("procIsOurs(self) = false, want true")
+	}
+	if procIsOurs(1) && os.Getuid() != 0 { // pid 1 is root's
+		t.Error("procIsOurs(pid 1) = true as an unprivileged user, want false")
+	}
+}
+
+// TestPsArgsReportsProbeRan checks the discovery probes distinguish a process
+// that is gone from an inspection that never happened.
+func TestPsArgsReportsProbeRan(t *testing.T) {
+	args, ran := psArgs(os.Getpid())
+	if !ran || args == "" {
+		t.Errorf("psArgs(self) = %q, %v; want args and true", args, ran)
+	}
+	// A pid that cannot exist: ps exits non-zero, which is still an answer.
+	if _, ran := psArgs(-1); !ran {
+		t.Error("psArgs(bad pid) reported the probe as not having run")
+	}
+}

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -1158,3 +1158,45 @@ func TestReuseDriftWarningRefusesUnsafeBinary(t *testing.T) {
 		t.Errorf("reuseDriftWarning = %q, want a refusal naming the permissions", w)
 	}
 }
+
+// TestProbeBounded separates the two failures a discovery command can have: a
+// clean non-zero exit is an answer, an unrunnable command is not.
+func TestProbeBounded(t *testing.T) {
+	if out, ran := probeBounded(nil, "sh", "-c", "echo hello"); out != "hello" || !ran {
+		t.Errorf("probeBounded(echo) = %q, %v; want %q, true", out, ran, "hello")
+	}
+	// pgrep reports "no match" as exit 1, which must not read as a failed probe.
+	if out, ran := probeBounded(nil, "sh", "-c", "exit 1"); out != "" || !ran {
+		t.Errorf("probeBounded(exit 1) = %q, %v; want empty, true", out, ran)
+	}
+	if _, ran := probeBounded(nil, "definitely-not-a-real-command-9f3c"); ran {
+		t.Error("probeBounded(missing command) reported the probe as having run")
+	}
+	if _, ran := probeBounded(nil, "sh", "-c", "sleep 60"); ran {
+		t.Error("probeBounded(hanging command) reported the probe as having run")
+	}
+}
+
+// TestReuseDriftWarningReplacedBelowPin covers the ordering: when the binary was
+// swapped and the replacement is itself below the pin, the replacement is the
+// true statement, since the below-pin text names a version nothing is serving.
+func TestReuseDriftWarningReplacedBelowPin(t *testing.T) {
+	t.Setenv("STUB_VERSION", "0.1.0")
+	exe := buildVersionStub(t)
+	pid := startStub(t, exe)
+
+	old := binaryReplaceSkew
+	binaryReplaceSkew = 0
+	t.Cleanup(func() { binaryReplaceSkew = old })
+
+	time.Sleep(1100 * time.Millisecond) // ps lstart is second-granular
+	now := time.Now()
+	if err := os.Chtimes(exe, now, now); err != nil {
+		t.Fatalf("touch stub: %v", err)
+	}
+
+	w := reuseDriftWarning(pid)
+	if !strings.Contains(w, "replaced") {
+		t.Errorf("reuseDriftWarning = %q, want the replacement reported, not the on-disk version", w)
+	}
+}

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -1015,6 +1015,48 @@ func TestBinaryVersionAtTimeout(t *testing.T) {
 	}
 }
 
+// TestBinaryVersionAtKillsForkedChild guards the probe against a --version that
+// forks: cancelling has to take the whole process group, since a kill aimed at
+// the direct child leaves the grandchild running.
+func TestBinaryVersionAtKillsForkedChild(t *testing.T) {
+	dir := t.TempDir()
+	beat := filepath.Join(dir, "beat")
+	forker := filepath.Join(dir, "forks")
+	script := "#!/bin/sh\n" +
+		"( while :; do sleep 1; printf x >> \"" + beat + "\"; done ) &\n" +
+		"sleep 60\n"
+	if err := os.WriteFile(forker, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	// Guarded: an ungrouped kill does not just leak the child, it never returns,
+	// and a plain call would hang until the package timeout instead of failing.
+	done := make(chan string, 1)
+	go func() { done <- binaryVersionAt(forker) }()
+	select {
+	case got := <-done:
+		if got != "" {
+			t.Errorf("binaryVersionAt(forking) = %q, want empty", got)
+		}
+	case <-time.After(versionProbeTimeout + 2*time.Second):
+		t.Fatal("binaryVersionAt never returned; the forked grandchild still holds the probe's stdout pipe")
+	}
+	beatSize := func() int64 {
+		info, err := os.Stat(beat)
+		if err != nil {
+			return -1
+		}
+		return info.Size()
+	}
+	before := beatSize()
+	if before < 0 {
+		t.Skip("the forked child never wrote; nothing to prove about killing it")
+	}
+	time.Sleep(2 * time.Second)
+	if after := beatSize(); after != before {
+		t.Errorf("forked child outlived the cancelled probe (beat grew %d -> %d)", before, after)
+	}
+}
+
 // stopProcess ends a helper process started by a test. Wait's error is the kill
 // we just sent, so only a Kill failure is worth reporting.
 func stopProcess(t *testing.T, cmd *exec.Cmd) {
@@ -1215,8 +1257,11 @@ func TestProcIsOurs(t *testing.T) {
 	if !procIsOurs(os.Getpid()) {
 		t.Error("procIsOurs(self) = false, want true")
 	}
-	if procIsOurs(1) && os.Getuid() != 0 { // pid 1 is root's
-		t.Error("procIsOurs(pid 1) = true as an unprivileged user, want false")
+	// Not "pid 1 is root's": under a rootless container it can be ours, and
+	// procIsOurs is then right to say true.
+	var st syscall.Stat_t
+	if err := syscall.Stat("/proc/1", &st); err == nil && int(st.Uid) != os.Getuid() && procIsOurs(1) {
+		t.Error("procIsOurs(pid 1) = true for a process owned by another user, want false")
 	}
 }
 

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/latebit-io/demarkus/client/fetch"
 	"github.com/latebit-io/demarkus/protocol"
@@ -842,5 +843,157 @@ func TestTokensFromArgv(t *testing.T) {
 		if got := tokensFromArgv(c.argv); got != c.want {
 			t.Errorf("%s: tokensFromArgv(%v) = %q, want %q", c.name, c.argv, got, c.want)
 		}
+	}
+}
+
+// TestSemverLess covers the ordering and the not-a-release cases where no
+// ordering exists, which the drift probe must treat as "say nothing".
+func TestSemverLess(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     string
+		wantLess bool
+		wantOK   bool
+	}{
+		{name: "patch behind", a: "0.35.0", b: "0.35.1", wantLess: true, wantOK: true},
+		{name: "minor behind", a: "0.17.19", b: "0.35.0", wantLess: true, wantOK: true},
+		{name: "major behind", a: "0.99.99", b: "1.0.0", wantLess: true, wantOK: true},
+		{name: "equal", a: "0.35.0", b: "0.35.0", wantOK: true},
+		{name: "ahead", a: "0.36.0", b: "0.35.0", wantOK: true},
+		{name: "numeric not lexical", a: "0.9.0", b: "0.10.0", wantLess: true, wantOK: true},
+		{name: "dev build", a: "dev", b: "0.35.0"},
+		{name: "tagged build", a: "0.35.0-rc1", b: "0.35.0"},
+		{name: "empty probe", a: "", b: "0.35.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			less, ok := semverLess(tt.a, tt.b)
+			if ok != tt.wantOK {
+				t.Fatalf("semverLess(%q, %q) ok = %v, want %v", tt.a, tt.b, ok, tt.wantOK)
+			}
+			if less != tt.wantLess {
+				t.Errorf("semverLess(%q, %q) less = %v, want %v", tt.a, tt.b, less, tt.wantLess)
+			}
+		})
+	}
+}
+
+// TestBinaryVersionAt checks the path-taking split reports a version, and stays
+// empty for the inputs the drift probe must not read a verdict into.
+func TestBinaryVersionAt(t *testing.T) {
+	dir := t.TempDir()
+
+	good := filepath.Join(dir, "answers")
+	if err := os.WriteFile(good, []byte("#!/bin/sh\necho 0.35.0\n"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	if got := binaryVersionAt(good); got != "0.35.0" {
+		t.Errorf("binaryVersionAt(executable) = %q, want %q", got, "0.35.0")
+	}
+
+	notExec := filepath.Join(dir, "not-exec")
+	if err := os.WriteFile(notExec, []byte("#!/bin/sh\necho 0.35.0\n"), 0o644); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	if got := binaryVersionAt(notExec); got != "" {
+		t.Errorf("binaryVersionAt(non-executable) = %q, want empty", got)
+	}
+	if got := binaryVersionAt(dir); got != "" {
+		t.Errorf("binaryVersionAt(directory) = %q, want empty", got)
+	}
+	if got := binaryVersionAt(filepath.Join(dir, "absent")); got != "" {
+		t.Errorf("binaryVersionAt(missing) = %q, want empty", got)
+	}
+}
+
+// TestProcessStart pins the contract the drift probe relies on: a real start
+// time for a live process, and ok=false rather than a zero time for a dead one.
+func TestProcessStart(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	started, ok := processStart(cmd.Process.Pid)
+	if !ok {
+		t.Fatalf("processStart(live pid) ok = false, want true")
+	}
+	if d := time.Since(started); d < -time.Minute || d > time.Minute {
+		t.Errorf("processStart(live pid) = %v, %v from now; want within a minute", started, d)
+	}
+
+	// Kill it, then ask about a pid that is certainly gone.
+	pid := cmd.Process.Pid
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+	if _, ok := processStart(pid); ok {
+		t.Errorf("processStart(dead pid) ok = true, want false")
+	}
+}
+
+// TestServerExecutable checks the resolver returns a runnable absolute path for
+// a live process on whichever mechanism this platform provides.
+func TestServerExecutable(t *testing.T) {
+	// Launch by absolute path: ps comm= echoes how the process was invoked, so a
+	// PATH-resolved name would test nothing the real adopted server does.
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skipf("no sleep on PATH: %v", err)
+	}
+	cmd := exec.Command(sleepPath, "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	exe := serverExecutable(cmd.Process.Pid)
+	if exe == "" {
+		t.Skip("no executable-path mechanism on this platform")
+	}
+	if !filepath.IsAbs(exe) {
+		t.Errorf("serverExecutable = %q, want an absolute path", exe)
+	}
+	if base := filepath.Base(exe); base != "sleep" {
+		t.Errorf("serverExecutable basename = %q, want %q", base, "sleep")
+	}
+}
+
+// TestReuseDriftWarningQuietOnHealthy guards the false-positive direction: a
+// live process whose binary predates it must produce no warning, or every
+// session start would nag. The test binary itself is exactly that shape.
+func TestReuseDriftWarningQuietOnHealthy(t *testing.T) {
+	if w := reuseDriftWarning(os.Getpid()); w != "" {
+		t.Errorf("reuseDriftWarning(self) = %q, want empty", w)
+	}
+}
+
+// TestReuseDriftWarningNoProcess checks an unresolvable pid stays silent rather
+// than inventing a verdict.
+func TestReuseDriftWarningNoProcess(t *testing.T) {
+	if w := reuseDriftWarning(-1); w != "" {
+		t.Errorf("reuseDriftWarning(bad pid) = %q, want empty", w)
+	}
+}
+
+// TestBinaryVersionAtTimeout checks a binary that never answers is bounded
+// rather than left to stall session start.
+func TestBinaryVersionAtTimeout(t *testing.T) {
+	hang := filepath.Join(t.TempDir(), "hangs")
+	if err := os.WriteFile(hang, []byte("#!/bin/sh\nsleep 60\n"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	start := time.Now()
+	if got := binaryVersionAt(hang); got != "" {
+		t.Errorf("binaryVersionAt(hanging) = %q, want empty", got)
+	}
+	if d := time.Since(start); d > 10*time.Second {
+		t.Errorf("binaryVersionAt(hanging) took %v, want bounded near %v", d, versionProbeTimeout)
 	}
 }

--- a/tools/demarkus-plugin/internal/provision/provision_test.go
+++ b/tools/demarkus-plugin/internal/provision/provision_test.go
@@ -915,12 +915,21 @@ func TestProcessStart(t *testing.T) {
 	}
 	t.Cleanup(func() { stopProcess(t, cmd) })
 
+	// Wait before the first lookup: an implementation that stamps the time of
+	// inspection rather than of launch would pass without this, and would then
+	// miss a binary replaced during the gap.
+	const settle = 2 * time.Second
+	time.Sleep(settle)
+
 	started, ok := processStart(cmd.Process.Pid)
 	if !ok {
 		t.Fatalf("processStart(live pid) ok = false, want true")
 	}
-	if d := time.Since(started); d < -time.Minute || d > time.Minute {
-		t.Errorf("processStart(live pid) = %v, %v from now; want within a minute", started, d)
+	if d := time.Since(started); d < settle-time.Second {
+		t.Errorf("processStart(live pid) = %v, only %v ago; want the launch time, not the lookup time", started, d)
+	}
+	if d := time.Since(started); d > time.Minute {
+		t.Errorf("processStart(live pid) = %v, %v ago; want within a minute", started, d)
 	}
 
 	// Kill it, then ask about a pid that is certainly gone.
@@ -1079,5 +1088,58 @@ func TestReuseDriftWarningBinaryReplaced(t *testing.T) {
 	w := reuseDriftWarning(pid)
 	if !strings.Contains(w, "replaced") || !strings.Contains(w, exe) {
 		t.Errorf("reuseDriftWarning = %q, want it to report %s was replaced", w, exe)
+	}
+}
+
+// TestExecRefusal pins the gate that stops the probe running a file another user
+// could have rewritten between the adoption and the probe.
+func TestExecRefusal(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name string, mode os.FileMode) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("#!/bin/sh\ntrue\n"), mode); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		if err := os.Chmod(p, mode); err != nil { // WriteFile respects umask
+			t.Fatalf("chmod %s: %v", name, err)
+		}
+		return p
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "owned and not writable by others", path: write("ok", 0o755)},
+		{name: "world writable", path: write("world-writable", 0o777), want: "is writable by other users"},
+		{name: "group writable", path: write("group-writable", 0o775), want: "is writable by other users"},
+		{name: "not executable", path: write("plain", 0o644), want: "is not a regular executable"},
+		{name: "directory", path: dir, want: "is not a regular executable"},
+		{name: "missing", path: filepath.Join(dir, "absent"), want: "cannot be read"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := execRefusal(tt.path); got != tt.want {
+				t.Errorf("execRefusal(%s) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReuseDriftWarningRefusesUnsafeBinary checks a binary others can rewrite is
+// reported as an unchecked server rather than passed off as healthy.
+func TestReuseDriftWarningRefusesUnsafeBinary(t *testing.T) {
+	t.Setenv("STUB_VERSION", "0.1.0")
+	exe := buildVersionStub(t)
+	pid := startStub(t, exe)
+	if err := os.Chmod(exe, 0o777); err != nil {
+		t.Fatalf("chmod stub: %v", err)
+	}
+
+	w := reuseDriftWarning(pid)
+	if !strings.Contains(w, "cannot version-check") || !strings.Contains(w, "writable by other users") {
+		t.Errorf("reuseDriftWarning = %q, want a refusal naming the permissions", w)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Provisioning no longer hangs when adopted binaries or inherited process pipes fail to respond.
  - Reuse-mode health checks now distinguish unavailable process scans from servers that are not running.
  - Added warnings for reused servers running outdated, replaced, or unsafe binaries.
  - Reuse checks continue verifying server liveness, version, executable ownership, permissions, and replacement status.
  - Improved warnings when reused servers do not meet required version standards.

- **Tests**
  - Expanded coverage for version checks, process inspection, reuse validation, binary replacement, safety checks, cleanup, and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->