### PR TITLE
fix(broker): isolate memory graphs and secure section reads

### DIFF
--- a/tools/benchmarks/corpora/soul-2026-09-12/README.md
+++ b/tools/benchmarks/corpora/soul-2026-09-12/README.md
@@ -56,6 +56,14 @@ source snippets in the rubric support those eight scoring rules, not a copy of
 the corpus. The model never receives the rubric. See the [policy comparison](../../answers/section-first-comparison-2026-09-12.md)
 for the original grading correction and measurement boundaries.
 
+## Source isolation replay
+
+[`after-isolation.json`](after-isolation.json) retains the 2026-09-13 metrics-only
+replay: 16/16 correct, 94,152 model tokens, 12,364 tool-result tokens. The
+[slice report](../../graph/source-isolation-2026-09-13.md) records comparison
+boundaries and the separate broker isolation measurements. Keep
+`baseline-section-first.json` as the fixed software-change before report.
+
 ## Rebuild an artifact deliberately
 
 Use new output filenames; pack never overwrites an artifact or manifest:

--- a/tools/benchmarks/corpora/soul-2026-09-12/after-isolation.json
+++ b/tools/benchmarks/corpora/soul-2026-09-12/after-isolation.json
@@ -1,0 +1,821 @@
+{
+  "spec": {
+    "suite": "soul-answer-v1",
+    "model": "openai/gpt-6-astra",
+    "variant": "low",
+    "opencode_version": "1.18.30",
+    "steps": 8,
+    "timeout": "3m0s",
+    "repeats": 2,
+    "fixture_hashes": {
+      "corpus": "sha256-b152758c5800ba293988417c52cf8f5044ec4e96e3c41099045cbe05ddd4fe4e",
+      "rubric": "sha256-3cae6ddddec611d3098c1645de632a3884d318950446a291e15b803b9f489a8e",
+      "tasks": "sha256-f0fb85b07672b1088df85ff6c2f1741eea23533b194e450bcdf54f1199715e55"
+    },
+    "reader_prompt_hash": "sha256-01235625313d96fa827cd43b33d11f17dbfa8f1b9345b5348306219c466bebdd",
+    "port": 16319,
+    "expected_attempts": 16,
+    "reader_config_hash": "sha256-1c6b23ca99db746a32eb09b17d51c25f52206b90b81e94d308e30c5825d81300",
+    "origin": "mark://soul.demarkus.io",
+    "documents": 311,
+    "versions": 2184,
+    "reader_policy": "section-first",
+    "scoring_version": "section-provenance-v2"
+  },
+  "generated": "2026-09-13T01:06:09.593047Z",
+  "implementation_hashes": {
+    "mcp": "sha256-43d5218b6085fcf564c239a46586d490092959793ad3216b4b04e0ae0a370dd9",
+    "runner": "sha256-456ca9f9691baf35629f3c09942678330e1a6d27624a0c0df291b0c61d918d23",
+    "server": "sha256-825dd7e45b05aa77a81410364f25394ef3c88d5a85f83500db66525694a82a32"
+  },
+  "attempts": [
+    {
+      "task": "s1",
+      "category": "protocol-facts",
+      "repeat": 1,
+      "elapsed_ms": 14057.303,
+      "protocol_requests": 3,
+      "trace": {
+        "session": "",
+        "usage": {
+          "input": 4185,
+          "output": 165,
+          "reasoning": 0,
+          "cache": {
+            "read": 1280,
+            "write": 0
+          }
+        },
+        "usage_complete": true,
+        "turns": 3,
+        "calls": [
+          {
+            "name": "fixture_mark_lookup",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          }
+        ],
+        "final": ""
+      },
+      "score": {
+        "correct": true
+      }
+    },
+    {
+      "task": "s2",
+      "category": "default-policy",
+      "repeat": 1,
+      "elapsed_ms": 14865.981,
+      "protocol_requests": 3,
+      "trace": {
+        "session": "",
+        "usage": {
+          "input": 3662,
+          "output": 141,
+          "reasoning": 0,
+          "cache": {
+            "read": 1280,
+            "write": 0
+          }
+        },
+        "usage_complete": true,
+        "turns": 3,
+        "calls": [
+          {
+            "name": "fixture_mark_lookup",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          }
+        ],
+        "final": ""
+      },
+      "score": {
+        "correct": true
+      }
+    },
+    {
+      "task": "s3",
+      "category": "licensing",
+      "repeat": 1,
+      "elapsed_ms": 24230.686,
+      "protocol_requests": 3,
+      "trace": {
+        "session": "",
+        "usage": {
+          "input": 3634,
+          "output": 268,
+          "reasoning": 0,
+          "cache": {
+            "read": 1536,
+            "write": 0
+          }
+        },
+        "usage_complete": true,
+        "turns": 3,
+        "calls": [
+          {
+            "name": "fixture_mark_lookup",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          }
+        ],
+        "final": ""
+      },
+      "score": {
+        "correct": true
+      }
+    },
+    {
+      "task": "s4",
+      "category": "supersession-multi-document",
+      "repeat": 1,
+      "elapsed_ms": 16381.323,
+      "protocol_requests": 4,
+      "trace": {
+        "session": "",
+        "usage": {
+          "input": 2380,
+          "output": 300,
+          "reasoning": 0,
+          "cache": {
+            "read": 2816,
+            "write": 0
+          }
+        },
+        "usage_complete": true,
+        "turns": 3,
+        "calls": [
+          {
+            "name": "fixture_mark_lookup",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          }
+        ],
+        "final": ""
+      },
+      "score": {
+        "correct": true
+      }
+    },
+    {
+      "task": "s5",
+      "category": "response-contract",
+      "repeat": 1,
+      "elapsed_ms": 14119.579,
+      "protocol_requests": 3,
+      "trace": {
+        "session": "",
+        "usage": {
+          "input": 4385,
+          "output": 178,
+          "reasoning": 0,
+          "cache": {
+            "read": 1536,
+            "write": 0
+          }
+        },
+        "usage_complete": true,
+        "turns": 3,
+        "calls": [
+          {
+            "name": "fixture_mark_lookup",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          }
+        ],
+        "final": ""
+      },
+      "score": {
+        "correct": true
+      }
+    },
+    {
+      "task": "s6",
+      "category": "oauth-policy",
+      "repeat": 1,
+      "elapsed_ms": 15182.112,
+      "protocol_requests": 3,
+      "trace": {
+        "session": "",
+        "usage": {
+          "input": 1272,
+          "output": 233,
+          "reasoning": 0,
+          "cache": {
+            "read": 4096,
+            "write": 0
+          }
+        },
+        "usage_complete": true,
+        "turns": 3,
+        "calls": [
+          {
+            "name": "fixture_mark_lookup",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          }
+        ],
+        "final": ""
+      },
+      "score": {
+        "correct": true
+      }
+    },
+    {
+      "task": "s7",
+      "category": "architecture-roles",
+      "repeat": 1,
+      "elapsed_ms": 18879.215,
+      "protocol_requests": 3,
+      "trace": {
+        "session": "",
+        "usage": {
+          "input": 2893,
+          "output": 173,
+          "reasoning": 0,
+          "cache": {
+            "read": 2816,
+            "write": 0
+          }
+        },
+        "usage_complete": true,
+        "turns": 3,
+        "calls": [
+          {
+            "name": "fixture_mark_lookup",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          }
+        ],
+        "final": ""
+      },
+      "score": {
+        "correct": true
+      }
+    },
+    {
+      "task": "s8",
+      "category": "historical-revision",
+      "repeat": 1,
+      "elapsed_ms": 18369.032,
+      "protocol_requests": 4,
+      "trace": {
+        "session": "",
+        "usage": {
+          "input": 6328,
+          "output": 263,
+          "reasoning": 0,
+          "cache": {
+            "read": 1280,
+            "write": 0
+          }
+        },
+        "usage_complete": true,
+        "turns": 4,
+        "calls": [
+          {
+            "name": "fixture_mark_lookup",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          }
+        ],
+        "final": ""
+      },
+      "score": {
+        "correct": true
+      }
+    },
+    {
+      "task": "s1",
+      "category": "protocol-facts",
+      "repeat": 2,
+      "elapsed_ms": 12936.708,
+      "protocol_requests": 3,
+      "trace": {
+        "session": "",
+        "usage": {
+          "input": 3929,
+          "output": 165,
+          "reasoning": 0,
+          "cache": {
+            "read": 1536,
+            "write": 0
+          }
+        },
+        "usage_complete": true,
+        "turns": 3,
+        "calls": [
+          {
+            "name": "fixture_mark_lookup",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          }
+        ],
+        "final": ""
+      },
+      "score": {
+        "correct": true
+      }
+    },
+    {
+      "task": "s2",
+      "category": "default-policy",
+      "repeat": 2,
+      "elapsed_ms": 16683.286,
+      "protocol_requests": 3,
+      "trace": {
+        "session": "",
+        "usage": {
+          "input": 3662,
+          "output": 141,
+          "reasoning": 0,
+          "cache": {
+            "read": 1280,
+            "write": 0
+          }
+        },
+        "usage_complete": true,
+        "turns": 3,
+        "calls": [
+          {
+            "name": "fixture_mark_lookup",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          }
+        ],
+        "final": ""
+      },
+      "score": {
+        "correct": true
+      }
+    },
+    {
+      "task": "s3",
+      "category": "licensing",
+      "repeat": 2,
+      "elapsed_ms": 19402.952,
+      "protocol_requests": 3,
+      "trace": {
+        "session": "",
+        "usage": {
+          "input": 1970,
+          "output": 268,
+          "reasoning": 0,
+          "cache": {
+            "read": 3200,
+            "write": 0
+          }
+        },
+        "usage_complete": true,
+        "turns": 3,
+        "calls": [
+          {
+            "name": "fixture_mark_lookup",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          }
+        ],
+        "final": ""
+      },
+      "score": {
+        "correct": true
+      }
+    },
+    {
+      "task": "s4",
+      "category": "supersession-multi-document",
+      "repeat": 2,
+      "elapsed_ms": 19928.54,
+      "protocol_requests": 4,
+      "trace": {
+        "session": "",
+        "usage": {
+          "input": 1100,
+          "output": 300,
+          "reasoning": 0,
+          "cache": {
+            "read": 4096,
+            "write": 0
+          }
+        },
+        "usage_complete": true,
+        "turns": 3,
+        "calls": [
+          {
+            "name": "fixture_mark_lookup",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          }
+        ],
+        "final": ""
+      },
+      "score": {
+        "correct": true
+      }
+    },
+    {
+      "task": "s5",
+      "category": "response-contract",
+      "repeat": 2,
+      "elapsed_ms": 13695.828,
+      "protocol_requests": 3,
+      "trace": {
+        "session": "",
+        "usage": {
+          "input": 4641,
+          "output": 178,
+          "reasoning": 0,
+          "cache": {
+            "read": 1280,
+            "write": 0
+          }
+        },
+        "usage_complete": true,
+        "turns": 3,
+        "calls": [
+          {
+            "name": "fixture_mark_lookup",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          }
+        ],
+        "final": ""
+      },
+      "score": {
+        "correct": true
+      }
+    },
+    {
+      "task": "s6",
+      "category": "oauth-policy",
+      "repeat": 2,
+      "elapsed_ms": 14101.385,
+      "protocol_requests": 3,
+      "trace": {
+        "session": "",
+        "usage": {
+          "input": 3832,
+          "output": 185,
+          "reasoning": 0,
+          "cache": {
+            "read": 1536,
+            "write": 0
+          }
+        },
+        "usage_complete": true,
+        "turns": 3,
+        "calls": [
+          {
+            "name": "fixture_mark_lookup",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          }
+        ],
+        "final": ""
+      },
+      "score": {
+        "correct": true
+      }
+    },
+    {
+      "task": "s7",
+      "category": "architecture-roles",
+      "repeat": 2,
+      "elapsed_ms": 14667.512,
+      "protocol_requests": 3,
+      "trace": {
+        "session": "",
+        "usage": {
+          "input": 2893,
+          "output": 173,
+          "reasoning": 0,
+          "cache": {
+            "read": 2816,
+            "write": 0
+          }
+        },
+        "usage_complete": true,
+        "turns": 3,
+        "calls": [
+          {
+            "name": "fixture_mark_lookup",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          }
+        ],
+        "final": ""
+      },
+      "score": {
+        "correct": true
+      }
+    },
+    {
+      "task": "s8",
+      "category": "historical-revision",
+      "repeat": 2,
+      "elapsed_ms": 17533.752,
+      "protocol_requests": 4,
+      "trace": {
+        "session": "",
+        "usage": {
+          "input": 2872,
+          "output": 263,
+          "reasoning": 0,
+          "cache": {
+            "read": 4736,
+            "write": 0
+          }
+        },
+        "usage_complete": true,
+        "turns": 4,
+        "calls": [
+          {
+            "name": "fixture_mark_lookup",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          },
+          {
+            "name": "fixture_mark_fetch",
+            "input": null,
+            "output": ""
+          }
+        ],
+        "final": ""
+      },
+      "score": {
+        "correct": true
+      }
+    }
+  ],
+  "summary": {
+    "attempts": 16,
+    "correct": 16,
+    "known_total_tokens": 94152,
+    "usage_complete": true,
+    "tokens_per_correct_answer": 5884.5,
+    "usage": {
+      "input": 53638,
+      "output": 3394,
+      "reasoning": 0,
+      "cache": {
+        "read": 37120,
+        "write": 0
+      }
+    },
+    "model_turns": 50,
+    "tool_calls": 36,
+    "protocol_requests": 52
+  },
+  "categories": {
+    "architecture-roles": {
+      "attempts": 2,
+      "correct": 2,
+      "known_total_tokens": 11764,
+      "usage_complete": true,
+      "tokens_per_correct_answer": 5882,
+      "usage": {
+        "input": 5786,
+        "output": 346,
+        "reasoning": 0,
+        "cache": {
+          "read": 5632,
+          "write": 0
+        }
+      },
+      "model_turns": 6,
+      "tool_calls": 4,
+      "protocol_requests": 6
+    },
+    "default-policy": {
+      "attempts": 2,
+      "correct": 2,
+      "known_total_tokens": 10166,
+      "usage_complete": true,
+      "tokens_per_correct_answer": 5083,
+      "usage": {
+        "input": 7324,
+        "output": 282,
+        "reasoning": 0,
+        "cache": {
+          "read": 2560,
+          "write": 0
+        }
+      },
+      "model_turns": 6,
+      "tool_calls": 4,
+      "protocol_requests": 6
+    },
+    "historical-revision": {
+      "attempts": 2,
+      "correct": 2,
+      "known_total_tokens": 15742,
+      "usage_complete": true,
+      "tokens_per_correct_answer": 7871,
+      "usage": {
+        "input": 9200,
+        "output": 526,
+        "reasoning": 0,
+        "cache": {
+          "read": 6016,
+          "write": 0
+        }
+      },
+      "model_turns": 8,
+      "tool_calls": 6,
+      "protocol_requests": 8
+    },
+    "licensing": {
+      "attempts": 2,
+      "correct": 2,
+      "known_total_tokens": 10876,
+      "usage_complete": true,
+      "tokens_per_correct_answer": 5438,
+      "usage": {
+        "input": 5604,
+        "output": 536,
+        "reasoning": 0,
+        "cache": {
+          "read": 4736,
+          "write": 0
+        }
+      },
+      "model_turns": 6,
+      "tool_calls": 4,
+      "protocol_requests": 6
+    },
+    "oauth-policy": {
+      "attempts": 2,
+      "correct": 2,
+      "known_total_tokens": 11154,
+      "usage_complete": true,
+      "tokens_per_correct_answer": 5577,
+      "usage": {
+        "input": 5104,
+        "output": 418,
+        "reasoning": 0,
+        "cache": {
+          "read": 5632,
+          "write": 0
+        }
+      },
+      "model_turns": 6,
+      "tool_calls": 4,
+      "protocol_requests": 6
+    },
+    "protocol-facts": {
+      "attempts": 2,
+      "correct": 2,
+      "known_total_tokens": 11260,
+      "usage_complete": true,
+      "tokens_per_correct_answer": 5630,
+      "usage": {
+        "input": 8114,
+        "output": 330,
+        "reasoning": 0,
+        "cache": {
+          "read": 2816,
+          "write": 0
+        }
+      },
+      "model_turns": 6,
+      "tool_calls": 4,
+      "protocol_requests": 6
+    },
+    "response-contract": {
+      "attempts": 2,
+      "correct": 2,
+      "known_total_tokens": 12198,
+      "usage_complete": true,
+      "tokens_per_correct_answer": 6099,
+      "usage": {
+        "input": 9026,
+        "output": 356,
+        "reasoning": 0,
+        "cache": {
+          "read": 2816,
+          "write": 0
+        }
+      },
+      "model_turns": 6,
+      "tool_calls": 4,
+      "protocol_requests": 6
+    },
+    "supersession-multi-document": {
+      "attempts": 2,
+      "correct": 2,
+      "known_total_tokens": 10992,
+      "usage_complete": true,
+      "tokens_per_correct_answer": 5496,
+      "usage": {
+        "input": 3480,
+        "output": 600,
+        "reasoning": 0,
+        "cache": {
+          "read": 6912,
+          "write": 0
+        }
+      },
+      "model_turns": 6,
+      "tool_calls": 6,
+      "protocol_requests": 8
+    }
+  },
+  "metrics_only": true,
+  "source_report_sha256": "sha256-6511f407095cb60db453cbd62108c668ef7c8978689f6d4f7701a83072e99515",
+  "tool_result_tokens": 12364
+}

