### PR TITLE
feat(server): seed a default write policy when a world is created empty

### DIFF
--- a/deploy/helm/demarkus-knowledge-server/README.md
+++ b/deploy/helm/demarkus-knowledge-server/README.md
@@ -8,9 +8,8 @@ stores each world in its own pre-provisioned GCS bucket.
 
 - Kubernetes 1.25+
 - GKE Workload Identity, or an existing Kubernetes ServiceAccount with equivalent identity
-- One initialized GCS bucket and immutable world ID per world
+- One GCS bucket and immutable world ID per world; an empty bucket is created on first start
 - One existing multi-SAN TLS Secret, or cert-manager and a suitable Issuer
-- Policy document at `/.well-known/demarkus/policy.md` in every bucket
 
 The chart never creates buckets, PVCs, or TLS Secrets. The optional
 `Certificate` asks cert-manager to populate the referenced TLS Secret.
@@ -26,10 +25,19 @@ provision token Secrets some other way. The Job's `tokens.bootstrap.image`
 defaults to kubectl 1.35, which supports API servers 1.34–1.36; override it
 to match older clusters (kubectl's skew policy is ±1 minor).
 
-Initialize each bucket with `demarkus-knowledge-bootstrap -bucket gs://<bucket>
--world-id <uuid> -policy-file <policy.md>`, which writes the world skeleton and
-seeds the policy document. The tool is idempotent and ships in the
-`demarkus-knowledge-server` release archive, not the container image.
+Buckets need no out-of-band initialization. A world whose bucket is empty is
+created on first start: the server writes the world skeleton and seeds a
+default write policy that warns rather than blocks, then enforces it. Publish
+your own policy to `/.well-known/demarkus/policy.md` through the protocol and
+it governs the next write; restarts never revert it. A bucket holding objects
+but no world head is refused, so a mistyped `bucket.url` fails the open
+instead of quietly becoming an empty world.
+
+To choose the policy before the first start instead, run
+`demarkus-knowledge-bootstrap -bucket gs://<bucket> -world-id <uuid>
+-policy-file <policy.md>` from somewhere with bucket write access. The tool is
+idempotent and ships in the `demarkus-knowledge-server` release archive, not
+the container image.
 
 ## Install
 

--- a/docs/site/deployment/kubernetes.md
+++ b/docs/site/deployment/kubernetes.md
@@ -21,8 +21,9 @@ One deployment serves every world on one UDP listener; TLS SNI selects the world
 Prerequisites per world:
 
 - A GCS bucket with an immutable world ID (a canonical RFC 4122 UUID).
-- The bucket initialized and its publish policy seeded with `demarkus-knowledge-bootstrap` (`-bucket gs://... -world-id <uuid> -policy-file policy.md`); the bootstrap binary ships in the `demarkus-knowledge-server` release archive.
 - A token Secret referenced by `worlds[].tokenSecret`.
+
+An empty bucket needs nothing else. The server writes the world skeleton on first start and seeds a default write policy at `/.well-known/demarkus/policy.md` that warns rather than blocks, then enforces it. Publish your own policy through the protocol to replace it; it takes effect on the next write and survives restarts. A bucket that holds objects but no world head is refused, so a mistyped `bucket.url` fails the open rather than becoming a second empty world. To pick the policy before the first start, run `demarkus-knowledge-bootstrap` (`-bucket gs://... -world-id <uuid> -policy-file policy.md`) from somewhere with bucket write access; it ships in the `demarkus-knowledge-server` release archive.
 
 Cluster prerequisites:
 

--- a/server/cmd/demarkus-knowledge-bootstrap/bootstrap.go
+++ b/server/cmd/demarkus-knowledge-bootstrap/bootstrap.go
@@ -5,76 +5,46 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/latebit-io/demarkus/protocol/publishpolicy"
 	protocolstore "github.com/latebit-io/demarkus/protocol/store"
 	"github.com/latebit-io/demarkus/server/internal/knowledge/blob"
 	"github.com/latebit-io/demarkus/server/internal/knowledge/bucketstore"
+	"github.com/latebit-io/demarkus/server/internal/knowledge/knowledgeseed"
 )
 
-var policyMetadata = map[string]string{
-	"title":      "Knowledge System Policy",
-	"tags":       "category:governance",
-	"importance": "1",
-	"type":       "Reference",
-}
+// policyMetadata is shared with the server's default seed so the two
+// entry points cannot drift on the catalog axes a policy must carry.
+var policyMetadata = knowledgeseed.PolicyMetadata()
 
 func bootstrap(ctx context.Context, objects blob.Store, worldID string, policy []byte) error {
-	if err := validatePolicy(policy); err != nil {
+	seed := bucketstore.PolicySeed{Body: policy, Metadata: policyMetadata}
+	if err := bucketstore.ValidatePolicySeed(seed); err != nil {
 		return err
 	}
 	if err := bucketstore.Initialize(ctx, objects, worldID); err != nil {
 		return fmt.Errorf("initialize bucket: %w", err)
 	}
-	store, err := bucketstore.Open(ctx, objects, bucketstore.Options{WorldID: worldID, RequirePolicy: false})
+	store, err := bucketstore.Open(ctx, objects, bucketstore.Options{WorldID: worldID})
 	if err != nil {
 		return fmt.Errorf("open initialized bucket: %w", err)
 	}
-	if err := seedPolicy(store, policy); err != nil {
+	if _, err := store.SeedPolicy(seed); err != nil {
+		return err
+	}
+	// Unlike the server, the operator named an exact policy: an existing
+	// document that differs is a mistake to report, not a world to adopt.
+	document, err := store.Get(publishpolicy.DocumentPath, 0)
+	if err != nil {
+		return fmt.Errorf("read seeded policy: %w", err)
+	}
+	if err := verifyPolicy(document, policy); err != nil {
 		return err
 	}
 	if _, err := bucketstore.Open(ctx, objects, bucketstore.Options{WorldID: worldID, RequirePolicy: true}); err != nil {
 		return fmt.Errorf("verify required policy: %w", err)
 	}
 	return nil
-}
-
-func validatePolicy(policy []byte) error {
-	if err := protocolstore.ValidateDocumentContent(publishpolicy.DocumentPath, policy); err != nil {
-		return fmt.Errorf("invalid policy document: %w", err)
-	}
-	if err := protocolstore.ValidateWrite(policy, policyMetadata); err != nil {
-		return fmt.Errorf("invalid policy write: %w", err)
-	}
-	parsed := publishpolicy.Parse(string(policy))
-	if err := parsed.Validate(); err != nil {
-		return fmt.Errorf("invalid policy: %w", err)
-	}
-	return nil
-}
-
-func seedPolicy(store *bucketstore.Store, policy []byte) error {
-	document, err := store.Get(publishpolicy.DocumentPath, 0)
-	switch {
-	case err == nil:
-		return verifyPolicy(document, policy)
-	case !errors.Is(err, os.ErrNotExist):
-		return fmt.Errorf("check existing policy: %w", err)
-	}
-
-	document, err = store.WriteVersion(publishpolicy.DocumentPath, 0, policy, policyMetadata)
-	if err == nil {
-		return verifyPolicy(document, policy)
-	}
-	if !errors.Is(err, protocolstore.ErrConflict) {
-		return fmt.Errorf("create policy: %w", err)
-	}
-	document, err = store.Get(publishpolicy.DocumentPath, 0)
-	if err != nil {
-		return fmt.Errorf("read concurrently created policy: %w", err)
-	}
-	return verifyPolicy(document, policy)
 }
 
 func verifyPolicy(document *protocolstore.Document, policy []byte) error {

--- a/server/cmd/demarkus-knowledge-bootstrap/bootstrap.go
+++ b/server/cmd/demarkus-knowledge-bootstrap/bootstrap.go
@@ -15,22 +15,22 @@ import (
 
 // policyMetadata is shared with the server's default seed so the two
 // entry points cannot drift on the catalog axes a policy must carry.
-var policyMetadata = knowledgeseed.PolicyMetadata()
+var policyMetadata = knowledgeseed.DefaultPolicySeed().Metadata
 
 func bootstrap(ctx context.Context, objects blob.Store, worldID string, policy []byte) error {
 	seed := bucketstore.PolicySeed{Body: policy, Metadata: policyMetadata}
+	// Validated before Initialize so an unusable policy creates no objects.
 	if err := bucketstore.ValidatePolicySeed(seed); err != nil {
 		return err
 	}
 	if err := bucketstore.Initialize(ctx, objects, worldID); err != nil {
 		return fmt.Errorf("initialize bucket: %w", err)
 	}
-	store, err := bucketstore.Open(ctx, objects, bucketstore.Options{WorldID: worldID})
+	store, err := bucketstore.Open(ctx, objects, bucketstore.Options{
+		WorldID: worldID, RequirePolicy: true, PolicySeed: &seed,
+	})
 	if err != nil {
-		return fmt.Errorf("open initialized bucket: %w", err)
-	}
-	if _, err := store.SeedPolicy(seed); err != nil {
-		return err
+		return fmt.Errorf("seed and enforce policy: %w", err)
 	}
 	// Unlike the server, the operator named an exact policy: an existing
 	// document that differs is a mistake to report, not a world to adopt.
@@ -38,13 +38,7 @@ func bootstrap(ctx context.Context, objects blob.Store, worldID string, policy [
 	if err != nil {
 		return fmt.Errorf("read seeded policy: %w", err)
 	}
-	if err := verifyPolicy(document, policy); err != nil {
-		return err
-	}
-	if _, err := bucketstore.Open(ctx, objects, bucketstore.Options{WorldID: worldID, RequirePolicy: true}); err != nil {
-		return fmt.Errorf("verify required policy: %w", err)
-	}
-	return nil
+	return verifyPolicy(document, policy)
 }
 
 func verifyPolicy(document *protocolstore.Document, policy []byte) error {

--- a/server/cmd/demarkus-knowledge-bootstrap/main.go
+++ b/server/cmd/demarkus-knowledge-bootstrap/main.go
@@ -12,6 +12,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/latebit-io/demarkus/protocol"
 	"github.com/latebit-io/demarkus/server/internal/knowledge/blob/gcs"
+	"github.com/latebit-io/demarkus/server/internal/knowledge/bucketstore"
 	"github.com/latebit-io/demarkus/server/internal/knowledgeconfig"
 )
 
@@ -102,7 +103,7 @@ func loadConfig(arguments []string) (config, error) {
 	if err != nil {
 		return config{}, err
 	}
-	if err := validatePolicy(policy); err != nil {
+	if err := bucketstore.ValidatePolicySeed(bucketstore.PolicySeed{Body: policy, Metadata: policyMetadata}); err != nil {
 		return config{}, err
 	}
 	return config{bucketName: bucketName, worldID: *worldID, policy: policy}, nil

--- a/server/cmd/demarkus-knowledge-server/worlds.go
+++ b/server/cmd/demarkus-knowledge-server/worlds.go
@@ -14,6 +14,7 @@ import (
 	"github.com/latebit-io/demarkus/server/internal/configwatch"
 	"github.com/latebit-io/demarkus/server/internal/knowledge/blob"
 	"github.com/latebit-io/demarkus/server/internal/knowledge/bucketstore"
+	"github.com/latebit-io/demarkus/server/internal/knowledge/knowledgeseed"
 	"github.com/latebit-io/demarkus/server/internal/knowledgeconfig"
 	"github.com/latebit-io/demarkus/server/internal/snirouter"
 	"github.com/latebit-io/demarkus/server/internal/worldruntime"
@@ -192,10 +193,15 @@ func (m *worldManager) openLocked(world *knowledgeconfig.WorldConfig) error {
 			return fmt.Errorf("bootstrap genesis: %w", err)
 		}
 	}
+	seed, err := m.prepareEnforcedWorld(ctx, objects, world)
+	if err != nil {
+		return err
+	}
 	store, err := bucketstore.Open(ctx, objects, bucketstore.Options{
 		WorldID:        world.Bucket.WorldID,
 		RequestTimeout: time.Duration(world.Limits.RequestTimeout),
 		RequirePolicy:  !world.Bootstrap,
+		PolicySeed:     seed,
 		MaxDocuments:   world.Limits.MaxDocuments,
 	})
 	if err != nil {
@@ -229,6 +235,33 @@ func (m *worldManager) openLocked(world *knowledgeconfig.WorldConfig) error {
 	m.acquireTokenWatchLocked(world.Auth.TokensFile)
 	m.logger.Info("world opened", "world", world.Name, "bootstrap", world.Bootstrap)
 	return nil
+}
+
+// prepareEnforcedWorld creates an enforcing world's genesis when its bucket
+// is empty and returns the policy seed to open with, so a new world needs no
+// out-of-band bootstrap. Nil for the provisioned and read-only paths.
+func (m *worldManager) prepareEnforcedWorld(
+	ctx context.Context,
+	objects blob.Store,
+	world *knowledgeconfig.WorldConfig,
+) (*bucketstore.PolicySeed, error) {
+	if world.Bootstrap || world.ReadOnly {
+		return nil, nil
+	}
+	created, err := bucketstore.EnsureWorld(ctx, objects, world.Bucket.WorldID)
+	if err != nil {
+		return nil, err
+	}
+	if created {
+		// Loud on purpose: an empty bucket is normally a first install,
+		// but it is also what a wrong bucket URL looks like.
+		m.logger.Warn("created a new world in an empty bucket",
+			"world", world.Name, "bucket", world.Bucket.Name(), "worldID", world.Bucket.WorldID)
+	}
+	return &bucketstore.PolicySeed{
+		Body:     knowledgeseed.PolicyBody(),
+		Metadata: knowledgeseed.PolicyMetadata(),
+	}, nil
 }
 
 // dirWatch is one refcounted configwatch watcher covering every world

--- a/server/cmd/demarkus-knowledge-server/worlds.go
+++ b/server/cmd/demarkus-knowledge-server/worlds.go
@@ -175,8 +175,8 @@ func (m *worldManager) apply(desired []knowledgeconfig.WorldConfig) error {
 	return errors.Join(firstErr, publishErr)
 }
 
-// openLocked opens one world: blob store, optional genesis bootstrap,
-// bucket store, runtime, and its token-file watcher.
+// openLocked opens one world: blob store, genesis, bucket store, runtime,
+// and its token-file watcher.
 func (m *worldManager) openLocked(world *knowledgeconfig.WorldConfig) error {
 	ctx, cancel := context.WithTimeout(context.Background(), worldAddTimeout)
 	defer cancel()
@@ -185,17 +185,15 @@ func (m *worldManager) openLocked(world *knowledgeconfig.WorldConfig) error {
 	if err != nil {
 		return fmt.Errorf("blob store: %w", err)
 	}
-	if world.Bootstrap {
-		// Genesis only; no policy document. The provisioner (memory
-		// broker) seeds policy through the protocol, so the store opens
-		// without requiring one.
-		if err := bucketstore.Initialize(ctx, objects, world.Bucket.WorldID); err != nil {
-			return fmt.Errorf("bootstrap genesis: %w", err)
-		}
+	if err := m.ensureGenesis(ctx, objects, world); err != nil {
+		return fmt.Errorf("genesis: %w", err)
 	}
-	seed, err := m.prepareEnforcedWorld(ctx, objects, world)
-	if err != nil {
-		return err
+	var seed *bucketstore.PolicySeed
+	if !world.Bootstrap && !world.ReadOnly {
+		// Provisioned worlds are seeded by their broker over the protocol,
+		// so only a statically configured world carries a default.
+		value := knowledgeseed.DefaultPolicySeed()
+		seed = &value
 	}
 	store, err := bucketstore.Open(ctx, objects, bucketstore.Options{
 		WorldID:        world.Bucket.WorldID,
@@ -237,20 +235,20 @@ func (m *worldManager) openLocked(world *knowledgeconfig.WorldConfig) error {
 	return nil
 }
 
-// prepareEnforcedWorld creates an enforcing world's genesis when its bucket
-// is empty and returns the policy seed to open with, so a new world needs no
-// out-of-band bootstrap. Nil for the provisioned and read-only paths.
-func (m *worldManager) prepareEnforcedWorld(
+// ensureGenesis creates the world's genesis when its bucket is empty, so a
+// new world needs no out-of-band bootstrap. A read-only world is skipped:
+// authoring its first object would contradict the declaration.
+func (m *worldManager) ensureGenesis(
 	ctx context.Context,
 	objects blob.Store,
 	world *knowledgeconfig.WorldConfig,
-) (*bucketstore.PolicySeed, error) {
-	if world.Bootstrap || world.ReadOnly {
-		return nil, nil
+) error {
+	if world.ReadOnly {
+		return nil
 	}
 	created, err := bucketstore.EnsureWorld(ctx, objects, world.Bucket.WorldID)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if created {
 		// Loud on purpose: an empty bucket is normally a first install,
@@ -258,10 +256,7 @@ func (m *worldManager) prepareEnforcedWorld(
 		m.logger.Warn("created a new world in an empty bucket",
 			"world", world.Name, "bucket", world.Bucket.Name(), "worldID", world.Bucket.WorldID)
 	}
-	return &bucketstore.PolicySeed{
-		Body:     knowledgeseed.PolicyBody(),
-		Metadata: knowledgeseed.PolicyMetadata(),
-	}, nil
+	return nil
 }
 
 // dirWatch is one refcounted configwatch watcher covering every world

--- a/server/cmd/demarkus-knowledge-server/worlds_test.go
+++ b/server/cmd/demarkus-knowledge-server/worlds_test.go
@@ -50,7 +50,9 @@ func testCertFiles(t *testing.T) (certFile, keyFile string) {
 	return certFile, keyFile
 }
 
-func fragmentWorld(name, worldID, tokensFile string) string {
+// worldFragment renders one world. Without bootstrap it is a statically
+// configured world, the path that enforces policy and seeds a default one.
+func worldFragment(name, worldID, tokensFile string, bootstrap bool) string {
 	return fmt.Sprintf(`  - name: %s
     authorities:
       - %s.memory.svc.cluster.local
@@ -59,22 +61,8 @@ func fragmentWorld(name, worldID, tokensFile string) string {
       worldID: %s
     auth:
       tokensFile: %s
-    bootstrap: true
-`, name, name, name, worldID, tokensFile)
-}
-
-// staticWorld is fragmentWorld without bootstrap: a statically configured
-// world, the path that enforces policy and seeds a default one.
-func staticWorld(name, worldID, tokensFile string) string {
-	return fmt.Sprintf(`  - name: %s
-    authorities:
-      - %s.knowledge.svc.cluster.local
-    bucket:
-      url: gs://knowledge-%s
-      worldID: %s
-    auth:
-      tokensFile: %s
-`, name, name, name, worldID, tokensFile)
+    bootstrap: %t
+`, name, name, name, worldID, tokensFile, bootstrap)
 }
 
 func newWorldsHarness(t *testing.T, fragment string) *worldsTestHarness {
@@ -90,17 +78,14 @@ func newWorldsHarness(t *testing.T, fragment string) *worldsTestHarness {
 	return h
 }
 
-// newStaticWorldsHarness runs a manager over statically configured worlds.
-// prepare, when set, runs against each world's fresh blob store before the
-// manager opens it, so a test can stage bucket contents.
-func newStaticWorldsHarness(t *testing.T, worlds string, prepare func(*testing.T, *blob.Memory)) (*worldsTestHarness, error) {
-	t.Helper()
-	return openHarness(t, t.TempDir(), "worlds:\n"+worlds, prepare)
-}
-
 // openHarness writes a config whose world set is worldsSection, either a
 // worldsFile pointer or an inline worlds list, and opens a manager over it.
-func openHarness(t *testing.T, dir, worldsSection string, prepare func(*testing.T, *blob.Memory)) (*worldsTestHarness, error) {
+// newStore overrides the blob-store factory; nil uses in-memory buckets.
+func openHarness(
+	t *testing.T,
+	dir, worldsSection string,
+	newStore func(context.Context, *knowledgeconfig.WorldConfig) (blob.Store, error),
+) (*worldsTestHarness, error) {
 	t.Helper()
 	certFile, keyFile := testCertFiles(t)
 	main := fmt.Sprintf(`version: 1
@@ -121,21 +106,20 @@ tls:
 		t.Fatalf("certsource: %v", err)
 	}
 	h := &worldsTestHarness{dir: dir, stores: map[string]*blob.Memory{}}
-	newStore := func(_ context.Context, world *knowledgeconfig.WorldConfig) (blob.Store, error) {
-		h.storesMu.Lock()
-		defer h.storesMu.Unlock()
-		if store, ok := h.stores[world.Name]; ok {
+	if newStore == nil {
+		newStore = func(_ context.Context, world *knowledgeconfig.WorldConfig) (blob.Store, error) {
+			h.storesMu.Lock()
+			defer h.storesMu.Unlock()
+			if store, ok := h.stores[world.Name]; ok {
+				return store, nil
+			}
+			store, err := blob.NewMemory(maxObjectBytes)
+			if err != nil {
+				return nil, err
+			}
+			h.stores[world.Name] = store
 			return store, nil
 		}
-		store, err := blob.NewMemory(maxObjectBytes)
-		if err != nil {
-			return nil, err
-		}
-		if prepare != nil {
-			prepare(t, store)
-		}
-		h.stores[world.Name] = store
-		return store, nil
 	}
 	watchCtx, cancel := context.WithCancel(context.Background())
 	group := &sync.WaitGroup{}
@@ -184,7 +168,7 @@ func (h *worldsTestHarness) routes(authority string) bool {
 func TestWorldManagerHotAddAndRemove(t *testing.T) {
 	tokensDir := t.TempDir()
 	tokensA := writeTokens(t, tokensDir, "alice")
-	h := newWorldsHarness(t, "worlds:\n"+fragmentWorld("alice", testWorldID, tokensA))
+	h := newWorldsHarness(t, "worlds:\n"+worldFragment("alice", testWorldID, tokensA, true))
 
 	if got := h.manager.WorldCount(); got != 1 {
 		t.Fatalf("initial worlds = %d, want 1", got)
@@ -196,8 +180,8 @@ func TestWorldManagerHotAddAndRemove(t *testing.T) {
 	// Hot add a second world through the fragment.
 	tokensB := writeTokens(t, tokensDir, "bob")
 	h.writeFragment(t, "worlds:\n"+
-		fragmentWorld("alice", testWorldID, tokensA)+
-		fragmentWorld("bob", testWorldIDB, tokensB))
+		worldFragment("alice", testWorldID, tokensA, true)+
+		worldFragment("bob", testWorldIDB, tokensB, true))
 	if err := h.manager.Reload(); err != nil {
 		t.Fatalf("reload after add: %v", err)
 	}
@@ -209,7 +193,7 @@ func TestWorldManagerHotAddAndRemove(t *testing.T) {
 	}
 
 	// Remove the first world.
-	h.writeFragment(t, "worlds:\n"+fragmentWorld("bob", testWorldIDB, tokensB))
+	h.writeFragment(t, "worlds:\n"+worldFragment("bob", testWorldIDB, tokensB, true))
 	if err := h.manager.Reload(); err != nil {
 		t.Fatalf("reload after remove: %v", err)
 	}
@@ -227,7 +211,7 @@ func TestWorldManagerHotAddAndRemove(t *testing.T) {
 func TestWorldManagerBootstrapInitializesGenesis(t *testing.T) {
 	tokensDir := t.TempDir()
 	tokens := writeTokens(t, tokensDir, "alice")
-	h := newWorldsHarness(t, "worlds:\n"+fragmentWorld("alice", testWorldID, tokens))
+	h := newWorldsHarness(t, "worlds:\n"+worldFragment("alice", testWorldID, tokens, true))
 
 	// The memory blob store started empty; a successful open proves the
 	// bootstrap path wrote genesis. The head object must now exist.
@@ -244,7 +228,7 @@ func TestWorldManagerBootstrapInitializesGenesis(t *testing.T) {
 
 func TestWorldManagerSeedsDefaultPolicyForStaticWorld(t *testing.T) {
 	tokens := writeTokens(t, t.TempDir(), "acme")
-	h, err := newStaticWorldsHarness(t, staticWorld("acme", testWorldID, tokens), nil)
+	h, err := openHarness(t, t.TempDir(), "worlds:\n"+worldFragment("acme", testWorldID, tokens, false), nil)
 	if err != nil {
 		t.Fatalf("static world with an empty bucket must come up: %v", err)
 	}
@@ -267,22 +251,24 @@ func TestWorldManagerSeedsDefaultPolicyForStaticWorld(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get seeded policy: %v", err)
 	}
-	if !bytes.Equal(document.Content, knowledgeseed.PolicyBody()) {
+	if !bytes.Equal(document.Content, knowledgeseed.DefaultPolicySeed().Body) {
 		t.Errorf("seeded policy = %q", document.Content)
 	}
 }
 
 func TestWorldManagerRefusesBucketWithForeignObjects(t *testing.T) {
 	tokens := writeTokens(t, t.TempDir(), "acme")
-	stage := func(t *testing.T, store *blob.Memory) {
-		t.Helper()
-		if _, err := store.Create(context.Background(), "someone-elses-data.json", []byte("{}")); err != nil {
-			t.Fatalf("stage foreign object: %v", err)
+	foreign := func(context.Context, *knowledgeconfig.WorldConfig) (blob.Store, error) {
+		store, err := blob.NewMemory(maxObjectBytes)
+		if err != nil {
+			return nil, err
 		}
+		_, err = store.Create(context.Background(), "someone-elses-data.json", []byte("{}"))
+		return store, err
 	}
 	// A typo'd bucket URL must fail the open, not silently become a new
 	// empty world that reports healthy.
-	_, err := newStaticWorldsHarness(t, staticWorld("acme", testWorldID, tokens), stage)
+	_, err := openHarness(t, t.TempDir(), "worlds:\n"+worldFragment("acme", testWorldID, tokens, false), foreign)
 	if err == nil {
 		t.Fatal("manager started over a bucket holding foreign objects")
 	}
@@ -294,14 +280,14 @@ func TestWorldManagerRefusesBucketWithForeignObjects(t *testing.T) {
 func TestWorldManagerPendingRetryOnMissingTokens(t *testing.T) {
 	tokensDir := t.TempDir()
 	tokensA := writeTokens(t, tokensDir, "alice")
-	h := newWorldsHarness(t, "worlds:\n"+fragmentWorld("alice", testWorldID, tokensA))
+	h := newWorldsHarness(t, "worlds:\n"+worldFragment("alice", testWorldID, tokensA, true))
 
 	// A world whose tokens file has not propagated yet: open fails,
 	// world parks in pending, others stay live.
 	missing := filepath.Join(tokensDir, "carol.toml")
 	h.writeFragment(t, "worlds:\n"+
-		fragmentWorld("alice", testWorldID, tokensA)+
-		fragmentWorld("carol", testWorldIDB, missing))
+		worldFragment("alice", testWorldID, tokensA, true)+
+		worldFragment("carol", testWorldIDB, missing, true))
 	if err := h.manager.Reload(); err != nil {
 		t.Fatalf("reload with missing tokens: %v (resilient mode must not fail)", err)
 	}
@@ -325,7 +311,7 @@ func TestWorldManagerPendingRetryOnMissingTokens(t *testing.T) {
 func TestWorldManagerRejectsBadFragmentKeepsRunning(t *testing.T) {
 	tokensDir := t.TempDir()
 	tokensA := writeTokens(t, tokensDir, "alice")
-	h := newWorldsHarness(t, "worlds:\n"+fragmentWorld("alice", testWorldID, tokensA))
+	h := newWorldsHarness(t, "worlds:\n"+worldFragment("alice", testWorldID, tokensA, true))
 
 	h.writeFragment(t, "worlds:\n  - name: broken\n    nonsense: true\n")
 	if err := h.manager.Reload(); err == nil {
@@ -340,41 +326,14 @@ func TestWorldManagerRejectsBadFragmentKeepsRunning(t *testing.T) {
 }
 
 func TestWorldManagerStaticModeFailsFast(t *testing.T) {
-	dir := t.TempDir()
-	certFile, keyFile := testCertFiles(t)
-	tokens := writeTokens(t, dir, "alice")
-	main := fmt.Sprintf(`version: 1
-tls:
-  certFile: %s
-  keyFile: %s
-worlds:
-%s`, certFile, keyFile, staticWorld("alice", testWorldID, tokens))
-	configFile := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(configFile, []byte(main), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	config, err := knowledgeconfig.Load(configFile)
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-	certs, err := certsource.Open(certFile, keyFile, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tokens := writeTokens(t, t.TempDir(), "alice")
 	// An unreachable bucket. An empty one is no longer a failure: the
 	// server creates that world and seeds its policy.
-	newStore := func(_ context.Context, _ *knowledgeconfig.WorldConfig) (blob.Store, error) {
+	unreachable := func(context.Context, *knowledgeconfig.WorldConfig) (blob.Store, error) {
 		return nil, errors.New("bucket unreachable")
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	group := &sync.WaitGroup{}
-	// Cleanup, not defer: a failed expectation here must not deadlock the
-	// package on background loops that outlive the test body.
-	t.Cleanup(func() {
-		cancel()
-		group.Wait()
-	})
-	if _, err := newWorldManager(ctx, group, configFile, config, newStore, certs, slog.Default()); err == nil {
+	worlds := "worlds:\n" + worldFragment("alice", testWorldID, tokens, false)
+	if _, err := openHarness(t, t.TempDir(), worlds, unreachable); err == nil {
 		t.Fatal("static mode must fail fast on an unopenable world")
 	}
 }

--- a/server/cmd/demarkus-knowledge-server/worlds_test.go
+++ b/server/cmd/demarkus-knowledge-server/worlds_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -10,8 +12,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/latebit-io/demarkus/protocol/publishpolicy"
 	"github.com/latebit-io/demarkus/server/internal/certsource"
 	"github.com/latebit-io/demarkus/server/internal/knowledge/blob"
+	"github.com/latebit-io/demarkus/server/internal/knowledge/bucketstore"
+	"github.com/latebit-io/demarkus/server/internal/knowledge/knowledgeseed"
 	"github.com/latebit-io/demarkus/server/internal/knowledgeconfig"
 )
 
@@ -58,21 +63,53 @@ func fragmentWorld(name, worldID, tokensFile string) string {
 `, name, name, name, worldID, tokensFile)
 }
 
+// staticWorld is fragmentWorld without bootstrap: a statically configured
+// world, the path that enforces policy and seeds a default one.
+func staticWorld(name, worldID, tokensFile string) string {
+	return fmt.Sprintf(`  - name: %s
+    authorities:
+      - %s.knowledge.svc.cluster.local
+    bucket:
+      url: gs://knowledge-%s
+      worldID: %s
+    auth:
+      tokensFile: %s
+`, name, name, name, worldID, tokensFile)
+}
+
 func newWorldsHarness(t *testing.T, fragment string) *worldsTestHarness {
 	t.Helper()
 	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "worlds.yaml"), []byte(fragment), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	h, err := openHarness(t, dir, "worldsFile: worlds.yaml\n", nil)
+	if err != nil {
+		t.Fatalf("open harness: %v", err)
+	}
+	return h
+}
+
+// newStaticWorldsHarness runs a manager over statically configured worlds.
+// prepare, when set, runs against each world's fresh blob store before the
+// manager opens it, so a test can stage bucket contents.
+func newStaticWorldsHarness(t *testing.T, worlds string, prepare func(*testing.T, *blob.Memory)) (*worldsTestHarness, error) {
+	t.Helper()
+	return openHarness(t, t.TempDir(), "worlds:\n"+worlds, prepare)
+}
+
+// openHarness writes a config whose world set is worldsSection, either a
+// worldsFile pointer or an inline worlds list, and opens a manager over it.
+func openHarness(t *testing.T, dir, worldsSection string, prepare func(*testing.T, *blob.Memory)) (*worldsTestHarness, error) {
+	t.Helper()
 	certFile, keyFile := testCertFiles(t)
 	main := fmt.Sprintf(`version: 1
 tls:
   certFile: %s
   keyFile: %s
-worldsFile: worlds.yaml
-`, certFile, keyFile)
+%s`, certFile, keyFile, worldsSection)
 	configFile := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(configFile, []byte(main), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "worlds.yaml"), []byte(fragment), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	config, err := knowledgeconfig.Load(configFile)
@@ -94,6 +131,9 @@ worldsFile: worlds.yaml
 		if err != nil {
 			return nil, err
 		}
+		if prepare != nil {
+			prepare(t, store)
+		}
 		h.stores[world.Name] = store
 		return store, nil
 	}
@@ -102,7 +142,8 @@ worldsFile: worlds.yaml
 	manager, err := newWorldManager(watchCtx, group, configFile, config, newStore, certs, slog.Default())
 	if err != nil {
 		cancel()
-		t.Fatalf("newWorldManager: %v", err)
+		group.Wait()
+		return nil, err
 	}
 	h.manager = manager
 	t.Cleanup(func() {
@@ -110,7 +151,7 @@ worldsFile: worlds.yaml
 		cancel()
 		group.Wait()
 	})
-	return h
+	return h, nil
 }
 
 func (h *worldsTestHarness) writeFragment(t *testing.T, fragment string) {
@@ -201,6 +242,55 @@ func TestWorldManagerBootstrapInitializesGenesis(t *testing.T) {
 	}
 }
 
+func TestWorldManagerSeedsDefaultPolicyForStaticWorld(t *testing.T) {
+	tokens := writeTokens(t, t.TempDir(), "acme")
+	h, err := newStaticWorldsHarness(t, staticWorld("acme", testWorldID, tokens), nil)
+	if err != nil {
+		t.Fatalf("static world with an empty bucket must come up: %v", err)
+	}
+	if got := h.manager.WorldCount(); got != 1 {
+		t.Fatalf("worlds = %d, want 1", got)
+	}
+
+	// The world enforces policy, so the open could only succeed if it
+	// created genesis and seeded the default policy itself.
+	h.storesMu.Lock()
+	objects := h.stores["acme"]
+	h.storesMu.Unlock()
+	store, err := bucketstore.Open(context.Background(), objects, bucketstore.Options{
+		WorldID: testWorldID, RequirePolicy: true,
+	})
+	if err != nil {
+		t.Fatalf("reopen seeded world: %v", err)
+	}
+	document, err := store.Get(publishpolicy.DocumentPath, 0)
+	if err != nil {
+		t.Fatalf("get seeded policy: %v", err)
+	}
+	if !bytes.Equal(document.Content, knowledgeseed.PolicyBody()) {
+		t.Errorf("seeded policy = %q", document.Content)
+	}
+}
+
+func TestWorldManagerRefusesBucketWithForeignObjects(t *testing.T) {
+	tokens := writeTokens(t, t.TempDir(), "acme")
+	stage := func(t *testing.T, store *blob.Memory) {
+		t.Helper()
+		if _, err := store.Create(context.Background(), "someone-elses-data.json", []byte("{}")); err != nil {
+			t.Fatalf("stage foreign object: %v", err)
+		}
+	}
+	// A typo'd bucket URL must fail the open, not silently become a new
+	// empty world that reports healthy.
+	_, err := newStaticWorldsHarness(t, staticWorld("acme", testWorldID, tokens), stage)
+	if err == nil {
+		t.Fatal("manager started over a bucket holding foreign objects")
+	}
+	if !strings.Contains(err.Error(), "no world head") {
+		t.Errorf("error does not name the cause: %v", err)
+	}
+}
+
 func TestWorldManagerPendingRetryOnMissingTokens(t *testing.T) {
 	tokensDir := t.TempDir()
 	tokensA := writeTokens(t, tokensDir, "alice")
@@ -258,7 +348,7 @@ tls:
   certFile: %s
   keyFile: %s
 worlds:
-%s`, certFile, keyFile, strings.ReplaceAll(fragmentWorld("alice", testWorldID, tokens), "bootstrap: true", "bootstrap: false"))
+%s`, certFile, keyFile, staticWorld("alice", testWorldID, tokens))
 	configFile := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(configFile, []byte(main), 0o600); err != nil {
 		t.Fatal(err)
@@ -271,16 +361,20 @@ worlds:
 	if err != nil {
 		t.Fatal(err)
 	}
+	// An unreachable bucket. An empty one is no longer a failure: the
+	// server creates that world and seeds its policy.
 	newStore := func(_ context.Context, _ *knowledgeconfig.WorldConfig) (blob.Store, error) {
-		store, err := blob.NewMemory(maxObjectBytes)
-		if err != nil {
-			return nil, err
-		}
-		return store, nil // empty, not bootstrapped: open must fail
+		return nil, errors.New("bucket unreachable")
 	}
+	ctx, cancel := context.WithCancel(context.Background())
 	group := &sync.WaitGroup{}
-	defer group.Wait()
-	if _, err := newWorldManager(t.Context(), group, configFile, config, newStore, certs, slog.Default()); err == nil {
+	// Cleanup, not defer: a failed expectation here must not deadlock the
+	// package on background loops that outlive the test body.
+	t.Cleanup(func() {
+		cancel()
+		group.Wait()
+	})
+	if _, err := newWorldManager(ctx, group, configFile, config, newStore, certs, slog.Default()); err == nil {
 		t.Fatal("static mode must fail fast on an unopenable world")
 	}
 }

--- a/server/internal/knowledge/bucketstore/policyseed.go
+++ b/server/internal/knowledge/bucketstore/policyseed.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/latebit-io/demarkus/protocol/publishpolicy"
 	protocolstore "github.com/latebit-io/demarkus/protocol/store"
@@ -33,19 +32,17 @@ func ValidatePolicySeed(seed PolicySeed) error {
 	return nil
 }
 
-// SeedPolicy publishes seed as the world's policy when it has none and
+// createPolicy publishes seed as the world's policy when it has none and
 // reports whether it created one. Create-only, so a restart never reverts
 // a policy that replaced an earlier seed.
-func (store *Store) SeedPolicy(seed PolicySeed) (bool, error) {
+func (store *Store) createPolicy(seed PolicySeed) (bool, error) {
+	// The installed snapshot is the same freshness currentPolicy trusts,
+	// and an archived entry counts as present so no seed overwrites it.
+	if _, exists := store.snapshot.Load().Paths[publishpolicy.DocumentPath]; exists {
+		return false, nil
+	}
 	if err := ValidatePolicySeed(seed); err != nil {
 		return false, err
-	}
-	_, err := store.Get(publishpolicy.DocumentPath, 0)
-	switch {
-	case err == nil:
-		return false, nil
-	case !errors.Is(err, os.ErrNotExist):
-		return false, fmt.Errorf("check existing policy: %w", err)
 	}
 	if _, err := store.WriteVersion(publishpolicy.DocumentPath, 0, seed.Body, seed.Metadata); err != nil {
 		// A concurrent replica won the create; its policy stands.
@@ -58,8 +55,8 @@ func (store *Store) SeedPolicy(seed PolicySeed) (bool, error) {
 }
 
 // EnsureWorld creates the world's genesis when the bucket is empty and
-// reports whether it did. Objects but no world head is refused: that is
-// another bucket, not a new world, usually a misconfigured bucket URL.
+// reports whether it did. Objects but no head is refused as a misconfigured
+// bucket URL: an advisory check, not a lock against foreign writers.
 func EnsureWorld(ctx context.Context, objects blob.Store, worldID string) (bool, error) {
 	if ctx == nil {
 		return false, fmt.Errorf("ensure world: %w: context is nil", blob.ErrPrecondition)
@@ -93,7 +90,12 @@ func EnsureWorld(ctx context.Context, objects blob.Store, worldID string) (bool,
 // the world actually holds.
 func (store *Store) ensurePolicy(ctx context.Context, seed *PolicySeed) error {
 	if seed != nil {
-		created, err := store.SeedPolicy(*seed)
+		// Mutations in this store carry their own request timeout, so a
+		// started write outlives a canceled ctx; refuse to start one.
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("seed policy: %w", err)
+		}
+		created, err := store.createPolicy(*seed)
 		if err != nil {
 			return err
 		}
@@ -104,9 +106,7 @@ func (store *Store) ensurePolicy(ctx context.Context, seed *PolicySeed) error {
 	}
 	requestCtx, cancel := context.WithTimeout(ctx, store.requestTimeout)
 	defer cancel()
-	view := &readView{ctx: requestCtx, objects: store.objects, snapshot: store.snapshot.Load()}
-	if _, err := view.currentPolicy(true); err != nil {
-		return err
-	}
-	return nil
+	view := &readView{ctx: requestCtx, cancel: func() {}, objects: store.objects, snapshot: store.snapshot.Load()}
+	_, err := view.currentPolicy(true)
+	return err
 }

--- a/server/internal/knowledge/bucketstore/policyseed.go
+++ b/server/internal/knowledge/bucketstore/policyseed.go
@@ -1,0 +1,112 @@
+package bucketstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/latebit-io/demarkus/protocol/publishpolicy"
+	protocolstore "github.com/latebit-io/demarkus/protocol/store"
+	"github.com/latebit-io/demarkus/server/internal/knowledge/blob"
+)
+
+// PolicySeed is a default policy document and the catalog metadata it is
+// published with.
+type PolicySeed struct {
+	Body     []byte
+	Metadata map[string]string
+}
+
+// ValidatePolicySeed rejects a seed that would not survive a publish:
+// wrong document shape, invalid write, or an unenforceable policy.
+func ValidatePolicySeed(seed PolicySeed) error {
+	if err := protocolstore.ValidateDocumentContent(publishpolicy.DocumentPath, seed.Body); err != nil {
+		return fmt.Errorf("invalid policy document: %w", err)
+	}
+	if err := protocolstore.ValidateWrite(seed.Body, seed.Metadata); err != nil {
+		return fmt.Errorf("invalid policy write: %w", err)
+	}
+	if err := publishpolicy.Parse(string(seed.Body)).Validate(); err != nil {
+		return fmt.Errorf("invalid policy: %w", err)
+	}
+	return nil
+}
+
+// SeedPolicy publishes seed as the world's policy when it has none and
+// reports whether it created one. Create-only, so a restart never reverts
+// a policy that replaced an earlier seed.
+func (store *Store) SeedPolicy(seed PolicySeed) (bool, error) {
+	if err := ValidatePolicySeed(seed); err != nil {
+		return false, err
+	}
+	_, err := store.Get(publishpolicy.DocumentPath, 0)
+	switch {
+	case err == nil:
+		return false, nil
+	case !errors.Is(err, os.ErrNotExist):
+		return false, fmt.Errorf("check existing policy: %w", err)
+	}
+	if _, err := store.WriteVersion(publishpolicy.DocumentPath, 0, seed.Body, seed.Metadata); err != nil {
+		// A concurrent replica won the create; its policy stands.
+		if errors.Is(err, protocolstore.ErrConflict) {
+			return false, nil
+		}
+		return false, fmt.Errorf("create policy: %w", err)
+	}
+	return true, nil
+}
+
+// EnsureWorld creates the world's genesis when the bucket is empty and
+// reports whether it did. Objects but no world head is refused: that is
+// another bucket, not a new world, usually a misconfigured bucket URL.
+func EnsureWorld(ctx context.Context, objects blob.Store, worldID string) (bool, error) {
+	if ctx == nil {
+		return false, fmt.Errorf("ensure world: %w: context is nil", blob.ErrPrecondition)
+	}
+	if nilStore(objects) {
+		return false, fmt.Errorf("ensure world: %w: blob store is nil", blob.ErrPrecondition)
+	}
+	_, err := objects.Head(ctx, headObjectKey)
+	switch {
+	case err == nil:
+		return false, nil
+	case !errors.Is(err, blob.ErrNotFound):
+		return false, fmt.Errorf("ensure world: check head: %w", err)
+	}
+	listed, err := objects.List(ctx, "", "")
+	if err != nil {
+		return false, fmt.Errorf("ensure world: list bucket: %w", err)
+	}
+	if len(listed.Objects) > 0 {
+		return false, fmt.Errorf("ensure world: %w: bucket holds %d objects but no world head",
+			blob.ErrPrecondition, len(listed.Objects))
+	}
+	if err := Initialize(ctx, objects, worldID); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// ensurePolicy makes the stored policy usable before enforcement starts:
+// seed it when absent and a seed is configured, then validate whatever
+// the world actually holds.
+func (store *Store) ensurePolicy(ctx context.Context, seed *PolicySeed) error {
+	if seed != nil {
+		created, err := store.SeedPolicy(*seed)
+		if err != nil {
+			return err
+		}
+		if created {
+			store.logger.Info("seeded the default write policy",
+				"world", store.worldID, "path", publishpolicy.DocumentPath)
+		}
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, store.requestTimeout)
+	defer cancel()
+	view := &readView{ctx: requestCtx, objects: store.objects, snapshot: store.snapshot.Load()}
+	if _, err := view.currentPolicy(true); err != nil {
+		return err
+	}
+	return nil
+}

--- a/server/internal/knowledge/bucketstore/policyseed_test.go
+++ b/server/internal/knowledge/bucketstore/policyseed_test.go
@@ -14,7 +14,7 @@ import (
 func defaultSeed() PolicySeed {
 	return PolicySeed{
 		Body:     []byte("# Write Policy\n\nDefault.\n\nstrictness: warn\n"),
-		Metadata: map[string]string{"title": "Write Policy", "tags": "category:governance", "importance": "1"},
+		Metadata: policyMetadata(),
 	}
 }
 
@@ -43,19 +43,16 @@ func TestOpenSeedsMissingPolicy(t *testing.T) {
 func TestOpenLeavesCuratedPolicyInPlace(t *testing.T) {
 	objects := initializedMemory(t)
 	seed := defaultSeed()
-	if _, err := Open(context.Background(), objects, Options{
+	store, err := Open(context.Background(), objects, Options{
 		WorldID: testWorldID, RequirePolicy: true, PolicySeed: &seed,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("first open: %v", err)
 	}
 
 	// The agent replaces the seed with the real policy, then the world
 	// restarts: a restart must not revert curated policy.
 	curated := "# Write Policy\n\nCurated.\n\nstrictness: block\nrequire_tags: category\n"
-	store, err := Open(context.Background(), objects, Options{WorldID: testWorldID})
-	if err != nil {
-		t.Fatalf("reopen for overwrite: %v", err)
-	}
 	seedPolicy(t, store, curated, 1)
 
 	restarted, err := Open(context.Background(), objects, Options{
@@ -80,8 +77,8 @@ func TestSeedPolicyRejectsInvalidSeed(t *testing.T) {
 		t.Fatalf("Open: %v", err)
 	}
 	seed := PolicySeed{Body: []byte("strictness: nonsense\n"), Metadata: map[string]string{"tags": "category:governance"}}
-	if _, err := store.SeedPolicy(seed); err == nil {
-		t.Fatal("SeedPolicy accepted an unenforceable policy")
+	if _, err := store.createPolicy(seed); err == nil {
+		t.Fatal("createPolicy accepted an unenforceable policy")
 	}
 	if _, err := store.Get(publishpolicy.DocumentPath, 0); err == nil {
 		t.Error("rejected seed was written anyway")
@@ -131,4 +128,23 @@ func TestEnsureWorld(t *testing.T) {
 			t.Errorf("error does not name the cause: %v", err)
 		}
 	})
+}
+
+func TestEnsurePolicyRefusesCanceledContext(t *testing.T) {
+	objects := initializedMemory(t)
+	store, err := Open(context.Background(), objects, Options{WorldID: testWorldID})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	// Cancellation can land after the index phase, the one window where a
+	// seeding write would otherwise outlive the open that asked for it.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	seed := defaultSeed()
+	if err := store.ensurePolicy(ctx, &seed); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ensurePolicy error = %v, want context canceled", err)
+	}
+	if _, err := store.Get(publishpolicy.DocumentPath, 0); err == nil {
+		t.Error("canceled open seeded a policy anyway")
+	}
 }

--- a/server/internal/knowledge/bucketstore/policyseed_test.go
+++ b/server/internal/knowledge/bucketstore/policyseed_test.go
@@ -1,0 +1,134 @@
+package bucketstore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/latebit-io/demarkus/protocol/publishpolicy"
+	"github.com/latebit-io/demarkus/server/internal/knowledge/blob"
+)
+
+func defaultSeed() PolicySeed {
+	return PolicySeed{
+		Body:     []byte("# Write Policy\n\nDefault.\n\nstrictness: warn\n"),
+		Metadata: map[string]string{"title": "Write Policy", "tags": "category:governance", "importance": "1"},
+	}
+}
+
+func TestOpenSeedsMissingPolicy(t *testing.T) {
+	objects := initializedMemory(t)
+	seed := defaultSeed()
+	store, err := Open(context.Background(), objects, Options{
+		WorldID: testWorldID, RequirePolicy: true, PolicySeed: &seed,
+	})
+	if err != nil {
+		t.Fatalf("Open with seed: %v", err)
+	}
+	document, err := store.Get(publishpolicy.DocumentPath, 0)
+	if err != nil {
+		t.Fatalf("get seeded policy: %v", err)
+	}
+	if !bytes.Equal(document.Content, seed.Body) || document.Version != 1 {
+		t.Fatalf("seeded policy = version %d %q", document.Version, document.Content)
+	}
+	// Enforcement must be live on the store the seeding open returned.
+	if !store.requirePolicy {
+		t.Error("store opened without enforcing the policy it seeded")
+	}
+}
+
+func TestOpenLeavesCuratedPolicyInPlace(t *testing.T) {
+	objects := initializedMemory(t)
+	seed := defaultSeed()
+	if _, err := Open(context.Background(), objects, Options{
+		WorldID: testWorldID, RequirePolicy: true, PolicySeed: &seed,
+	}); err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+
+	// The agent replaces the seed with the real policy, then the world
+	// restarts: a restart must not revert curated policy.
+	curated := "# Write Policy\n\nCurated.\n\nstrictness: block\nrequire_tags: category\n"
+	store, err := Open(context.Background(), objects, Options{WorldID: testWorldID})
+	if err != nil {
+		t.Fatalf("reopen for overwrite: %v", err)
+	}
+	seedPolicy(t, store, curated, 1)
+
+	restarted, err := Open(context.Background(), objects, Options{
+		WorldID: testWorldID, RequirePolicy: true, PolicySeed: &seed,
+	})
+	if err != nil {
+		t.Fatalf("restart with seed: %v", err)
+	}
+	document, err := restarted.Get(publishpolicy.DocumentPath, 0)
+	if err != nil {
+		t.Fatalf("get policy after restart: %v", err)
+	}
+	if string(document.Content) != curated || document.Version != 2 {
+		t.Fatalf("policy after restart = version %d %q, want curated v2", document.Version, document.Content)
+	}
+}
+
+func TestSeedPolicyRejectsInvalidSeed(t *testing.T) {
+	objects := initializedMemory(t)
+	store, err := Open(context.Background(), objects, Options{WorldID: testWorldID})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	seed := PolicySeed{Body: []byte("strictness: nonsense\n"), Metadata: map[string]string{"tags": "category:governance"}}
+	if _, err := store.SeedPolicy(seed); err == nil {
+		t.Fatal("SeedPolicy accepted an unenforceable policy")
+	}
+	if _, err := store.Get(publishpolicy.DocumentPath, 0); err == nil {
+		t.Error("rejected seed was written anyway")
+	}
+}
+
+func TestEnsureWorld(t *testing.T) {
+	t.Run("creates genesis in an empty bucket", func(t *testing.T) {
+		objects := newTestMemory(t)
+		created, err := EnsureWorld(context.Background(), objects, testWorldID)
+		if err != nil {
+			t.Fatalf("EnsureWorld: %v", err)
+		}
+		if !created {
+			t.Error("created = false for an empty bucket")
+		}
+		if _, err := Open(context.Background(), objects, Options{WorldID: testWorldID}); err != nil {
+			t.Fatalf("open created world: %v", err)
+		}
+	})
+
+	t.Run("leaves an existing world alone", func(t *testing.T) {
+		objects := initializedMemory(t)
+		before := getObject(t, objects, headObjectKey).Attributes.Generation
+		created, err := EnsureWorld(context.Background(), objects, testWorldID)
+		if err != nil {
+			t.Fatalf("EnsureWorld: %v", err)
+		}
+		if created {
+			t.Error("created = true for an initialized bucket")
+		}
+		if after := getObject(t, objects, headObjectKey).Attributes.Generation; after != before {
+			t.Errorf("head generation changed from %d to %d", before, after)
+		}
+	})
+
+	t.Run("refuses a non-empty bucket with no head", func(t *testing.T) {
+		objects := newTestMemory(t)
+		if _, err := objects.Create(context.Background(), "someone-elses-data.json", []byte("{}")); err != nil {
+			t.Fatalf("seed foreign object: %v", err)
+		}
+		_, err := EnsureWorld(context.Background(), objects, testWorldID)
+		if !errors.Is(err, blob.ErrPrecondition) {
+			t.Fatalf("EnsureWorld error = %v, want ErrPrecondition", err)
+		}
+		if !strings.Contains(err.Error(), "no world head") {
+			t.Errorf("error does not name the cause: %v", err)
+		}
+	})
+}

--- a/server/internal/knowledge/bucketstore/store.go
+++ b/server/internal/knowledge/bucketstore/store.go
@@ -31,6 +31,9 @@ type Options struct {
 	RequestTimeout time.Duration
 	ShardWorkers   int
 	RequirePolicy  bool
+	// PolicySeed is published create-only when RequirePolicy is set and
+	// the world holds no policy yet; nil makes a missing policy fatal.
+	PolicySeed *PolicySeed
 	// MaxDocuments caps distinct document paths (0 = unlimited); a new
 	// path beyond the cap is rejected. Approximate under concurrency:
 	// a per-tenant quota, not an exact invariant.
@@ -130,7 +133,9 @@ func Open(ctx context.Context, objects blob.Store, options Options) (*Store, err
 		worldID:        options.WorldID,
 		requestTimeout: options.RequestTimeout,
 		shardWorkers:   options.ShardWorkers,
-		requirePolicy:  options.RequirePolicy,
+		// Enforcement switches on only after ensurePolicy: a seeding
+		// write must not be gated by the policy it is creating.
+		requirePolicy:  false,
 		logger:         options.Logger,
 		maxDocuments:   options.MaxDocuments,
 		commitToken:    make(chan struct{}, 1),
@@ -156,15 +161,14 @@ func Open(ctx context.Context, objects blob.Store, options Options) (*Store, err
 		store.refreshMu.Unlock()
 		return nil, fmt.Errorf("open bucket store: %w", err)
 	}
-	if store.requirePolicy {
-		view := &readView{ctx: requestCtx, objects: store.objects, snapshot: loaded}
-		if _, err := view.currentPolicy(true); err != nil {
-			store.refreshMu.Unlock()
-			return nil, fmt.Errorf("open bucket store: %w", err)
-		}
-	}
 	store.snapshot.Store(loaded)
 	store.refreshMu.Unlock()
+	if options.RequirePolicy {
+		if err := store.ensurePolicy(ctx, options.PolicySeed); err != nil {
+			return nil, fmt.Errorf("open bucket store: %w", err)
+		}
+		store.requirePolicy = true
+	}
 	return store, nil
 }
 

--- a/server/internal/knowledge/bucketstore/store.go
+++ b/server/internal/knowledge/bucketstore/store.go
@@ -133,9 +133,6 @@ func Open(ctx context.Context, objects blob.Store, options Options) (*Store, err
 		worldID:        options.WorldID,
 		requestTimeout: options.RequestTimeout,
 		shardWorkers:   options.ShardWorkers,
-		// Enforcement switches on only after ensurePolicy: a seeding
-		// write must not be gated by the policy it is creating.
-		requirePolicy:  false,
 		logger:         options.Logger,
 		maxDocuments:   options.MaxDocuments,
 		commitToken:    make(chan struct{}, 1),
@@ -167,6 +164,8 @@ func Open(ctx context.Context, objects blob.Store, options Options) (*Store, err
 		if err := store.ensurePolicy(ctx, options.PolicySeed); err != nil {
 			return nil, fmt.Errorf("open bucket store: %w", err)
 		}
+		// Enforcement switches on only here: a seeding write must not be
+		// gated by the policy it creates, and no caller holds the store yet.
 		store.requirePolicy = true
 	}
 	return store, nil

--- a/server/internal/knowledge/knowledgeseed/policy.md
+++ b/server/internal/knowledge/knowledgeseed/policy.md
@@ -1,0 +1,27 @@
+# Write Policy
+
+This world was created with the default policy, so violations warn instead of blocking and no tag axes are required yet.
+
+```yaml
+strictness: warn
+```
+
+Replace this document once the world has conventions worth enforcing. Publish a new version to the same path and it governs the next write. A malformed replacement is rejected rather than stored, and tightening is always safe because this version gates the write that replaces it.
+
+## Metadata every publish carries
+
+Set a `metadata` object with `tags`, a comma-separated list of subjects drawn from the content, and `importance`, a float from 0 to 1 with 0.8 and above reserved for hubs, architecture, and accepted decisions. An untagged document is findable only by its title or its exact path.
+
+Metadata travels out of band, so none of it belongs in the body. A document that opens with a frontmatter fence stores that fence literally.
+
+## Enforcement you can add
+
+Use `require_tags: category` to demand a category axis on every publish, and `require_fields: type` to demand a document kind. Keep the two satisfiable together, because one publish has to be able to meet every axis and field at once.
+
+Raise strictness to `block` once the taxonomy is settled, or to `ask` when a person should approve a violating write.
+
+## Style baseline
+
+Every document opens with a `# H1` name and a one-sentence summary directly beneath it. Headings are anchors, so they stay unique within a document. No em dashes.
+
+Never set `metadata.retention` unless the owner asks for it. It permanently deletes all but the newest versions, and history is the point of a versioned store.

--- a/server/internal/knowledge/knowledgeseed/policy.md
+++ b/server/internal/knowledge/knowledgeseed/policy.md
@@ -14,14 +14,8 @@ Set a `metadata` object with `tags`, a comma-separated list of subjects drawn fr
 
 Metadata travels out of band, so none of it belongs in the body. A document that opens with a frontmatter fence stores that fence literally.
 
-## Enforcement you can add
-
-Use `require_tags: category` to demand a category axis on every publish, and `require_fields: type` to demand a document kind. Keep the two satisfiable together, because one publish has to be able to meet every axis and field at once.
-
-Raise strictness to `block` once the taxonomy is settled, or to `ask` when a person should approve a violating write.
-
 ## Style baseline
 
 Every document opens with a `# H1` name and a one-sentence summary directly beneath it. Headings are anchors, so they stay unique within a document. No em dashes.
 
-Never set `metadata.retention` unless the owner asks for it. It permanently deletes all but the newest versions, and history is the point of a versioned store.
+Never set `metadata.retention` on curated knowledge: a positive value permanently deletes every version but the newest few it keeps, and that history is the point of a versioned store. Reserve it for generated documents such as graph exports and indexes, and only when the owner asks for it.

--- a/server/internal/knowledge/knowledgeseed/seed.go
+++ b/server/internal/knowledge/knowledgeseed/seed.go
@@ -1,0 +1,35 @@
+// Package knowledgeseed holds the documents a knowledge world is seeded
+// with the first time it is created.
+package knowledgeseed
+
+import (
+	"bytes"
+	_ "embed"
+	"maps"
+)
+
+// policyBody is the default write policy. Directives parse anywhere in the
+// body, so prose must never begin a line with one.
+//
+//go:embed policy.md
+var policyBody []byte
+
+// policyMetadata is the catalog metadata a seeded policy carries. The
+// category axis is set so a later category requirement cannot lock out
+// edits to the policy itself.
+var policyMetadata = map[string]string{
+	"title":      "Knowledge System Policy",
+	"tags":       "category:governance",
+	"importance": "1",
+	"type":       "Reference",
+}
+
+// PolicyBody returns a copy of the default write policy document.
+func PolicyBody() []byte {
+	return bytes.Clone(policyBody)
+}
+
+// PolicyMetadata returns a copy of the default policy's catalog metadata.
+func PolicyMetadata() map[string]string {
+	return maps.Clone(policyMetadata)
+}

--- a/server/internal/knowledge/knowledgeseed/seed.go
+++ b/server/internal/knowledge/knowledgeseed/seed.go
@@ -6,6 +6,8 @@ import (
 	"bytes"
 	_ "embed"
 	"maps"
+
+	"github.com/latebit-io/demarkus/server/internal/knowledge/bucketstore"
 )
 
 // policyBody is the default write policy. Directives parse anywhere in the
@@ -24,12 +26,11 @@ var policyMetadata = map[string]string{
 	"type":       "Reference",
 }
 
-// PolicyBody returns a copy of the default write policy document.
-func PolicyBody() []byte {
-	return bytes.Clone(policyBody)
-}
-
-// PolicyMetadata returns a copy of the default policy's catalog metadata.
-func PolicyMetadata() map[string]string {
-	return maps.Clone(policyMetadata)
+// DefaultPolicySeed returns the default write policy as a fresh seed, so a
+// caller can neither mutate the embedded body nor share its metadata map.
+func DefaultPolicySeed() bucketstore.PolicySeed {
+	return bucketstore.PolicySeed{
+		Body:     bytes.Clone(policyBody),
+		Metadata: maps.Clone(policyMetadata),
+	}
 }

--- a/server/internal/knowledge/knowledgeseed/seed_test.go
+++ b/server/internal/knowledge/knowledgeseed/seed_test.go
@@ -1,0 +1,52 @@
+package knowledgeseed
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/latebit-io/demarkus/protocol/publishpolicy"
+)
+
+func TestPolicyBodyParsesPermissive(t *testing.T) {
+	policy := publishpolicy.Parse(string(PolicyBody()))
+	if err := policy.Validate(); err != nil {
+		t.Fatalf("validate default policy: %v", err)
+	}
+	if policy.Strictness != publishpolicy.Warn {
+		t.Errorf("strictness = %q, want %q", policy.Strictness, publishpolicy.Warn)
+	}
+	// Prose documents the tightening directives; a seeded world must not
+	// inherit them, or its first publish fails on axes nobody chose.
+	if len(policy.RequiredTagAxes) != 0 {
+		t.Errorf("required tag axes = %v, want none", policy.RequiredTagAxes)
+	}
+	if len(policy.RequiredFields) != 0 {
+		t.Errorf("required fields = %v, want none", policy.RequiredFields)
+	}
+}
+
+func TestPolicyBodyFollowsStyleBaseline(t *testing.T) {
+	body := string(PolicyBody())
+	if !strings.HasPrefix(body, "# ") {
+		t.Error("policy does not open with an H1 name")
+	}
+	if strings.HasPrefix(body, "---") {
+		t.Error("policy opens with a frontmatter fence")
+	}
+	if strings.Contains(body, "—") {
+		t.Error("policy contains an em dash")
+	}
+}
+
+func TestAccessorsCopy(t *testing.T) {
+	body := PolicyBody()
+	body[0] = 'x'
+	if PolicyBody()[0] != '#' {
+		t.Error("PolicyBody exposed the embedded slice")
+	}
+	metadata := PolicyMetadata()
+	metadata["tags"] = "mutated"
+	if PolicyMetadata()["tags"] == "mutated" {
+		t.Error("PolicyMetadata exposed the shared map")
+	}
+}

--- a/server/internal/knowledge/knowledgeseed/seed_test.go
+++ b/server/internal/knowledge/knowledgeseed/seed_test.go
@@ -7,16 +7,16 @@ import (
 	"github.com/latebit-io/demarkus/protocol/publishpolicy"
 )
 
-func TestPolicyBodyParsesPermissive(t *testing.T) {
-	policy := publishpolicy.Parse(string(PolicyBody()))
+func TestDefaultPolicyParsesPermissive(t *testing.T) {
+	policy := publishpolicy.Parse(string(DefaultPolicySeed().Body))
 	if err := policy.Validate(); err != nil {
 		t.Fatalf("validate default policy: %v", err)
 	}
 	if policy.Strictness != publishpolicy.Warn {
 		t.Errorf("strictness = %q, want %q", policy.Strictness, publishpolicy.Warn)
 	}
-	// Prose documents the tightening directives; a seeded world must not
-	// inherit them, or its first publish fails on axes nobody chose.
+	// A seeded world must not inherit axes nobody chose, so prose naming a
+	// directive must never start the line it sits on.
 	if len(policy.RequiredTagAxes) != 0 {
 		t.Errorf("required tag axes = %v, want none", policy.RequiredTagAxes)
 	}
@@ -25,28 +25,22 @@ func TestPolicyBodyParsesPermissive(t *testing.T) {
 	}
 }
 
-func TestPolicyBodyFollowsStyleBaseline(t *testing.T) {
-	body := string(PolicyBody())
+func TestDefaultPolicyFollowsStyleBaseline(t *testing.T) {
+	body := string(DefaultPolicySeed().Body)
 	if !strings.HasPrefix(body, "# ") {
 		t.Error("policy does not open with an H1 name")
-	}
-	if strings.HasPrefix(body, "---") {
-		t.Error("policy opens with a frontmatter fence")
 	}
 	if strings.Contains(body, "—") {
 		t.Error("policy contains an em dash")
 	}
 }
 
-func TestAccessorsCopy(t *testing.T) {
-	body := PolicyBody()
-	body[0] = 'x'
-	if PolicyBody()[0] != '#' {
-		t.Error("PolicyBody exposed the embedded slice")
-	}
-	metadata := PolicyMetadata()
-	metadata["tags"] = "mutated"
-	if PolicyMetadata()["tags"] == "mutated" {
-		t.Error("PolicyMetadata exposed the shared map")
+func TestDefaultPolicySeedIsFresh(t *testing.T) {
+	seed := DefaultPolicySeed()
+	seed.Body[0] = 'x'
+	seed.Metadata["tags"] = "mutated"
+	fresh := DefaultPolicySeed()
+	if fresh.Body[0] != '#' || fresh.Metadata["tags"] == "mutated" {
+		t.Error("DefaultPolicySeed shares state between calls")
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Empty storage buckets are initialized automatically when the server starts.
  * A default warning-only write policy is created when no policy exists.
  * Existing policies are preserved, while non-empty buckets without a world head are rejected.
  * Operators can optionally preselect a policy using the bootstrap utility.

* **Documentation**
  * Updated deployment guidance to reflect automatic initialization, policy behavior, and bootstrap options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->