--- a/tools/benchmarks/graph/README.md
+++ b/tools/benchmarks/graph/README.md
@@ -2,6 +2,8 @@
 
 Recorded baseline: [2026-09-12](baseline-2026-09-12/README.md).
 
+First slice: [source isolation, 2026-09-13](source-isolation-2026-09-13.md).
+
 Run **before the first roadmap fix**, then after each slice, on the same machine:
 
 ```bash

--- a/tools/benchmarks/graph/source-isolation-2026-09-13.md
+++ b/tools/benchmarks/graph/source-isolation-2026-09-13.md
@@ -1,0 +1,73 @@
+# Source isolation: 2026-09-13
+
+Branch `fix/graph-source-isolation`, base `3275da5`. Broker graph data, seed etags,
+refresh timestamps and in-flight refreshes are tenant-scoped. Identity or backend
+changes replace the whole scope. Tenant snapshots admit only owned source rows;
+the knowledge profile retains organizational cross-world reads. The tenant gate
+also checks document URLs before section-aware fetch/explore handlers strip anchors.
+
+## Mechanical comparison
+
+Against [the fixed baseline](baseline-2026-09-12/README.md), Apple M2, Go 1.26.4,
+darwin/arm64, six samples, 200 ms, `-cpu 1`. No concurrent test/build/reader run
+was launched during sampling; background system load and power mode were not
+instrumented. Figures are synthetic handler sample medians, not production latency.
+
+| Metric | Before | After |
+|---|---:|---:|
+| Backlinks leaked responses/op | 1 | **0** |
+| Explore leaked responses/op | 1 | **0** |
+| Missing own source/op, both handlers | 0 | **0** |
+| Backlinks time | 2.831 µs | 2.484 µs (-12.26%) |
+| Explore time | 37.74 µs | 39.93 µs (+5.78%) |
+| Backlinks allocations/op | 35 | 28 |
+| Explore allocations/op | 541 | 534 |
+| Backlinks allocated bytes/op | 2,912 | 2,160 |
+| Explore allocated bytes/op | 78.27 KiB | 77.68 KiB |
+
+Pinned benchstat reports `p=0.002`, `n=6` for both handler timing differences.
+Results contain one permitted source rather than two sources including a leak;
+this is not an equal-output general graph speed comparison. Other packages also
+show timing variation without changed implementations. Source isolation is the
+acceptance criterion; the explore timing increase remains visible.
+
+Context evidence recall, duplication, result tokens and budget overflow are
+unchanged. Relative-target and silent-incomplete defects remain for subsequent
+roadmap slices. Warm graph queries retain the same returned rows and allocations.
+
+Raw samples and manifest remain local under ignored
+`tools/benchmarks/artifacts/graph-after-isolation-2026-09-13/`; `status.txt` is
+`complete`. Recorded tracked-diff hash: `e84c2be02f84f532d57f6174e42e8120e8918a76`.
+Fixture, benchmark-source and dependency hashes match the before manifest.
+The runner script hash differs because merged review fixes added the pre-output
+untracked-input guard; benchmark invocations and parameters are unchanged.
+
+## Frozen real-soul reader replay
+
+[Metrics-only after report](../corpora/soul-2026-09-12/after-isolation.json), compared
+with [section-first before](../corpora/soul-2026-09-12/baseline-section-first.json).
+Strict comparison accepts the pinned corpus, questions, rubric, policy, model,
+OpenCode version and `section-provenance-v2` scorer. No regrading or reader retries.
+
+| Metric | Before | After |
+|---|---:|---:|
+| Correct supported outcomes | 16/16 | **16/16** |
+| Total model tokens | 95,041 | 94,152 |
+| Model tokens/correct outcome | 5,940.0625 | 5,884.5 (-0.94%) |
+| Tool-result tokens | 12,364 | 12,364 |
+| Model turns / MCP calls / protocol requests | 50 / 36 / 52 | 50 / 36 / 52 |
+
+The replay exercises the local production server/client, not the broker tenant
+boundary. It is a retrieval regression check, not evidence that isolation lowers
+model cost. This small point-estimate token delta does not establish an improvement.
+Private report/traces remain under ignored
+`tools/benchmarks/artifacts/answers-after-isolation-2026-09-13/`.
+
+## Verification
+
+`make test`, targeted broker race tests and `bash pre-commit.sh` passed. Enforcing
+regressions first reproduced both backlink/explore leaks and the foreign-section
+fetch bypass. Coverage includes both tenant call orders, local crawls, legacy and
+sharded snapshots, source title/label/anchor/count fidelity, spoofed foreign source
+rows, revocation, identity/address/dial changes, refresh replacement, independent
+tenants, late retired refresh completion and authorized organizational discovery.

--- a/tools/internal/broker/mcp_gateway.go
+++ b/tools/internal/broker/mcp_gateway.go
@@ -25,28 +25,61 @@ type mcpGateway struct {
 	// profile selects the product surface (knowledge vs memory):
 	// tool set, instructions, tenant scoping, memory seeding.
 	profile *GatewayProfile
-	// graphStore is an ephemeral in-process graph store backing
-	// mark_backlinks / mark_graph / mark_graph_export /
-	// mark_graph_publish. Lifetime = broker pod lifetime: any
-	// restart drops the store and the agent re-crawls. Plan v5
-	// 4b/5 decision (Fritz, 2026-05-21): the broker is a
-	// wire-shape adapter, not a stateful protocol surface; an
-	// alternate bucket-backed persistent store is parked for a
-	// post-broker design window (see /thoughts.md "On Bucket
-	// Stores").
-	graphStore *graphstore.Store
-	// fetchSeen is the per-MCP-session unchanged-fetch dedup state
-	// (mcp_tools_fetchmode.go). Session entries are evicted by the
-	// OnUnregisterSession hook wired in newMCPGateway; like graphStore
-	// it is ephemeral per-pod state, consistent with the wire-shape-
-	// adapter framing.
+	// Knowledge graphs are shared; memory calls select an isolated tenant graph.
+	knowledgeGraph *gatewayGraph
+	tenantGraphsMu sync.Mutex
+	tenantGraphs   map[string]*tenantGraph
+	// Session-end hooks evict unchanged-fetch dedup state.
 	fetchSeen *sessionSeen
+	// memorySeed tracks per-world memory-template seeding (memory profile).
+	memorySeed memorySeeder
+}
+
+// gatewayGraph keeps graph data and refresh state in the same isolation scope.
+// Both are ephemeral and disappear on broker restart.
+type gatewayGraph struct {
+	graphStore *graphstore.Store
+	tenant     string // empty for the organizational graph
 	// graphSeedMu guards per-world refresh single-flight and successful checks.
 	graphSeedMu         sync.Mutex
 	graphSeedChecked    map[string]time.Time
 	graphSeedRefreshing map[string]chan struct{}
-	// memorySeed tracks per-world memory-template seeding (memory profile).
-	memorySeed memorySeeder
+}
+
+type tenantGraph struct {
+	identity string
+	address  string
+	dial     string
+	graph    *gatewayGraph
+}
+
+// graphFor resolves scope on every call. Identity or backend changes retire
+// the entire graph, including etags; in-flight work retains only the old graph.
+func (g *mcpGateway) graphFor(ctx context.Context) (*gatewayGraph, error) {
+	if !g.profile.TenantScoped {
+		return g.knowledgeGraph, nil
+	}
+	w, err := g.tenantWorld(ctx)
+	if err != nil {
+		return nil, err
+	}
+	claims, ok := claimsFromCtx(ctx)
+	if !ok {
+		return nil, ErrNotAuthorized
+	}
+	identity := identityKey(g.srv.cfg.OIDC.Issuer, claims.Subject)
+	address := resolveWorldAddress(&w)
+	g.tenantGraphsMu.Lock()
+	defer g.tenantGraphsMu.Unlock()
+	entry := g.tenantGraphs[w.Name]
+	if entry == nil || entry.identity != identity || entry.address != address || entry.dial != w.DialAddress {
+		entry = &tenantGraph{
+			identity: identity, address: address, dial: w.DialAddress,
+			graph: &gatewayGraph{graphStore: graphstore.New(), tenant: w.Name},
+		}
+		g.tenantGraphs[w.Name] = entry
+	}
+	return entry.graph, nil
 }
 
 // newMCPGateway registers the profile's tools and wraps them in Streamable
@@ -65,15 +98,13 @@ func newMCPGateway(s *Server, version string, dispatcher worldDispatcher, profil
 	// scoping can never diverge from the gateway's.
 	s.profile = profile
 	g := &mcpGateway{
-		srv:        s,
-		log:        s.log,
-		dispatcher: dispatcher,
-		profile:    profile,
-		// Ephemeral graph store — empty on each gateway
-		// construction, dies with the broker pod. See the
-		// graphStore field doc for the design framing.
-		graphStore: graphstore.New(),
-		fetchSeen:  fetchSeen,
+		srv:            s,
+		log:            s.log,
+		dispatcher:     dispatcher,
+		profile:        profile,
+		knowledgeGraph: &gatewayGraph{graphStore: graphstore.New()},
+		tenantGraphs:   make(map[string]*tenantGraph),
+		fetchSeen:      fetchSeen,
 	}
 	opts := []mcpserver.ServerOption{
 		// listChanged=false: the tool set is static across a session,

--- a/tools/internal/broker/mcp_gateway.go
+++ b/tools/internal/broker/mcp_gateway.go
@@ -82,6 +82,18 @@ func (g *mcpGateway) graphFor(ctx context.Context) (*gatewayGraph, error) {
 	return entry.graph, nil
 }
 
+// Failed resolution has no world name. Retire every scope owned by the identity
+// so later reauthorization cannot reuse its graph or seed bookkeeping.
+func (g *mcpGateway) evictTenantGraphs(identity string) {
+	g.tenantGraphsMu.Lock()
+	defer g.tenantGraphsMu.Unlock()
+	for world, entry := range g.tenantGraphs {
+		if entry.identity == identity {
+			delete(g.tenantGraphs, world)
+		}
+	}
+}
+
 // newMCPGateway registers the profile's tools and wraps them in Streamable
 // HTTP. Production supplies *worldPool; tests inject a dispatcher fake.
 func newMCPGateway(s *Server, version string, dispatcher worldDispatcher, profile *GatewayProfile) *mcpGateway {

--- a/tools/internal/broker/mcp_tenant.go
+++ b/tools/internal/broker/mcp_tenant.go
@@ -133,7 +133,9 @@ func (g *mcpGateway) tenantGate(next mcpserver.ToolHandlerFunc) mcpserver.ToolHa
 			if raw == "" {
 				continue // the handler's own required-arg check reports it
 			}
-			worldName, _, perr := parseToolURL(raw)
+			// Section-aware handlers strip fragments before fetching the document.
+			docURL, _, _ := strings.Cut(raw, "#")
+			worldName, _, perr := parseToolURL(docURL)
 			if perr != nil {
 				continue // the handler's own URL validation reports it
 			}

--- a/tools/internal/broker/mcp_tenant.go
+++ b/tools/internal/broker/mcp_tenant.go
@@ -58,6 +58,7 @@ func (g *mcpGateway) tenantWorld(ctx context.Context) (WorldConfig, error) {
 	}
 	w, err := tenantWorldFor(g.srv.cfg, claims)
 	if err != nil {
+		g.evictTenantGraphs(identityKey(g.srv.cfg.OIDC.Issuer, claims.Subject))
 		var ambiguous errAmbiguousTenant
 		if errors.As(err, &ambiguous) {
 			g.log.Warn("tenant resolution ambiguous; denying closed",

--- a/tools/internal/broker/mcp_tenant_test.go
+++ b/tools/internal/broker/mcp_tenant_test.go
@@ -526,6 +526,78 @@ func TestMemoryGraphScopeTransitions(t *testing.T) {
 	}
 }
 
+func TestMemoryGraphReauthorizationStartsFresh(t *testing.T) {
+	for _, failure := range []string{"revoke", "deprovision"} {
+		for _, entrypoint := range []string{"graph", "gate"} {
+			t.Run(failure+"/"+entrypoint, func(t *testing.T) {
+				testMemoryGraphReauthorization(t, failure, entrypoint)
+			})
+		}
+	}
+}
+
+func testMemoryGraphReauthorization(t *testing.T, failure, entrypoint string) {
+	t.Helper()
+	cfg := memoryTestConfig()
+	aliceWorld := cfg.Worlds[0]
+	identities := map[string]string{identityKey(cfg.OIDC.Issuer, "google|alice"): aliceWorld.Name}
+	if failure == "deprovision" {
+		cfg.Worlds = cfg.Worlds[1:]
+		cfg.SetDynamicWorlds([]WorldConfig{aliceWorld}, identities)
+	}
+	d := seededDispatcher()
+	for _, tenant := range []string{"alice", "bob"} {
+		d.published[tenant+"-w/source.md"] = fetch.Result{Response: protocol.Response{
+			Status: protocol.StatusOK, Body: "# " + tenant + "_TITLE\n[" + tenant + "_LABEL](mark://" + tenant + "-w/index.md)",
+		}}
+	}
+	g := newMemoryGateway(t, cfg, d)
+	tenantGraphCall(t, g, "alice", "mark_graph", "/source.md")
+	tenantGraphCall(t, g, "bob", "mark_graph", "/source.md")
+	ctx := withAliceClaims(t.Context())
+	old, err := g.graphFor(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old.graphStore.SetSeedEtag("alice-w", "retired-etag")
+	if failure == "deprovision" {
+		cfg.SetDynamicWorlds(nil, nil)
+	} else {
+		cfg.Worlds[0].Allow.Emails = []string{"replacement@example.com"}
+	}
+	if entrypoint == "graph" {
+		if _, err := g.graphFor(ctx); !errors.Is(err, ErrNotAuthorized) {
+			t.Fatalf("graphFor error = %v, want ErrNotAuthorized", err)
+		}
+	} else {
+		res, err := g.tenantGate(g.handleMarkFetch)(ctx, callToolReq("mark_fetch", map[string]any{"url": "mark://alice-w/index.md"}))
+		if err != nil || res == nil || !res.IsError {
+			t.Fatalf("gate did not deny access: err=%v result=%v", err, res)
+		}
+	}
+	if _, retained := g.tenantGraphs["alice-w"]; retained {
+		t.Error("authorization failure retained Alice's cached graph")
+	}
+	if failure == "deprovision" {
+		cfg.SetDynamicWorlds([]WorldConfig{aliceWorld}, identities)
+	} else {
+		cfg.Worlds[0] = aliceWorld
+	}
+	current, err := g.graphFor(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current == old || current.graphStore.NodeCount() != 0 || current.graphStore.SeedEtag("alice-w") != "" || len(current.graphSeedChecked) != 0 {
+		t.Error("reauthorization reused retired graph data or seed bookkeeping")
+	}
+	for _, tool := range []string{"mark_backlinks", "mark_explore"} {
+		if text := tenantGraphCall(t, g, "alice", tool, "/index.md"); strings.Contains(text, "alice-w/source.md") {
+			t.Errorf("%s resurrected retired source: %s", tool, text)
+		}
+	}
+	assertTenantBacklinks(t, g, "bob", "alice")
+}
+
 func TestMemoryGraphSeedRefreshIsScoped(t *testing.T) {
 	d := seededDispatcher()
 	empty := false
@@ -575,11 +647,19 @@ func TestMemoryGraphRefreshDoesNotBlockAnotherTenant(t *testing.T) {
 	}
 	g := newMemoryGateway(t, memoryTestConfig(), d)
 	finished := make(chan struct{})
+	var aliceResult *mcp.CallToolResult
+	var aliceErr error
 	go func() {
 		defer close(finished)
-		tenantGraphCall(t, g, "alice", "mark_backlinks", "/index.md")
+		aliceResult, aliceErr = g.tenantGate(g.handleMarkBacklinks)(withAliceClaims(t.Context()), callToolReq("mark_backlinks", map[string]any{"url": "mark://alice-w/index.md"}))
 	}()
-	defer func() { close(release); <-finished }()
+	defer func() {
+		close(release)
+		<-finished
+		if aliceErr != nil || aliceResult == nil || aliceResult.IsError {
+			t.Errorf("Alice query failed: err=%v result=%v", aliceErr, aliceResult)
+		}
+	}()
 	select {
 	case <-started:
 	case <-time.After(5 * time.Second):

--- a/tools/internal/broker/mcp_tenant_test.go
+++ b/tools/internal/broker/mcp_tenant_test.go
@@ -7,10 +7,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/latebit-io/demarkus/client/fetch"
+	"github.com/latebit-io/demarkus/client/graph"
+	"github.com/latebit-io/demarkus/client/graphstore"
 	"github.com/latebit-io/demarkus/protocol"
 	"github.com/mark3labs/mcp-go/mcp"
 	"k8s.io/client-go/kubernetes/fake"
@@ -243,6 +246,20 @@ func TestTenantGateDeniesUnclassifiedTool(t *testing.T) {
 	}
 }
 
+func TestTenantGateDeniesForeignSections(t *testing.T) {
+	for _, tool := range []string{"mark_fetch", "mark_explore"} {
+		t.Run(tool, func(t *testing.T) {
+			d := seededDispatcher()
+			g := newMemoryGateway(t, memoryTestConfig(), d)
+			res, err := g.tenantGate(g.toolHandlers()[tool])(withAliceClaims(t.Context()), callToolReq(tool, map[string]any{"url": "mark://bob-w/index.md#memory"}))
+			if err != nil || res == nil || !res.IsError {
+				t.Fatalf("foreign section allowed: err=%v result=%v", err, res)
+			}
+			assertNoWorldTraffic(t, d, "bob-w")
+		})
+	}
+}
+
 // TestTenantGateDeniesUnknownIdentity: an authenticated identity with
 // no provisioned world gets a denial, not a fallback world.
 func TestTenantGateDeniesUnknownIdentity(t *testing.T) {
@@ -339,6 +356,307 @@ func TestMemoryCrawlNeverLeavesTenantWorld(t *testing.T) {
 		t.Fatalf("own-world crawl denied: %s", toolResultText(t, res))
 	}
 	assertNoWorldTraffic(t, d, "bob-w")
+}
+
+func tenantGraphCall(t *testing.T, g *mcpGateway, tenant, tool, path string) string {
+	t.Helper()
+	ctx := ctxWithClaims(t.Context(), &Claims{Subject: "google|" + tenant, Email: tenant + "@example.com", EmailVerified: true})
+	res, err := g.tenantGate(g.toolHandlers()[tool])(ctx, callToolReq(tool, map[string]any{"url": "mark://" + tenant + "-w" + path}))
+	if err != nil || res == nil || res.IsError {
+		t.Fatalf("%s %s: err=%v result=%v", tenant, tool, err, res)
+	}
+	return toolResultText(t, res)
+}
+
+func assertTenantBacklinks(t *testing.T, g *mcpGateway, tenant, foreign string) {
+	t.Helper()
+	for _, tool := range []string{"mark_backlinks", "mark_explore"} {
+		text := tenantGraphCall(t, g, tenant, tool, "/index.md")
+		count := "Backlinks for mark://" + tenant + "-w/index.md (1)"
+		if tool == "mark_explore" {
+			count = "## Backlinks (1)"
+		}
+		for _, want := range []string{tenant + "-w/source.md", tenant + "_TITLE", tenant + "_LABEL", count} {
+			if !strings.Contains(text, want) {
+				t.Errorf("%s missing %q:\n%s", tool, want, text)
+			}
+		}
+		for _, secret := range []string{foreign + "-w/source.md", foreign + "_TITLE", foreign + "_LABEL", foreign + "_ANCHOR", foreign + "_anchor", "spoof"} {
+			if strings.Contains(text, secret) {
+				t.Errorf("%s leaked %q:\n%s", tool, secret, text)
+			}
+		}
+	}
+}
+
+func TestMemoryGraphSourcesIsolated(t *testing.T) {
+	for _, order := range [][]string{{"alice", "bob"}, {"bob", "alice"}} {
+		t.Run(strings.Join(order, "-"), func(t *testing.T) {
+			d := seededDispatcher()
+			for _, tenant := range order {
+				d.published[tenant+"-w/source.md"] = fetch.Result{Response: protocol.Response{
+					Status: protocol.StatusOK,
+					Body:   "# " + tenant + "_TITLE\n## " + tenant + "_ANCHOR\n[" + tenant + "_LABEL](mark://alice-w/index.md)\n[" + tenant + "_LABEL](mark://bob-w/index.md)\n",
+				}}
+			}
+			g := newMemoryGateway(t, memoryTestConfig(), d)
+			for _, tenant := range order {
+				tenantGraphCall(t, g, tenant, "mark_graph", "/source.md")
+			}
+			assertTenantBacklinks(t, g, "alice", "bob")
+			assertTenantBacklinks(t, g, "bob", "alice")
+		})
+	}
+}
+
+func TestMemoryGraphSeedSourcesIsolated(t *testing.T) {
+	for _, format := range []string{"legacy", "snapshot"} {
+		t.Run(format, func(t *testing.T) { testMemoryGraphSeedSources(t, format) })
+	}
+}
+
+func tenantSeedGraph(tenant string) *graphstore.Store {
+	gr := graph.New()
+	for _, owner := range []string{"alice", "bob"} {
+		title := owner + "_TITLE"
+		if owner != tenant {
+			title = "spoof " + title
+		}
+		source := "mark://" + owner + "-w." + owner + "-w.svc.cluster.local:6309/source.md"
+		gr.AddNode(&graph.Node{URL: source, Title: title, Status: "ok"})
+		for _, target := range []string{"alice", "bob"} {
+			gr.AddEdgeInfo(graph.Edge{From: source, To: "mark://" + target + "-w/index.md", Rel: "related", Label: owner + "_LABEL", Anchor: owner + "_ANCHOR", Count: 7})
+		}
+	}
+	store := graphstore.New()
+	store.Merge(gr, nil)
+	return store
+}
+
+func testMemoryGraphSeedSources(t *testing.T, format string) {
+	t.Helper()
+	for _, order := range [][]string{{"alice", "bob"}, {"bob", "alice"}} {
+		t.Run(strings.Join(order, "-"), func(t *testing.T) {
+			d := seededDispatcher()
+			responses := make(map[string]protocol.Response)
+			for _, tenant := range order {
+				body := tenantSeedGraph(tenant).Export()
+				if format == "legacy" {
+					responses[tenant+"-w/graph.md"] = protocol.Response{Status: protocol.StatusOK, Body: body, Metadata: map[string]string{"etag": "same-etag"}}
+					continue
+				}
+				nodes, edges, err := graphstore.ParseExportStrict(body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				manifest, shards := brokerSnapshotRows(t, nodes, edges)
+				responses[tenant+"-w"+graphstore.SnapshotManifestPath] = manifest
+				for path, shard := range shards {
+					d.published[tenant+"-w"+path] = fetch.Result{Response: shard}
+				}
+			}
+			d.fetchCondFn = func(world, path, _, _ string) (fetch.Result, error) {
+				response, ok := responses[world+path]
+				if !ok {
+					return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+				}
+				return fetch.Result{Response: response}, nil
+			}
+			g := newMemoryGateway(t, memoryTestConfig(), d)
+			for _, tenant := range order {
+				tenantGraphCall(t, g, tenant, "mark_backlinks", "/index.md")
+			}
+			assertTenantBacklinks(t, g, "alice", "bob")
+			assertTenantBacklinks(t, g, "bob", "alice")
+			for _, tenant := range order {
+				text := tenantGraphCall(t, g, tenant, "mark_backlinks", "/index.md")
+				for _, want := range []string{"[related]", "#" + tenant + "_ANCHOR", "x7"} {
+					if !strings.Contains(text, want) {
+						t.Errorf("own provenance missing %q: %s", want, text)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestMemoryGraphScopeTransitions(t *testing.T) {
+	for _, change := range []string{"identity", "address", "dial", "revoke"} {
+		t.Run(change, func(t *testing.T) {
+			cfg := memoryTestConfig()
+			d := seededDispatcher()
+			d.published["alice-w/source.md"] = fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: "# old secret\n[old](mark://alice-w/index.md)"}}
+			g := newMemoryGateway(t, cfg, d)
+			tenantGraphCall(t, g, "alice", "mark_graph", "/source.md")
+			ctx := withAliceClaims(t.Context())
+			old, err := g.graphFor(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			old.graphStore.SetSeedEtag("alice-w", "old-etag")
+			switch change {
+			case "identity":
+				ctx = ctxWithClaims(t.Context(), &Claims{Subject: "new-alice", Email: "alice@example.com", EmailVerified: true})
+			case "address":
+				cfg.Worlds[0].InternalAddress = "replacement:6309"
+			case "dial":
+				cfg.Worlds[0].DialAddress = "replacement:6310"
+			case "revoke":
+				cfg.Worlds[0].Allow.Emails = []string{"new-owner@example.com"}
+			}
+			for _, tool := range []string{"mark_backlinks", "mark_explore"} {
+				res, err := g.tenantGate(g.toolHandlers()[tool])(ctx, callToolReq(tool, map[string]any{"url": "mark://alice-w/index.md"}))
+				if err != nil || res == nil || res.IsError != (change == "revoke") {
+					t.Fatalf("%s: err=%v result=%v", tool, err, res)
+				}
+				if text := toolResultText(t, res); strings.Contains(text, "source.md") || strings.Contains(text, "old secret") {
+					t.Fatalf("stale graph after %s: %s", change, text)
+				}
+			}
+			if change != "revoke" {
+				current, err := g.graphFor(ctx)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if current == old || current.graphStore.SeedEtag("alice-w") != "" {
+					t.Fatal("scope change retained old graph or seed etag")
+				}
+			}
+		})
+	}
+}
+
+func TestMemoryGraphSeedRefreshIsScoped(t *testing.T) {
+	d := seededDispatcher()
+	empty := false
+	d.fetchCondFn = func(world, path, _, etag string) (fetch.Result, error) {
+		if path != "/graph.md" {
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+		}
+		if empty && world == "alice-w" {
+			if etag != "initial-etag" {
+				t.Errorf("refresh etag = %q", etag)
+			}
+			return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: graphstore.New().Export(), Metadata: map[string]string{"etag": "empty-etag"}}}, nil
+		}
+		return fetch.Result{Response: protocol.Response{Status: protocol.StatusOK, Body: tenantSeedGraph(strings.TrimSuffix(world, "-w")).Export(), Metadata: map[string]string{"etag": "initial-etag"}}}, nil
+	}
+	g := newMemoryGateway(t, memoryTestConfig(), d)
+	assertTenantBacklinks(t, g, "alice", "bob")
+	assertTenantBacklinks(t, g, "bob", "alice")
+	state, err := g.graphFor(withAliceClaims(t.Context()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.graphSeedMu.Lock()
+	state.graphSeedChecked["alice-w"] = time.Now().Add(-2 * seedCheckInterval)
+	state.graphSeedMu.Unlock()
+	empty = true
+	for _, tool := range []string{"mark_backlinks", "mark_explore"} {
+		if text := tenantGraphCall(t, g, "alice", tool, "/index.md"); strings.Contains(text, "source.md") {
+			t.Fatalf("removed seed source survived: %s", text)
+		}
+	}
+	assertTenantBacklinks(t, g, "bob", "alice")
+	if state.graphStore.SeedEtag("alice-w") != "empty-etag" {
+		t.Fatal("Alice seed did not refresh")
+	}
+}
+
+func TestMemoryGraphRefreshDoesNotBlockAnotherTenant(t *testing.T) {
+	d := seededDispatcher()
+	started, release := make(chan struct{}), make(chan struct{})
+	d.fetchCondFn = func(world, path, _, _ string) (fetch.Result, error) {
+		if world == "alice-w" && path == graphstore.SnapshotManifestPath {
+			close(started)
+			<-release
+		}
+		return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+	}
+	g := newMemoryGateway(t, memoryTestConfig(), d)
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		tenantGraphCall(t, g, "alice", "mark_backlinks", "/index.md")
+	}()
+	defer func() { close(release); <-finished }()
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Alice seed did not start")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	ctx = ctxWithClaims(ctx, &Claims{Subject: "google|bob", Email: "bob@example.com", EmailVerified: true})
+	res, err := g.tenantGate(g.handleMarkBacklinks)(ctx, callToolReq("mark_backlinks", map[string]any{"url": "mark://bob-w/index.md"}))
+	if err != nil || res == nil || res.IsError || ctx.Err() != nil {
+		t.Fatalf("Bob waited for Alice seed: err=%v result=%v context=%v", err, res, ctx.Err())
+	}
+	if _, ok := g.tenantGraphs["bob-w"]; !ok {
+		t.Fatal("Bob graph was not initialized independently")
+	}
+}
+
+func TestMemoryGraphRetiredRefreshCannotPopulateNewScope(t *testing.T) {
+	d := seededDispatcher()
+	manifest, shards := brokerSnapshotRows(t,
+		[]graphstore.StoredNode{{URL: "mark://alice-w/source.md", Title: "old private source", Status: "ok"}},
+		[]graphstore.StoredEdge{{From: "mark://alice-w/source.md", To: "mark://alice-w/index.md", Count: 1}})
+	for path, shard := range shards {
+		d.published["alice-w"+path] = fetch.Result{Response: shard}
+	}
+	started, release := make(chan struct{}), make(chan struct{})
+	var first atomic.Bool
+	d.fetchCondFn = func(_, path, _, _ string) (fetch.Result, error) {
+		if path == graphstore.SnapshotManifestPath && !first.Swap(true) {
+			close(started)
+			<-release
+			return fetch.Result{Response: manifest}, nil
+		}
+		return fetch.Result{Response: protocol.Response{Status: protocol.StatusNotFound}}, nil
+	}
+	g := newMemoryGateway(t, memoryTestConfig(), d)
+	handler := g.tenantGate(g.handleMarkBacklinks)
+	req := callToolReq("mark_backlinks", map[string]any{"url": "mark://alice-w/index.md"})
+	finished := make(chan struct{})
+	var oldResult *mcp.CallToolResult
+	var oldErr error
+	go func() {
+		defer close(finished)
+		oldResult, oldErr = handler(withAliceClaims(t.Context()), req)
+	}()
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+		<-finished
+	}()
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("old seed did not start")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	ctx = ctxWithClaims(ctx, &Claims{Subject: "replacement-alice", Email: "alice@example.com", EmailVerified: true})
+	res, err := handler(ctx, req)
+	if err != nil || res == nil || res.IsError || ctx.Err() != nil {
+		t.Fatalf("new owner waited on retired seed: err=%v result=%v context=%v", err, res, ctx.Err())
+	}
+	close(release)
+	released = true
+	<-finished
+	if oldErr != nil || oldResult == nil || oldResult.IsError || !strings.Contains(toolResultText(t, oldResult), "old private source") {
+		t.Fatalf("old seed did not finish: err=%v result=%v", oldErr, oldResult)
+	}
+	res, err = handler(ctx, req)
+	if err != nil || res == nil || res.IsError {
+		t.Fatalf("new owner query: err=%v result=%v", err, res)
+	}
+	if text := toolResultText(t, res); strings.Contains(text, "source.md") || strings.Contains(text, "old private") {
+		t.Fatalf("late retired seed contaminated replacement scope: %s", text)
+	}
 }
 
 // TestMemoryGatewayEndToEnd drives the full Streamable HTTP transport:

--- a/tools/internal/broker/mcp_tools_explore.go
+++ b/tools/internal/broker/mcp_tools_explore.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/latebit-io/demarkus/client/fetch"
 	"github.com/latebit-io/demarkus/client/graph"
+	"github.com/latebit-io/demarkus/client/graphstore"
 	listingpage "github.com/latebit-io/demarkus/client/listing"
 	"github.com/latebit-io/demarkus/client/mcpfmt"
 	"github.com/latebit-io/demarkus/client/mdoutline"
@@ -19,12 +20,7 @@ import (
 // demarkus-mcp value.
 const exploreSectionCap = 10
 
-// handleMarkExplore implements the mark_explore tool: one call returns a
-// neighborhood card for a document — outline head (heading tree + opening
-// paragraph), outbound links, recorded backlinks, and the sibling listing
-// of its parent directory. Mirrors client/cmd/demarkus-mcp markExplore;
-// the broker differences are the world-name URL shape and that backlinks
-// come from the broker's ephemeral graph store.
+// Explore mirrors the client card, using world-name URLs and scoped backlinks.
 func (g *mcpGateway) handleMarkExplore(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
 	raw, err := req.RequireString("url")
 	if err != nil {
@@ -74,8 +70,12 @@ func (g *mcpGateway) handleMarkExplore(ctx context.Context, req mcp.CallToolRequ
 		mdoutline.CappedList(&b, out, exploreSectionCap, "links")
 	}
 
-	g.seedGraphStore(ctx)
-	g.writeBacklinksSection(&b, docURL)
+	state, err := g.graphFor(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("graph scope: %v", err)), nil
+	}
+	g.seedGraphStore(ctx, state)
+	writeBacklinksSection(&b, state.graphStore.BacklinksEnriched(docURL))
 	g.writeSiblingsSection(&b, worldName, path)
 
 	fmt.Fprintf(&b, "\nfetch %s#<anchor> for a section; mark_fetch force=true for the full body\n", docURL)
@@ -86,12 +86,8 @@ func (g *mcpGateway) handleMarkExplore(ctx context.Context, req mcp.CallToolRequ
 	return mcp.NewToolResultText(mcpfmt.FormatWith(result, b.String(), extra, opts)), nil
 }
 
-// writeBacklinksSection appends the backlinks card section from the
-// broker's ephemeral graph store. An empty store degrades to a note,
-// never an error. The store is keyed by full mark://{worldName}/{path}
-// URLs — the same shape mark_graph crawls record.
-func (g *mcpGateway) writeBacklinksSection(b *strings.Builder, docURL string) {
-	backlinks := g.graphStore.BacklinksEnriched(docURL)
+// Counts and truncation operate only on the caller's scoped rows.
+func writeBacklinksSection(b *strings.Builder, backlinks []graphstore.BacklinkEntry) {
 	fmt.Fprintf(b, "\n## Backlinks (%d)\n", len(backlinks))
 	if len(backlinks) == 0 {
 		b.WriteString("(none recorded; run mark_graph to populate; the broker's graph store is per-pod and resets on restart)\n")

--- a/tools/internal/broker/mcp_tools_explore_test.go
+++ b/tools/internal/broker/mcp_tools_explore_test.go
@@ -103,7 +103,7 @@ func TestHandleMarkExploreBacklinksFromGraphStore(t *testing.T) {
 	gr.AddNode(&graph.Node{URL: "mark://team-a/a.md", Title: "Page A", Status: "ok"})
 	gr.AddNode(&graph.Node{URL: "mark://team-a/hub.md", Title: "Hub", Status: "ok"})
 	gr.AddEdge("mark://team-a/a.md", "mark://team-a/hub.md")
-	g.graphStore.Merge(gr, nil)
+	g.knowledgeGraph.graphStore.Merge(gr, nil)
 
 	text := exploreResultText(t, g, "mark://team-a/hub.md")
 	if !strings.Contains(text, "## Backlinks (1)") || !strings.Contains(text, "[Page A](mark://team-a/a.md)") {

--- a/tools/internal/broker/mcp_tools_graph.go
+++ b/tools/internal/broker/mcp_tools_graph.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -22,36 +23,8 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 )
 
-// mcp_tools_graph.go ships the five graph-store-backed federation
-// tools for Slice 4b+5 of the broker MCP gateway plan:
-//
-//   - mark_backlinks (4b) — local query against the broker's
-//     ephemeral graph store. No dispatch.
-//   - mark_graph (4b) — crawl world(s), persist to the broker's
-//     ephemeral graph store, return the discovered graph.
-//   - mark_index (5) — crawl a source world, collect content
-//     hashes, build an index document, optionally publish to a
-//     target world.
-//   - mark_graph_export (5) — export the broker's ephemeral
-//     graph store as a markdown document. Local-only.
-//   - mark_graph_publish (5) — export + publish in one shot
-//     against a target world.
-//
-// The broker's graph store is ephemeral per the plan v5 4b
-// decision (Fritz, 2026-05-21): drops on every broker pod
-// restart, agents re-crawl to repopulate. An alternate
-// bucket-backed persistent store is parked for the post-broker
-// design window (see /thoughts.md "On Bucket Stores as a
-// k8s-Native Alternate Filestore").
-
-// brokerCrawlParseURL splits a mark:// URL into worldName + path
-// for the crawler. Lenient compared to parseToolURL — fragments
-// and queries are stripped silently because links inside crawled
-// documents legitimately carry them (e.g. `mark://team-a/foo.md#section`
-// referring to a heading), and we want the crawler to fetch
-// the document itself even when the link carries a fragment.
-// parseToolURL stays strict for agent input, where a fragment
-// is a typo signal.
+// Crawl links may carry sections/queries; fetch only the document.
+// Agent-supplied root URLs still pass strict parseToolURL validation.
 func brokerCrawlParseURL(raw string) (worldName, urlPath string, err error) {
 	u, parseErr := url.Parse(raw)
 	if parseErr != nil {
@@ -107,60 +80,54 @@ func (g *mcpGateway) crawlFetchFn(ctx context.Context) graphstore.FetchFunc {
 // interval; the first graph-tool call after a pod restart always checks.
 const seedCheckInterval = 5 * time.Minute
 
-// seedGraphStore seeds from every world in the caller's scope (tenant
-// mode: only the caller's own world, so one tenant's traffic never pulls
-// another's graph into the shared per-pod store); throttled per world.
-func (g *mcpGateway) seedGraphStore(ctx context.Context) {
+// Seed checks and graph writes use the same scope selected by the handler.
+func (g *mcpGateway) seedGraphStore(ctx context.Context, state *gatewayGraph) {
 	worlds := g.scopedWorlds(ctx)
 	for j := range worlds {
 		if ctx.Err() != nil {
 			return
 		}
-		g.seedWorldGraph(ctx, worlds[j].Name)
+		g.seedWorldGraph(ctx, state, worlds[j].Name)
 	}
 }
 
-// seedWorldGraph refreshes the broker's ephemeral graph store from the
-// world's published /graph.md aggregate, so a cold pod answers backlinks
-// without a crawl. Local crawls win (see graphstore.SeedFromExport).
-// Never fatal: every failure degrades silently to the unseeded store,
-// warn-logging real errors. Conditional on the stored seed etag; a
-// not-modified response keeps the previously seeded rows.
-func (g *mcpGateway) seedWorldGraph(ctx context.Context, worldName string) {
-	g.graphSeedMu.Lock()
-	if done := g.graphSeedRefreshing[worldName]; done != nil {
-		g.graphSeedMu.Unlock()
+// Cold pods seed published snapshots; local crawls win. Fetch/parse failures
+// are best effort and warn-logged; not-modified preserves the previous seed.
+func (g *mcpGateway) seedWorldGraph(ctx context.Context, state *gatewayGraph, worldName string) {
+	state.graphSeedMu.Lock()
+	if done := state.graphSeedRefreshing[worldName]; done != nil {
+		state.graphSeedMu.Unlock()
 		select {
 		case <-done:
 		case <-ctx.Done():
 		}
 		return
 	}
-	if last, ok := g.graphSeedChecked[worldName]; ok && time.Since(last) < seedCheckInterval {
-		g.graphSeedMu.Unlock()
+	if last, ok := state.graphSeedChecked[worldName]; ok && time.Since(last) < seedCheckInterval {
+		state.graphSeedMu.Unlock()
 		return
 	}
-	if g.graphSeedChecked == nil {
-		g.graphSeedChecked = make(map[string]time.Time)
+	if state.graphSeedChecked == nil {
+		state.graphSeedChecked = make(map[string]time.Time)
 	}
-	if g.graphSeedRefreshing == nil {
-		g.graphSeedRefreshing = make(map[string]chan struct{})
+	if state.graphSeedRefreshing == nil {
+		state.graphSeedRefreshing = make(map[string]chan struct{})
 	}
 	done := make(chan struct{})
-	g.graphSeedRefreshing[worldName] = done
-	g.graphSeedMu.Unlock()
+	state.graphSeedRefreshing[worldName] = done
+	state.graphSeedMu.Unlock()
 	success := false
 	defer func() {
-		g.graphSeedMu.Lock()
+		state.graphSeedMu.Lock()
 		if success {
-			g.graphSeedChecked[worldName] = time.Now()
+			state.graphSeedChecked[worldName] = time.Now()
 		}
 		close(done)
-		delete(g.graphSeedRefreshing, worldName)
-		g.graphSeedMu.Unlock()
+		delete(state.graphSeedRefreshing, worldName)
+		state.graphSeedMu.Unlock()
 	}()
 
-	etag := g.graphStore.SeedEtag(worldName)
+	etag := state.graphStore.SeedEtag(worldName)
 	result, err := g.dispatcher.FetchConditionalContext(ctx, worldName, graphstore.SnapshotManifestPath, "", etag)
 	if err != nil {
 		g.log.Warn("graph seed fetch failed", "world", worldName, "err", err)
@@ -180,9 +147,9 @@ func (g *mcpGateway) seedWorldGraph(ctx context.Context, worldName string) {
 			return
 		}
 		g.translateSeedURLs(nodes, edges)
-		g.graphStore.ReplaceSeed(worldName, nodes, edges)
+		state.replaceSeed(worldName, nodes, edges)
 		if snapshotEtag := result.Response.Metadata["etag"]; snapshotEtag != "" {
-			g.graphStore.SetSeedEtag(worldName, snapshotEtag)
+			state.graphStore.SetSeedEtag(worldName, snapshotEtag)
 		}
 		success = true
 		return
@@ -215,11 +182,25 @@ func (g *mcpGateway) seedWorldGraph(ctx context.Context, worldName string) {
 		return
 	}
 	g.translateSeedURLs(nodes, edges)
-	g.graphStore.ReplaceSeed(worldName, nodes, edges)
+	state.replaceSeed(worldName, nodes, edges)
 	if e := result.Response.Metadata["etag"]; e != "" {
-		g.graphStore.SetSeedEtag(worldName, e)
+		state.graphStore.SetSeedEtag(worldName, e)
 	}
 	success = true
+}
+
+// A tenant snapshot cannot introduce another world's source rows, even if
+// it aggregates several worlds. Destinations remain labels from owned sources.
+func (state *gatewayGraph) replaceSeed(owner string, nodes []graphstore.StoredNode, edges []graphstore.StoredEdge) {
+	if state.tenant != "" {
+		owned := func(raw string) bool {
+			world, _, err := parseToolURL(links.CanonicalURL(raw))
+			return err == nil && world == state.tenant
+		}
+		nodes = slices.DeleteFunc(nodes, func(n graphstore.StoredNode) bool { return !owned(n.URL) })
+		edges = slices.DeleteFunc(edges, func(e graphstore.StoredEdge) bool { return !owned(e.From) })
+	}
+	state.graphStore.ReplaceSeed(owner, nodes, edges)
 }
 
 // translateSeedURLs rewrites world dial addresses to mark://{worldName}/...;
@@ -252,11 +233,7 @@ func (g *mcpGateway) translateSeedURLs(nodes []graphstore.StoredNode, edges []gr
 	}
 }
 
-// handleMarkBacklinks queries the broker's ephemeral graph store
-// for documents linking to a given URL, seeding the store from the
-// world's published /graph.md first so cold pods still answer.
-// First-time callers on a world with no /graph.md see an empty
-// result (and a hint to run mark_graph first).
+// Seed before querying so cold pods can answer without a local crawl.
 func (g *mcpGateway) handleMarkBacklinks(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go's AddTool API
 	raw, err := req.RequireString("url")
 	if err != nil {
@@ -267,8 +244,12 @@ func (g *mcpGateway) handleMarkBacklinks(ctx context.Context, req mcp.CallToolRe
 	if _, _, perr := parseToolURL(raw); perr != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", perr)), nil
 	}
-	g.seedGraphStore(ctx)
-	backlinks := g.graphStore.BacklinksEnriched(raw)
+	state, err := g.graphFor(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("graph scope: %v", err)), nil
+	}
+	g.seedGraphStore(ctx, state)
+	backlinks := state.graphStore.BacklinksEnriched(raw)
 	if len(backlinks) == 0 {
 		return mcp.NewToolResultText(
 			fmt.Sprintf("No backlinks found for %s\nRun mark_graph to populate the broker's graph store. (Note: the broker's graph store is ephemeral; it resets on broker restart.)", raw),
@@ -299,12 +280,16 @@ func (g *mcpGateway) handleMarkGraph(ctx context.Context, req mcp.CallToolReques
 		return mcp.NewToolResultError(fmt.Sprintf("invalid URL: %v", perr)), nil
 	}
 	depth := max(1, min(req.GetInt("depth", 2), 5))
+	state, err := g.graphFor(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("graph scope: %v", err)), nil
+	}
 
 	// Seed before crawling so depth-limited crawls still benefit from
 	// hub context.
-	g.seedGraphStore(ctx)
+	g.seedGraphStore(ctx, state)
 
-	crawled, crawlErr := g.graphStore.CrawlAndPersist(
+	crawled, crawlErr := state.graphStore.CrawlAndPersist(
 		ctx,
 		raw,
 		g.crawlFetchFn(ctx),
@@ -360,8 +345,12 @@ func formatGraphSummary(gr *graph.Graph, startURL string) string {
 // handleMarkGraphExport returns the broker's ephemeral graph
 // store as a publishable markdown document. Pure local read.
 // Empty store → empty document (still valid markdown).
-func (g *mcpGateway) handleMarkGraphExport(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go
-	return mcp.NewToolResultText(g.graphStore.Export()), nil
+func (g *mcpGateway) handleMarkGraphExport(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go
+	state, err := g.graphFor(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("graph scope: %v", err)), nil
+	}
+	return mcp.NewToolResultText(state.graphStore.Export()), nil
 }
 
 // defaultGraphRetention bounds the published graph document's version
@@ -370,13 +359,7 @@ func (g *mcpGateway) handleMarkGraphExport(_ context.Context, _ mcp.CallToolRequ
 // growth; 20 versions is enough to debug a bad crawl.
 const defaultGraphRetention = 20
 
-// handleMarkGraphPublish exports the broker's ephemeral graph
-// store and PUBLISHes it to a target world. Same expected_version
-// + on_conflict semantics as mark_publish (Slice 3); on_conflict
-// support is deliberately not part of this tool's surface today
-// (the local demarkus-mcp doesn't expose it either — graph
-// publishes are single-writer flows where conflict really means
-// "the agent forgot to fetch first," not a merge case).
+// Graph publication is single-writer: version conflicts surface without merging.
 func (g *mcpGateway) handleMarkGraphPublish(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) { //nolint:gocritic // signature required by mcp-go
 	raw, err := req.RequireString("url")
 	if err != nil {
@@ -405,7 +388,11 @@ func (g *mcpGateway) handleMarkGraphPublish(ctx context.Context, req mcp.CallToo
 	if _, errRes := g.gateWrite(claims, worldName); errRes != nil {
 		return errRes, nil
 	}
-	body := g.graphStore.Export()
+	state, err := g.graphFor(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("graph scope: %v", err)), nil
+	}
+	body := state.graphStore.Export()
 	meta := agentMetaFromClaims(claims)
 	if retention > 0 {
 		meta["retention"] = strconv.Itoa(retention)
@@ -417,7 +404,7 @@ func (g *mcpGateway) handleMarkGraphPublish(ctx context.Context, req mcp.CallToo
 		return g.toolErrorFor("graph publish", worldName, err), nil
 	}
 	var out strings.Builder
-	fmt.Fprintf(&out, "Published graph (%d nodes, %d edges) to %s\n", g.graphStore.NodeCount(), g.graphStore.EdgeCount(), raw)
+	fmt.Fprintf(&out, "Published graph (%d nodes, %d edges) to %s\n", state.graphStore.NodeCount(), state.graphStore.EdgeCount(), raw)
 	out.WriteString(mcpfmt.Full(result, "version", "modified", "server-version"))
 	return mcp.NewToolResultText(out.String()), nil
 }

--- a/tools/internal/broker/mcp_tools_graph_seed_test.go
+++ b/tools/internal/broker/mcp_tools_graph_seed_test.go
@@ -47,13 +47,18 @@ func seedingDispatcher(etag string) *fakeDispatcher {
 
 func brokerSnapshot(t *testing.T) (protocol.Response, map[string]protocol.Response) { //nolint:gocritic // fixture returns manifest and shard set
 	t.Helper()
-	exported := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
 	const base = "mark://team-a.team-a.svc.cluster.local:6309"
 	nodes := []graphstore.StoredNode{
 		{URL: base + "/a.md", Title: "Page A", Status: "ok", LinkCount: 1},
 		{URL: base + "/b.md", Title: "Page B", Status: "ok"},
 	}
 	edges := []graphstore.StoredEdge{{From: base + "/a.md", To: base + "/b.md", Count: 1}}
+	return brokerSnapshotRows(t, nodes, edges)
+}
+
+func brokerSnapshotRows(t *testing.T, nodes []graphstore.StoredNode, edges []graphstore.StoredEdge) (protocol.Response, map[string]protocol.Response) { //nolint:gocritic // fixture returns manifest and shard set
+	t.Helper()
+	exported := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
 	artifacts, err := graphstore.BuildSnapshotShards(graphstore.SnapshotManifestPath, graphstore.SnapshotSlotA, nodes, edges, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -103,7 +108,7 @@ func TestSeedWorldGraphPrefersAtomicSnapshot(t *testing.T) {
 	if text := toolResultText(t, res); !strings.Contains(text, "mark://team-a/a.md") {
 		t.Fatalf("translated snapshot backlink missing: %s", text)
 	}
-	if got := g.graphStore.SeedEtag("team-a"); got != "snapshot-etag-1" {
+	if got := g.knowledgeGraph.graphStore.SeedEtag("team-a"); got != "snapshot-etag-1" {
 		t.Fatalf("seed etag = %q", got)
 	}
 }
@@ -156,7 +161,7 @@ func TestSeedConsumesAgentExportContract(t *testing.T) {
 
 	// Addressability invariant: every seeded mark:// row on a configured
 	// world address must be translated; none may keep the dial-address form.
-	for _, n := range g.graphStore.AllNodes() {
+	for _, n := range g.knowledgeGraph.graphStore.AllNodes() {
 		if strings.Contains(n.URL, ".svc.cluster.local") {
 			t.Errorf("unaddressable seeded row survived translation: %s", n.URL)
 		}
@@ -206,10 +211,10 @@ func TestSeedTranslatesInternalAddressesToWorldNames(t *testing.T) {
 	// The external URL is not a world address and must stay as-is, on the
 	// node and on the edge destination (asserted via the store; the tool
 	// URL grammar only admits mark:// URLs).
-	if n := g.graphStore.GetNode("https://example.com/ext"); n == nil {
+	if n := g.knowledgeGraph.graphStore.GetNode("https://example.com/ext"); n == nil {
 		t.Error("external node URL was rewritten or dropped")
 	}
-	if bl := g.graphStore.Backlinks("https://example.com/ext"); len(bl) != 1 || bl[0] != "mark://team-a/a.md" {
+	if bl := g.knowledgeGraph.graphStore.Backlinks("https://example.com/ext"); len(bl) != 1 || bl[0] != "mark://team-a/a.md" {
 		t.Errorf("external edge destination = %v, want [mark://team-a/a.md]", bl)
 	}
 }
@@ -358,9 +363,9 @@ func TestSeedWorldGraphEtagRoundTrip(t *testing.T) {
 	}
 
 	// Expire the throttle so the next call re-checks with the stored etag.
-	g.graphSeedMu.Lock()
-	g.graphSeedChecked["team-a"] = time.Now().Add(-2 * seedCheckInterval)
-	g.graphSeedMu.Unlock()
+	g.knowledgeGraph.graphSeedMu.Lock()
+	g.knowledgeGraph.graphSeedChecked["team-a"] = time.Now().Add(-2 * seedCheckInterval)
+	g.knowledgeGraph.graphSeedMu.Unlock()
 
 	res, err := g.handleMarkBacklinks(ctx, callToolReq("mark_backlinks", map[string]any{
 		"url": "mark://team-a/b.md",

--- a/tools/internal/broker/mcp_tools_graph_test.go
+++ b/tools/internal/broker/mcp_tools_graph_test.go
@@ -50,6 +50,28 @@ func TestHandleMarkBacklinksEmptyStoreHintsAtMarkGraph(t *testing.T) {
 	}
 }
 
+func TestKnowledgeGraphPreservesCrossWorldSources(t *testing.T) {
+	d := seededDispatcher()
+	d.published["bob-w/source.md"] = fetch.Result{Response: protocol.Response{
+		Status: protocol.StatusOK, Body: "# Shared source\n[reference](mark://alice-w/index.md)",
+	}}
+	g := newGatewayWithDispatcher(t, memoryTestConfig(), d)
+	ctx := withAliceClaims(t.Context())
+	res, err := g.handleMarkGraph(ctx, callToolReq("mark_graph", map[string]any{"url": "mark://bob-w/source.md"}))
+	if err != nil || res == nil || res.IsError {
+		t.Fatalf("cross-world crawl: err=%v result=%v", err, res)
+	}
+	for _, tool := range []string{"mark_backlinks", "mark_explore", "mark_graph_export"} {
+		res, err := g.toolHandlers()[tool](ctx, callToolReq(tool, map[string]any{"url": "mark://alice-w/index.md"}))
+		if err != nil || res == nil || res.IsError {
+			t.Fatalf("%s: err=%v result=%v", tool, err, res)
+		}
+		if text := toolResultText(t, res); !strings.Contains(text, "bob-w/source.md") || !strings.Contains(text, "Shared source") {
+			t.Errorf("%s lost authorized cross-world source: %s", tool, text)
+		}
+	}
+}
+
 func TestHandleMarkBacklinksMissingURL(t *testing.T) {
 	g := newGatewayWithDispatcher(t, mcpTestConfig(), &fakeDispatcher{})
 	res, err := g.handleMarkBacklinks(withAliceClaims(context.Background()), callToolReq("mark_backlinks", nil))
@@ -151,7 +173,7 @@ func TestEphemeralGraphStoreResetsAcrossGatewayInstances(t *testing.T) {
 	})); err != nil || res.IsError {
 		t.Fatalf("first crawl: %v %v", err, res.IsError)
 	}
-	if g1.graphStore.NodeCount() == 0 {
+	if g1.knowledgeGraph.graphStore.NodeCount() == 0 {
 		t.Fatal("first crawl produced an empty graph; cannot exercise the reset property")
 	}
 
@@ -159,7 +181,7 @@ func TestEphemeralGraphStoreResetsAcrossGatewayInstances(t *testing.T) {
 	// using the SAME server config, the new mcpGateway
 	// instance must have an empty graph store.
 	g2 := newGatewayWithDispatcher(t, cfg, d)
-	if got := g2.graphStore.NodeCount(); got != 0 {
+	if got := g2.knowledgeGraph.graphStore.NodeCount(); got != 0 {
 		t.Errorf("new gateway's graph store has %d nodes, want 0 (ephemeral semantics broken)", got)
 	}
 
@@ -263,13 +285,13 @@ func TestHandleMarkGraphDepthClamping(t *testing.T) {
 	// the same NodeCount (likely the deep count since the full
 	// chain would be reachable). The strict inequality is what
 	// pins the clamp behavior.
-	if gShallow.graphStore.NodeCount() == gDeep.graphStore.NodeCount() {
+	if gShallow.knowledgeGraph.graphStore.NodeCount() == gDeep.knowledgeGraph.graphStore.NodeCount() {
 		t.Errorf("shallow node count (%d) == deep node count (%d) — depth not producing different traversal scopes",
-			gShallow.graphStore.NodeCount(), gDeep.graphStore.NodeCount())
+			gShallow.knowledgeGraph.graphStore.NodeCount(), gDeep.knowledgeGraph.graphStore.NodeCount())
 	}
-	if gShallow.graphStore.NodeCount() >= gDeep.graphStore.NodeCount() {
+	if gShallow.knowledgeGraph.graphStore.NodeCount() >= gDeep.knowledgeGraph.graphStore.NodeCount() {
 		t.Errorf("shallow node count (%d) should be < deep node count (%d)",
-			gShallow.graphStore.NodeCount(), gDeep.graphStore.NodeCount())
+			gShallow.knowledgeGraph.graphStore.NodeCount(), gDeep.knowledgeGraph.graphStore.NodeCount())
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Graph data, backlinks, crawls, exports, and publications are now isolated to the active tenant scope.
  - Unauthorized cross-tenant sections are rejected before processing.
  - Graph state resets correctly when identity, connection, or authorization details change.
  - Tenant refreshes no longer interfere with one another.
  - URL validation now handles section fragments consistently.

- **Documentation**
  - Added benchmark reports covering source isolation, replay metrics, verification results, and graph performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->